### PR TITLE
Decompose accessors into a factory.

### DIFF
--- a/api/notebooks.go
+++ b/api/notebooks.go
@@ -571,7 +571,6 @@ func (self *ApiServer) CancelNotebookCell(
 			"User is not allowed to edit notebooks.")
 	}
 
-	fmt.Printf("Cancelling %s !\n", in.CellId)
 	return &empty.Empty{}, services.NotifyListener(self.config, in.CellId)
 }
 

--- a/glob/accessor_darwin.go
+++ b/glob/accessor_darwin.go
@@ -115,9 +115,9 @@ func (u *OSFileInfo) UnmarshalJSON(data []byte) error {
 // Real implementation for non windows OSs:
 type OSFileSystemAccessor struct{}
 
-func (self OSFileSystemAccessor) New(scope *vfilter.Scope) FileSystemAccessor {
+func (self OSFileSystemAccessor) New(scope *vfilter.Scope) (FileSystemAccessor, nil) {
 	result := &OSFileSystemAccessor{}
-	return result
+	return result, nil
 }
 
 func (self OSFileSystemAccessor) Lstat(filename string) (FileInfo, error) {

--- a/glob/accessor_darwin.go
+++ b/glob/accessor_darwin.go
@@ -115,7 +115,7 @@ func (u *OSFileInfo) UnmarshalJSON(data []byte) error {
 // Real implementation for non windows OSs:
 type OSFileSystemAccessor struct{}
 
-func (self OSFileSystemAccessor) New(scope *vfilter.Scope) (FileSystemAccessor, nil) {
+func (self OSFileSystemAccessor) New(scope *vfilter.Scope) (FileSystemAccessor, error) {
 	result := &OSFileSystemAccessor{}
 	return result, nil
 }

--- a/glob/accessor_linux.go
+++ b/glob/accessor_linux.go
@@ -150,9 +150,8 @@ func (self *OSFileInfo) UnmarshalJSON(data []byte) error {
 // Real implementation for non windows OSs:
 type OSFileSystemAccessor struct{}
 
-func (self OSFileSystemAccessor) New(scope *vfilter.Scope) FileSystemAccessor {
-	result := &OSFileSystemAccessor{}
-	return result
+func (self OSFileSystemAccessor) New(scope *vfilter.Scope) (FileSystemAccessor, error) {
+	return &OSFileSystemAccessor{}, nil
 }
 
 func (self OSFileSystemAccessor) Lstat(filename string) (FileInfo, error) {

--- a/glob/data.go
+++ b/glob/data.go
@@ -31,8 +31,8 @@ import (
 
 type DataFilesystemAccessor struct{}
 
-func (self DataFilesystemAccessor) New(scope *vfilter.Scope) FileSystemAccessor {
-	return DataFilesystemAccessor{}
+func (self DataFilesystemAccessor) New(scope *vfilter.Scope) (FileSystemAccessor, error) {
+	return DataFilesystemAccessor{}, nil
 }
 
 func (self DataFilesystemAccessor) Lstat(filename string) (FileInfo, error) {

--- a/gui/static/angular-components/hunt/new-hunt-wizard/form-directive.js
+++ b/gui/static/angular-components/hunt/new-hunt-wizard/form-directive.js
@@ -60,7 +60,7 @@ FormController.prototype.onValueChange_ = function(page_index) {
     if (self.hunt_conditions.condition == "labels") {
         createHuntArgs.condition = {"labels": {"label": [self.hunt_conditions.label]}};
     } else if(self.hunt_conditions.condition == "os") {
-        createHuntArgs.condition = {"os": {"os": "OSX"}};
+        createHuntArgs.condition = {"os": {"os": self.hunt_conditions.os}};
     }
 
 };

--- a/vql/filesystem/me.go
+++ b/vql/filesystem/me.go
@@ -202,9 +202,12 @@ func (self MEFileSystemAccessor) PathJoin(root, stem string) string {
 	return path.Join(root, stem)
 }
 
-func (self MEFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
-	base := ZipFileSystemAccessor{}
-	return &MEFileSystemAccessor{base.New(scope).(*ZipFileSystemAccessor)}
+func (self MEFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
+	base, err := ZipFileSystemAccessor{}.New(scope)
+	if err != nil {
+		return nil, err
+	}
+	return &MEFileSystemAccessor{base.(*ZipFileSystemAccessor)}, nil
 }
 
 func init() {

--- a/vql/filesystem/raw_registry.go
+++ b/vql/filesystem/raw_registry.go
@@ -287,8 +287,8 @@ func (self *RawRegFileSystemAccessor) getRegHive(
 
 const RawRegFileSystemTag = "_RawReg"
 
-func (self *RawRegFileSystemAccessor) New(
-	scope *vfilter.Scope) glob.FileSystemAccessor {
+func (self *RawRegFileSystemAccessor) New(scope *vfilter.Scope) (
+	glob.FileSystemAccessor, error) {
 
 	result_any := vql_subsystem.CacheGet(scope, RawRegFileSystemTag)
 	if result_any == nil {
@@ -307,10 +307,10 @@ func (self *RawRegFileSystemAccessor) New(
 				v.fd.Close()
 			}
 		})
-		return result
+		return result, nil
 	}
 
-	return result_any.(glob.FileSystemAccessor)
+	return result_any.(glob.FileSystemAccessor), nil
 }
 
 func (self *RawRegFileSystemAccessor) ReadDir(key_path string) ([]glob.FileInfo, error) {

--- a/vql/filesystem/zip.go
+++ b/vql/filesystem/zip.go
@@ -417,7 +417,7 @@ const (
 	ZipFileSystemAccessorTag = "_ZipFS"
 )
 
-func (self ZipFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
+func (self ZipFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
 	result_any := vql_subsystem.CacheGet(scope, ZipFileSystemAccessorTag)
 	if result_any == nil {
 		// Create a new cache in the scope.
@@ -434,10 +434,10 @@ func (self ZipFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAcces
 				v.fd.Close()
 			}
 		})
-		return result
+		return result, nil
 	}
 
-	return result_any.(glob.FileSystemAccessor)
+	return result_any.(glob.FileSystemAccessor), nil
 }
 
 type SeekableZip struct {

--- a/vql/windows/filesystems/auto_windows.go
+++ b/vql/windows/filesystems/auto_windows.go
@@ -13,11 +13,21 @@ type AutoFilesystemAccessor struct {
 	file_delegate glob.FileSystemAccessor
 }
 
-func (self AutoFilesystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
-	return &AutoFilesystemAccessor{
-		ntfs_delegate: NTFSFileSystemAccessor{}.New(scope),
-		file_delegate: OSFileSystemAccessor{}.New(scope),
+func (self AutoFilesystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
+	ntfs_base, err := NTFSFileSystemAccessor{}.New(scope)
+	if err != nil {
+		return nil, err
 	}
+
+	os_base, err := OSFileSystemAccessor{}.New(scope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AutoFilesystemAccessor{
+		ntfs_delegate: ntfs_base,
+		file_delegate: os_base,
+	}, nil
 }
 
 func (self *AutoFilesystemAccessor) ReadDir(path string) ([]glob.FileInfo, error) {

--- a/vql/windows/filesystems/mft_windows.go
+++ b/vql/windows/filesystems/mft_windows.go
@@ -37,9 +37,12 @@ type MFTFileSystemAccessor struct {
 	*NTFSFileSystemAccessor
 }
 
-func (self MFTFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
-	ntfs_accessor := NTFSFileSystemAccessor{}.New(scope).(*NTFSFileSystemAccessor)
-	return &MFTFileSystemAccessor{ntfs_accessor}
+func (self MFTFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
+	ntfs_accessor, err := NTFSFileSystemAccessor{}.New(scope)
+	if err != nil {
+		return nil, err
+	}
+	return &MFTFileSystemAccessor{ntfs_accessor.(*NTFSFileSystemAccessor)}, nil
 }
 
 func (self MFTFileSystemAccessor) ReadDir(path string) ([]glob.FileInfo, error) {

--- a/vql/windows/filesystems/ntfs_lazy_windows.go
+++ b/vql/windows/filesystems/ntfs_lazy_windows.go
@@ -248,10 +248,12 @@ type LazyNTFSFileSystemAccessor struct {
 	*NTFSFileSystemAccessor
 }
 
-func (self LazyNTFSFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
-	return &LazyNTFSFileSystemAccessor{
-		NTFSFileSystemAccessor{}.New(scope).(*NTFSFileSystemAccessor),
+func (self LazyNTFSFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
+	base, err := NTFSFileSystemAccessor{}.New(scope)
+	if err != nil {
+		return nil, err
 	}
+	return &LazyNTFSFileSystemAccessor{base.(*NTFSFileSystemAccessor)}, nil
 }
 
 func (self *LazyNTFSFileSystemAccessor) ReadDir(path string) (res []glob.FileInfo, err error) {

--- a/vql/windows/filesystems/ntfs_windows.go
+++ b/vql/windows/filesystems/ntfs_windows.go
@@ -177,7 +177,7 @@ type NTFSFileSystemAccessor struct {
 	timestamp time.Time                   // Protected by mutex
 }
 
-func (self NTFSFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
+func (self NTFSFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
 	result_any := vql_subsystem.CacheGet(scope, NTFSFileSystemTag)
 	if result_any == nil {
 		// Create a new cache in the scope.
@@ -196,10 +196,10 @@ func (self NTFSFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAcce
 				v.fd.Close()
 			}
 		})
-		return result
+		return result, nil
 	}
 
-	return result_any.(glob.FileSystemAccessor)
+	return result_any.(glob.FileSystemAccessor), nil
 }
 
 func (self *NTFSFileSystemAccessor) getRootMFTEntry(ntfs_ctx *ntfs.NTFSContext) (

--- a/vql/windows/filesystems/os_windows.go
+++ b/vql/windows/filesystems/os_windows.go
@@ -169,9 +169,9 @@ type OSFileSystemAccessor struct {
 	follow_links bool
 }
 
-func (self OSFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
+func (self OSFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
 	result := &OSFileSystemAccessor{follow_links: self.follow_links}
-	return result
+	return result, nil
 }
 
 func discoverDriveLetters() ([]glob.FileInfo, error) {

--- a/vql/windows/filesystems/registry_windows.go
+++ b/vql/windows/filesystems/registry_windows.go
@@ -217,8 +217,8 @@ func NewValueBuffer(buf []byte, stat glob.FileInfo) *ValueBuffer {
 
 type RegFileSystemAccessor struct{}
 
-func (self *RegFileSystemAccessor) New(scope *vfilter.Scope) glob.FileSystemAccessor {
-	return self
+func (self *RegFileSystemAccessor) New(scope *vfilter.Scope) (glob.FileSystemAccessor, error) {
+	return self, nil
 }
 
 func (self RegFileSystemAccessor) ReadDir(path string) ([]glob.FileInfo, error) {


### PR DESCRIPTION
Delays initialization of full accessor while allowing registration. This mean we wont attempt to initiate connection to the data store until we needed it.