### PR TITLE
Velociraptor/add vql mods

### DIFF
--- a/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
+++ b/artifacts/definitions/Windows/Persistence/Wow64cpu.yaml
@@ -13,7 +13,6 @@ sources:
       SELECT OS From info() where OS = 'windows'
 
     queries:
-    - LET users <= SELECT Name, UUID FROM Artifact.Windows.Sys.Users()
     - |
       SELECT dirname(path=FullPath) as KeyPath,
         Name as KeyName,
@@ -21,5 +20,4 @@ sources:
         timestamp(epoch=Mtime.Sec) AS LastModified
       FROM glob(globs=split(string=TargetRegKey, sep=","), accessor="reg")
       WHERE Data.value and
-        not (Name = "@" and (Data.value = "wow64cpu.dll"
-            or Data.value = "wowarmhw.dll" or Data.value = "xtajit.dll"))
+        not (Name = "@" and (Data.value =~ "(wow64cpu.dll|wowarmhw.dll|xtajit.dll)"

--- a/artifacts/definitions/Windows/Registry/NTUser.yaml
+++ b/artifacts/definitions/Windows/Registry/NTUser.yaml
@@ -33,20 +33,30 @@ parameters:
  - name: KeyGlob
    default: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\**
 
- - name: UserHomes
-   default: C:\Users\*\NTUSER.DAT
-
 sources:
  - queries:
      - |
+        LET UserProfiles = SELECT Uid, 
+            Gid, 
+            Name as Username, 
+            Description, 
+            UUID,  
+            {
+                SELECT FullPath FROM glob(globs=expand(path=Directory) + "//NTUSER.DAT", accessor="file")
+            } as FullPath,
+            expand(path=Directory) as Directory
+        FROM Artifact.Windows.Sys.Users()
+        WHERE Directory and FullPath
+     - |
        SELECT * FROM foreach(
-         row={
-            SELECT FullPath FROM glob(globs=UserHomes)
-         },
-         query={
-            SELECT FullPath, Data, Mtime.Sec AS Mtime FROM glob(
-               globs=url(scheme="ntfs",
-                  path=FullPath,
-                  fragment=KeyGlob).String,
-               accessor="raw_reg")
-         })
+            row={
+                SELECT * FROM UserProfiles
+            },
+            query={
+                SELECT FullPath, Data, Mtime.Sec AS Mtime, Username, Description, Uid, Gid, UUID, Directory
+                FROM glob(
+                    globs=url(scheme="ntfs",
+                    path=FullPath,
+                    fragment=KeyGlob).String,
+                    accessor="raw_reg")
+            })


### PR DESCRIPTION
First go at adding the NTUser changes discussed here - https://github.com/Velocidex/velociraptor/pull/29
Output should be the same as the old version with additional SYSTEM hives and feilds enabled by leveraging Artifact.Windows.Sys.Users(). The additional fields are UserName and other user metadata that is useful during a query to pull out at the same time.

I also added a commit on a slight fix on some redundant VQL.