### PR TITLE
Fix I30

### DIFF
--- a/artifacts/definitions/Windows/NTFS/I30.yaml
+++ b/artifacts/definitions/Windows/NTFS/I30.yaml
@@ -19,7 +19,7 @@ sources:
          LET inodes = SELECT FullPath, Data.mft AS MFT,
              parse_ntfs(device=FullPath, inode=Data.mft) AS MFTInfo
          FROM glob(globs=DirectoryGlobs, accessor="ntfs")
-         WHERE IsDir AND Data.name_type =~ "Win32"
+         WHERE IsDir
        - |
          LET upload_streams = SELECT * FROM foreach(
             row=MFTInfo.Attributes,


### PR DESCRIPTION
Add fix for Windows.NTFS.I30 artefact. Testing this failed to collect attributes from some folders due to folder type check