### PR TITLE
Fixed bug in lazy ntfs.

### DIFF
--- a/artifacts/artifacts.go
+++ b/artifacts/artifacts.go
@@ -89,11 +89,11 @@ func (self *Repository) LoadDirectory(dirname string) (*int, error) {
 				strings.HasSuffix(info.Name(), ".yml")) {
 				data, err := ioutil.ReadFile(file_path)
 				if err != nil {
-					return errors.WithStack(err)
+					return errors.Wrap(err, "While reading "+info.Name())
 				}
 				_, err = self.LoadYaml(string(data), false)
 				if err != nil {
-					return err
+					return errors.Wrap(err, "While reading "+info.Name())
 				}
 
 				count += 1

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -211,7 +211,7 @@ sources:
 
       LET definitions <= SELECT * FROM chain(
       a = { SELECT name, description, parameters, sources, reports
-            FROM artifact_definitions(names=Artifacts)
+            FROM artifact_definitions(names=Artifacts + template)
             WHERE name =~ "^(Custom|Packs)\\." AND
               log(message="Adding artifact_definition for " + name) },
 

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -62,7 +62,7 @@ parameters:
       LET filename <= regex_replace(
           source=format(format="Collection-%s-%s",
                         args=[baseline[0].Fqdn, timestamp(epoch=now())]),
-          re="[^0-9A-Za-z\\-. ]", replace="_")
+          re="[^0-9A-Za-z\\-.]", replace="_")
 
       LET _ <= log(message="Will collect package " + filename)
 
@@ -81,7 +81,7 @@ parameters:
       LET filename <= regex_replace(
           source=format(format="Collection-%s-%s",
                         args=[baseline[0].Fqdn, timestamp(epoch=now())]),
-          re="[^0-9A-Za-z\\-. ]", replace="_")
+          re="[^0-9A-Za-z\\-.]", replace="_")
 
       LET _ <= log(message="Will collect package " + filename +
          " and upload to s3 bucket " + TargetArgs.bucket)
@@ -114,7 +114,7 @@ parameters:
       LET filename <= regex_replace(
           source=format(format="Collection-%s-%s",
                         args=[baseline[0].Fqdn, timestamp(epoch=now())]),
-          re="[^0-9A-Za-z\\-. ]", replace="_")
+          re="[^0-9A-Za-z\\-.]", replace="_")
 
       LET _ <= log(message="Will collect package " + filename +
          " and upload to GCS bucket " + TargetArgs.bucket)

--- a/artifacts/definitions/Windows/KapeFiles/Targets.yaml
+++ b/artifacts/definitions/Windows/KapeFiles/Targets.yaml
@@ -1025,6 +1025,9 @@ parameters:
     type: bool
     default:
     description: If set we run the collection across all VSS and collect only unique changes.
+  - name: DontBeLazy
+    description: Normally we prefer to use lazy_ntfs for speed. Sometimes this might miss stuff so setting this will fallback to the regular ntfs accessor.
+    type: bool
 
 sources:
   - name: All File Metadata
@@ -1057,7 +1060,8 @@ sources:
                       collectionSpec=serialize(item=rule_specs_ntfs, format="csv"))
                }, b={
                    SELECT * FROM Artifact.Windows.Collectors.VSS(
-                      RootDevice=Device, Accessor="lazy_ntfs",
+                      RootDevice=Device, Accessor=if(condition=DontBeLazy,
+                                                     then="ntfs", else="lazy_ntfs"),
                       collectionSpec=serialize(item=rule_specs_lazy_ntfs, format="csv"))
                })
            }, else={
@@ -1068,7 +1072,8 @@ sources:
                       collectionSpec=serialize(item=rule_specs_ntfs, format="csv"))
                }, b={
                    SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device, Accessor="lazy_ntfs",
+                      RootDevice=Device, Accessor=if(condition=DontBeLazy,
+                                                     then="ntfs", else="lazy_ntfs"),
                       collectionSpec=serialize(item=rule_specs_lazy_ntfs, format="csv"))
                })
            })

--- a/artifacts/testdata/server/testcases/fifo.in.yaml
+++ b/artifacts/testdata/server/testcases/fifo.in.yaml
@@ -1,0 +1,10 @@
+Parameters:
+  test_1: |
+    [{"A":1},{"A":2},{"A":3}]
+
+Queries:
+  - LET _ <= SELECT mock(plugin='test_plugin', results=parse_json_array(data=test_1))
+     FROM scope()
+  - LET rows = SELECT * FROM test_plugin()
+  - LET _ <= SELECT * FROM fifo(query=rows, max_rows=1)
+  - SELECT * FROM fifo(query=rows, max_rows=1)

--- a/artifacts/testdata/server/testcases/fifo.out.yaml
+++ b/artifacts/testdata/server/testcases/fifo.out.yaml
@@ -1,0 +1,5 @@
+LET _ <= SELECT mock(plugin='test_plugin', results=parse_json_array(data=test_1)) FROM scope()[]LET rows = SELECT * FROM test_plugin()[]LET _ <= SELECT * FROM fifo(query=rows, max_rows=1)[]SELECT * FROM fifo(query=rows, max_rows=1)[
+ {
+  "A": 3
+ }
+]

--- a/artifacts/testdata/windows/ntfs.in.yaml
+++ b/artifacts/testdata/windows/ntfs.in.yaml
@@ -11,6 +11,11 @@ Queries:
   - SELECT FullPath FROM glob(globs="c:\\*", accessor="ntfs")
     WHERE Name =~ "txt"
 
+    # Make sure lazy_ntfs can see the $LogFile
+  - SELECT FullPath FROM glob(globs="C:/$LogFile", accessor="lazy_ntfs")
+  - SELECT FullPath FROM glob(globs="C:/$LogFile", accessor="ntfs")
+
+    # Check lazy_ntfs produces drives for root.
   - SELECT FullPath FROM glob(globs="/*", accessor="lazy_ntfs")
   - SELECT FullPath FROM glob(globs="\\*", accessor="lazy_ntfs")
   - SELECT FullPath FROM glob(globs="\\\\.\\c:\\*", accessor="lazy_ntfs")

--- a/artifacts/testdata/windows/ntfs.out.yaml
+++ b/artifacts/testdata/windows/ntfs.out.yaml
@@ -43,6 +43,14 @@ SELECT FullPath FROM glob(globs="/*", accessor="ntfs")[
  {
   "FullPath": "\\\\.\\c:\\hello.txt:myads"
  }
+]SELECT FullPath FROM glob(globs="C:/$LogFile", accessor="lazy_ntfs")[
+ {
+  "FullPath": "\\\\.\\C:\\$LogFile"
+ }
+]SELECT FullPath FROM glob(globs="C:/$LogFile", accessor="ntfs")[
+ {
+  "FullPath": "\\\\.\\C:\\$LogFile"
+ }
 ]SELECT FullPath FROM glob(globs="/*", accessor="lazy_ntfs")[
  {
   "FullPath": "\\\\.\\C:"

--- a/scripts/kape_files.py
+++ b/scripts/kape_files.py
@@ -163,6 +163,9 @@ parameters:
     type: bool
     default:
     description: If set we run the collection across all VSS and collect only unique changes.
+  - name: DontBeLazy
+    description: Normally we prefer to use lazy_ntfs for speed. Sometimes this might miss stuff so setting this will fallback to the regular ntfs accessor.
+    type: bool
 
 sources:
   - name: All File Metadata
@@ -195,7 +198,8 @@ sources:
                       collectionSpec=serialize(item=rule_specs_ntfs, format="csv"))
                }, b={
                    SELECT * FROM Artifact.Windows.Collectors.VSS(
-                      RootDevice=Device, Accessor="lazy_ntfs",
+                      RootDevice=Device, Accessor=if(condition=DontBeLazy,
+                                                     then="ntfs", else="lazy_ntfs"),
                       collectionSpec=serialize(item=rule_specs_lazy_ntfs, format="csv"))
                })
            }, else={
@@ -206,7 +210,8 @@ sources:
                       collectionSpec=serialize(item=rule_specs_ntfs, format="csv"))
                }, b={
                    SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device, Accessor="lazy_ntfs",
+                      RootDevice=Device, Accessor=if(condition=DontBeLazy,
+                                                     then="ntfs", else="lazy_ntfs"),
                       collectionSpec=serialize(item=rule_specs_lazy_ntfs, format="csv"))
                })
            })

--- a/vql/windows/filesystems/ntfs_lazy_windows.go
+++ b/vql/windows/filesystems/ntfs_lazy_windows.go
@@ -39,6 +39,7 @@ import (
 
 func ExtractI30List(accessor_ctx *AccessorContext,
 	mft_entry *ntfs.MFT_ENTRY, path string) []glob.FileInfo {
+
 	result := []glob.FileInfo{}
 	ntfs_ctx := accessor_ctx.ntfs_ctx
 
@@ -50,10 +51,6 @@ func ExtractI30List(accessor_ctx *AccessorContext,
 	} else {
 		lru_map = make(map[string]*cacheMFT)
 		for _, record := range mft_entry.Dir(ntfs_ctx) {
-			if !record.IsValid() {
-				continue
-			}
-
 			filename := record.File()
 			name_type := filename.NameType().Name
 			if name_type == "DOS" {
@@ -123,25 +120,19 @@ func (self *LazyNTFSFileInfo) ensureCachedInfo() {
 }
 
 func (self *LazyNTFSFileInfo) IsDir() bool {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 	return self.cached_info.IsDir
 
 	return true
 }
 
 func (self *LazyNTFSFileInfo) Size() int64 {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 	return self.cached_info.Size
 }
 
 func (self *LazyNTFSFileInfo) Data() interface{} {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 
 	result := ordereddict.NewDict().
 		Set("mft", self.cached_info.MFTId).
@@ -170,9 +161,7 @@ func (self *LazyNTFSFileInfo) Mode() os.FileMode {
 }
 
 func (self *LazyNTFSFileInfo) ModTime() time.Time {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 	return self.cached_info.Mtime
 }
 
@@ -181,9 +170,7 @@ func (self *LazyNTFSFileInfo) FullPath() string {
 }
 
 func (self *LazyNTFSFileInfo) Mtime() utils.TimeVal {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 
 	return utils.TimeVal{
 		Sec: self.cached_info.Mtime.Unix(),
@@ -191,9 +178,7 @@ func (self *LazyNTFSFileInfo) Mtime() utils.TimeVal {
 }
 
 func (self *LazyNTFSFileInfo) Ctime() utils.TimeVal {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 
 	return utils.TimeVal{
 		Sec: self.cached_info.Ctime.Unix(),
@@ -201,9 +186,7 @@ func (self *LazyNTFSFileInfo) Ctime() utils.TimeVal {
 }
 
 func (self *LazyNTFSFileInfo) Atime() utils.TimeVal {
-	if self.cached_info == nil {
-		self.ensureCachedInfo()
-	}
+	self.ensureCachedInfo()
 
 	return utils.TimeVal{
 		Sec: self.cached_info.Atime.Unix(),
@@ -301,7 +284,8 @@ func (self *LazyNTFSFileSystemAccessor) ReadDir(path string) (res []glob.FileInf
 		return nil, err
 	}
 
-	return ExtractI30List(accessor_ctx, dir, path), nil
+	result = ExtractI30List(accessor_ctx, dir, path)
+	return result, nil
 }
 
 func (self *LazyNTFSFileSystemAccessor) Open(path string) (res glob.ReadSeekCloser, err error) {

--- a/vql/windows/filesystems/ntfs_windows.go
+++ b/vql/windows/filesystems/ntfs_windows.go
@@ -544,10 +544,12 @@ func (self *NTFSFileSystemAccessor) Lstat(path string) (res glob.FileInfo, err e
 	for _, info := range ntfs.ListDir(ntfs_ctx, dir) {
 		if strings.ToLower(info.Name) == strings.ToLower(
 			components[len(components)-1]) {
-			return &NTFSFileInfo{
+			res := &NTFSFileInfo{
 				info:       info,
 				_full_path: device + dirname + "\\" + info.Name,
-			}, nil
+			}
+			return res, nil
+
 		}
 	}
 


### PR DESCRIPTION
The lazy_ntfs accessor is faster because it only looks at $I30
records.  The lazy_ntfs accessor was calling record.IsValid() to make
sure the records are valid. However in practice $I30 records are not
always fully populated in particular $LogFile has wrong timestamps.

This change does not force this check any more.