### PR TITLE
Parse IPs in a proxy-compatible way

### DIFF
--- a/config/proto/config.pb.go
+++ b/config/proto/config.pb.go
@@ -956,6 +956,7 @@ type FrontendConfig struct {
 	DoNotCompressArtifacts bool          `protobuf:"varint,10,opt,name=do_not_compress_artifacts,json=doNotCompressArtifacts,proto3" json:"do_not_compress_artifacts,omitempty"`
 	MaxUploadSize          uint64        `protobuf:"varint,11,opt,name=max_upload_size,json=maxUploadSize,proto3" json:"max_upload_size,omitempty"`
 	DynDns                 *DynDNSConfig `protobuf:"bytes,12,opt,name=dyn_dns,json=dynDns,proto3" json:"dyn_dns,omitempty"`
+	ProxyHeader            string        `protobuf:"bytes,13,opt,name=proxy_header,json=proxyHeader,proto3" json:"proxy_header,omitempty"`
 	XXX_NoUnkeyedLiteral   struct{}      `json:"-"`
 	XXX_unrecognized       []byte        `json:"-"`
 	XXX_sizecache          int32         `json:"-"`
@@ -1061,6 +1062,13 @@ func (m *FrontendConfig) GetDynDns() *DynDNSConfig {
 		return m.DynDns
 	}
 	return nil
+}
+
+func (m *FrontendConfig) GetProxyHeader() string {
+	if m != nil {
+		return m.ProxyHeader
+	}
+	return ""
 }
 
 type DatastoreConfig struct {

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -322,6 +322,10 @@ message FrontendConfig {
     DynDNSConfig dyn_dns = 12 [(sem_type) = {
             description: "If set we start the dyn dns service.",
         }];
+
+    string proxy_header = 13 [(sem_type) = {
+            description: "Header defined by the proxy containing the remote address",
+        }];
 }
 
 

--- a/server/comms.go
+++ b/server/comms.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"www.velocidex.com/golang/velociraptor/utils"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -343,9 +344,9 @@ func control(server_obj *Server) http.Handler {
 			http.Error(w, "", http.StatusForbidden)
 			return
 		}
-		message_info.RemoteAddr = req.RemoteAddr
+		message_info.RemoteAddr = utils.RemoteAddr(req, server_obj.config.Frontend.GetProxyHeader())
 		logger.Debug("Received a post of length %v from %v (%v)", len(body),
-			req.RemoteAddr, message_info.Source)
+			message_info.RemoteAddr, message_info.Source)
 
 		// Very few Unauthenticated client messages are valid
 		// - currently only enrolment requests.

--- a/utils/proxy.go
+++ b/utils/proxy.go
@@ -1,0 +1,15 @@
+package utils;
+
+import (
+	"net/http"
+)
+
+// Retrieve the Remote Address from a request in a reverse-proxy compatible way.
+func RemoteAddr(req *http.Request, header string) string {
+	if len(header) > 0 {
+		if addr := req.Header.Get(header); len(addr) > 0 {
+			return addr
+		}
+	}
+	return req.RemoteAddr
+}


### PR DESCRIPTION
### Concept
(Reverse-)Proxies such as Nginx modify the apparent IP of an endpoint leading to all endpoints having the same IP.
This pull request adds the ability to trust a custom header such as `X-Real-IP` in order to neutralize the above-described proxy side-effect (Fixes #53).

#### Before
![Screenshot_2019-08-24 Velociraptor C c64b83e523f46dd5 Host Information(1)](https://user-images.githubusercontent.com/46688461/63635956-02105000-c669-11e9-96d2-974fcbcf9947.png)

#### After
![Screenshot_2019-08-24 Velociraptor C c64b83e523f46dd5 Host Information](https://user-images.githubusercontent.com/46688461/63635959-05a3d700-c669-11e9-806f-089d0c00b3dd.png)

### Usage
The configuration of the header to check is done in the server's `frontend` configuration through the `proxy_header` setting.

```yaml
Frontend:
  bind_address: 127.0.0.1
  bind_port: 8000
  certificate: [...]
  private_key: [...]
  public_path: /tmp/public
  max_upload_size: 10485760
  proxy_header: X-Real-IP
``` 

### Considerations
The usage of this feature assumes that endpoints are only able to reach the frontend through the reverse proxy. Should however an endpoint be able to directly access `bind_address:bind_port` while having the `proxy_header` configured would enable an attacker to fake its last seen IP by forging the header (`X-Real-IP` in this case).

Logs produced by Velociraptor aren't affected by this setting as proxies perform logging of their own and "faking" the logs would complicate troubleshooting.