### PR TITLE
Fix repack command to no longer require --append.

### DIFF
--- a/bin/repack.go
+++ b/bin/repack.go
@@ -130,7 +130,7 @@ func doRepack() {
 	data, err := ioutil.ReadAll(fd)
 	kingpin.FatalIfError(err, "Unable to read executable")
 
-	if repack_command_append != nil {
+	if *repack_command_append != nil {
 		// A PE file - adjust the size of the .rsrc section to
 		// cover the entire binary.
 		if string(data[0:2]) == "MZ" {


### PR DESCRIPTION
Repacking the velociraptor binary requires always a file to append due
to a missing dereference operator.

How to reproduce?

1. Build a Velociraptor release from source (or take the last CI build).
2. Create a valid config (e.g., use the one from
https://medium.com/velociraptor-ir/triage-with-velociraptor-pt-2-d0f79066ca0e).
3. Repack the binary:

$ velociraptor.exe config repack myconfig.yaml my_velo.exe
velociraptor.exe: error: Unable to read appended file: invalid argument

4. Create an file, containing some simple text, or take an
already existing file:

$ velociraptor.exe config repack --append=sometext.txt myconfig.yaml my_velo.exe
(no output)

After applying the "fix" (adding the dereference operator) and a rebuild:

$ velociraptor-fixed.exe config repack myconfig.yaml my_velo.exe
(no output)