### PR TITLE
Add EventLogs and SchTasks to use ntfs accessor

### DIFF
--- a/artifacts/definitions/Windows/Triage/Collectors/EventLogs.yaml
+++ b/artifacts/definitions/Windows/Triage/Collectors/EventLogs.yaml
@@ -2,15 +2,15 @@ name: Windows.Triage.Collectors.EventLogs
 description: |
   Collect event log files.
 
-parameters:
-  - name: EventLogGlobs
-    default: C:\Windows\system32\config\*.evt,C:\Windows\system32\winevt\logs\*.evtx
-
 precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: triageTable
+    default: |
+      Type,Accessor,Glob
+      EventLogs,ntfs,C:\Windows\system32\winevt\logs\*.evtx
+      EventLogs,ntfs,C:\Windows\system32\config\*.evt
 
 sources:
   - queries:
-      - |
-        SELECT * FROM Artifact.Triage.Collection.Upload(
-           type="EventLogs",
-           path=split(string=EventLogGlobs, sep=","))
+      - SELECT * FROM Artifact.Triage.Collection.UploadTable(triageTable=triageTable)

--- a/artifacts/definitions/Windows/Triage/Collectors/ScheduledTasks.yaml
+++ b/artifacts/definitions/Windows/Triage/Collectors/ScheduledTasks.yaml
@@ -4,20 +4,14 @@ description: |
 
 precondition: SELECT OS From info() where OS = 'windows'
 
+parameters:
+  - name: triageTable
+    default: |
+      Type,Accessor,Glob
+      XML,ntfs,C:\Windows\system32\Tasks\**
+      at SchedLgU.txt,ntfs,C:\Windows\SchedLgU.txt
+      at .job,ntfs,C:\Windows\Tasks\*.job
+
 sources:
   - queries:
-      - |
-        SELECT * FROM chain(
-          a1={ SELECT * FROM Artifact.Triage.Collection.Upload(
-               type="at .job",
-               path="C:\\Windows\\Tasks\\*.job")
-          },
-          a1={ SELECT * FROM Artifact.Triage.Collection.Upload(
-               type="at SchedLgU.txt",
-               path="C:\\Windows\\SchedLgU.txt")
-          },
-          a2={ SELECT * FROM Artifact.Triage.Collection.Upload(
-               type="XML",
-               path="C:\\Windows\\system32\\Tasks\\**")
-          }
-        )
+      - SELECT * FROM Artifact.Triage.Collection.UploadTable(triageTable=triageTable)


### PR DESCRIPTION
A quick change to EventLogs and ScheduledTask artefacts to use ntfs accessor via Artifact.Triage.Collection.UploadTable(). Previously both of these artefacts appeared to use the default Artifact.Triage.Collection.Upload() file accessor.