### PR TITLE
Fix WebDAV upload timeout

### DIFF
--- a/vql/tools/webdav_upload.go
+++ b/vql/tools/webdav_upload.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/Velocidex/ordereddict"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -102,8 +103,14 @@ func upload_webdav(ctx context.Context, scope *vfilter.Scope,
 	}
 	parsedUrl.Path = path.Join(parsedUrl.Path, name)
 
+	var netTransport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second, // TCP connect timeout
+		}).DialContext,
+		TLSHandshakeTimeout: 30 * time.Second,
+	}
 	client := &http.Client{
-		Timeout: time.Second * 30,
+		Transport: netTransport,
 	}
 
 	req, err := http.NewRequest(http.MethodPut, parsedUrl.String(), reader)


### PR DESCRIPTION
Turns out the `Timeout` field in `http.Client` cannot be used for uploads, because - especially for larger files - it will always time out waiting for a server response, which will not arrive until the upload has finished. Instead, we are adding TCP connect/TLS handshake timeouts.