### PR TITLE
Add Windows.Remediation.Quarantine

### DIFF
--- a/artifacts/definitions/Windows/Remediation/Quarantine.yaml
+++ b/artifacts/definitions/Windows/Remediation/Quarantine.yaml
@@ -2,8 +2,8 @@ name: Windows.Remediation.Quarantine
 description: |
       **Apply quarantine via Windows local IPSec policy**  
       
-      - By default the current configured frontend configuration is applied 
-      as an exclusion using resolved IP address at time of application. 
+      - By default the current client configuration is applied as an exclusion 
+      using resolved IP address at time of application. 
       - A configurable lookup table is also used to generate additional entries 
       using the same syntax as netsh ipsec configuration.  
         - DNS and DHCP are 
@@ -54,22 +54,24 @@ parameters:
 sources:
     - queries:
       # If a MessageBox configured truncate to 256 character limit
-      - LET MessageBox <= if(condition=MessageBox,
-                then=parse_string_with_regex(
-                    string=MessageBox,
-                    regex=['^(?P<Message>.{0,255}).*']
-                ).Message)
+      - LET MessageBox <=  parse_string_with_regex(
+                regex='^(?P<Message>.{0,255}).*', 
+                string=MessageBox).Message
                 
       # extract configurable policy from lookuptable
       - LET configurable_policy <= SELECT 
-                Action,
+                if(condition= lowcase(string=Action)= 'permit',
+                    then= 'Permit',
+                    else= if(condition= lowcase(string=Action)= 'block',
+                        then= 'Block')
+                    ) AS Action,
                 SrcAddr,
                 format(format='%v',args=SrcMask) AS SrcMask,
                 format(format='%v',args=SrcPort) AS SrcPort,
                 DstAddr,
                 format(format='%v',args=DstMask) AS DstMask,
                 format(format='%v',args=DstPort) AS DstPort,
-                Protocol,
+                format(format='%v',args=Protocol) AS Protocol,
                 Mirrored,
                 Description
             FROM parse_csv(filename=RuleLookupTable, accessor='data') 
@@ -83,39 +85,48 @@ sources:
                         'me' AS SrcAddr,
                         '' As SrcMask,
                         '0' AS SrcPort,
-                        split(
-                            string=regex_replace(
-                                source=_value,
-                                re='^https://(.+)/',
-                                replace='$1'),
-                            sep=':'
-                                )[0] as DstAddr,
-                                '' As DstMask,
-                        if(condition=split(string=regex_replace(
-                                    source=_value,
-                                    re='^https://(.+)/',
-                                    replace='$1'),
-                                sep=':')[1], 
-                            then= split(string=regex_replace(
-                                    source=_value,
-                                    re='^https://(.+)/',
-                                    replace='$1'),sep=':')[1],
-                            else='443') as DstPort,
+                        parse_string_with_regex(
+                            string=_value,
+                            regex='^https?://(?P<Domain>[^:/]+)'
+                                ).Domain AS DstAddr,
+                        '' As DstMask,
+                        parse_string_with_regex(
+                                string=_value,
+                                regex='^https?://[^:/]+(:(?P<Port>[0-9]*))?/'
+                                    ).Port AS DstPort,
                         'tcp' AS Protocol,
                         'yes' AS Mirrored,
-                        'VelociraptorFrontEnd' AS Description
+                        'VelociraptorFrontEnd' AS Description,
+                        _value
                     FROM scope()
                 })
                 
       # build policy with extracted config and lookuptable
-      - LET policy <= SELECT *,   
-                if(condition= Action='Permit',
-                    then= PolicyName + '_PermitFilterList',
-                    else= PolicyName + '_BlockFilterList') AS FilterList
+      - LET policy <= SELECT *
             FROM chain(
-                a=extracted_config,
+                a={
+                    SELECT
+                        Action,
+                        SrcAddr,
+                        SrcMask,
+                        SrcPort,
+                        DstAddr,
+                        DstMask,
+                        if(condition=DstPort,
+                            then= DstPort,
+                            else= if(condition= _value=~'^https:',
+                                then='443',
+                                else= if(condition= _value=~'^http:',
+                                    then='80'))
+                                ) AS DstPort,
+                        Protocol,
+                        Mirrored,
+                        Description
+                    FROM extracted_config
+                },
                 b=configurable_policy
             )
+            WHERE Action =~ 'Permit|Block'
       
       # build netsh ipsec policy commandlines by switchcase
       - LET cmdline = SELECT 
@@ -140,23 +151,22 @@ sources:
                 action={
                     SELECT 
                         ('netsh','ipsec','static','add','filteraction',
-                            'name=' + PolicyName + '_' + Action + 'Action',
+                            'name=' + PolicyName + ' ' + Action + 'Action',
                             'action=' + Action
                                 ) AS CMD
                     FROM scope()
-                    WHERE FilterAction AND Action =~ 'Permit|Block'
+                    WHERE CreateFilterAction
                 },
                 rule={
                     SELECT 
                         ('netsh','ipsec','static','add','rule',
-                            'name=' + PolicyName + '_' + Action,
+                            'name=' + PolicyName + ' ' + Action + 'Rule',
                             'policy=' + PolicyName,
-                            'filterlist=' + PolicyName + '_' + Action + 'FilterList',
-                            'filteraction=' + PolicyName + '_' + Action + 'Action'
+                            'filterlist=' + PolicyName + ' ' + Action + 'FilterList',
+                            'filteraction=' + PolicyName + ' ' + Action + 'Action',
                                 ) AS CMD
                     FROM scope()
-                    WHERE 
-                        Rule AND Action =~ 'Permit|Block'
+                    WHERE CreateRule
                 },
                 enable={
                     SELECT 
@@ -170,7 +180,7 @@ sources:
                 policy= {
                     SELECT
                         ('netsh','ipsec','static','add','filter',
-                            'filterlist=' + FilterList,
+                            'filterlist=' + PolicyName + ' ' + Action + 'FilterList',
                             'srcaddr=' + SrcAddr,
                             'srcmask=' + SrcMask,
                             'srcport=' + SrcPort,
@@ -183,7 +193,7 @@ sources:
                                 ) AS CMD
                     FROM scope() 
                     WHERE 
-                        SrcAddr AND DstAddr              
+                        CreateFilters AND SrcAddr AND DstAddr     
                 })
             
       # delete old or unwanted policy 
@@ -195,7 +205,7 @@ sources:
                         PolicyName + ' IPSec policy removed.' AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
-                    GROUP BY Stdout
+                    GROUP BY Result
                 })
       
       # first step is creating IPSec policy
@@ -213,11 +223,16 @@ sources:
                             ))) AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Result
                 })
                 
       # second step is to create policy filters
       - LET create_filters = SELECT * FROM foreach(
-                row=policy,
+                row={ 
+                    SELECT *, 
+                        'TRUE' AS CreateFilters 
+                    FROM policy
+                },
                 query={
                     SELECT 
                         timestamp(epoch=now()) as Time,
@@ -232,17 +247,17 @@ sources:
                             ))) AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
-                    GROUP BY Results
+                    GROUP BY Result
                 })
       
-      # third step is to create policy actions
+      # third step is to create policy filter actions
       - LET create_actions = SELECT * FROM foreach(
                 row= { 
                     SELECT 
-                        Action, 
-                        'TRUE' as FilterAction 
+                        Action,
+                        'TRUE' AS CreateFilterAction 
                     FROM policy 
-                    GROUP BY Action 
+                    GROUP BY Action
                 },
                 query={
                     SELECT 
@@ -258,16 +273,17 @@ sources:
                             ))) AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Result
                 })
     
       # fourth step combines action lists and actions in a Rule
       - LET create_rules = SELECT * FROM foreach(
                 row= { 
                     SELECT 
-                        Action, 
-                        'TRUE' AS Rule 
+                        Action,
+                        'TRUE' AS CreateRule  
                     FROM policy 
-                    GROUP BY Action 
+                    GROUP BY Action
                 },
                 query={
                     SELECT 
@@ -283,6 +299,7 @@ sources:
                             ))) AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Result
                 })
       
       # fith step is to enable our IPSec policy
@@ -300,6 +317,7 @@ sources:
                             ))) AS Result
                     FROM 
                         execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Result
                 })
       
       # test connection to a frontend server
@@ -354,6 +372,5 @@ sources:
                         d=create_actions,
                         e=create_rules,
                         g=enable_policy,
-                        h=final_check)	
+                        h=final_check)  
                 })
-                

--- a/artifacts/definitions/Windows/Remediation/Quarantine.yaml
+++ b/artifacts/definitions/Windows/Remediation/Quarantine.yaml
@@ -1,0 +1,359 @@
+name: Windows.Remediation.Quarantine
+description: |
+      **Apply quarantine via Windows local IPSec policy**  
+      
+      - By default the current configured frontend configuration is applied 
+      as an exclusion using resolved IP address at time of application. 
+      - A configurable lookup table is also used to generate additional entries 
+      using the same syntax as netsh ipsec configuration.  
+        - DNS and DHCP are 
+      entires here allowed by default.
+      - An optional MessageBox may also be configured to alert all logged in users.
+        - The message will be truncated to 256 characters.
+      - After policy application, connection back to the Velociraptor 
+      frontend is tested and the policy removed if connection unavailable.
+      - To remove policy, select the RemovePolicy checkbox.  
+      - To update policy, simply rerun the artifact.
+        
+      NOTE:  
+      
+      - Remember DNS resolution may change. It is highly recommended to plan 
+      policy accordingly and not rely on DNS lookups.  
+      - Local IPSec policy can not be applied when Domain IPSec policy
+      is already enforced. Please configure at GPO level in this case.
+
+author: Matt Green - @mgreen27
+
+reference:
+  - https://mgreen27.github.io/posts/2020/07/23/IPSEC.html
+
+required_permissions:
+  - EXECVE
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: PolicyName
+    default: "VelociraptorQuarantine"
+  - name: RuleLookupTable
+    type: csv 
+    default: |
+        Action,SrcAddr,SrcMask,SrcPort,DstAddr,DstMask,DstPort,Protocol,Mirrored,Description
+        Permit,me,,0,any,,53,udp,yes,DNS
+        Permit,me,,0,any,,53,tcp,yes,DNS TCP
+        Permit,me,,68,any,,67,udp,yes,DHCP
+        Block,any,,,any,,,,yes,All other traffic
+  - name: MessageBox
+    description: |
+        Optional message box notification to send to logged in users. 256 
+        character limit.
+  - name: RemovePolicy
+    type: bool
+    description: Tickbox to remove policy.
+    
+sources:
+    - queries:
+      # If a MessageBox configured truncate to 256 character limit
+      - LET MessageBox <= if(condition=MessageBox,
+                then=parse_string_with_regex(
+                    string=MessageBox,
+                    regex=['^(?P<Message>.{0,255}).*']
+                ).Message)
+                
+      # extract configurable policy from lookuptable
+      - LET configurable_policy <= SELECT 
+                Action,
+                SrcAddr,
+                format(format='%v',args=SrcMask) AS SrcMask,
+                format(format='%v',args=SrcPort) AS SrcPort,
+                DstAddr,
+                format(format='%v',args=DstMask) AS DstMask,
+                format(format='%v',args=DstPort) AS DstPort,
+                Protocol,
+                Mirrored,
+                Description
+            FROM parse_csv(filename=RuleLookupTable, accessor='data') 
+            
+      # extract Velociraptor config for policy 
+      - LET extracted_config <= SELECT * FROM foreach(
+                row=config.server_urls,
+                query={ 
+                    SELECT 
+                        'Permit' AS Action,
+                        'me' AS SrcAddr,
+                        '' As SrcMask,
+                        '0' AS SrcPort,
+                        split(
+                            string=regex_replace(
+                                source=_value,
+                                re='^https://(.+)/',
+                                replace='$1'),
+                            sep=':'
+                                )[0] as DstAddr,
+                                '' As DstMask,
+                        if(condition=split(string=regex_replace(
+                                    source=_value,
+                                    re='^https://(.+)/',
+                                    replace='$1'),
+                                sep=':')[1], 
+                            then= split(string=regex_replace(
+                                    source=_value,
+                                    re='^https://(.+)/',
+                                    replace='$1'),sep=':')[1],
+                            else='443') as DstPort,
+                        'tcp' AS Protocol,
+                        'yes' AS Mirrored,
+                        'VelociraptorFrontEnd' AS Description
+                    FROM scope()
+                })
+                
+      # build policy with extracted config and lookuptable
+      - LET policy <= SELECT *,   
+                if(condition= Action='Permit',
+                    then= PolicyName + '_PermitFilterList',
+                    else= PolicyName + '_BlockFilterList') AS FilterList
+            FROM chain(
+                a=extracted_config,
+                b=configurable_policy
+            )
+      
+      # build netsh ipsec policy commandlines by switchcase
+      - LET cmdline = SELECT 
+                filter(list=CMD, regex='^(\\w+|\\w+=.+)$') AS CMD
+            FROM switch(
+                delete={
+                    SELECT 
+                        ('netsh','ipsec','static','delete','policy',
+                            'name=' + PolicyName
+                                ) AS CMD
+                    FROM scope()
+                    WHERE _value = 'DeletePolicy'
+                },
+                create={
+                    SELECT
+                        ('netsh','ipsec','static','add','policy',
+                            'name=' + PolicyName
+                                ) AS CMD
+                    FROM scope()
+                    WHERE _value = 'CreatePolicy'
+                },
+                action={
+                    SELECT 
+                        ('netsh','ipsec','static','add','filteraction',
+                            'name=' + PolicyName + '_' + Action + 'Action',
+                            'action=' + Action
+                                ) AS CMD
+                    FROM scope()
+                    WHERE FilterAction AND Action =~ 'Permit|Block'
+                },
+                rule={
+                    SELECT 
+                        ('netsh','ipsec','static','add','rule',
+                            'name=' + PolicyName + '_' + Action,
+                            'policy=' + PolicyName,
+                            'filterlist=' + PolicyName + '_' + Action + 'FilterList',
+                            'filteraction=' + PolicyName + '_' + Action + 'Action'
+                                ) AS CMD
+                    FROM scope()
+                    WHERE 
+                        Rule AND Action =~ 'Permit|Block'
+                },
+                enable={
+                    SELECT 
+                        ('netsh','ipsec','static','set','policy',
+                            'name=' + PolicyName,
+                            'assign=y'
+                                ) AS CMD
+                    FROM scope()
+                    WHERE _value = 'EnablePolicy'
+                },
+                policy= {
+                    SELECT
+                        ('netsh','ipsec','static','add','filter',
+                            'filterlist=' + FilterList,
+                            'srcaddr=' + SrcAddr,
+                            'srcmask=' + SrcMask,
+                            'srcport=' + SrcPort,
+                            'dstaddr=' + DstAddr,
+                            'dstmask=' + DstMask,
+                            'dstport=' + DstPort,
+                            'protocol=' + Protocol,
+                            'mirrored=' + Mirrored,
+                            'description=' + Description
+                                ) AS CMD
+                    FROM scope() 
+                    WHERE 
+                        SrcAddr AND DstAddr              
+                })
+            
+      # delete old or unwanted policy 
+      - LET delete_policy = SELECT * FROM foreach(
+                row=['DeletePolicy'],
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        PolicyName + ' IPSec policy removed.' AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Stdout
+                })
+      
+      # first step is creating IPSec policy
+      - LET create_policy = SELECT * FROM foreach(
+                row=['CreatePolicy'],
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=Stdout, 
+                            then=Stdout, 
+                            else= if(condition=Stderr,
+                                then=Stderr,
+                                else= if(condition= ReturnCode=0, 
+                                    then=PolicyName + ' IPSec policy created.'       
+                            ))) AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                })
+                
+      # second step is to create policy filters
+      - LET create_filters = SELECT * FROM foreach(
+                row=policy,
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=Stdout, 
+                            then=Stdout, 
+                            else= if(condition=Stderr,
+                                then=Stderr,
+                                else= if(condition= ReturnCode=0, 
+                                    then ='Entry added: ' + 
+                                        join(array=filter(list=cmdline[0].CMD,
+                                            regex='^\\w+=.+'),sep=' ')       
+                            ))) AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                    GROUP BY Results
+                })
+      
+      # third step is to create policy actions
+      - LET create_actions = SELECT * FROM foreach(
+                row= { 
+                    SELECT 
+                        Action, 
+                        'TRUE' as FilterAction 
+                    FROM policy 
+                    GROUP BY Action 
+                },
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=Stdout, 
+                            then=Stdout, 
+                            else= if(condition=Stderr,
+                                then=Stderr,
+                                else= if(condition= ReturnCode=0, 
+                                    then ='FilterAction added: ' + 
+                                        join(array=filter(list=cmdline[0].CMD,
+                                            regex='^\\w+=.+'),sep=' ')       
+                            ))) AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                })
+    
+      # fourth step combines action lists and actions in a Rule
+      - LET create_rules = SELECT * FROM foreach(
+                row= { 
+                    SELECT 
+                        Action, 
+                        'TRUE' AS Rule 
+                    FROM policy 
+                    GROUP BY Action 
+                },
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=Stdout, 
+                            then=Stdout, 
+                            else= if(condition=Stderr,
+                                then=Stderr,
+                                else= if(condition= ReturnCode=0, 
+                                    then ='Rule added: ' + 
+                                        join(array=filter(list=cmdline[0].CMD,
+                                            regex='^\\w+=.+'),sep=' ')       
+                            ))) AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                })
+      
+      # fith step is to enable our IPSec policy
+      - LET enable_policy = SELECT * FROM foreach(
+                row=['EnablePolicy'],
+                query={
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=Stdout, 
+                            then=Stdout, 
+                            else= if(condition=Stderr,
+                                then=Stderr,
+                                else= if(condition= ReturnCode=0, 
+                                    then = PolicyName + ' IPSec policy applied.'    
+                            ))) AS Result
+                    FROM 
+                        execve(argv=cmdline[0].CMD,sep='\r\n')
+                })
+      
+      # test connection to a frontend server
+      - LET test_connection = SELECT * FROM foreach(
+                row={
+                    SELECT * FROM policy
+                    WHERE Description = 'VelociraptorFrontEnd'
+                },
+                query={
+                    SELECT *
+                        Url, 
+                        response 
+                    FROM 
+                        http_client(url='https://' + DstAddr + ':' + DstPort + '/server.pem',
+                            disable_ssl_security='TRUE')
+                    WHERE Response = 200
+                    LIMIT 1
+                })
+      
+      # final check to keep or remove policy
+      - LET final_check = SELECT * FROM if(condition= test_connection, 
+                then={ 
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        if(condition=MessageBox,
+                            then= PolicyName + ' connection test successful. MessageBox sent.',
+                            else= PolicyName + ' connection test successful.' 
+                            ) AS Result
+                    FROM if(condition=MessageBox,
+                        then= {
+                            SELECT * FROM execve(argv=['msg','*',MessageBox])
+                        },
+                        else={ 
+                            SELECT * FROM scope() 
+                        })
+                }, 
+                else={ 
+                    SELECT 
+                        timestamp(epoch=now()) as Time,
+                        PolicyName + ' failed connection test. Removing IPSec policy.' AS Result
+                    FROM delete_policy 
+                })
+                
+      # Execute content
+      - SELECT * FROM if(condition=RemovePolicy,
+                then=delete_policy,
+                else={
+                    SELECT * FROM chain(
+                        a=delete_policy,
+                        b=create_policy,
+                        c=create_filters,
+                        d=create_actions,
+                        e=create_rules,
+                        g=enable_policy,
+                        h=final_check)	
+                })
+                


### PR DESCRIPTION
name: Windows.Remediation.Quarantine
description: |
      **Apply quarantine via Windows local IPSec policy**  
      
      - By default the current configured frontend configuration is applied 
      as an exclusion using resolved IP address at time of application. 
      - A configurable lookup table is also used to generate additional entries 
      using the same syntax as netsh ipsec configuration.  
        - DNS and DHCP are 
      entires here allowed by default.
      - An optional MessageBox may also be configured to alert all logged in users.
        - The message will be truncated to 256 characters.
      - After policy application, connection back to the Velociraptor 
      frontend is tested and the policy removed if connection unavailable.
      - To remove policy, select the RemovePolicy checkbox.  
      - To update policy, simply rerun the artifact.
        
      NOTE:  
      
      - Remember DNS resolution may change. It is highly recommended to plan 
      policy accordingly and not rely on DNS lookups.  
      - Local IPSec policy can not be applied when Domain IPSec policy
      is already enforced. Please configure at GPO level in this case.

author: Matt Green - @mgreen27

reference:
  - https://mgreen27.github.io/posts/2020/07/23/IPSEC.html

![image](https://user-images.githubusercontent.com/13081800/88253284-b8a30780-ccf4-11ea-8435-230bb04d9dc7.png)
