### PR TITLE
Update Services.yaml

### DIFF
--- a/artifacts/definitions/Windows/System/Services.yaml
+++ b/artifacts/definitions/Windows/System/Services.yaml
@@ -28,6 +28,9 @@ sources:
                {
                  SELECT ServiceDll FROM read_reg_key(globs=servicesKeyGlob + Name + "\\Parameters")
                } AS ServiceDll,
+               {
+                 SELECT FailureCommand FROM read_reg_key(globs=servicesKeyGlob + Name)
+               } AS FailureCommand,
                parse_string_with_regex(regex=
                  ['^"(?P<AbsoluteExePath>[^"]+)','(?P<AbsoluteExePath>^[^ "]+)'], 
                  string=PathName).AbsoluteExePath as AbsoluteExePath


### PR DESCRIPTION
Updated the artifact to enhance visibility in a stealthy way that attackers can use to make malware persistent, namely service failure recovery. https://isc.sans.edu/diary/Wipe+the+drive+Stealthy+Malware+Persistence+-+Part+2/15406

![image](https://user-images.githubusercontent.com/11965973/78546319-7addaa00-77fd-11ea-8239-2aba338a3148.png)

