### PR TITLE
Changed a link on the readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ File issues on https://gitlab.com/velocidex/velociraptor
 
 Read more about Velociraptor on our blog:
 
-https://www.velocidex.com/docs/
+https://www.velocidex.com/blog/


### PR DESCRIPTION
Just a quick update to the readme page to point the link to the blog in the right direction.