### PR TITLE
 Populate env in report renderer.

### DIFF
--- a/artifacts/testdata/server/testcases/mock.out.yaml
+++ b/artifacts/testdata/server/testcases/mock.out.yaml
@@ -146,6 +146,10 @@ LET X <= SELECT mock(plugin='info', results=[dict(foo='bar'), dict(foo='baz')] )
   "Family": "IPv4",
   "Type": "TCP",
   "Status": "ESTAB",
+  "Laddr.IP": null,
+  "Laddr.Port": null,
+  "Raddr.IP": null,
+  "Raddr.Port": null,
   "Timestamp": "2019-12-07T03:30:58Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }

--- a/artifacts/testdata/server/testcases/plist.out.yaml
+++ b/artifacts/testdata/server/testcases/plist.out.yaml
@@ -4,7 +4,10 @@ SELECT * FROM Artifact.MacOS.System.Users(UserPlistGlob=srcDir + '/artifacts/tes
   "RealName": "vagrant",
   "UserShell": "/bin/bash",
   "HomeDir": "/Users/vagrant",
+  "AppleId": null,
+  "CreationTime": null,
   "FailedLoginCount": 0,
+  "FailedLoginTimestamp": null,
   "PasswordLastSetTime": "2017-11-25T00:36:29.728411912Z",
   "_Source": "MacOS.System.Users"
  }

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -258,26 +258,6 @@
     required: false
   category: event
 - name: collect
-  description: Launch an artifact collection against a client.
-  type: Function
-  args:
-  - name: client_id
-    description: The client id to schedule a collection on
-    type: string
-    repeated: false
-    required: true
-  - name: artifacts
-    description: A list of artifacts to collect
-    type: string
-    repeated: true
-    required: true
-  - name: env
-    description: Parameters to apply to the artifacts
-    type: vfilter.Any
-    repeated: false
-    required: false
-  category: server
-- name: collect
   description: Collect artifacts into a local file.
   type: Plugin
   args:

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20190703150313-0469fa2f85cf
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b
+	www.velocidex.com/golang/vfilter v0.0.0-20200421141923-435ca194b3c4
 	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -598,7 +598,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196 h1:3oYZ7hPN
 www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196/go.mod h1:i7M+d4Vxir8nmDACh+c6CsUU1r1Wcj00aRgNp8mXcPQ=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
-www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b h1:zfTlVEw7ZkQ9BRnF8sESTRhjoujqN4tA1VuB22yArfo=
-www.velocidex.com/golang/vfilter v0.0.0-20200420151951-97f879dc266b/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
+www.velocidex.com/golang/vfilter v0.0.0-20200421141923-435ca194b3c4 h1:TEtT/57iYXPZ6ne4o7URocZ8c3E1RQAm23yufn90iS0=
+www.velocidex.com/golang/vfilter v0.0.0-20200421141923-435ca194b3c4/go.mod h1:BEzARVqbdGAqh+R1lQHztwNPbfVIAUzLqU6dwYiT8+w=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/gui/static/angular-components/client/virtual-file-system/file-stats-view-directive.js
+++ b/gui/static/angular-components/client/virtual-file-system/file-stats-view-directive.js
@@ -59,7 +59,7 @@ FileStatsViewController.prototype.getAccessorAndPath = function(path) {
     var accessor = 'file';
     if (components.length > 0) {
         accessor = components[0];
-        path = components.slice(1).join("\\");
+        path = components.slice(1).join("/");
     }
 
     if (accessor == 'ntfs' && components.length > 1) {

--- a/reporting/gui.go
+++ b/reporting/gui.go
@@ -255,8 +255,9 @@ func (self *GuiTemplateEngine) Query(queries ...string) interface{} {
 		ctx, cancel := context.WithCancel(self.ctx)
 		defer cancel()
 
+		subscope := self.Scope.Copy().AppendVars(self.Env)
 		for _, vql := range multi_vql {
-			for row := range vql.Eval(ctx, self.Scope) {
+			for row := range vql.Eval(ctx, subscope) {
 				result = append(result, row)
 
 				// Do not let the query collect too many rows

--- a/vql/common/sampler.go
+++ b/vql/common/sampler.go
@@ -30,6 +30,10 @@ func (self _SamplerPlugin) Call(ctx context.Context,
 			return
 		}
 
+		if arg.N == 0 {
+			arg.N = 1
+		}
+
 		count := 0
 		for row := range arg.Query.Eval(ctx, scope) {
 			if count%int(arg.N) == 0 {


### PR DESCRIPTION
Fix crash in sample() plugin when no samples are provided.

VQL now supports backtick quotes to allow spaces in symbol names.