### PR TITLE
Upload windows binary again to appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,5 +59,5 @@ test_script:
 on_finish:
   - ps: Get-ChildItem artifacts/testdata/windows/*.out.yaml | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem artifacts/testdata/server/testcases/*.out.yaml | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-#  - ps: Get-ChildItem output/velociraptor.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem output/velociraptor.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 #  - ps: Get-ChildItem output/velociraptor-linux.elf | % { Push-AppveyorArtifact $_.FullName -FileName "velociraptor-linux.elf" }


### PR DESCRIPTION
Appveyor does not require auth which make it easier to use.