### PR TITLE
Reverted flot dependency to 3.2.10.

### DIFF
--- a/artifacts/artifacts.go
+++ b/artifacts/artifacts.go
@@ -282,7 +282,17 @@ func (self *Repository) GetQueryDependencies(
 
 		// Now search the referred to artifact's query for its
 		// own dependencies.
+		err := self.GetQueryDependencies(dep.Precondition, depth+1, dependency)
+		if err != nil {
+			return err
+		}
+
 		for _, source := range dep.Sources {
+			err := self.GetQueryDependencies(source.Precondition, depth+1, dependency)
+			if err != nil {
+				return err
+			}
+
 			for _, query := range source.Queries {
 				err := self.GetQueryDependencies(query, depth+1, dependency)
 				if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20200318045557-4e6dd1214c32
+	www.velocidex.com/golang/vfilter v0.0.0-20200319140232-0cbb9bea6f4f
 	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -609,5 +609,7 @@ www.velocidex.com/golang/vfilter v0.0.0-20200229165303-f920fb048f83 h1:FFLIW5NEy
 www.velocidex.com/golang/vfilter v0.0.0-20200229165303-f920fb048f83/go.mod h1:8G8/0EbJ/fzUKBC+mMe7UE61aC1VX8gLRCNmRxZ3p0A=
 www.velocidex.com/golang/vfilter v0.0.0-20200318045557-4e6dd1214c32 h1:26uaZoRzpQ08QaiQGnXypVSEeJ6uyG+PF9etMKhHKiU=
 www.velocidex.com/golang/vfilter v0.0.0-20200318045557-4e6dd1214c32/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
+www.velocidex.com/golang/vfilter v0.0.0-20200319140232-0cbb9bea6f4f h1:xYzIdl8Znh9S9zzOmvmswnqXVAsASEs8hwFAf3xzOYc=
+www.velocidex.com/golang/vfilter v0.0.0-20200319140232-0cbb9bea6f4f/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/gui/static/package-lock.json
+++ b/gui/static/package-lock.json
@@ -2427,9 +2427,9 @@
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
     },
     "flot": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/flot/-/flot-4.2.0.tgz",
-      "integrity": "sha512-Uy+0hPOpi8X2mvTG2MOnuI8fbQt5mz/vewyoxA5DZXWhYmywZS+PfFnLANb0Os5VXongqKos9ahF+Wu2U4Cp1g=="
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/flot/-/flot-3.2.10.tgz",
+      "integrity": "sha512-wFKQP1A3SNUR4xU+EjLxDRvC2xwfROSY9El/pC1z6qoT9zAT5/4aWTSM+AH+3YN3WPDE1b0mw3gfNdMQRAChXw=="
     },
     "flush-write-stream": {
       "version": "1.1.1",

--- a/gui/static/package.json
+++ b/gui/static/package.json
@@ -20,7 +20,7 @@
     "datatables.net-buttons": "^1.6.1",
     "datatables.net-colreorder": "^1.5.2",
     "del": "^3.0.0",
-    "flot": "^4.2.0",
+    "flot": "^3.2.10",
     "font-awesome": "^4.7.0",
     "gulp-cli": "^2.2.0",
     "gulp-uglify": "^3.0.2",


### PR DESCRIPTION
Later versions seem to have a broken selector plugin. We need to
investigate this further or switch to a different graphing library.

Narrowed it down to commit
https://github.com/flot/flot/commit/d1fef6172385069657c44c72ff199f40a9876941

which introduced a breaking change on drag/drop in jquery.

Also compile artifact dependency in preconditions and updated vfilter.