### PR TITLE
velociraptor/Add improvement to Binary Fetch

### DIFF
--- a/artifacts/definitions/Windows/Utils/FetchBinary.yaml
+++ b/artifacts/definitions/Windows/Utils/FetchBinary.yaml
@@ -17,8 +17,7 @@ parameters:
 sources:
   - queries:
       - |
-        LET download = SELECT FullPath as TempPath,
-            expand(path=binPath) + "\\" + basename(path=binaryURL) as FullPath,
+        LET download = expand(path=binPath) + "\\" + basename(path=binaryURL) as FullPath,
             hash(path=Content) as Hash, 
             {
                 SELECT * FROM execve(

--- a/artifacts/definitions/Windows/Utils/FetchBinary.yaml
+++ b/artifacts/definitions/Windows/Utils/FetchBinary.yaml
@@ -10,22 +10,28 @@ parameters:
   - name: binaryURL
     default: https://live.sysinternals.com/tools/autorunsc64.exe
   - name: expectedHash
-    default: "bea5da8b6487dac6e0c7ab5a4c6f0dc0c2b89d6870199dc6f75ae425bde896a6"
+    default: bea5da8b6487dac6e0c7ab5a4c6f0dc0c2b89d6870199dc6f75ae425bde896a6
+  - name: binPath
+    default: "%TEMP%"
 
 sources:
   - queries:
       - |
-        LET download = SELECT Content AS FullPath, hash(path=Content) as Hash, {
-           SELECT * FROM execve(
-               argv=["cmd.exe", "/c", "copy", Content,
-                     expand(path="%TEMP%\\") + basename(path=binaryURL)])
-        } AS CopyDetails
+        LET download = SELECT FullPath as TempPath,
+            expand(path=binPath) + "\\" + basename(path=binaryURL) as FullPath,
+            hash(path=Content) as Hash, 
+            {
+                SELECT * FROM execve(
+                    argv=["cmd.exe", "/c", "copy", Content,
+                        expand(path=binPath) + "\\" + basename(path=binaryURL)])
+            } AS CopyDetails
         FROM http_client(url=binaryURL, tempfile_extension=".exe")
         WHERE Hash.SHA256 = expectedHash
 
       - |
-        LET existing = SELECT FullPath, hash(path=FullPath) AS Hash
-        FROM stat(filename=expand(path="%TEMP%\\") + basename(path=binaryURL))
+        LET existing = SELECT FullPath,
+            hash(path=FullPath) AS Hash
+        FROM stat(filename=expand(path=binPath) + "\\" + basename(path=binaryURL))
         WHERE Hash.SHA256 = expectedHash
 
       - SELECT * FROM chain(a=existing, b=download) LIMIT 1


### PR DESCRIPTION
I added some slight mods to the binary fetch utility after testing.

Added binPath to allow configuration of specific path (default is still %TEMP%). For example adding binPath = c:\Program Files\Velociraptor\bin works nicely :)
I also modded "\\" outside the expand function to accommodate this.

Potential things for us to look at in future:
1) built in copy /  move / delete functions to remove the need to shell out which can be noisy for process monitoring
2) reporting of failure - if hash doesn't match nothing passed to calling artefact.
