### PR TITLE
Switch plugin should evaluate by definition order.

### DIFF
--- a/artifacts/testdata/server/testcases/common.in.yaml
+++ b/artifacts/testdata/server/testcases/common.in.yaml
@@ -1,3 +1,12 @@
 Queries:
   - SELECT * FROM items(item=[1,2])
   - SELECT * FROM items(item=dict(X=1, Y=2))
+
+  # Check that switch() evaluates clauses by definition order
+  - SELECT * FROM switch(
+      zcase={
+          SELECT "First" FROM scope()
+      },
+      acase={
+          SELECT "Second" FROM scope()
+      })

--- a/artifacts/testdata/server/testcases/common.out.yaml
+++ b/artifacts/testdata/server/testcases/common.out.yaml
@@ -16,4 +16,8 @@ SELECT * FROM items(item=[1,2])[
   "_key": "Y",
   "_value": 2
  }
+]SELECT * FROM switch( zcase={ SELECT "First" FROM scope() }, acase={ SELECT "Second" FROM scope() })[
+ {
+  "\"First\"": "First"
+ }
 ]

--- a/vql/common/switch.go
+++ b/vql/common/switch.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"sort"
 
 	"github.com/Velocidex/ordereddict"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
@@ -21,7 +20,6 @@ func (self _SwitchPlugin) Call(ctx context.Context,
 
 		queries := []vfilter.StoredQuery{}
 		members := scope.GetMembers(args)
-		sort.Strings(members)
 
 		for _, member := range members {
 			member_obj, _ := args.Get(member)


### PR DESCRIPTION
Previously it evaluated by lexical order which is non-intuitive.