### PR TITLE
Run Artifact Plugin in a new scope.

### DIFF
--- a/api/vql.go
+++ b/api/vql.go
@@ -40,20 +40,13 @@ func RunVQL(
 
 	result := &api_proto.GetTableResponse{}
 
-	repository, err := artifacts.GetGlobalRepository(config_obj)
-	if err != nil {
-		return nil, err
-	}
-
-	env.Set("server_config", config_obj).
-		Set(vql_subsystem.ACL_MANAGER_VAR,
-			vql_subsystem.NewServerACLManager(config_obj, principal))
-
-	scope := artifacts.MakeScope(repository).AppendVars(env)
+	scope := artifacts.ScopeBuilder{
+		Config:     config_obj,
+		Env:        env,
+		ACLManager: vql_subsystem.NewServerACLManager(config_obj, principal),
+		Logger:     logging.NewPlainLogger(config_obj, &logging.ToolComponent),
+	}.Build()
 	defer scope.Close()
-
-	scope.Logger = logging.NewPlainLogger(config_obj,
-		&logging.ToolComponent)
 
 	vql, err := vfilter.Parse(query)
 	if err != nil {
@@ -91,20 +84,14 @@ func StoreVQLAsCSVFile(
 	query string,
 	writer io.Writer) error {
 
-	repository, err := artifacts.GetGlobalRepository(config_obj)
-	if err != nil {
-		return err
-	}
-
-	env.Set("server_config", config_obj).
-		Set(vql_subsystem.ACL_MANAGER_VAR,
-			vql_subsystem.NewServerACLManager(config_obj, principal))
-
-	scope := artifacts.MakeScope(repository).AppendVars(env)
+	scope := artifacts.ScopeBuilder{
+		Config:     config_obj,
+		ACLManager: vql_subsystem.NewServerACLManager(config_obj, principal),
+		Logger: logging.NewPlainLogger(config_obj,
+			&logging.ToolComponent),
+		Env: env,
+	}.Build()
 	defer scope.Close()
-
-	scope.Logger = logging.NewPlainLogger(config_obj,
-		&logging.ToolComponent)
 
 	vql, err := vfilter.Parse(query)
 	if err != nil {

--- a/artifacts/builder.go
+++ b/artifacts/builder.go
@@ -1,0 +1,49 @@
+package artifacts
+
+import (
+	"log"
+
+	"github.com/Velocidex/ordereddict"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/uploads"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+)
+
+// Make it easier to build a query scope using the aritfact
+// repository.
+type ScopeBuilder struct {
+	Config     *config_proto.Config
+	ACLManager vql_subsystem.ACLManager
+	Uploader   uploads.Uploader
+	Logger     *log.Logger
+	Env        *ordereddict.Dict
+}
+
+func (self ScopeBuilder) Build() *vfilter.Scope {
+	if self.Env == nil {
+		self.Env = ordereddict.NewDict()
+	}
+
+	self.Env.Set(constants.SCOPE_CONFIG, self.Config.Client).
+		Set(constants.SCOPE_SERVER_CONFIG, self.Config).
+		Set(vql_subsystem.CACHE_VAR, vql_subsystem.NewScopeCache())
+
+	if self.ACLManager != nil {
+		self.Env.Set(vql_subsystem.ACL_MANAGER_VAR, self.ACLManager)
+	}
+
+	if self.Uploader != nil {
+		self.Env.Set(constants.SCOPE_UPLOADER, self.Uploader)
+	}
+
+	repository, err := GetGlobalRepository(self.Config)
+	if err != nil {
+		panic(err)
+	}
+	scope := MakeScope(repository).AppendVars(self.Env)
+	scope.Logger = self.Logger
+
+	return scope
+}

--- a/artifacts/plugin.go
+++ b/artifacts/plugin.go
@@ -165,7 +165,9 @@ func (self *ArtifactRepositoryPlugin) Call(
 func (self *ArtifactRepositoryPlugin) copyScope(scope *vfilter.Scope) *vfilter.Scope {
 	env := ordereddict.NewDict()
 	for _, field := range []string{
-		vql_subsystem.ACL_MANAGER_VAR, vql_subsystem.CACHE_VAR,
+		vql_subsystem.ACL_MANAGER_VAR,
+		vql_subsystem.CACHE_VAR,
+		constants.SCOPE_MOCK,
 		constants.SCOPE_CONFIG,
 		constants.SCOPE_SERVER_CONFIG,
 		constants.SCOPE_THROTTLE,
@@ -176,10 +178,8 @@ func (self *ArtifactRepositoryPlugin) copyScope(scope *vfilter.Scope) *vfilter.S
 		}
 	}
 
-	mock := scope.GetContext(constants.SCOPE_MOCK)
 	result := scope.Copy()
 	result.ClearContext()
-	result.SetContext(constants.SCOPE_MOCK, mock)
 
 	return result.AppendVars(env)
 }

--- a/artifacts/testdata/server/testcases/mock.out.yaml
+++ b/artifacts/testdata/server/testcases/mock.out.yaml
@@ -146,10 +146,6 @@ LET X <= SELECT mock(plugin='info', results=[dict(foo='bar'), dict(foo='baz')] )
   "Family": "IPv4",
   "Type": "TCP",
   "Status": "ESTAB",
-  "Laddr.IP": null,
-  "Laddr.Port": null,
-  "Raddr.IP": null,
-  "Raddr.Port": null,
   "Timestamp": "2019-12-07T03:30:58Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }

--- a/artifacts/testdata/server/testcases/plist.out.yaml
+++ b/artifacts/testdata/server/testcases/plist.out.yaml
@@ -4,10 +4,7 @@ SELECT * FROM Artifact.MacOS.System.Users(UserPlistGlob=srcDir + '/artifacts/tes
   "RealName": "vagrant",
   "UserShell": "/bin/bash",
   "HomeDir": "/Users/vagrant",
-  "AppleId": null,
-  "CreationTime": null,
   "FailedLoginCount": 0,
-  "FailedLoginTimestamp": null,
   "PasswordLastSetTime": "2017-11-25T00:36:29.728411912Z",
   "_Source": "MacOS.System.Users"
  }

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -33,10 +33,12 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	artifacts "www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/flows"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/tools"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
 
@@ -99,7 +101,9 @@ func runTest(fixture *testFixture) (string, error) {
 		ACLManager: vql_subsystem.NewRoleACLManager("administrator"),
 		Logger:     log.New(os.Stderr, "velociraptor: ", log.Lshortfile),
 		Uploader:   container,
-		Env:        ordereddict.NewDict().Set("GoldenOutput", tmpfile.Name()),
+		Env: ordereddict.NewDict().
+			Set("GoldenOutput", tmpfile.Name()).
+			Set(constants.SCOPE_MOCK, &tools.MockingScopeContext{}),
 	}
 
 	if env_map != nil {

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -83,16 +83,8 @@ func vqlCollectorArgsFromFixture(
 
 func runTest(fixture *testFixture) (string, error) {
 	config_obj := get_config_or_default()
-	repository := getRepository(config_obj)
 
-	env := ordereddict.NewDict().
-		Set("config", config_obj.Client).
-		Set("server_config", config_obj).
-		// Run tests as administrator - disable ACLs.
-		Set(vql_subsystem.ACL_MANAGER_VAR,
-			vql_subsystem.NewRoleACLManager("administrator")).
-		Set(vql_subsystem.CACHE_VAR, vql_subsystem.NewScopeCache())
-
+	// Any uploads go into the container.
 	// Create an output container.
 	tmpfile, err := ioutil.TempFile("", "golden")
 	if err != nil {
@@ -102,30 +94,33 @@ func runTest(fixture *testFixture) (string, error) {
 	container, err := reporting.NewContainer(tmpfile.Name())
 	kingpin.FatalIfError(err, "Can not create output container")
 
-	// Any uploads go into the container.
-	env.Set("$uploader", container)
-	env.Set("GoldenOutput", tmpfile.Name())
+	builder := artifacts.ScopeBuilder{
+		Config:     config_obj,
+		ACLManager: vql_subsystem.NewRoleACLManager("administrator"),
+		Logger:     log.New(os.Stderr, "velociraptor: ", log.Lshortfile),
+		Uploader:   container,
+		Env:        ordereddict.NewDict().Set("GoldenOutput", tmpfile.Name()),
+	}
 
 	if env_map != nil {
 		for k, v := range *env_map {
-			env.Set(k, v)
+			builder.Env.Set(k, v)
 		}
 	}
 
-	scope := artifacts.MakeScope(repository).AppendVars(env)
+	vql_collector_args := vqlCollectorArgsFromFixture(config_obj, fixture)
+	for _, env_spec := range vql_collector_args.Env {
+		builder.Env.Set(env_spec.Key, env_spec.Value)
+	}
+
+	// Cleanup after the query.
+	scope := builder.Build()
 	defer scope.Close()
 
 	scope.AddDestructor(func() {
 		container.Close()
 		os.Remove(tmpfile.Name()) // clean up
 	})
-
-	scope.Logger = log.New(os.Stderr, "velociraptor: ", log.Lshortfile)
-	vql_collector_args := vqlCollectorArgsFromFixture(
-		config_obj, fixture)
-	for _, env_spec := range vql_collector_args.Env {
-		env.Set(env_spec.Key, env_spec.Value)
-	}
 
 	result := ""
 	for _, query := range fixture.Queries {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -64,6 +64,14 @@ const (
 
 	// Internal artifact names.
 	CLIENT_INFO_ARTIFACT = "Generic.Client.Info"
+
+	// Globals set in VQL scopes.
+	SCOPE_CONFIG        = "$config"
+	SCOPE_SERVER_CONFIG = "$server_config"
+	SCOPE_THROTTLE      = "$throttle"
+	SCOPE_UPLOADER      = "$uploader"
+	SCOPE_RESPONDER     = "$responder"
+	SCOPE_MOCK          = "$mock"
 )
 
 var (

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -66,8 +66,8 @@ const (
 	CLIENT_INFO_ARTIFACT = "Generic.Client.Info"
 
 	// Globals set in VQL scopes.
-	SCOPE_CONFIG        = "$config"
-	SCOPE_SERVER_CONFIG = "$server_config"
+	SCOPE_CONFIG        = "config"
+	SCOPE_SERVER_CONFIG = "server_config"
 	SCOPE_THROTTLE      = "$throttle"
 	SCOPE_UPLOADER      = "$uploader"
 	SCOPE_RESPONDER     = "$responder"

--- a/go.mod
+++ b/go.mod
@@ -1,127 +1,127 @@
 module www.velocidex.com/golang/velociraptor
 
 require (
-	cloud.google.com/go v0.47.0 // indirect
-	cloud.google.com/go/bigquery v1.1.0 // indirect
-	cloud.google.com/go/storage v1.1.1
-	github.com/Depado/bfchroma v1.2.0
-	github.com/Masterminds/goutils v1.1.0 // indirect
-	github.com/Masterminds/semver v1.4.2 // indirect
-	github.com/Masterminds/sprig v2.20.0+incompatible
-	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
-	github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
-	github.com/Velocidex/ahocorasick v0.0.0-20180712114356-e1c353eeaaee
-	github.com/Velocidex/cgofuse v1.1.2
-	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
-	github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9
-	github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7
-	github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
-	github.com/Velocidex/yaml/v2 v2.2.5
-	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
-	github.com/alecthomas/chroma v0.7.2
-	github.com/alecthomas/participle v0.4.1
-	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
-	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
-	github.com/aws/aws-sdk-go v1.26.7
-	github.com/c-bata/go-prompt v0.2.3
-	github.com/cevaris/ordered_map v0.0.0-20180310183325-0efaee1733e3
-	github.com/clbanning/mxj v1.8.4
-	github.com/creack/pty v1.1.9 // indirect
-	github.com/crewjam/saml v0.3.1
-	github.com/davecgh/go-spew v1.1.1
-	github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/dustin/go-humanize v1.0.0
-	github.com/elastic/go-elasticsearch/v7 v7.3.0 // indirect
-	github.com/elastic/go-libaudit v0.4.0
-	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
-	github.com/go-ole/go-ole v1.2.4
-	github.com/go-sql-driver/mysql v1.5.0
-	github.com/gogo/protobuf v1.1.1
-	github.com/golang/mock v1.4.3
-	github.com/golang/protobuf v1.3.5
-	github.com/golang/snappy v0.0.1
-	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
-	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
-	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
-	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
-	github.com/google/uuid v1.1.1 // indirect
-	github.com/gorilla/csrf v1.6.2
-	github.com/gorilla/schema v1.1.0
-	github.com/grpc-ecosystem/grpc-gateway v1.11.3
-	github.com/hanwen/go-fuse v1.0.1-0.20190726130028-2f298055551b
-	github.com/hillu/go-ntdll v0.0.0-20190226223014-dd4204aa705e
-	github.com/hillu/go-yara v1.2.2 // indirect
-	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-	github.com/huandu/xstrings v1.2.0 // indirect
-	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
-	github.com/jmoiron/sqlx v1.2.0
-	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/kierdavis/dateparser v0.0.0-20171227112021-81e70b820720
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/kr/pretty v0.2.0 // indirect
-	github.com/kr/pty v1.1.8 // indirect
-	github.com/lestrrat-go/file-rotatelogs v2.2.0+incompatible
-	github.com/lestrrat-go/strftime v0.0.0-20190725011945-5c849dd2c51d // indirect
-	github.com/lib/pq v1.2.0 // indirect
-	github.com/magefile/mage v1.9.0
-	github.com/mattn/go-pointer v0.0.0-20180825124634-49522c3f3791
-	github.com/mattn/go-runewidth v0.0.8 // indirect
-	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.2
-	github.com/olekukonko/tablewriter v0.0.2
-	github.com/pkg/errors v0.9.1
-	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
-	github.com/processout/grpc-go-pool v1.2.1
-	github.com/prometheus/client_golang v1.2.1
-	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
-	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
-	github.com/russross/blackfriday/v2 v2.0.1
-	github.com/sebdah/goldie v1.0.0
-	github.com/sergi/go-diff v1.0.0
-	github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5
-	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.5.1
-	github.com/tebeka/strftime v0.1.3 // indirect
-	github.com/tink-ab/tempfile v0.0.0-20180226111222-33beb0518f1a
-	github.com/vjeantet/grok v1.0.0
-	github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 // indirect
-	github.com/xor-gate/debpkg v0.0.0-20181217150151-a0c70a3d4213
-	golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
-	golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e // indirect
-	golang.org/x/mod v0.2.0 // indirect
-	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
-	golang.org/x/tools v0.0.0-20200207131002-533eb2654509 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
-	google.golang.org/api v0.11.0
-	google.golang.org/appengine v1.6.5 // indirect
-	google.golang.org/genproto v0.0.0-20200409111301-baae70f3302d
-	google.golang.org/grpc v1.28.1
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
-	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
-	howett.net/plist v0.0.0-20181124034731-591f970eefbb
-	www.velocidex.com/golang/evtx v0.0.2-0.20191118125331-191dc946afdf
-	www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321
-	www.velocidex.com/golang/go-ntfs v0.0.0-20200110083657-950cbe916617
-	www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6
-	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
-	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
-	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e
-	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
+        cloud.google.com/go v0.47.0 // indirect
+        cloud.google.com/go/bigquery v1.1.0 // indirect
+        cloud.google.com/go/storage v1.1.1
+        github.com/Depado/bfchroma v1.2.0
+        github.com/Masterminds/goutils v1.1.0 // indirect
+        github.com/Masterminds/semver v1.4.2 // indirect
+        github.com/Masterminds/sprig v2.20.0+incompatible
+        github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
+        github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
+        github.com/Velocidex/ahocorasick v0.0.0-20180712114356-e1c353eeaaee
+        github.com/Velocidex/cgofuse v1.1.2
+        github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
+        github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9
+        github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7
+        github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
+        github.com/Velocidex/yaml/v2 v2.2.5
+        github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
+        github.com/alecthomas/chroma v0.7.2
+        github.com/alecthomas/participle v0.4.1
+        github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
+        github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
+        github.com/aws/aws-sdk-go v1.26.7
+        github.com/c-bata/go-prompt v0.2.3
+        github.com/cevaris/ordered_map v0.0.0-20180310183325-0efaee1733e3
+        github.com/clbanning/mxj v1.8.4
+        github.com/creack/pty v1.1.9 // indirect
+        github.com/crewjam/saml v0.3.1
+        github.com/davecgh/go-spew v1.1.1
+        github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
+        github.com/dgrijalva/jwt-go v3.2.0+incompatible
+        github.com/dustin/go-humanize v1.0.0
+        github.com/elastic/go-elasticsearch/v7 v7.3.0 // indirect
+        github.com/elastic/go-libaudit v0.4.0
+        github.com/evanphx/json-patch v4.5.0+incompatible
+        github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
+        github.com/go-ole/go-ole v1.2.4
+        github.com/go-sql-driver/mysql v1.5.0
+        github.com/gogo/protobuf v1.1.1
+        github.com/golang/mock v1.4.3
+        github.com/golang/protobuf v1.3.5
+        github.com/golang/snappy v0.0.1
+        github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
+        github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
+        github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
+        github.com/google/go-cmp v0.3.1 // indirect
+        github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
+        github.com/google/uuid v1.1.1 // indirect
+        github.com/gorilla/csrf v1.6.2
+        github.com/gorilla/schema v1.1.0
+        github.com/grpc-ecosystem/grpc-gateway v1.11.3
+        github.com/hanwen/go-fuse v1.0.1-0.20190726130028-2f298055551b
+        github.com/hillu/go-ntdll v0.0.0-20190226223014-dd4204aa705e
+        github.com/hillu/go-yara v1.2.2 // indirect
+        github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
+        github.com/huandu/xstrings v1.2.0 // indirect
+        github.com/imdario/mergo v0.3.7 // indirect
+        github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
+        github.com/jmoiron/sqlx v1.2.0
+        github.com/jstemmer/go-junit-report v0.9.1 // indirect
+        github.com/kierdavis/dateparser v0.0.0-20171227112021-81e70b820720
+        github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+        github.com/kr/pretty v0.2.0 // indirect
+        github.com/kr/pty v1.1.8 // indirect
+        github.com/lestrrat-go/file-rotatelogs v2.2.0+incompatible
+        github.com/lestrrat-go/strftime v0.0.0-20190725011945-5c849dd2c51d // indirect
+        github.com/lib/pq v1.2.0 // indirect
+        github.com/magefile/mage v1.9.0
+        github.com/mattn/go-pointer v0.0.0-20180825124634-49522c3f3791
+        github.com/mattn/go-runewidth v0.0.8 // indirect
+        github.com/mattn/go-sqlite3 v1.11.0
+        github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
+        github.com/microcosm-cc/bluemonday v1.0.2
+        github.com/olekukonko/tablewriter v0.0.2
+        github.com/pkg/errors v0.9.1
+        github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
+        github.com/processout/grpc-go-pool v1.2.1
+        github.com/prometheus/client_golang v1.2.1
+        github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
+        github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
+        github.com/russross/blackfriday/v2 v2.0.1
+        github.com/sebdah/goldie v1.0.0
+        github.com/sergi/go-diff v1.0.0
+        github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5
+        github.com/sirupsen/logrus v1.4.2
+        github.com/stretchr/testify v1.5.1
+        github.com/tebeka/strftime v0.1.3 // indirect
+        github.com/tink-ab/tempfile v0.0.0-20180226111222-33beb0518f1a
+        github.com/vjeantet/grok v1.0.0
+        github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 // indirect
+        github.com/xor-gate/debpkg v0.0.0-20181217150151-a0c70a3d4213
+        golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
+        golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e // indirect
+        golang.org/x/mod v0.2.0 // indirect
+        golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+        golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+        golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+        golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
+        golang.org/x/tools v0.0.0-20200207131002-533eb2654509 // indirect
+        golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+        google.golang.org/api v0.11.0
+        google.golang.org/appengine v1.6.5 // indirect
+        google.golang.org/genproto v0.0.0-20200409111301-baae70f3302d
+        google.golang.org/grpc v1.28.1
+        gopkg.in/alecthomas/kingpin.v2 v2.2.6
+        gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+        gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
+        gopkg.in/sourcemap.v1 v1.0.5 // indirect
+        gopkg.in/yaml.v2 v2.2.8 // indirect
+        howett.net/plist v0.0.0-20181124034731-591f970eefbb
+        www.velocidex.com/golang/evtx v0.0.2-0.20191118125331-191dc946afdf
+        www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321
+        www.velocidex.com/golang/go-ntfs v0.0.0-20200110083657-950cbe916617
+        www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6
+        www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
+        www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
+        www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
+        www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e
+        www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 
-// replace www.velocidex.com/golang/vfilter => /home/mic/projects/vfilter
+replace www.velocidex.com/golang/vfilter => /home/mic/projects/vfilter
 // replace www.velocidex.com/golang/go-ntfs => /home/mic/projects/go-ntfs
 // replace www.velocidex.com/golang/evtx => /home/mic/projects/evtx
 // replace www.velocidex.com/golang/go-ese => /home/mic/projects/go-ese

--- a/go.mod
+++ b/go.mod
@@ -1,127 +1,127 @@
 module www.velocidex.com/golang/velociraptor
 
 require (
-        cloud.google.com/go v0.47.0 // indirect
-        cloud.google.com/go/bigquery v1.1.0 // indirect
-        cloud.google.com/go/storage v1.1.1
-        github.com/Depado/bfchroma v1.2.0
-        github.com/Masterminds/goutils v1.1.0 // indirect
-        github.com/Masterminds/semver v1.4.2 // indirect
-        github.com/Masterminds/sprig v2.20.0+incompatible
-        github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
-        github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
-        github.com/Velocidex/ahocorasick v0.0.0-20180712114356-e1c353eeaaee
-        github.com/Velocidex/cgofuse v1.1.2
-        github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
-        github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9
-        github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7
-        github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
-        github.com/Velocidex/yaml/v2 v2.2.5
-        github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
-        github.com/alecthomas/chroma v0.7.2
-        github.com/alecthomas/participle v0.4.1
-        github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
-        github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
-        github.com/aws/aws-sdk-go v1.26.7
-        github.com/c-bata/go-prompt v0.2.3
-        github.com/cevaris/ordered_map v0.0.0-20180310183325-0efaee1733e3
-        github.com/clbanning/mxj v1.8.4
-        github.com/creack/pty v1.1.9 // indirect
-        github.com/crewjam/saml v0.3.1
-        github.com/davecgh/go-spew v1.1.1
-        github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
-        github.com/dgrijalva/jwt-go v3.2.0+incompatible
-        github.com/dustin/go-humanize v1.0.0
-        github.com/elastic/go-elasticsearch/v7 v7.3.0 // indirect
-        github.com/elastic/go-libaudit v0.4.0
-        github.com/evanphx/json-patch v4.5.0+incompatible
-        github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
-        github.com/go-ole/go-ole v1.2.4
-        github.com/go-sql-driver/mysql v1.5.0
-        github.com/gogo/protobuf v1.1.1
-        github.com/golang/mock v1.4.3
-        github.com/golang/protobuf v1.3.5
-        github.com/golang/snappy v0.0.1
-        github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
-        github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
-        github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
-        github.com/google/go-cmp v0.3.1 // indirect
-        github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
-        github.com/google/uuid v1.1.1 // indirect
-        github.com/gorilla/csrf v1.6.2
-        github.com/gorilla/schema v1.1.0
-        github.com/grpc-ecosystem/grpc-gateway v1.11.3
-        github.com/hanwen/go-fuse v1.0.1-0.20190726130028-2f298055551b
-        github.com/hillu/go-ntdll v0.0.0-20190226223014-dd4204aa705e
-        github.com/hillu/go-yara v1.2.2 // indirect
-        github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-        github.com/huandu/xstrings v1.2.0 // indirect
-        github.com/imdario/mergo v0.3.7 // indirect
-        github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
-        github.com/jmoiron/sqlx v1.2.0
-        github.com/jstemmer/go-junit-report v0.9.1 // indirect
-        github.com/kierdavis/dateparser v0.0.0-20171227112021-81e70b820720
-        github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-        github.com/kr/pretty v0.2.0 // indirect
-        github.com/kr/pty v1.1.8 // indirect
-        github.com/lestrrat-go/file-rotatelogs v2.2.0+incompatible
-        github.com/lestrrat-go/strftime v0.0.0-20190725011945-5c849dd2c51d // indirect
-        github.com/lib/pq v1.2.0 // indirect
-        github.com/magefile/mage v1.9.0
-        github.com/mattn/go-pointer v0.0.0-20180825124634-49522c3f3791
-        github.com/mattn/go-runewidth v0.0.8 // indirect
-        github.com/mattn/go-sqlite3 v1.11.0
-        github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
-        github.com/microcosm-cc/bluemonday v1.0.2
-        github.com/olekukonko/tablewriter v0.0.2
-        github.com/pkg/errors v0.9.1
-        github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
-        github.com/processout/grpc-go-pool v1.2.1
-        github.com/prometheus/client_golang v1.2.1
-        github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
-        github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
-        github.com/russross/blackfriday/v2 v2.0.1
-        github.com/sebdah/goldie v1.0.0
-        github.com/sergi/go-diff v1.0.0
-        github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5
-        github.com/sirupsen/logrus v1.4.2
-        github.com/stretchr/testify v1.5.1
-        github.com/tebeka/strftime v0.1.3 // indirect
-        github.com/tink-ab/tempfile v0.0.0-20180226111222-33beb0518f1a
-        github.com/vjeantet/grok v1.0.0
-        github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 // indirect
-        github.com/xor-gate/debpkg v0.0.0-20181217150151-a0c70a3d4213
-        golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
-        golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e // indirect
-        golang.org/x/mod v0.2.0 // indirect
-        golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
-        golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-        golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-        golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
-        golang.org/x/tools v0.0.0-20200207131002-533eb2654509 // indirect
-        golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
-        google.golang.org/api v0.11.0
-        google.golang.org/appengine v1.6.5 // indirect
-        google.golang.org/genproto v0.0.0-20200409111301-baae70f3302d
-        google.golang.org/grpc v1.28.1
-        gopkg.in/alecthomas/kingpin.v2 v2.2.6
-        gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-        gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
-        gopkg.in/sourcemap.v1 v1.0.5 // indirect
-        gopkg.in/yaml.v2 v2.2.8 // indirect
-        howett.net/plist v0.0.0-20181124034731-591f970eefbb
-        www.velocidex.com/golang/evtx v0.0.2-0.20191118125331-191dc946afdf
-        www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321
-        www.velocidex.com/golang/go-ntfs v0.0.0-20200110083657-950cbe916617
-        www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6
-        www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
-        www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
-        www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-        www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e
-        www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
+	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/bigquery v1.1.0 // indirect
+	cloud.google.com/go/storage v1.1.1
+	github.com/Depado/bfchroma v1.2.0
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.4.2 // indirect
+	github.com/Masterminds/sprig v2.20.0+incompatible
+	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
+	github.com/Showmax/go-fqdn v0.0.0-20180501083314-6f60894d629f
+	github.com/Velocidex/ahocorasick v0.0.0-20180712114356-e1c353eeaaee
+	github.com/Velocidex/cgofuse v1.1.2
+	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
+	github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9
+	github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7
+	github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
+	github.com/Velocidex/yaml/v2 v2.2.5
+	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
+	github.com/alecthomas/chroma v0.7.2
+	github.com/alecthomas/participle v0.4.1
+	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
+	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
+	github.com/aws/aws-sdk-go v1.26.7
+	github.com/c-bata/go-prompt v0.2.3
+	github.com/cevaris/ordered_map v0.0.0-20180310183325-0efaee1733e3
+	github.com/clbanning/mxj v1.8.4
+	github.com/creack/pty v1.1.9 // indirect
+	github.com/crewjam/saml v0.3.1
+	github.com/davecgh/go-spew v1.1.1
+	github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustin/go-humanize v1.0.0
+	github.com/elastic/go-elasticsearch/v7 v7.3.0 // indirect
+	github.com/elastic/go-libaudit v0.4.0
+	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
+	github.com/go-ole/go-ole v1.2.4
+	github.com/go-sql-driver/mysql v1.5.0
+	github.com/gogo/protobuf v1.1.1
+	github.com/golang/mock v1.4.3
+	github.com/golang/protobuf v1.3.5
+	github.com/golang/snappy v0.0.1
+	github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 // indirect
+	github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995 // indirect
+	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e // indirect
+	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/gorilla/csrf v1.6.2
+	github.com/gorilla/schema v1.1.0
+	github.com/grpc-ecosystem/grpc-gateway v1.11.3
+	github.com/hanwen/go-fuse v1.0.1-0.20190726130028-2f298055551b
+	github.com/hillu/go-ntdll v0.0.0-20190226223014-dd4204aa705e
+	github.com/hillu/go-yara v1.2.2 // indirect
+	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
+	github.com/huandu/xstrings v1.2.0 // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
+	github.com/jmoiron/sqlx v1.2.0
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/kierdavis/dateparser v0.0.0-20171227112021-81e70b820720
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/kr/pty v1.1.8 // indirect
+	github.com/lestrrat-go/file-rotatelogs v2.2.0+incompatible
+	github.com/lestrrat-go/strftime v0.0.0-20190725011945-5c849dd2c51d // indirect
+	github.com/lib/pq v1.2.0 // indirect
+	github.com/magefile/mage v1.9.0
+	github.com/mattn/go-pointer v0.0.0-20180825124634-49522c3f3791
+	github.com/mattn/go-runewidth v0.0.8 // indirect
+	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.2
+	github.com/olekukonko/tablewriter v0.0.2
+	github.com/pkg/errors v0.9.1
+	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
+	github.com/processout/grpc-go-pool v1.2.1
+	github.com/prometheus/client_golang v1.2.1
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
+	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
+	github.com/russross/blackfriday/v2 v2.0.1
+	github.com/sebdah/goldie v1.0.0
+	github.com/sergi/go-diff v1.0.0
+	github.com/shirou/gopsutil v0.0.0-20190627142359-4c8b404ee5c5
+	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.5.1
+	github.com/tebeka/strftime v0.1.3 // indirect
+	github.com/tink-ab/tempfile v0.0.0-20180226111222-33beb0518f1a
+	github.com/vjeantet/grok v1.0.0
+	github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 // indirect
+	github.com/xor-gate/debpkg v0.0.0-20181217150151-a0c70a3d4213
+	golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
+	golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e // indirect
+	golang.org/x/mod v0.2.0 // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
+	golang.org/x/tools v0.0.0-20200207131002-533eb2654509 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	google.golang.org/api v0.11.0
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20200409111301-baae70f3302d
+	google.golang.org/grpc v1.28.1
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+	howett.net/plist v0.0.0-20181124034731-591f970eefbb
+	www.velocidex.com/golang/evtx v0.0.2-0.20191118125331-191dc946afdf
+	www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321
+	www.velocidex.com/golang/go-ntfs v0.0.0-20200110083657-950cbe916617
+	www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6
+	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
+	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
+	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
+	www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db
+	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 
-replace www.velocidex.com/golang/vfilter => /home/mic/projects/vfilter
+// replace www.velocidex.com/golang/vfilter => /home/mic/projects/vfilter
 // replace www.velocidex.com/golang/go-ntfs => /home/mic/projects/go-ntfs
 // replace www.velocidex.com/golang/evtx => /home/mic/projects/evtx
 // replace www.velocidex.com/golang/go-ese => /home/mic/projects/go-ese

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/Velocidex/cgofuse v1.1.2
 	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
 	github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9
-	github.com/Velocidex/ordereddict v0.0.0-20200418081115-17494970552f
+	github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7
 	github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49
 	github.com/Velocidex/yaml/v2 v2.2.5
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
@@ -117,7 +117,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20200417165231-2dfd54916f9b
+	www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e
 	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 
@@ -126,6 +126,7 @@ require (
 // replace www.velocidex.com/golang/evtx => /home/mic/projects/evtx
 // replace www.velocidex.com/golang/go-ese => /home/mic/projects/go-ese
 // replace github.com/Velocidex/ordereddict => /home/mic/projects/ordereddict
+
 // replace www.velocidex.com/golang/go-yara => /home/mic/projects/go-yara
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db
+	www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b
 	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9 h1:zatH9PNN7I
 github.com/Velocidex/go-yara v1.1.10-0.20200414034554-457848df11f9/go.mod h1:N1A2MzBKorQm3WixuPUSm4gmzGA6i5sYrwHyUBvY5lg=
 github.com/Velocidex/ordereddict v0.0.0-20191103011020-3b5a5f6957d4/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
-github.com/Velocidex/ordereddict v0.0.0-20200418081115-17494970552f h1:LpyxGF2GG8bhOmEWAJkNidOc1x6kFNSYOV7oq3Z8Zek=
-github.com/Velocidex/ordereddict v0.0.0-20200418081115-17494970552f/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
+github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7 h1:kOuTDzcjsrEE+JM+/PkKLIfoyy+7nGxiG5idfZYKA5M=
+github.com/Velocidex/ordereddict v0.0.0-20200419183704-bc44e4ef79c7/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49 h1:TJVN1zYl5sKJUq571gYqU/5VqFIap9MUo2KNujc0fcg=
 github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49/go.mod h1:kfPUQ2gP0xtIydiR52dirNYt4OvCr+iZuepL4XaIk58=
 github.com/Velocidex/yaml/v2 v2.2.5 h1:8XZwR8tmm5UWAXotI3fL17s9fjKEMqZ293fgqUiMhBw=
@@ -598,7 +598,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196 h1:3oYZ7hPN
 www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196/go.mod h1:i7M+d4Vxir8nmDACh+c6CsUU1r1Wcj00aRgNp8mXcPQ=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
-www.velocidex.com/golang/vfilter v0.0.0-20200417165231-2dfd54916f9b h1:SINzeb9DzrWtNgybNTl09aGGD/leCevLv1wPrmkV2Tg=
-www.velocidex.com/golang/vfilter v0.0.0-20200417165231-2dfd54916f9b/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
+www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e h1:3PmsR00Jfvd/IJXN0bUv9iFktcAfsSt5GiUdzrzU/d0=
+www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/go.sum
+++ b/go.sum
@@ -598,7 +598,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196 h1:3oYZ7hPN
 www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196/go.mod h1:i7M+d4Vxir8nmDACh+c6CsUU1r1Wcj00aRgNp8mXcPQ=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
-www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e h1:3PmsR00Jfvd/IJXN0bUv9iFktcAfsSt5GiUdzrzU/d0=
-www.velocidex.com/golang/vfilter v0.0.0-20200419183006-5e67794db35e/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
+www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db h1:n07UZUhu72tbyFPAFmM1yQONd7MUK25lzAN061VvWdA=
+www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/go.sum
+++ b/go.sum
@@ -598,7 +598,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196 h1:3oYZ7hPN
 www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196/go.mod h1:i7M+d4Vxir8nmDACh+c6CsUU1r1Wcj00aRgNp8mXcPQ=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
-www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db h1:n07UZUhu72tbyFPAFmM1yQONd7MUK25lzAN061VvWdA=
-www.velocidex.com/golang/vfilter v0.0.0-20200420053049-a6682561c4db/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
+www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b h1:zfTlVEw7ZkQ9BRnF8sESTRhjoujqN4tA1VuB22yArfo=
+www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/reporting/expand.go
+++ b/reporting/expand.go
@@ -28,25 +28,23 @@ func EvalQueryToTable(ctx context.Context,
 	output_chan := vql.Eval(ctx, scope)
 	table := tablewriter.NewWriter(out)
 
-	columns := vql.Columns(scope)
-	table.SetHeader(*columns)
+	columns := []string{}
 	table.SetCaption(true, vql.ToString(scope))
 	table.SetAutoFormatHeaders(false)
 	table.SetAutoWrapText(false)
 
 	for row := range output_chan {
 		string_row := []string{}
-		if len(*columns) == 0 {
-			members := scope.GetMembers(row)
-			table.SetHeader(members)
-			columns = &members
+		if len(columns) == 0 {
+			columns := scope.GetMembers(row)
+			table.SetHeader(columns)
 		}
 
-		for _, key := range *columns {
+		for _, key := range columns {
 			cell := ""
 			value, pres := scope.Associative(row, key)
 			if pres && !utils.IsNil(value) {
-				cell = utils.Stringify(value, scope, 120/len(*columns))
+				cell = utils.Stringify(value, scope, 120/len(columns))
 			}
 			string_row = append(string_row, cell)
 		}

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -280,20 +280,17 @@ func newBaseTemplateEngine(
 			"Artifact %v not known.", artifact_name)
 	}
 
-	env := ordereddict.NewDict().
-		Set("config", config_obj.Client).
-		Set("server_config", config_obj).
-		Set(vql_subsystem.ACL_MANAGER_VAR,
-			vql_subsystem.NewServerACLManager(
-				config_obj, principal)).
-		Set(vql_subsystem.CACHE_VAR, vql_subsystem.NewScopeCache())
+	scope := artifacts.ScopeBuilder{
+		Config:     config_obj,
+		ACLManager: vql_subsystem.NewServerACLManager(config_obj, principal),
+	}.Build()
 
-	scope := artifacts.MakeScope(repository).AppendVars(env)
+	// Closing the scope is deferred to closing the template.
 
 	return &BaseTemplateEngine{
 		Artifact: artifact,
 		Scope:    scope,
-		Env:      env,
+		Env:      ordereddict.NewDict(),
 		logger:   logging.GetLogger(config_obj, &logging.FrontendComponent),
 	}, nil
 }

--- a/services/interrogation.go
+++ b/services/interrogation.go
@@ -40,17 +40,10 @@ func (self *InterrogationService) Start(
 	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 	logger.Info("Starting interrogation service.")
 
-	env := ordereddict.NewDict().
-		Set("config", self.config_obj.Client).
-		Set(vql_subsystem.ACL_MANAGER_VAR,
-			vql_subsystem.NewRoleACLManager("administrator")).
-		Set("server_config", self.config_obj)
-
-	repository, err := artifacts.GetGlobalRepository(self.config_obj)
-	if err != nil {
-		return err
-	}
-	scope := artifacts.MakeScope(repository).AppendVars(env)
+	scope := artifacts.ScopeBuilder{
+		Config:     self.config_obj,
+		ACLManager: vql_subsystem.NewRoleACLManager("administrator"),
+	}.Build()
 	defer scope.Close()
 
 	scope.Logger = logging.NewPlainLogger(self.config_obj,

--- a/vql/common/copy.go
+++ b/vql/common/copy.go
@@ -22,8 +22,7 @@ import (
 	"os"
 
 	"github.com/Velocidex/ordereddict"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -43,13 +42,10 @@ func (self *CopyFunction) Call(ctx context.Context,
 	args *ordereddict.Dict) vfilter.Any {
 
 	// Check the config if we are allowed to execve at all.
-	scope_config, pres := scope.Resolve(constants.SCOPE_CONFIG)
-	if pres {
-		config_obj, ok := scope_config.(*config_proto.ClientConfig)
-		if ok && config_obj.PreventExecve {
-			scope.Log("copy: Not allowed to write by configuration.")
-			return vfilter.Null{}
-		}
+	config_obj, ok := artifacts.GetConfig(scope)
+	if ok && config_obj.PreventExecve {
+		scope.Log("copy: Not allowed to write by configuration.")
+		return vfilter.Null{}
 	}
 
 	arg := &CopyFunctionArgs{}

--- a/vql/common/copy.go
+++ b/vql/common/copy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -42,7 +43,7 @@ func (self *CopyFunction) Call(ctx context.Context,
 	args *ordereddict.Dict) vfilter.Any {
 
 	// Check the config if we are allowed to execve at all.
-	scope_config, pres := scope.Resolve("config")
+	scope_config, pres := scope.Resolve(constants.SCOPE_CONFIG)
 	if pres {
 		config_obj, ok := scope_config.(*config_proto.ClientConfig)
 		if ok && config_obj.PreventExecve {

--- a/vql/common/diff.go
+++ b/vql/common/diff.go
@@ -87,7 +87,7 @@ check_row:
 			}
 			new_key := fmt.Sprintf("%v", new_key_any)
 
-			dict_row := vql_subsystem.RowToDict(scope, row)
+			dict_row := vfilter.RowToDict(ctx, scope, row)
 
 			self.rows[new_key] = append(self.rows[new_key], dict_row)
 

--- a/vql/common/mail.go
+++ b/vql/common/mail.go
@@ -25,6 +25,7 @@ import (
 	gomail "gopkg.in/gomail.v2"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
@@ -61,7 +62,7 @@ func (self MailPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/common/mail.go
+++ b/vql/common/mail.go
@@ -24,8 +24,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	gomail "gopkg.in/gomail.v2"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
@@ -62,8 +61,7 @@ func (self MailPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
@@ -64,7 +65,7 @@ func (self ShellPlugin) Call(
 		}
 
 		// Check the config if we are allowed to execve at all.
-		scope_config, pres := scope.Resolve("config")
+		scope_config, pres := scope.Resolve(constants.SCOPE_CONFIG)
 		if pres {
 			config_obj, ok := scope_config.(*config_proto.ClientConfig)
 			if ok && config_obj.PreventExecve {

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -28,8 +28,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
@@ -65,13 +64,10 @@ func (self ShellPlugin) Call(
 		}
 
 		// Check the config if we are allowed to execve at all.
-		scope_config, pres := scope.Resolve(constants.SCOPE_CONFIG)
-		if pres {
-			config_obj, ok := scope_config.(*config_proto.ClientConfig)
-			if ok && config_obj.PreventExecve {
-				scope.Log("shell: Not allowed to execve by configuration.")
-				return
-			}
+		config_obj, ok := artifacts.GetConfig(scope)
+		if ok && config_obj.PreventExecve {
+			scope.Log("shell: Not allowed to execve by configuration.")
+			return
 		}
 
 		arg := &ShellPluginArgs{}

--- a/vql/filesystem/filesystem.go
+++ b/vql/filesystem/filesystem.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/disk"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -47,7 +48,7 @@ func (self GlobPlugin) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			config_obj = &config_proto.Config{}

--- a/vql/filesystem/filesystem.go
+++ b/vql/filesystem/filesystem.go
@@ -24,8 +24,8 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/disk"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -48,8 +48,7 @@ func (self GlobPlugin) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			config_obj = &config_proto.Config{}
 		}

--- a/vql/filesystem/filesystem.go
+++ b/vql/filesystem/filesystem.go
@@ -107,7 +107,6 @@ func (self GlobPlugin) Info(scope *vfilter.Scope, type_map *vfilter.TypeMap) *vf
 	return &vfilter.PluginInfo{
 		Name:    "glob",
 		Doc:     "Retrieve files based on a list of glob expressions",
-		RowType: type_map.AddType(scope, glob.NewVirtualDirectoryPath("", nil)),
 		ArgType: type_map.AddType(scope, &GlobPluginArgs{}),
 	}
 }
@@ -227,7 +226,6 @@ func (self ReadFilePlugin) Info(scope *vfilter.Scope, type_map *vfilter.TypeMap)
 	return &vfilter.PluginInfo{
 		Name:    "read_file",
 		Doc:     "Read files in chunks.",
-		RowType: type_map.AddType(scope, ReadFileResponse{}),
 		ArgType: type_map.AddType(scope, &ReadFileArgs{}),
 	}
 }
@@ -362,7 +360,6 @@ func init() {
 				}
 				return result
 			},
-			RowType: disk.PartitionStat{},
 		})
 	vql_subsystem.RegisterPlugin(&StatPlugin{})
 	vql_subsystem.RegisterFunction(&ReadFileFunction{})

--- a/vql/filesystem/filesystems.go
+++ b/vql/filesystem/filesystems.go
@@ -72,7 +72,6 @@ func init() {
 
 				return result
 			},
-			RowType: ExtendedFileSystemInfo{},
 			ArgType: &PartitionsArgs{},
 			Doc:     "List all partititions",
 		})

--- a/vql/filesystem/raw_registry.go
+++ b/vql/filesystem/raw_registry.go
@@ -44,8 +44,8 @@ import (
 	"github.com/Velocidex/ordereddict"
 	errors "github.com/pkg/errors"
 	"www.velocidex.com/golang/regparser"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -409,8 +409,7 @@ func (self ReadKeyValues) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			config_obj = &config_proto.Config{}
 		}

--- a/vql/filesystem/raw_registry.go
+++ b/vql/filesystem/raw_registry.go
@@ -45,6 +45,7 @@ import (
 	errors "github.com/pkg/errors"
 	"www.velocidex.com/golang/regparser"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -408,7 +409,7 @@ func (self ReadKeyValues) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			config_obj = &config_proto.Config{}

--- a/vql/linux/connections.go
+++ b/vql/linux/connections.go
@@ -47,7 +47,6 @@ func init() {
 				}
 				return result
 			},
-			Doc:     "List all active connections",
-			RowType: net.ConnectionStat{},
+			Doc: "List all active connections",
 		})
 }

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -260,7 +260,7 @@ func (self *_HttpPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_CONFIG)
 		config_obj := any_config_obj.(*config_proto.ClientConfig)
 
 		params := encodeParams(arg, scope)

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"github.com/tink-ab/tempfile"
 	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	constants "www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -260,8 +261,7 @@ func (self *_HttpPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_CONFIG)
-		config_obj := any_config_obj.(*config_proto.ClientConfig)
+		config_obj, _ := artifacts.GetConfig(scope)
 
 		params := encodeParams(arg, scope)
 		client := getHttpClient(config_obj, arg)

--- a/vql/networking/network.go
+++ b/vql/networking/network.go
@@ -50,7 +50,6 @@ func init() {
 
 				return result
 			},
-			RowType: net.Interface{},
-			Doc:     "List all active interfaces.",
+			Doc: "List all active interfaces.",
 		})
 }

--- a/vql/networking/upload.go
+++ b/vql/networking/upload.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/Velocidex/ordereddict"
+	constants "www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/uploads"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -41,7 +42,7 @@ func (self *UploadFunction) Call(ctx context.Context,
 	scope *vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	uploader_obj, ok := scope.Resolve("$uploader")
+	uploader_obj, ok := scope.Resolve(constants.SCOPE_UPLOADER)
 	if !ok {
 		scope.Log("upload: Uploader not configured.")
 		return vfilter.Null{}
@@ -138,7 +139,7 @@ func (self *UploadPlugin) Call(
 			return
 		}
 
-		uploader_obj, _ := scope.Resolve("$uploader")
+		uploader_obj, _ := scope.Resolve(constants.SCOPE_UPLOADER)
 		uploader, ok := uploader_obj.(uploads.Uploader)
 		if !ok {
 			scope.Log("upload: Uploader not configured.")

--- a/vql/parsers/csv/csv.go
+++ b/vql/parsers/csv/csv.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/glob"
@@ -184,9 +183,6 @@ func (self WriteCSVPlugin) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, _ := any_config_obj.(*config_proto.Config)
-
 		arg := &WriteCSVPluginArgs{}
 		err := vfilter.ExtractArgs(scope, args, arg)
 		if err != nil {
@@ -219,6 +215,12 @@ func (self WriteCSVPlugin) Call(
 			err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
 			if err != nil {
 				scope.Log("write_csv: %s", err)
+				return
+			}
+
+			config_obj, ok := artifacts.GetServerConfig(scope)
+			if !ok {
+				scope.Log("Command can only run on the server")
 				return
 			}
 

--- a/vql/parsers/csv/csv.go
+++ b/vql/parsers/csv/csv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/glob"
@@ -183,7 +184,7 @@ func (self WriteCSVPlugin) Call(
 	go func() {
 		defer close(output_chan)
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, _ := any_config_obj.(*config_proto.Config)
 
 		arg := &WriteCSVPluginArgs{}

--- a/vql/parsers/ole.go
+++ b/vql/parsers/ole.go
@@ -143,7 +143,7 @@ func (self _OLEVBAPlugin) Call(
 			}
 
 			for _, macro_info := range macros {
-				output_chan <- vql_subsystem.RowToDict(scope, macro_info).Set(
+				output_chan <- vfilter.RowToDict(ctx, scope, macro_info).Set(
 					"filename", filename)
 			}
 		}

--- a/vql/process.go
+++ b/vql/process.go
@@ -112,7 +112,6 @@ func init() {
 			return result
 		},
 		ArgType: &PslistArgs{},
-		RowType: &process.Process{},
 		Doc:     "List processes",
 	})
 }

--- a/vql/server/artifacts.go
+++ b/vql/server/artifacts.go
@@ -27,6 +27,7 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/api"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
 	"www.velocidex.com/golang/velociraptor/grpc_client"
@@ -58,7 +59,7 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/artifacts.go
+++ b/vql/server/artifacts.go
@@ -26,8 +26,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/api"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
 	"www.velocidex.com/golang/velociraptor/grpc_client"
@@ -59,8 +58,7 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/clients.go
+++ b/vql/server/clients.go
@@ -28,7 +28,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/api"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -63,8 +63,7 @@ func (self ClientsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/clients.go
+++ b/vql/server/clients.go
@@ -63,7 +63,7 @@ func (self ClientsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/compress.go
+++ b/vql/server/compress.go
@@ -25,8 +25,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -56,8 +55,7 @@ func (self *Compress) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/compress.go
+++ b/vql/server/compress.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -55,7 +56,7 @@ func (self *Compress) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/elastic.go
+++ b/vql/server/elastic.go
@@ -195,7 +195,7 @@ func append_row_to_buffer(
 	row vfilter.Row, id int64, buf *bytes.Buffer,
 	arg *_ElasticPluginArgs) error {
 
-	row_dict := vfilter.RowToDict(ctx, scope, row, nil)
+	row_dict := vfilter.RowToDict(ctx, scope, row)
 	index := arg.Index
 	index_any, pres := row_dict.Get("_index")
 	if pres {

--- a/vql/server/event_monitoring.go
+++ b/vql/server/event_monitoring.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/grpc_client"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -36,7 +37,7 @@ func (self GetClientMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")
@@ -91,7 +92,7 @@ func (self SetClientMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")
@@ -166,7 +167,7 @@ func (self GetServerMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")
@@ -221,7 +222,7 @@ func (self SetServerMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/event_monitoring.go
+++ b/vql/server/event_monitoring.go
@@ -7,8 +7,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"github.com/golang/protobuf/ptypes/empty"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/grpc_client"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -37,8 +36,7 @@ func (self GetClientMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}
@@ -92,8 +90,7 @@ func (self SetClientMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}
@@ -167,8 +164,7 @@ func (self GetServerMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}
@@ -222,8 +218,7 @@ func (self SetServerMonitoring) Call(
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/file_store.go
+++ b/vql/server/file_store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -55,7 +56,7 @@ func (self *DeleteFileStore) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")
@@ -105,7 +106,7 @@ func (self *FileStore) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/file_store.go
+++ b/vql/server/file_store.go
@@ -25,8 +25,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -56,8 +55,7 @@ func (self *DeleteFileStore) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}
@@ -106,8 +104,7 @@ func (self *FileStore) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/flows.go
+++ b/vql/server/flows.go
@@ -7,8 +7,6 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
@@ -49,8 +47,7 @@ func (self FlowsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -123,8 +120,7 @@ func (self *CancelFlowFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}
@@ -173,8 +169,7 @@ func (self EnumerateFlowPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/flows.go
+++ b/vql/server/flows.go
@@ -8,6 +8,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
@@ -48,7 +49,7 @@ func (self FlowsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -122,7 +123,7 @@ func (self *CancelFlowFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")
@@ -172,7 +173,7 @@ func (self EnumerateFlowPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/hunt.go
+++ b/vql/server/hunt.go
@@ -26,8 +26,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
@@ -60,8 +59,7 @@ func (self *ScheduleHuntFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/hunt.go
+++ b/vql/server/hunt.go
@@ -27,6 +27,7 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
@@ -59,7 +60,7 @@ func (self *ScheduleHuntFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/hunts.go
+++ b/vql/server/hunts.go
@@ -29,7 +29,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
@@ -65,8 +64,7 @@ func (self HuntsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -144,8 +142,7 @@ func (self HuntResultsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -302,8 +299,7 @@ func (self HuntFlowsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/hunts.go
+++ b/vql/server/hunts.go
@@ -65,7 +65,7 @@ func (self HuntsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -144,7 +144,7 @@ func (self HuntResultsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -302,7 +302,7 @@ func (self HuntFlowsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/labels.go
+++ b/vql/server/labels.go
@@ -25,9 +25,8 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/clients"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 )
@@ -57,8 +56,7 @@ func (self *AddLabels) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-	config_obj, ok := any_config_obj.(*config_proto.Config)
+	config_obj, ok := artifacts.GetServerConfig(scope)
 	if !ok {
 		scope.Log("Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/labels.go
+++ b/vql/server/labels.go
@@ -27,6 +27,7 @@ import (
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/clients"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 )
@@ -56,7 +57,7 @@ func (self *AddLabels) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	any_config_obj, _ := scope.Resolve("server_config")
+	any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 	config_obj, ok := any_config_obj.(*config_proto.Config)
 	if !ok {
 		scope.Log("Command can only run on the server")

--- a/vql/server/monitoring.go
+++ b/vql/server/monitoring.go
@@ -28,6 +28,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/glob"
@@ -59,7 +60,7 @@ func (self MonitoringPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -216,7 +217,7 @@ func (self WatchMonitoringPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/monitoring.go
+++ b/vql/server/monitoring.go
@@ -28,7 +28,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/glob"
@@ -60,8 +59,7 @@ func (self MonitoringPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -217,8 +215,7 @@ func (self WatchMonitoringPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/results.go
+++ b/vql/server/results.go
@@ -30,7 +30,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/flows"
@@ -63,8 +62,8 @@ func (self UploadsPlugins) Call(
 		}
 
 		arg := &UploadsPluginsArgs{}
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -136,8 +135,7 @@ func (self SourcePlugin) Call(
 		}
 
 		arg := &SourcePluginArgs{}
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return
@@ -410,8 +408,7 @@ func (self FlowResultsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/results.go
+++ b/vql/server/results.go
@@ -30,6 +30,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/csv"
 	"www.velocidex.com/golang/velociraptor/flows"
@@ -62,7 +63,7 @@ func (self UploadsPlugins) Call(
 		}
 
 		arg := &UploadsPluginsArgs{}
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -135,7 +136,7 @@ func (self SourcePlugin) Call(
 		}
 
 		arg := &SourcePluginArgs{}
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")
@@ -409,7 +410,7 @@ func (self FlowResultsPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/search.go
+++ b/vql/server/search.go
@@ -101,7 +101,7 @@ func (self SearchPlugin) Call(
 			arg.Limit = 10000
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/search.go
+++ b/vql/server/search.go
@@ -56,7 +56,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -101,8 +101,7 @@ func (self SearchPlugin) Call(
 			arg.Limit = 10000
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/server/users.go
+++ b/vql/server/users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/users"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -27,7 +28,7 @@ func (self UsersPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve("server_config")
+		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
 		config_obj, ok := any_config_obj.(*config_proto.Config)
 		if !ok {
 			scope.Log("Command can only run on the server")

--- a/vql/server/users.go
+++ b/vql/server/users.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/users"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -28,8 +27,7 @@ func (self UsersPlugin) Call(
 			return
 		}
 
-		any_config_obj, _ := scope.Resolve(constants.SCOPE_SERVER_CONFIG)
-		config_obj, ok := any_config_obj.(*config_proto.Config)
+		config_obj, ok := artifacts.GetServerConfig(scope)
 		if !ok {
 			scope.Log("Command can only run on the server")
 			return

--- a/vql/tools/collector.go
+++ b/vql/tools/collector.go
@@ -8,7 +8,6 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/config"
-	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -79,18 +78,13 @@ func (self CollectPlugin) Call(
 			return
 		}
 
+		builder := artifacts.ScopeBuilderFromScope(scope)
+		builder.Uploader = container
+
 		for _, name := range arg.Artifacts {
-			// Make a new scope for each artifact.
-			// Any uploads go into the container.
-			subscope := scope.Copy()
-			env := ordereddict.NewDict().
-				Set(constants.SCOPE_UPLOADER, container)
-
-			subscope.AppendVars(env)
-
 			artifact, pres := repository.Get(name)
 			if !pres {
-				subscope.Log("collect: Unknown artifact %v", name)
+				scope.Log("collect: Unknown artifact %v", name)
 				continue
 
 			}
@@ -98,14 +92,15 @@ func (self CollectPlugin) Call(
 			request := &actions_proto.VQLCollectorArgs{}
 			err := repository.Compile(artifact, request)
 			if err != nil {
-				subscope.Log("collect: Invalid artifact %v: %v",
+				scope.Log("collect: Invalid artifact %v: %v",
 					name, err)
 				continue
 			}
 
 			// First set defaulst
+			builder.Env = ordereddict.NewDict()
 			for _, e := range request.Env {
-				env.Set(e.Key, e.Value)
+				builder.Env.Set(e.Key, e.Value)
 			}
 
 			in_params := func(key string) bool {
@@ -118,19 +113,23 @@ func (self CollectPlugin) Call(
 			}
 
 			// Now override provided parameters
-			for _, key := range subscope.GetMembers(arg.Args) {
+			for _, key := range scope.GetMembers(arg.Args) {
 				if !in_params(key) {
 					scope.Log("Unknown arg %v to artifact collector",
 						key)
 					return
 				}
 
-				value, pres := subscope.Associative(arg.Args,
+				value, pres := scope.Associative(arg.Args,
 					key)
 				if pres {
-					env.Set(key, value)
+					builder.Env.Set(key, value)
 				}
 			}
+
+			// Make a new scope for each artifact.
+			// Any uploads go into the container.
+			subscope := builder.Build()
 
 			for _, query := range request.Query {
 				vql, err := vfilter.Parse(query.VQL)

--- a/vql/tools/collector.go
+++ b/vql/tools/collector.go
@@ -8,6 +8,7 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	"www.velocidex.com/golang/velociraptor/config"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -83,7 +84,7 @@ func (self CollectPlugin) Call(
 			// Any uploads go into the container.
 			subscope := scope.Copy()
 			env := ordereddict.NewDict().
-				Set("$uploader", container)
+				Set(constants.SCOPE_UPLOADER, container)
 
 			subscope.AppendVars(env)
 

--- a/vql/tools/mocker.go
+++ b/vql/tools/mocker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/artifacts"
+	"www.velocidex.com/golang/velociraptor/constants"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 )
@@ -162,12 +163,12 @@ func (self *MockFunction) Call(ctx context.Context,
 
 	var scope_context *_MockingScopeContext
 
-	scope_context_any := scope.GetContext("_mock_")
+	scope_context_any := scope.GetContext(constants.SCOPE_MOCK)
 	if scope_context_any != nil {
 		scope_context = scope_context_any.(*_MockingScopeContext)
 	} else {
 		scope_context = &_MockingScopeContext{}
-		scope.SetContext("_mock_", scope_context)
+		scope.SetContext(constants.SCOPE_MOCK, scope_context)
 	}
 
 	if arg.Plugin != "" {
@@ -236,12 +237,12 @@ func (self *MockCheckFunction) Call(ctx context.Context,
 
 	var scope_context *_MockingScopeContext
 
-	scope_context_any := scope.GetContext("_mock_")
+	scope_context_any := scope.GetContext(constants.SCOPE_MOCK)
 	if scope_context_any != nil {
 		scope_context = scope_context_any.(*_MockingScopeContext)
 	} else {
 		scope_context = &_MockingScopeContext{}
-		scope.SetContext("_mock_", scope_context)
+		scope.SetContext(constants.SCOPE_MOCK, scope_context)
 	}
 
 	if arg.Plugin != "" {

--- a/vql/tools/mocker.go
+++ b/vql/tools/mocker.go
@@ -12,20 +12,20 @@ import (
 	"www.velocidex.com/golang/vfilter"
 )
 
-type _MockingScopeContext struct {
+type MockingScopeContext struct {
 	plugins   []*MockerPlugin
 	functions []*MockerFunction
 }
 
-func (self *_MockingScopeContext) AddPlugin(pl *MockerPlugin) {
+func (self *MockingScopeContext) AddPlugin(pl *MockerPlugin) {
 	self.plugins = append(self.plugins, pl)
 }
 
-func (self *_MockingScopeContext) AddFunction(pl *MockerFunction) {
+func (self *MockingScopeContext) AddFunction(pl *MockerFunction) {
 	self.functions = append(self.functions, pl)
 }
 
-func (self *_MockingScopeContext) GetPlugin(name string) *MockerPlugin {
+func (self *MockingScopeContext) GetPlugin(name string) *MockerPlugin {
 	for _, pl := range self.plugins {
 		if name == pl.name {
 			return pl
@@ -35,7 +35,7 @@ func (self *_MockingScopeContext) GetPlugin(name string) *MockerPlugin {
 	return nil
 }
 
-func (self _MockingScopeContext) GetFunction(name string) *MockerFunction {
+func (self MockingScopeContext) GetFunction(name string) *MockerFunction {
 	for _, pl := range self.functions {
 		if name == pl.name {
 			return pl
@@ -45,7 +45,7 @@ func (self _MockingScopeContext) GetFunction(name string) *MockerFunction {
 	return nil
 }
 
-func (self *_MockingScopeContext) Reset() {
+func (self *MockingScopeContext) Reset() {
 	for _, pl := range self.plugins {
 		pl.ctx.call_count = 0
 	}
@@ -161,14 +161,10 @@ func (self *MockFunction) Call(ctx context.Context,
 		}
 	}
 
-	var scope_context *_MockingScopeContext
-
-	scope_context_any := scope.GetContext(constants.SCOPE_MOCK)
-	if scope_context_any != nil {
-		scope_context = scope_context_any.(*_MockingScopeContext)
-	} else {
-		scope_context = &_MockingScopeContext{}
-		scope.SetContext(constants.SCOPE_MOCK, scope_context)
+	scope_context, ok := GetMockContext(scope)
+	if !ok {
+		scope.Log("mock_check: Not running in test.")
+		return vfilter.Null{}
 	}
 
 	if arg.Plugin != "" {
@@ -235,14 +231,10 @@ func (self *MockCheckFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	var scope_context *_MockingScopeContext
-
-	scope_context_any := scope.GetContext(constants.SCOPE_MOCK)
-	if scope_context_any != nil {
-		scope_context = scope_context_any.(*_MockingScopeContext)
-	} else {
-		scope_context = &_MockingScopeContext{}
-		scope.SetContext(constants.SCOPE_MOCK, scope_context)
+	scope_context, ok := GetMockContext(scope)
+	if !ok {
+		scope.Log("mock_check: Not running in test.")
+		return vfilter.Null{}
 	}
 
 	if arg.Plugin != "" {
@@ -289,6 +281,16 @@ func (self MockCheckFunction) Info(
 		Doc:     "Check expectations on a mock.",
 		ArgType: type_map.AddType(scope, &MockCheckArgs{}),
 	}
+}
+
+func GetMockContext(scope *vfilter.Scope) (*MockingScopeContext, bool) {
+	scope_mocker, pres := scope.Resolve(constants.SCOPE_MOCK)
+	if !pres {
+		return nil, false
+	}
+
+	mocker, ok := scope_mocker.(*MockingScopeContext)
+	return mocker, ok
 }
 
 func init() {

--- a/vql/utils.go
+++ b/vql/utils.go
@@ -47,24 +47,6 @@ func ExtractRows(vql_response *actions_proto.VQLResponse) ([]vfilter.Row, error)
 	return result, nil
 }
 
-func RowToDict(scope *vfilter.Scope, row vfilter.Row) *ordereddict.Dict {
-	// If the row is already a dict nothing to do:
-	result, ok := row.(*ordereddict.Dict)
-	if ok {
-		return result
-	}
-
-	result = ordereddict.NewDict()
-	for _, column := range scope.GetMembers(row) {
-		value, pres := scope.Associative(row, column)
-		if pres {
-			result.Set(column, value)
-		}
-	}
-
-	return result
-}
-
 // GetStringFromRow gets a string value from row. If it is not there
 // or not a string return ""
 func GetStringFromRow(scope *vfilter.Scope,

--- a/vql/windows/users.go
+++ b/vql/windows/users.go
@@ -200,7 +200,6 @@ func init() {
 		Doc: "Display information about workstation local users. " +
 			"This is obtained through the NetUserEnum() API.",
 		Function: getUsers,
-		RowType:  UserRecord{},
 	})
 
 	vql_subsystem.RegisterFunction(&LookupSidFunction{})


### PR DESCRIPTION
When running a sub-artifact using the `Artifact.` plugin, we used to
copy the scope from the calling context. This causes some weird
effects like the sub artifact being able to access values set in
callers scope and leading to scope over-write warnings.

This change creates a new scope for the sub-artifact. We still need to
propagate global variables (like the ACL manager) to the subscope
though.