### PR TITLE
Enrich EVTX parsing with expanded event message.

### DIFF
--- a/artifacts/testdata/server/testcases/evtx.out.yaml
+++ b/artifacts/testdata/server/testcases/evtx.out.yaml
@@ -1,6 +1,5 @@
 SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1_record.evtx')[
  {
-  "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event",
   "System": {
    "Provider": {
     "Name": "Microsoft-Windows-Eventlog",
@@ -29,19 +28,18 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   },
   "UserData": {
    "LogFileCleared": {
-    "xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
     "SubjectUserSid": "S-1-5-21-546003962-2713609280-610790815-1001",
     "SubjectUserName": "test",
     "SubjectDomainName": "TESTCOMPUTER",
     "SubjectLogonId": 135562
    }
-  }
+  },
+  "Message": "The audit log was cleared.\nSubject:\n\tSecurity ID:\tS-1-5-21-546003962-2713609280-610790815-1001\n\tAccount Name:\ttest\n\tDomain Name:\tTESTCOMPUTER\n\tLogon ID:\t135562\r\n"
  }
 ]SELECT UserData FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1_record.evtx') WHERE System.EventId.Value = 1102[]SELECT UserData FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1_record.evtx') WHERE System.EventId.Value != 1102[
  {
   "UserData": {
    "LogFileCleared": {
-    "xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
     "SubjectUserSid": "S-1-5-21-546003962-2713609280-610790815-1001",
     "SubjectUserName": "test",
     "SubjectDomainName": "TESTCOMPUTER",

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Velocidex/cgofuse v1.1.2
 	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
 	github.com/Velocidex/go-yara v1.1.9
-	github.com/Velocidex/ordereddict v0.0.0-20191103011020-3b5a5f6957d4
+	github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403
 	github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
 	github.com/Velocidex/yaml v0.0.0-20190812045153-ad0acda9eea0
 	github.com/alecthomas/chroma v0.6.0
@@ -86,7 +86,7 @@ require (
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c
+	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd
 	golang.org/x/tools v0.0.0-20191022074931-774d2ec196ee // indirect
 	google.golang.org/api v0.11.0
 	google.golang.org/appengine v1.6.5 // indirect
@@ -99,7 +99,7 @@ require (
 	gopkg.in/russross/blackfriday.v2 v2.0.1
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
-	www.velocidex.com/golang/evtx v0.0.0-20191103233437-ed66e9bc366e
+	www.velocidex.com/golang/evtx v0.0.0-20191106094253-bdccd0816780
 	www.velocidex.com/golang/go-ntfs v0.0.0-20191007011621-167c7fa020db
 	www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6
 	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
@@ -116,6 +116,7 @@ require (
 replace github.com/alecthomas/chroma => github.com/Velocidex/chroma v0.6.8-0.20191004150416-dcd285bf46f1
 
 // replace www.velocidex.com/golang/go-ntfs => /home/mic/projects/go-ntfs
+// replace www.velocidex.com/golang/evtx => /home/mic/projects/evtx
 
 replace gopkg.in/russross/blackfriday.v2 v2.0.1 => github.com/russross/blackfriday/v2 v2.0.1
 

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/Velocidex/go-yara v1.1.9 h1:XFtozFms5mruc6fXV9E+ov5V6rBYgcX3hUrsoLFfP
 github.com/Velocidex/go-yara v1.1.9/go.mod h1:2QU3qksRdRiX8sde+Hy9CYudPRXza7i08u5r1/0al3s=
 github.com/Velocidex/ordereddict v0.0.0-20191103011020-3b5a5f6957d4 h1:0sJvmFhuTT8W/qOlka2y3L1FrbRcP9ZxXMKejTGMCno=
 github.com/Velocidex/ordereddict v0.0.0-20191103011020-3b5a5f6957d4/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
+github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403 h1:IyE0Jbkgftu+no3dqzrQOKsISicXDk5ob6IYdXaxlS8=
+github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49 h1:TJVN1zYl5sKJUq571gYqU/5VqFIap9MUo2KNujc0fcg=
 github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49/go.mod h1:kfPUQ2gP0xtIydiR52dirNYt4OvCr+iZuepL4XaIk58=
 github.com/Velocidex/yaml v0.0.0-20190812045153-ad0acda9eea0 h1:rFd07P9lqQPsmgPVvS0crnGpq63eFyd7qQyyvLgBrMY=
@@ -426,6 +428,8 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c h1:S/FtSvpNLtFBgjTqcKsRpsa6aVsI6iztaz1bQd9BJwE=
 golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd h1:3x5uuvBgE6oaXJjCOvpCC1IpgJogqQ+PqGGU3ZxAgII=
+golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -512,9 +516,10 @@ honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXe
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
+www.velocidex.com/golang/binparsergen v0.1.0 h1:oNsMHGnlb4jrGwxKxqqmsics6FgYin3HR5UNtLXc8S0=
 www.velocidex.com/golang/binparsergen v0.1.0/go.mod h1:UC43Ecj0mjsidlClTYZ3H4dXdyv7CVI0HsYi4yY3qtc=
-www.velocidex.com/golang/evtx v0.0.0-20191103233437-ed66e9bc366e h1:R2qYCOkgwlHH5xrEhs2gTUj3S8UZJYEup7vDjoPTvco=
-www.velocidex.com/golang/evtx v0.0.0-20191103233437-ed66e9bc366e/go.mod h1:8nidC7NBB/XMz66lTC03J2UjeT/1F5t3feEzLaaRM7A=
+www.velocidex.com/golang/evtx v0.0.0-20191106094253-bdccd0816780 h1:3lxyxSiGhnkUMIuA//QB5iawf8V43LonxxFfW25p9ow=
+www.velocidex.com/golang/evtx v0.0.0-20191106094253-bdccd0816780/go.mod h1:+u26IeGeVIwL9j5V0I/UafWFaMV61pQNwXZK/VQksLQ=
 www.velocidex.com/golang/go-ntfs v0.0.0-20191007011621-167c7fa020db h1:KxrG77cDNesk56zDxYFAYt4o32nwx6xNjj19omdI5sU=
 www.velocidex.com/golang/go-ntfs v0.0.0-20191007011621-167c7fa020db/go.mod h1:RURmuGxhf8w3yTlERqW1rpYZXgHQH5N2T8FQYkPYJUY=
 www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6 h1:t+4cuel1gs9H854UvXSVwL/Ph7wAhGUq8xNEiEuG7x4=

--- a/vql/parsers/event_logs/evtx.go
+++ b/vql/parsers/event_logs/evtx.go
@@ -79,7 +79,8 @@ func (self _ParseEvtxPlugin) Call(
 						if ok {
 							event, pres := event_map.Get("Event")
 							if pres {
-								output_chan <- event
+								output_chan <- maybeEnrichEvent(
+									event.(*ordereddict.Dict))
 							}
 						}
 					}

--- a/vql/parsers/event_logs/evtx_nonwindows.go
+++ b/vql/parsers/event_logs/evtx_nonwindows.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package event_logs
+
+import "github.com/Velocidex/ordereddict"
+
+func maybeEnrichEvent(event *ordereddict.Dict) *ordereddict.Dict {
+	return event
+}

--- a/vql/parsers/event_logs/evtx_windows.go
+++ b/vql/parsers/event_logs/evtx_windows.go
@@ -1,0 +1,64 @@
+// +build windows
+
+package event_logs
+
+import (
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/evtx"
+	"www.velocidex.com/golang/velociraptor/third_party/cache"
+)
+
+var (
+	lru *cache.LRUCache = cache.NewLRUCache(1000)
+)
+
+type cachedMessageSet struct {
+	*evtx.MessageSet
+}
+
+func (self cachedMessageSet) Size() int {
+	return 1
+}
+
+// maybeEnrichEvent searches for the event messages in the system's
+// event providers.
+func maybeEnrichEvent(event *ordereddict.Dict) *ordereddict.Dict {
+	// Event.System.Provider.Name
+	provider, ok := ordereddict.GetString(event, "System.Provider.Name")
+	if !ok {
+		return event
+	}
+
+	channel, ok := ordereddict.GetString(event, "System.Channel")
+	if !ok {
+		return event
+	}
+
+	event_id, ok := ordereddict.GetInt(event, "System.EventID.Value")
+	if !ok {
+		return event
+	}
+
+	key := channel + provider
+	var message_set *evtx.MessageSet
+	var err error
+
+	cached_message_set, pres := lru.Get(key)
+	if !pres {
+		message_set, err = evtx.GetMessages(provider, channel)
+		if err != nil {
+			return event
+		}
+
+		lru.Set(key, cachedMessageSet{message_set})
+	} else {
+		message_set = cached_message_set.(cachedMessageSet).MessageSet
+	}
+
+	msg, pres := message_set.Messages[event_id]
+	if pres {
+		event.Set("Message", evtx.ExpandMessage(event, msg.Message))
+	}
+
+	return event
+}


### PR DESCRIPTION
This provides much needed context around event message information -
particularly for uncommon event providers where we may not easily find
the message tables.

Velociraptor will search the registry for the correct event provider,
and parse out the message tables in the message dlls to provide the
message text. We then interpolate the event data into the message text.