### PR TITLE
Add MountPoints2 hunt using new NTUser artefact

### DIFF
--- a/artifacts/definitions/Windows/Registry/MountPoints2.yaml
+++ b/artifacts/definitions/Windows/Registry/MountPoints2.yaml
@@ -1,8 +1,9 @@
 name: Windows.Registry.MountPoints2
 description: |
-    This Detection will collect any items in the MountPoints2 registry key with a "$" in the share path. 
-    MountPoints2 is stored in the user hive and will store all remotely mapped drives unless removd.
-    This is a great datapoint to stack and hunt for simple admin $ mapping based lateral movement.
+    This detection will collect any items in the MountPoints2 registry key.
+    With a "$" in the share path. This key will store all remotely mapped
+    drives unless removed so is a great hunt for simple admin $ mapping based
+    lateral movement.
     
 author: Matt Green - @mgreen27
 
@@ -15,11 +16,11 @@ parameters:
 sources:
  - queries:
      - |
-        SELECT regex_replace(
-                   source=basename(path=FullPath), re="%23", replace="\\") as MountPoint,
-            timestamp(epoch=Mtime) as ModifiedTime,
-            Username,
-            url(parse=FullPath).Path as Hive,
-            url(parse=FullPath).Fragment as Key
+        SELECT regex_replace(source=basename(path=url(parse=FullPath).Fragment), 
+          re="#", replace="\\") as MountPoint,
+          timestamp(epoch=Mtime) as ModifiedTime,
+          Username,
+          url(parse=FullPath).Path as Hive,
+          url(parse=FullPath).Fragment as Key
         FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob)
         WHERE FullPath =~ "\\$"

--- a/artifacts/definitions/Windows/Registry/MountPoints2.yaml
+++ b/artifacts/definitions/Windows/Registry/MountPoints2.yaml
@@ -1,0 +1,25 @@
+name: Windows.Registry.MountPoints2
+description: |
+    This Detection will collect any items in the MountPoints2 registry key with a "$" in the share path. 
+    MountPoints2 is stored in the user hive and will store all remotely mapped drives unless removd.
+    This is a great datapoint to stack and hunt for simple admin $ mapping based lateral movement.
+    
+author: Matt Green - @mgreen27
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+ - name: KeyGlob
+   default: Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2\*
+
+sources:
+ - queries:
+     - |
+        SELECT regex_replace(
+                   source=basename(path=FullPath), re="%23", replace="\\") as MountPoint,
+            timestamp(epoch=Mtime) as ModifiedTime,
+            Username,
+            url(parse=FullPath).Path as Hive,
+            url(parse=FullPath).Fragment as Key
+        FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob)
+        WHERE FullPath =~ "\\$"


### PR DESCRIPTION
Adding an example of leveraging new NTUser artefact for hive enrichment.
This hunt collects all mountpoints sub keys with $ in path indicating an admin share.