### PR TITLE
Fix a bug in the windows Registry accessor

### DIFF
--- a/vql/windows/filesystems/registry_windows.go
+++ b/vql/windows/filesystems/registry_windows.go
@@ -160,7 +160,7 @@ type RegValueInfo struct {
 }
 
 func (self *RegValueInfo) Sys() interface{} {
-	return self.Data
+	return self._data
 }
 
 func (self *RegValueInfo) IsDir() bool {


### PR DESCRIPTION
The Sys() method returned self.Data - which is a function instead of self._data which is the actual data. This caused errors when converted to json:
```
[INFO] 2019-10-23T22:18:31Z Unable to serialize: json: error calling MarshalJSON for type *vfilter.Dict: json: unsupported type: func() interface {}
```