### PR TITLE
Delay logs in autoexec until flags are parsed.

### DIFF
--- a/bin/autoexec.go
+++ b/bin/autoexec.go
@@ -4,13 +4,13 @@ import (
 	"os"
 
 	"www.velocidex.com/golang/velociraptor/config"
-	logging "www.velocidex.com/golang/velociraptor/logging"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 )
 
-func maybeUnpackConfig(args []string) []string {
+func maybeUnpackConfig(args []string) ([]string, *config_proto.Config) {
 	embedded_config, err := config.ReadEmbeddedConfig()
 	if err != nil || embedded_config.Autoexec == nil {
-		return args
+		return args, nil
 	}
 
 	argv := []string{}
@@ -18,8 +18,5 @@ func maybeUnpackConfig(args []string) []string {
 		argv = append(argv, os.ExpandEnv(arg))
 	}
 
-	logging.GetLogger(embedded_config, &logging.ToolComponent).
-		Info("Autoexec with parameters: %s", argv)
-
-	return argv
+	return argv, embedded_config
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -114,6 +114,13 @@ func (self *LogManager) GetLogger(
 	return ctx
 }
 
+func (self *LogManager) Reset() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.contexts = make(map[*string]*LogContext)
+}
+
 func getRotator(
 	config_obj *config_proto.Config,
 	base_path string) *rotatelogs.RotateLogs {


### PR DESCRIPTION
Fixes a bug where logs are always verbose because the first message is
emitted before flags are parsed.