### PR TITLE
Windows.System.TaskScheduler/add Arguments to default artifact results

### DIFF
--- a/artifacts/definitions/Windows/System/TaskScheduler.yaml
+++ b/artifacts/definitions/Windows/System/TaskScheduler.yaml
@@ -36,6 +36,8 @@ sources:
 
       - SELECT FullPath,
             XML.Task.Actions.Exec.Command AS Command,
+            XML.Task.Actions.Exec.Arguments as Arguments,
             XML.Task.Actions.ComHandler.ClassId AS ComHandler,
-            XML.Task.Principals.Principal.UserId as UserId, XML AS _XML
+            XML.Task.Principals.Principal.UserId as UserId,
+            XML AS _XML
         FROM foreach(row=Uploads, query=parse_task)

--- a/artifacts/definitions/Windows/System/TaskScheduler.yaml
+++ b/artifacts/definitions/Windows/System/TaskScheduler.yaml
@@ -35,9 +35,9 @@ sources:
         FROM read_file(filenames=FullPath)
 
       - SELECT FullPath,
-            XML.Task.Actions.Exec.Command AS Command,
+            XML.Task.Actions.Exec.Command as Command,
             XML.Task.Actions.Exec.Arguments as Arguments,
-            XML.Task.Actions.ComHandler.ClassId AS ComHandler,
+            XML.Task.Actions.ComHandler.ClassId as ComHandler,
             XML.Task.Principals.Principal.UserId as UserId,
-            XML AS _XML
+            XML as _XML
         FROM foreach(row=Uploads, query=parse_task)


### PR DESCRIPTION
Windows.System.TaskScheduler
- Been using this artifact for quick wins in GUI and adding Arguments to default artifact results is helpful.
- standardised "as" case