### PR TITLE
Only build all binaries on push to master.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,11 +1,13 @@
 # Only trigger when a PR is committed.
 name: Linux Build All Arches
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
 
 jobs:
+  if: github.event.pull_request.merged
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 jobs:
-  if: github.event.pull_request.merged
   build:
+    if: github.event.pull_request.merged
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ name: Linux Build All Arches
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,5 @@
 name: Windows Test
-on: [push, pull_request]
+on: [create, pull_request]
 jobs:
   build:
     name: Windows Test


### PR DESCRIPTION
This ensures only accepted PRs are available for users.