### PR TITLE
Anti virus hunting

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/Symantec.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Symantec.yaml
@@ -49,5 +49,7 @@ sources:
             EventTime > DateAfterTime AND
             format(format="%v",args=System.EventID.Value) =~ RegexEventIds AND
             EventData =~ TargetRegex AND
-            EventData =~ IgnoreRegex
+            if(condition=IgnoreRegex, 
+                then= NOT EventData=~IgnoreRegex, 
+                else= True)
                     

--- a/artifacts/definitions/Windows/EventLogs/Symantec.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Symantec.yaml
@@ -1,0 +1,53 @@
+name: Windows.EventLogs.Symantec
+description: |
+  Query the Semantec Endpoint Protection Event Logs. The default artifact will 
+  return EventId 51 and high value strings with goals bubble up some events for 
+  triage.
+  
+  Note:  
+  EventID selection is controlled by regex to allow multiple EID selections.  
+  If running a hunt, consider also hunting EventId 45 - Tamper Protection 
+  Detection (this will be noisy so whitelist is required).  
+  IgnoreRegex allows filtering out events relevant to the target environment.  
+  
+reference: 
+    - https://www.nextron-systems.com/wp-content/uploads/2019/10/Antivirus_Event_Analysis_CheatSheet_1.7.2.pdf
+  
+author: Matt Green - @mgreen27
+
+parameters:
+  - name: SymantecEventLog
+    default: C:\Windows\system32\winevt\logs\Symantec Endpoint Protection Client.evtx
+  - name: RegexEventIds
+    description: "Regex of Event IDs to hunt for. Consider EID 45 for Tamper Protection Detection"
+    default: ^51$
+  - name: TargetRegex
+    description: "Regex to hunt for - default is high value SEP detections"
+    default: "Infostealer|Hacktool|Mimi|SecurityRisk|WinCredEd|NetCat|Backdoor|Pwdump|SuperScan|XScan|PasswordRevealer|Trojan|Malscript|Agent|Malware|Exploit|webshell|cobalt|Mpreter|sploit|Meterpreter|RAR|7z|encrypted|tsclient|PerfLogs" 
+  - name: IgnoreRegex
+    description: "Regex to ignore events with EventData strings matching."
+  - name: DateAfter
+    type: timestamp
+    description: "search for events after this date. YYYY-MM-DDTmm:hh:ssZ"
+  - name: DateBefore
+    type: timestamp
+    description: "search for events before this date. YYYY-MM-DDTmm:hh:ssZ"
+    
+sources:
+    - queries:
+      - LET DateAfterTime <= if(condition=DateAfter, 
+            then=timestamp(epoch=DateAfter), else=timestamp(epoch="1600-01-01"))
+      - LET DateBeforeTime <= if(condition=DateBefore, 
+            then=timestamp(epoch=DateBefore), else=timestamp(epoch="2200-01-01"))
+      - SELECT timestamp(epoch=System.TimeCreated.SystemTime) As EventTime,
+              System.EventID.Value as EventId,
+              System.Computer as Computer,
+              EventData.Data[0] as EventData
+        FROM parse_evtx(filename=SymantecEventLog)
+        WHERE
+            EventTime < DateBeforeTime AND
+            EventTime > DateAfterTime AND
+            format(format="%v",args=System.EventID.Value) =~ RegexEventIds AND
+            EventData =~ TargetRegex AND
+            EventData =~ IgnoreRegex
+                    

--- a/artifacts/definitions/Windows/EventLogs/Symantec.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Symantec.yaml
@@ -1,6 +1,6 @@
 name: Windows.EventLogs.Symantec
 description: |
-  Query the Semantec Endpoint Protection Event Logs. The default artifact will 
+  Query the Symantec Endpoint Protection Event Logs. The default artifact will 
   return EventId 51 and high value strings with goals bubble up some events for 
   triage.
   


### PR DESCRIPTION
name: Windows.EventLogs.Symantec
description: |
  Query the Symantec Endpoint Protection Event Logs. The default artifact will 
  return EventId 51 and high value strings with goals bubble up some events for 
  triage.
  
  Note:  
  EventID selection is controlled by regex to allow multiple EID selections.  
  If running a hunt, consider also hunting EventId 45 - Tamper Protection 
  Detection (this will be noisy so whitelist is required).  
  IgnoreRegex allows filtering out events relevant to the target environment.  
  
reference: 
    - https://www.nextron-systems.com/wp-content/uploads/2019/10/Antivirus_Event_Analysis_CheatSheet_1.7.2.pdf