### PR TITLE
Add Windows.Timeline.MFT and test

### DIFF
--- a/artifacts/definitions/Windows/Timeline/MFT.yaml
+++ b/artifacts/definitions/Windows/Timeline/MFT.yaml
@@ -1,0 +1,212 @@
+name: Windows.Timeline.MFT
+description: |
+  # Output all filtered MFT records.
+
+  This Artifact enables querying the MFT with advanced filters 
+  such as time, path or other ntfs attributes.
+
+  Output is to Timeline field format to enable simple review accross Timeline
+  queries. The TimeOutput paramater enables configuring which NTFS attribute 
+  timestamps are in focus as event_time. for example: 
+    STANDARD_INFORMATION (4), FILE_NAME (4) or ALL (8)
+
+  This artifact also has the same anomaly logic as AnalyzeMFT added to 
+  each row to assist analysis.
+  
+author: Matt Green - @mgreen27
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: MFTFilename
+    default: "C:/$MFT"
+  - name: Accessor
+    default: ntfs
+  - name: PathRegex
+    description: "regex search over FullPath."
+    default: .
+  - name: NameRegex
+    default: .
+    description: "regex search over File Name"
+  - name: Inode
+    type: int64
+    description: "search for inode"
+  - name: DateAfter
+    type: timestamp
+    description: "search for events after this date. YYYY-MM-DDTmm:hh:ssZ"
+  - name: DateBefore
+    type: timestamp
+    description: "search for events before this date. YYYY-MM-DDTmm:hh:ssZ"
+  - name: SizeMax
+    type: int64
+    description: "Entries in the MFT over this size in bytes."
+  - name: SizeMin
+    type: int64
+    description: "Entries in the MFT under this size in bytes."
+  - name: EntryType
+    description: |
+        Type of entry. File, Directory or Both.
+    type: choices
+    default: Both
+    choices:
+       - File
+       - Directory
+       - Both
+  - name: AllocatedType
+    description: |
+        Type of entry. Allocated, Unallocated or Both.
+    type: choices
+    default: Both
+    choices:
+       - Allocated
+       - Unallocated
+       - Both
+  - name: TimeOutput
+    description: |
+        Timestamps to output as event_time. SI, FN or both. 
+        NOTE: both will output 8 rows per MFT entry.
+    type: choices
+    default: STANDARD_INFORMATION
+    choices:
+       - STANDARD_INFORMATION
+       - FILE_NAME
+       - ALL
+    
+sources:
+  - queries:
+        - LET hostname <= SELECT Fqdn FROM info()
+        - LET DateAfterTime <= if(condition=DateAfter, then=timestamp(epoch=DateAfter), else=timestamp(epoch="1600-01-01"))
+        - LET DateBeforeTime <= if(condition=DateBefore, then=timestamp(epoch=DateBefore), else=timestamp(epoch="2200-01-01")) 
+        - LET records = SELECT *,
+                if(condition=Created0x10.Unix < Created0x30.Unix, 
+                    then=True, else=False) as FNCreatedShift,
+                if(condition=Created0x10.Unix * 1000000000 = Created0x10.UnixNano, 
+                    then=True, else=False) as USecZero,
+                if(condition=Created0x10.Unix > LastModified0x10.Unix, 
+                    then=True, else=False) as PossibleCopy,
+                if(condition=LastAccess0x10.Unix > LastModified0x10.Unix AND LastAccess0x10.Unix > Created0x10.Unix, 
+                    then=True, else=False) as VolumeCopy
+            FROM parse_mft(filename=MFTFilename, accessor=Accessor)
+            WHERE 
+                FullPath =~ PathRegex AND 
+                FileName =~ NameRegex AND
+                if(condition=Inode, then= EntryNumber=atoi(string=Inode)
+                    OR ParentEntryNumber=atoi(string=Inode), 
+                    else=TRUE) AND                     
+                if(condition=SizeMax, then=FileSize < atoi(string=SizeMax),
+                    else=TRUE) AND 
+                if(condition=SizeMin, then=FileSize > atoi(string=SizeMin),
+                    else=TRUE) AND
+                if(condition= EntryType="Both", then=TRUE,
+                    else= if(condition= EntryType="File", 
+                        then= IsDir=False,
+                    else= if(condition= EntryType="Directory",
+                        then= IsDir=True))) AND
+                if(condition= AllocatedType="Both", then=TRUE,
+                    else= if(condition= AllocatedType="Allocated", 
+                        then= InUse=True,
+                    else= if(condition= AllocatedType="Unallocated",
+                        then= InUse=False))) AND
+                (((Created0x10 > DateAfterTime) AND (Created0x10 < DateBeforeTime)) OR
+                ((Created0x30 > DateAfterTime) AND (Created0x30 < DateBeforeTime)) OR
+                ((LastModified0x10 > DateAfterTime) AND (LastModified0x10 < DateBeforeTime)) OR
+                ((LastModified0x30 > DateAfterTime) AND (LastModified0x30 < DateBeforeTime)) OR
+                ((LastRecordChange0x10 > DateAfterTime) AND (LastRecordChange0x10 < DateBeforeTime)) OR
+                ((LastRecordChange0x30 > DateAfterTime) AND (LastRecordChange0x30 < DateBeforeTime)) OR
+                ((LastAccess0x10 > DateAfterTime) AND (LastAccess0x10 < DateBeforeTime)) OR
+                ((LastAccess0x30 > DateAfterTime) AND (LastAccess0x30 < DateBeforeTime)))
+
+        - LET common_fields = SELECT EntryNumber, ParentEntryNumber,
+                FullPath, FileName, FileSize, IsDir,InUse,
+                Created0x10, Created0x30, 
+                LastModified0x10, LastModified0x30,
+                LastRecordChange0x10, LastRecordChange0x30,
+                LastAccess0x10, LastAccess0x30,
+                FNCreatedShift, USecZero, PossibleCopy, VolumeCopy
+            FROM scope()
+
+        - LET standard_information_rows = SELECT * FROM chain(
+            si_modified = { 
+                SELECT *,
+                    LastModified0x10 as event_time,
+                    format(format="MFTEntry:%v $STANDARD_INFORMATION (0x10) LastModified time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            si_access = { 
+                SELECT *,
+                    LastAccess0x10 as event_time,
+                    format(format="MFTEntry:%v $STANDARD_INFORMATION (0x10) LastAccess time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            si_created = { 
+                SELECT *,
+                    LastRecordChange0x10 as event_time,
+                    format(format="MFTEntry:%v $STANDARD_INFORMATION (0x10) LastRecordChange time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            si_born = { 
+                SELECT *,
+                    Created0x10 as event_time,
+                    format(format="MFTEntry:%v $STANDARD_INFORMATION (0x10) Created time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            })
+        - LET file_name_rows = SELECT * FROM chain(
+            fn_modified = { 
+                SELECT *,
+                    LastModified0x30 as event_time,
+                    format(format="MFTEntry:%v $FILE_NAME (0x30) LastModified time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            fn_access = { 
+                SELECT *,
+                    LastAccess0x30 as event_time,
+                    format(format="MFTEntry:%v $FILE_NAME (0x30) LastAccess time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            fn_created = { 
+                SELECT *,
+                    LastRecordChange0x30 as event_time,
+                    format(format="MFTEntry:%v $FILE_NAME (0x30) LastRecordChange time", 
+                      args=EntryNumber) as message
+                FROM common_fields
+            },
+            fn_born = { 
+                SELECT *,
+                    Created0x30 as event_time,
+                      format(format="MFTEntry:%v $FILE_NAME (0x30) Created time", 
+                        args=EntryNumber) as message
+                FROM common_fields
+            })
+        - SELECT
+            event_time,
+            hostname.Fqdn[0] as hostname,
+            "MFT" as parser,
+            MFTFilename as source,
+            message,
+            FullPath as path,
+            { SELECT EntryNumber,ParentEntryNumber,FileSize, IsDir, InUse FROM scope() } as optional_1,
+            { SELECT FNCreatedShift, USecZero, PossibleCopy, VolumeCopy FROM scope() } as optional_2,
+            { SELECT LastModified0x10,LastAccess0x10,LastRecordChange0x10,Created0x10 FROM scope() } as optional_3,
+            { SELECT LastModified0x30,LastAccess0x30,LastRecordChange0x30,Created0x30 FROM scope() } as optional_4
+          FROM foreach(
+            row=records,
+            query={
+                SELECT * FROM chain(
+                    standard_information={
+                        SELECT * FROM if(
+                            condition=TimeOutput="STANDARD_INFORMATION" OR TimeOutput="ALL",
+                            then=standard_information_rows)
+                    },
+                    file_name={
+                        SELECT * FROM if(
+                            condition=TimeOutput="FILE_NAME" OR TimeOutput="ALL",
+                            then=file_name_rows)
+                    })
+            }) 
+            

--- a/artifacts/testdata/server/testcases/timeline.in.yaml
+++ b/artifacts/testdata/server/testcases/timeline.in.yaml
@@ -1,0 +1,59 @@
+Parameters:
+  ParseMFTMock: |
+    [
+     {
+      "EntryNumber": 64560,
+      "InUse": true,
+      "ParentEntryNumber": 95295,
+      "FullPath": "Users/yolo/Desktop/evil.txt",
+      "FileName": "evil.txt",
+      "FileSize": 1346,
+      "ReferenceCount": 1,
+      "IsDir": false,
+      "Created0x10s": 1485390072,
+      "Created0x30s": 1588167507,
+      "LastModified0x10s": 1485390072,
+      "LastModified0x30s": 1588167507,
+      "LastRecordChange0x10s": 1485390072,
+      "LastRecordChange0x30s": 1588167507,
+      "LastAccess0x10s": 1485390072,
+      "LastAccess0x30s": "2020-04-29T13:38:27.0905243Z"
+     },
+     {
+      "EntryNumber": 187444,
+      "InUse": true,
+      "ParentEntryNumber": 95309,
+      "FullPath": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+      "FileName": "evil.txt.lnk",
+      "FileSize": 524,
+      "ReferenceCount": 2,
+      "IsDir": false,
+      "Created0x10s": 1485390072,
+      "Created0x30s": 1485390072,
+      "LastModified0x10s": 1485390072,
+      "LastModified0x30s": 1485390072,
+      "LastRecordChange0x10s": 1485390072,
+      "LastRecordChange0x30s": 1485390072,
+      "LastAccess0x10s": 1485390072,
+      "LastAccess0x30s": 1485390072
+     }]
+
+Queries:
+  # Mock up test for Windows.Timeline.RMFT
+  #- SELECT * from Artifact.Windows.Timeline.MFT(CompressedOutput=FALSE,Inode=64560,TimeOutput='FILE_NAME')
+  #- SELECT * from Artifact.Windows.Timeline.MFT(CompressedOutput=TRUE,Inode=64560)
+  - LET my_mocks <= SELECT *, timestamp(epoch=Created0x10s) AS Created0x10,
+          timestamp(epoch=Created0x30s) AS Created0x30,
+          timestamp(epoch=LastModified0x10s) AS LastModified0x10,
+          timestamp(epoch=LastModified0x30s) AS LastModified0x30,
+          timestamp(epoch=LastRecordChange0x10s) AS LastRecordChange0x10,
+          timestamp(epoch=LastRecordChange0x30s) AS LastRecordChange0x30,
+          timestamp(epoch=LastAccess0x10s) AS LastAccess0x10,
+          timestamp(epoch=LastAccess0x30s) AS LastAccess0x30
+       FROM parse_json_array(data=ParseMFTMock)
+  - LET _ <= SELECT mock(plugin='info', results=[dict(Fqdn='DESKTOP-687T2NR', OS='windows')]),
+        mock(plugin="parse_mft", results=my_mocks)
+      FROM scope()
+  - SELECT * FROM Artifact.Windows.Timeline.MFT(Inode="64560")
+  - SELECT * FROM Artifact.Windows.Timeline.MFT(SizeMin="100",SizeMax="750")
+  - SELECT * FROM Artifact.Windows.Timeline.MFT(DateBefore="2020-01-01")

--- a/artifacts/testdata/server/testcases/timeline.out.yaml
+++ b/artifacts/testdata/server/testcases/timeline.out.yaml
@@ -1,0 +1,548 @@
+LET my_mocks <= SELECT *, timestamp(epoch=Created0x10s) AS Created0x10, timestamp(epoch=Created0x30s) AS Created0x30, timestamp(epoch=LastModified0x10s) AS LastModified0x10, timestamp(epoch=LastModified0x30s) AS LastModified0x30, timestamp(epoch=LastRecordChange0x10s) AS LastRecordChange0x10, timestamp(epoch=LastRecordChange0x30s) AS LastRecordChange0x30, timestamp(epoch=LastAccess0x10s) AS LastAccess0x10, timestamp(epoch=LastAccess0x30s) AS LastAccess0x30 FROM parse_json_array(data=ParseMFTMock)[]LET _ <= SELECT mock(plugin='info', results=[dict(Fqdn='DESKTOP-687T2NR', OS='windows')]), mock(plugin="parse_mft", results=my_mocks) FROM scope()[]SELECT * FROM Artifact.Windows.Timeline.MFT(Inode="64560")[
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastAccess time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) Created time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastRecordChange time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastModified time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ }
+]SELECT * FROM Artifact.Windows.Timeline.MFT(SizeMin="100",SizeMax="750")[
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastAccess time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) Created time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastRecordChange time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastModified time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ }
+]SELECT * FROM Artifact.Windows.Timeline.MFT(DateBefore="2020-01-01")[
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastAccess time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) Created time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastRecordChange time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:64560 $STANDARD_INFORMATION (0x10) LastModified time",
+  "path": "Users/yolo/Desktop/evil.txt",
+  "optional_1": {
+   "EntryNumber": 64560,
+   "ParentEntryNumber": 95295,
+   "FileSize": 1346,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": true,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2020-04-29T13:38:27Z",
+   "LastAccess0x30": "2020-04-29T13:38:27.0905243Z",
+   "LastRecordChange0x30": "2020-04-29T13:38:27Z",
+   "Created0x30": "2020-04-29T13:38:27Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastAccess time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) Created time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastRecordChange time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ },
+ {
+  "event_time": "2017-01-26T00:21:12Z",
+  "hostname": "DESKTOP-687T2NR",
+  "parser": "MFT",
+  "source": "C:/$MFT",
+  "message": "MFTEntry:187444 $STANDARD_INFORMATION (0x10) LastModified time",
+  "path": "Users/yolo/AppData/Roaming/Microsoft/Windows/Recent/evil.txt.lnk",
+  "optional_1": {
+   "EntryNumber": 187444,
+   "ParentEntryNumber": 95309,
+   "FileSize": 524,
+   "IsDir": false,
+   "InUse": true
+  },
+  "optional_2": {
+   "FNCreatedShift": false,
+   "USecZero": true,
+   "PossibleCopy": false,
+   "VolumeCopy": false
+  },
+  "optional_3": {
+   "LastModified0x10": "2017-01-26T00:21:12Z",
+   "LastAccess0x10": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x10": "2017-01-26T00:21:12Z",
+   "Created0x10": "2017-01-26T00:21:12Z"
+  },
+  "optional_4": {
+   "LastModified0x30": "2017-01-26T00:21:12Z",
+   "LastAccess0x30": "2017-01-26T00:21:12Z",
+   "LastRecordChange0x30": "2017-01-26T00:21:12Z",
+   "Created0x30": "2017-01-26T00:21:12Z"
+  },
+  "_Source": "Windows.Timeline.MFT"
+ }
+]


### PR DESCRIPTION
Add MFT timeline artefact.
Some performance tweaks.
Aligning to better field formatting.

  This Artifact enables querying the MFT with advanced filters 
  such as time, path or other ntfs attributes.

  Output is to Timeline field format to enable simple review accross Timeline
  queries. The TimeOutput paramater enables configuring which NTFS attribute 
  timestamps are in focus as event_time. for example: 
    STANDARD_INFORMATION (4), FILE_NAME (4) or ALL (8)

  This artifact also has the same anomaly logic as AnalyzeMFT added to 
  each row to assist analysis.