### PR TITLE
Implemented a central event log watcher service.

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -58,6 +58,8 @@ const (
 	// monitoring artifacts.
 	ServerMonitoringFlowURN = "/config/server_monitoring.json"
 	ClientMonitoringFlowURN = "/config/client_monitoring.json"
+
+	USER_AGENT = "Velociraptor - Dig Deeper!"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module www.velocidex.com/golang/velociraptor
 
 require (
 	cloud.google.com/go v0.41.0 // indirect
+	github.com/Depado/bfchroma v1.1.2
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.20.0+incompatible
@@ -12,6 +13,7 @@ require (
 	github.com/Velocidex/cgofuse v1.1.2
 	github.com/Velocidex/go-yara v1.1.9
 	github.com/Velocidex/yaml v0.0.0-20190812045153-ad0acda9eea0
+	github.com/alecthomas/chroma v0.6.0
 	github.com/alecthomas/participle v0.3.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
@@ -76,6 +78,7 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20150902115704-41f357289737
 	gopkg.in/olivere/elastic.v5 v5.0.81
+	gopkg.in/russross/blackfriday.v2 v2.0.1
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 	www.velocidex.com/golang/evtx v0.0.0-20190210013513-b45fe1505163
 	www.velocidex.com/golang/go-ntfs v0.0.0-20190701133924-d467c5e7dca0
@@ -88,3 +91,5 @@ require (
 )
 
 // replace www.velocidex.com/golang/vfilter => /home/mic/projects/vfilter
+
+replace gopkg.in/russross/blackfriday.v2 v2.0.1 => github.com/russross/blackfriday/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go v0.41.0/go.mod h1:OauMR7DV8fzvZIl2qg6rkaIhD/vmgk4iwEw/h6ercm
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Depado/bfchroma v1.1.2 h1:kYP1mmZw7G4//kglQl/2xgu7Zd7u4psxTLTjQfBB5sw=
+github.com/Depado/bfchroma v1.1.2/go.mod h1:e/OCIC6Kzzk0k0ICOXsLtatfsvC/dm/5fkkVboNfBFU=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
@@ -30,6 +32,10 @@ github.com/Velocidex/yaml v0.0.0-20190812045153-ad0acda9eea0 h1:rFd07P9lqQPsmgPV
 github.com/Velocidex/yaml v0.0.0-20190812045153-ad0acda9eea0/go.mod h1:LVK71wXgKJYbhcGaK+QDA6QM+yLgcO21ZihAoxAdMak=
 github.com/airking05/termui v2.2.0+incompatible h1:S3j2WJzr70u8KjUktaQ0Cmja+R0edOXChltFoQSGG8I=
 github.com/airking05/termui v2.2.0+incompatible/go.mod h1:B/M5sgOwSZlvGm3TsR98s1BSzlSH4wPQzUUNwZG+uUM=
+github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
+github.com/alecthomas/chroma v0.6.0 h1:gcvXlpe0/NoQP3BvneRfgcauLIJDw9VblkoFwZ5XGFs=
+github.com/alecthomas/chroma v0.6.0/go.mod h1:MmozekIi2rfQSzDcdEZ2BoJ9Pxs/7uc2Y4Boh+hIeZo=
+github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
 github.com/alecthomas/participle v0.2.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
 github.com/alecthomas/participle v0.3.0 h1:e8vhrYR1nDjzDxyDwpLO27TWOYWilaT+glkwbPadj50=
 github.com/alecthomas/participle v0.3.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
@@ -56,6 +62,8 @@ github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73/go.mod h1:507v
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -63,6 +71,8 @@ github.com/daviddengcn/go-colortext v0.0.0-20171126034257-17e75f6184bc h1:nqMZEd
 github.com/daviddengcn/go-colortext v0.0.0-20171126034257-17e75f6184bc/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dlclark/regexp2 v1.1.6 h1:CqB4MjHw0MFCDj+PHHjiESmHX+N7t0tJzKvC6M97BRg=
+github.com/dlclark/regexp2 v1.1.6/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 h1:Ghm4eQYC0nEPnSJdVkTrXpu9KtoVCSo1hg7mtI7G9KU=
@@ -217,6 +227,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sebdah/goldie v0.0.0-20180424091453-8784dd1ab561/go.mod h1:lvjGftC8oe7XPtyrOidaMi0rp5B9+XY/ZRUynGnuaxQ=
 github.com/sebdah/goldie v0.0.0-20190531093107-d313ffb52c77 h1:Msb6XRY62jQOueNNlB5LGin1rljK7c49NLniGwJG2bg=
 github.com/sebdah/goldie v0.0.0-20190531093107-d313ffb52c77/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
@@ -226,6 +238,8 @@ github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5 h1:t5PgljoKFvOqjzO
 github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/reporting/gui.go
+++ b/reporting/gui.go
@@ -12,10 +12,12 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/Depado/bfchroma"
 	"github.com/Masterminds/sprig"
 	"github.com/microcosm-cc/bluemonday"
 
-	//	blackfriday "github.com/russross/blackfriday/v2"
+	chroma_html "github.com/alecthomas/chroma/formatters/html"
+	blackfriday "gopkg.in/russross/blackfriday.v2"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/vfilter"
@@ -193,21 +195,20 @@ func (self *GuiTemplateEngine) Execute(template_string string) (string, error) {
 
 	// We expect the template to be in markdown format, so now
 	// generate the HTML
-	/*
-			output := blackfriday.Run(
-				buffer.Bytes(),
-				blackfriday.WithRenderer(bfchroma.NewRenderer(
-					bfchroma.ChromaOptions(
-						chroma_html.ClassPrefix("chroma"),
-						chroma_html.WithClasses(),
-						chroma_html.WithLineNumbers()),
-					bfchroma.Style("github"),
-				)))
-		output_string := string(output)
-	*/
-	output_string := ""
+	output := blackfriday.Run(
+		buffer.Bytes(),
+		blackfriday.WithRenderer(bfchroma.NewRenderer(
+			bfchroma.ChromaOptions(
+				chroma_html.ClassPrefix("chroma"),
+				chroma_html.WithClasses(),
+				chroma_html.WithLineNumbers()),
+			bfchroma.Style("github"),
+		)))
+
+	output_string := string(output)
+
 	/* This is used to dump out the CSS to be included in
-	/* reporting.scss.
+	   reporting.scss.
 
 	formatter := chroma_html.New(
 		chroma_html.ClassPrefix("chroma"),

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -129,6 +129,7 @@ func GenerateArtifactDescriptionReport(
 			return template_engine.Execute(report.Template)
 		}
 	}
+
 	return "", nil
 }
 

--- a/server/comms.go
+++ b/server/comms.go
@@ -264,6 +264,7 @@ func StartTLSServer(
 		WriteTimeout: 900 * time.Second,
 		IdleTimeout:  15 * time.Second,
 		TLSConfig: &tls.Config{
+			MinVersion:     tls.VersionTLS12,
 			GetCertificate: certManager.GetCertificate,
 		},
 	}

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/tink-ab/tempfile"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	constants "www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
@@ -264,6 +265,8 @@ func (self *_HttpPlugin) Call(
 		}
 
 		scope.Log("Fetching %v\n", arg.Url)
+
+		req.Header.Set("User-Agent", constants.USER_AGENT)
 
 		http_resp, err := client.Do(req)
 		if http_resp != nil {

--- a/vql/parsers/event_logs/watcher.go
+++ b/vql/parsers/event_logs/watcher.go
@@ -1,0 +1,215 @@
+package event_logs
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"www.velocidex.com/golang/evtx"
+	"www.velocidex.com/golang/velociraptor/glob"
+	"www.velocidex.com/golang/vfilter"
+)
+
+var (
+	GlobalEventLogService = NewEventLogWatcherService()
+)
+
+// This service watches one or more many event logs files and
+// multiplexes events to multiple readers.
+type EventLogWatcherService struct {
+	mu sync.Mutex
+
+	registrations map[string][]*Handle
+}
+
+func NewEventLogWatcherService() *EventLogWatcherService {
+	return &EventLogWatcherService{
+		registrations: make(map[string][]*Handle),
+	}
+}
+
+func (self *EventLogWatcherService) Register(
+	filename string,
+	accessor string,
+	ctx context.Context,
+	scope *vfilter.Scope,
+	output_chan chan vfilter.Row) {
+
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	handle := &Handle{
+		ctx:         ctx,
+		output_chan: output_chan,
+		scope:       scope}
+
+	key := filename + accessor
+	registration, pres := self.registrations[key]
+	if !pres {
+		registration = []*Handle{}
+		self.registrations[key] = registration
+		go self.StartMonitoring(filename, accessor)
+	}
+
+	registration = append(registration, handle)
+	self.registrations[key] = registration
+
+	scope.Log("Registering watcher for %v", filename)
+}
+
+// Monitor the filename for new events and emit them to all interested
+// listeners. If no listeners exist we terminate.
+func (self *EventLogWatcherService) StartMonitoring(
+	filename string, accessor string) {
+	last_event := self.findLastEvent(filename, accessor)
+	key := filename + accessor
+	for {
+		self.mu.Lock()
+		registration, pres := self.registrations[key]
+		self.mu.Unlock()
+
+		// No more listeners left, we are done.
+		if !pres || len(registration) == 0 {
+			return
+		}
+
+		last_event = self.monitorOnce(
+			filename, accessor, last_event)
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (self *EventLogWatcherService) findLastEvent(
+	filename string,
+	accessor_name string) int {
+	last_event := 0
+
+	accessor, err := glob.GetAccessor(
+		accessor_name, context.Background())
+	if err != nil {
+		return 0
+	}
+
+	fd, err := accessor.Open(filename)
+	if err != nil {
+		return 0
+	}
+	defer fd.Close()
+
+	chunks, err := evtx.GetChunks(fd)
+	if err != nil {
+		return 0
+	}
+
+	for _, c := range chunks {
+		if int(c.Header.LastEventRecID) <= last_event {
+			continue
+		}
+
+		records, _ := c.Parse(int(last_event))
+		for _, record := range records {
+			if int(record.Header.RecordID) > last_event {
+				last_event = int(record.Header.RecordID)
+			}
+		}
+	}
+
+	return last_event
+}
+
+func (self *EventLogWatcherService) monitorOnce(
+	filename string,
+	accessor_name string,
+	last_event int) int {
+
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	key := filename + accessor_name
+	handles, pres := self.registrations[key]
+	if !pres {
+		return 0
+	}
+
+	accessor, err := glob.GetAccessor(
+		accessor_name, context.Background())
+	if err != nil {
+		return 0
+	}
+
+	fd, err := accessor.Open(filename)
+	if err != nil {
+		for _, handle := range handles {
+			handle.scope.Log("Unable to open file %s: %v",
+				filename, err)
+		}
+		return 0
+	}
+	defer fd.Close()
+
+	chunks, err := evtx.GetChunks(fd)
+	if err != nil {
+		return 0
+	}
+
+	new_last_event := last_event
+	for _, c := range chunks {
+		if int(c.Header.LastEventRecID) <= last_event {
+			continue
+		}
+
+		records, _ := c.Parse(int(last_event))
+		for _, record := range records {
+			event_id := int(record.Header.RecordID)
+			if event_id > new_last_event {
+				new_last_event = event_id
+			}
+			event_map, ok := record.Event.(map[string]interface{})
+			if ok {
+				event := event_map["Event"]
+
+				new_handles := make([]*Handle, 0, len(handles))
+				for _, handle := range handles {
+					select {
+					case <-handle.ctx.Done():
+						// Remove and close
+						// handles that are
+						// not currently
+						// active.
+						handle.scope.Log(
+							"Removing watcher for %v",
+							filename)
+						close(handle.output_chan)
+
+					case handle.output_chan <- event:
+						new_handles = append(new_handles, handle)
+					}
+				}
+
+				// No more listeners - we dont care any more.
+				if len(new_handles) == 0 {
+					delete(self.registrations, key)
+					return new_last_event
+				}
+
+				// Update the registrations - possibly
+				// omitting finished listeners.
+				self.registrations[key] = new_handles
+				handles = new_handles
+			}
+		}
+	}
+
+	return new_last_event
+}
+
+// A handle is given for each interested party. We write the event on
+// to the output_chan unless the context is done. When all interested
+// party are done we may destroy the monitoring go routine and remote
+// the registration.
+type Handle struct {
+	ctx         context.Context
+	output_chan chan vfilter.Row
+	scope       *vfilter.Scope
+}


### PR DESCRIPTION
This is useful when multiple event queries need to watch the same
event log file. They all register watchers for events from the log
file. The log file is parsed once and all listeners get the same
event.