### PR TITLE
Add Persistence IOC for wow64cpu.dll replacement 

### DIFF
--- a/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
+++ b/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
@@ -1,7 +1,6 @@
 name: Windows.Persistence.wow64cpu
 description: |
   Checks for wow64cpu.dll replacement Autorun in Windows 10.
-  HKLM\SOFTWARE\Microsoft\Wow64\x86\
   http://www.hexacorn.com/blog/2019/07/11/beyond-good-ol-run-key-part-108-2/
 
 author: Matt Green - @mgreen27
@@ -21,4 +20,6 @@ sources:
         Data.value as Value,
         timestamp(epoch=Mtime.Sec) AS LastModified
       FROM glob(globs=split(string=TargetRegKey, sep=","), accessor="reg")
-      WHERE not (Name = "@" and Data.value = "wow64cpu.dll") and Data.value
+      WHERE Data.value and 
+        not (Name = "@" and (Data.value = "wow64cpu.dll"
+            or Data.value = "wowarmhw.dll" or Data.value = "xtajit.dll"))

--- a/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
+++ b/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
@@ -1,0 +1,23 @@
+name: Windows.Registry.wow64cpu
+description: |
+  Checks for wow64cpu.dll replacement Autorun in Windows 10.
+  Beyond Good Old RunKey 108
+  http://www.hexacorn.com/blog/2019/07/11/beyond-good-ol-run-key-part-108-2/
+Author: "@mgreen27"
+
+parameters:
+   - name: TargetRegKey
+     default: HKEY_LOCAL_MACHINE\Software\Microsoft\Wow64\x86\*
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    queries:
+    - LET users <= SELECT Name, UUID FROM Artifact.Windows.Sys.Users()
+    - |
+      SELECT dirname(path=FullPath) as KeyPath,
+        Name as KeyName,
+        Data.value as Value,
+        timestamp(epoch=Mtime.Sec) AS LastModified
+      FROM glob(globs=split(string=TargetRegKey, sep=","), accessor="reg")
+      WHERE not (Name = "@" and Data.value = "wow64cpu.dll")

--- a/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
+++ b/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
@@ -1,9 +1,10 @@
-name: Windows.Registry.wow64cpu
+name: Windows.Persistence.wow64cpu
 description: |
   Checks for wow64cpu.dll replacement Autorun in Windows 10.
-  Beyond Good Old RunKey 108
+  HKLM\SOFTWARE\Microsoft\Wow64\x86\
   http://www.hexacorn.com/blog/2019/07/11/beyond-good-ol-run-key-part-108-2/
-Author: "@mgreen27"
+
+author: Matt Green - @mgreen27
 
 parameters:
    - name: TargetRegKey

--- a/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
+++ b/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
@@ -8,7 +8,7 @@ author: Matt Green - @mgreen27
 
 parameters:
    - name: TargetRegKey
-     default: HKEY_LOCAL_MACHINE\Software\Microsoft\Wow64\x86\*
+     default: HKEY_LOCAL_MACHINE\Software\Microsoft\Wow64\**
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
@@ -21,4 +21,4 @@ sources:
         Data.value as Value,
         timestamp(epoch=Mtime.Sec) AS LastModified
       FROM glob(globs=split(string=TargetRegKey, sep=","), accessor="reg")
-      WHERE not (Name = "@" and Data.value = "wow64cpu.dll")
+      WHERE not (Name = "@" and Data.value = "wow64cpu.dll") and Data.value


### PR DESCRIPTION
Add IOC for wow64cpu.dll replacement
http://www.hexacorn.com/blog/2019/07/11/beyond-good-ol-run-key-part-108-2/
(fixed logic to also cover use cases here - https://wbenny.github.io/2018/11/04/wow64-internals.html)