### PR TITLE
Add S3 upload functionality.

### DIFF
--- a/vql/tools/s3_upload.go
+++ b/vql/tools/s3_upload.go
@@ -5,6 +5,7 @@ package tools
 import (
 	"io"
 
+	"github.com/Velocidex/ordereddict"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -30,7 +31,7 @@ type S3UploadFunction struct{}
 
 func (self *S3UploadFunction) Call(ctx context.Context,
 	scope *vfilter.Scope,
-	args *vfilter.Dict) vfilter.Any {
+	args *ordereddict.Dict) vfilter.Any {
 
 	arg := &S3UploadArgs{}
 	err := vfilter.ExtractArgs(scope, args, arg)

--- a/vql/tools/s3_upload.go
+++ b/vql/tools/s3_upload.go
@@ -1,0 +1,127 @@
+//+build extras
+
+package tools
+
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"golang.org/x/net/context"
+	"www.velocidex.com/golang/velociraptor/glob"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/networking"
+	"www.velocidex.com/golang/vfilter"
+)
+
+type S3UploadArgs struct {
+	File              string `vfilter:"required,field=file,doc=The file to upload"`
+	Name              string `vfilter:"optional,field=name,doc=The name of the file that should be stored on the server"`
+	Accessor          string `vfilter:"optional,field=accessor,doc=The accessor to use"`
+	Bucket            string `vfilter:"required,field=bucket,doc=The bucket to upload to"`
+	Region            string `vfilter:"required,field=region,doc=The region the bucket is in"`
+	CredentialsKey    string `vfilter:"required,field=credentialskey,doc=The AWS key credentials to use"`
+	CredentialsSecret string `vfilter:"required,field=credentialssecret,doc=The AWS secret credentials to use"`
+}
+
+type S3UploadFunction struct{}
+
+func (self *S3UploadFunction) Call(ctx context.Context,
+	scope *vfilter.Scope,
+	args *vfilter.Dict) vfilter.Any {
+
+	arg := &S3UploadArgs{}
+	err := vfilter.ExtractArgs(scope, args, arg)
+	if err != nil {
+		scope.Log("upload_S3: %s", err.Error())
+		return vfilter.Null{}
+	}
+
+	accessor, err := glob.GetAccessor(arg.Accessor, ctx)
+	if err != nil {
+		scope.Log("upload_S3: %v", err)
+		return vfilter.Null{}
+	}
+
+	file, err := accessor.Open(arg.File)
+	if err != nil {
+		scope.Log("upload_S3: Unable to open %s: %s",
+			arg.File, err.Error())
+		return &vfilter.Null{}
+	}
+	defer file.Close()
+
+	if arg.Name == "" {
+		arg.Name = arg.File
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		scope.Log("upload_S3: Unable to stat %s: %v",
+			arg.File, err)
+	} else if !stat.IsDir() {
+		upload_response, err := upload_S3(
+			ctx, scope, file,
+			arg.Bucket,
+			arg.Name, arg.CredentialsKey, arg.CredentialsSecret, arg.Region)
+		if err != nil {
+			scope.Log("upload_S3: %v", err)
+			return vfilter.Null{}
+		}
+		return upload_response
+	}
+
+	return vfilter.Null{}
+}
+
+func upload_S3(ctx context.Context, scope *vfilter.Scope,
+	reader io.Reader,
+	bucket, name string,
+	credentialsKey string, credentialsSecret string, region string) (
+	*networking.UploadResponse, error) {
+
+	scope.Log("upload_S3: Uploading %v to %v", name, bucket)
+
+	token := ""
+	creds := credentials.NewStaticCredentials(credentialsKey, credentialsSecret, token)
+	_, err := creds.Get()
+	if err != nil {
+		return &networking.UploadResponse{
+			Error: err.Error(),
+		}, err
+	}
+
+	conf := aws.NewConfig().WithRegion(region).WithCredentials(creds)
+	sess := session.New(conf)
+	uploader := s3manager.NewUploader(sess)
+
+	result, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(name),
+		Body:   reader,
+	})
+	if err != nil {
+		return &networking.UploadResponse{
+			Error: err.Error(),
+		}, err
+	}
+
+	return &networking.UploadResponse{
+		Path: result.Location,
+	}, nil
+}
+
+func (self S3UploadFunction) Info(
+	scope *vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:    "upload_s3",
+		Doc:     "Upload files to S3.",
+		ArgType: type_map.AddType(scope, &S3UploadArgs{}),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&S3UploadFunction{})
+}


### PR DESCRIPTION
S3 upload functionality similar to GCS upload functionality.

To test you need a S3 bucket and AWS user API key/secret combination.

s3-upload-test.yaml

```
autoexec:
    # These parameters are run when the binary is started without args. 
    # It will just collect our custom artifact and quit.
    argv: ["artifacts", "collect", "-v", "AcquireAndUploadToS3"]
    artifact_definitions:
      - name: AcquireAndUploadToS3
        parameters:
           - name: S3Key
             description: S3 IAM account key with access to S3 bucket
             default: [AWS IAM API Key for user with S3 bucket access]
           - name: S3Secret
             description: S3 IAM account secret with access to S3 bucket
             default: [AWS IAM API Secret for user with S3 bucket access]
           - name: S3bucket
             description: S3 bucket name
             default: velociraptor-s3-test
           - name: S3region
             description: region the bucket is located in
             default: eu-central-1

        sources:
           - queries:
                # This collects the WebBrowsers target from KapeFiles into 
                # a tempfile, then uploads the tempfile to S3 with the 
                # above credentials.
                - SELECT upload_s3(
                     file=Container,
                     bucket=S3bucket,
                     region=S3region,
                     name=format(format="Collection %s.zip", args=[timestamp(epoch=now())]),
                     credentialskey=S3Key,
                     credentialssecret=S3Secret) AS Uploaded
                  FROM collect(
                     artifacts="Windows.KapeFiles.Targets",
                     args=dict(WebBrowsers="Y"),
                     password="MyPassword",
                     output=tempfile(extension=".zip"))

```
```
$ velociraptor.exe config repack s3-upload-test.yaml velociraptor-s3.exe
```