### PR TITLE
Remove newline from Autoruns param default.

### DIFF
--- a/artifacts/definitions/Windows/Sysinternals/Autoruns.yaml
+++ b/artifacts/definitions/Windows/Sysinternals/Autoruns.yaml
@@ -16,8 +16,7 @@ parameters:
   - name: AutorunArgs
     description: |
       A space separated list of args to run with.
-    default: |
-      -nobanner -accepteula -t -a * -c *
+    default: '-nobanner -accepteula -t -a * -c *'
   - name: ToolInfo
     description: Override Tool information.
 


### PR DESCRIPTION
A small change to the `Windows.Sysinternals.Autoruns` artifact definition to address #470, as requested by @scudette.

Ran a full test build and this removes the trailing newline in the UI and shows all Autoruns results by default, as intended.  Thanks again!