### PR TITLE
Initialize services for query command.

### DIFF
--- a/bin/query.go
+++ b/bin/query.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sync"
 
 	"github.com/Velocidex/ordereddict"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -34,6 +35,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/grpc_client"
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/reporting"
+	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/uploads"
 	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -236,6 +238,17 @@ func doQuery() {
 		return
 	}
 
+	// Try to start essential services in case they are needed. It
+	// is not an error if we can not.
+	_ = services.StartJournalService(config_obj)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+
+	_ = services.StartNotificationService(ctx, wg, config_obj)
+
 	repository, err := artifacts.GetGlobalRepository(config_obj)
 	kingpin.FatalIfError(err, "Artifact GetGlobalRepository ")
 
@@ -273,7 +286,7 @@ func doQuery() {
 	// Install throttler into the scope.
 	vfilter.InstallThrottler(scope, vfilter.NewTimeThrottler(float64(*rate)))
 
-	ctx := InstallSignalHandler(scope)
+	ctx = InstallSignalHandler(scope)
 
 	if *trace_vql_flag {
 		scope.Tracer = log.New(os.Stderr, "VQL Trace: ", log.Lshortfile)

--- a/bin/query.go
+++ b/bin/query.go
@@ -238,14 +238,14 @@ func doQuery() {
 		return
 	}
 
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+
 	// Try to start essential services in case they are needed. It
 	// is not an error if we can not.
 	_ = services.StartJournalService(config_obj)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	wg := &sync.WaitGroup{}
-	defer wg.Wait()
 
 	_ = services.StartNotificationService(ctx, wg, config_obj)
 

--- a/config/loader.go
+++ b/config/loader.go
@@ -192,6 +192,10 @@ func (self *Loader) WithEmbedded() *Loader {
 }
 
 func (self *Loader) WithApiLoader(filename string) *Loader {
+	if filename == "" {
+		return self
+	}
+
 	self = self.Copy()
 	self.loaders = append(self.loaders, func() (*config_proto.Config, error) {
 		result, err := read_api_config_from_file(filename)

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -98,6 +98,10 @@ type DataStore interface {
 }
 
 func GetDB(config_obj *config_proto.Config) (DataStore, error) {
+	if config_obj.Datastore == nil {
+		return nil, errors.New("no datastore configured")
+	}
+
 	switch config_obj.Datastore.Implementation {
 	case "FileBaseDataStore":
 		return file_based_imp, nil

--- a/file_store/file_store.go
+++ b/file_store/file_store.go
@@ -32,6 +32,10 @@ import (
 // GetFileStore selects an appropriate FileStore object based on
 // config.
 func GetFileStore(config_obj *config_proto.Config) api.FileStore {
+	if config_obj.Datastore == nil {
+		return nil
+	}
+
 	switch config_obj.Datastore.Implementation {
 	case "Test":
 		return memory.Test_memory_file_store
@@ -55,6 +59,10 @@ func GetFileStore(config_obj *config_proto.Config) api.FileStore {
 // Gets an accessor that can access the file store.
 func GetFileStoreFileSystemAccessor(
 	config_obj *config_proto.Config) (glob.FileSystemAccessor, error) {
+	if config_obj.Datastore == nil {
+		return nil, errors.New("Datastore not configured")
+	}
+
 	switch config_obj.Datastore.Implementation {
 	case "MySQL":
 		datastore, err := mysql.NewSqlFileStore(config_obj)

--- a/file_store/queue.go
+++ b/file_store/queue.go
@@ -14,6 +14,10 @@ import (
 // GetQueueManager selects an appropriate QueueManager object based on
 // config.
 func GetQueueManager(config_obj *config_proto.Config) (api.QueueManager, error) {
+	if config_obj.Datastore == nil {
+		return nil, errors.New("Datastore not configured")
+	}
+
 	file_store := GetFileStore(config_obj)
 
 	switch config_obj.Datastore.Implementation {

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20200523222454-059865788121
+	golang.org/x/sys v0.0.0-20200610111108-226ff32320da
 	golang.org/x/tools v0.0.0-20200207131002-533eb2654509 // indirect
 	google.golang.org/api v0.11.0
 	google.golang.org/appengine v1.6.5 // indirect
@@ -108,7 +108,7 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb
-	www.velocidex.com/golang/evtx v0.0.2-0.20200505002428-02e98e3e472b
+	www.velocidex.com/golang/evtx v0.0.2-0.20200610130036-cc23ac7defb8
 	www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321
 	www.velocidex.com/golang/go-ntfs v0.0.0-20200530234845-9c557c0b9eec
 	www.velocidex.com/golang/go-pe v0.1.1-0.20191103232346-ac12e8190bb6

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200610111108-226ff32320da h1:bGb80FudwxpeucJUjPYJXuJ8Hk91vNtfvrymzwiei38=
+golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -556,6 +558,8 @@ www.velocidex.com/golang/binparsergen v0.1.0 h1:oNsMHGnlb4jrGwxKxqqmsics6FgYin3H
 www.velocidex.com/golang/binparsergen v0.1.0/go.mod h1:UC43Ecj0mjsidlClTYZ3H4dXdyv7CVI0HsYi4yY3qtc=
 www.velocidex.com/golang/evtx v0.0.2-0.20200505002428-02e98e3e472b h1:WCN8TCDUdt6oimdAkmRL0JxW6776jGUxF1sxFaoiYvk=
 www.velocidex.com/golang/evtx v0.0.2-0.20200505002428-02e98e3e472b/go.mod h1:+u26IeGeVIwL9j5V0I/UafWFaMV61pQNwXZK/VQksLQ=
+www.velocidex.com/golang/evtx v0.0.2-0.20200610130036-cc23ac7defb8 h1:usWUlYjmerbeKK4FDs3UlrejoRVXEEDQFgMyV0jsRz8=
+www.velocidex.com/golang/evtx v0.0.2-0.20200610130036-cc23ac7defb8/go.mod h1:+u26IeGeVIwL9j5V0I/UafWFaMV61pQNwXZK/VQksLQ=
 www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321 h1:0FELGb4G9dT2y6rrBL2B5nbEw2foiPXtEO7jHppQGe0=
 www.velocidex.com/golang/go-ese v0.0.0-20200111070159-4b7484475321/go.mod h1:d3PHzQhyhe+AO9RYBnDKZ40As15T+38zr++Dnv4ufuc=
 www.velocidex.com/golang/go-ntfs v0.0.0-20200530234845-9c557c0b9eec h1:nI9RVeWl++octztqHgd5M6Nwa/0//eXFC0b20bXY09M=

--- a/services/journal.go
+++ b/services/journal.go
@@ -36,6 +36,12 @@ type JournalService struct {
 
 func (self *JournalService) Watch(queue_name string) (
 	output <-chan *ordereddict.Dict, cancel func()) {
+
+	if self == nil || self.qm == nil {
+		// Readers block on nil channel.
+		return nil, func() {}
+	}
+
 	return self.qm.Watch(queue_name)
 }
 

--- a/services/notfications.go
+++ b/services/notfications.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/Velocidex/ordereddict"
+	"github.com/pkg/errors"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/notifications"
@@ -41,6 +42,10 @@ func StartNotificationService(
 	config_obj *config_proto.Config) error {
 	pool_mu.Lock()
 	defer pool_mu.Unlock()
+
+	if config_obj.Datastore == nil {
+		return errors.New("Filestore not configured")
+	}
 
 	if notification_pool != nil {
 		notification_pool.Shutdown()


### PR DESCRIPTION
CLI `query` command is sometimes used to run server side VQL and this requires
services to be running. Otherwise a panic occurs when server side VQL
tries to access the filestore.