### PR TITLE
Add/PowershellScriptblock VSS refactor

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
+++ b/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
@@ -86,7 +86,7 @@ sources:
             })
 
         -- Main query
-        LET hit = SELECT *
+        LET hits = SELECT *
           FROM foreach(
             row=files,
             query={

--- a/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
+++ b/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
@@ -86,32 +86,56 @@ sources:
             })
 
         -- Main query
-        SELECT *
-        FROM foreach(
-          row=files,
-          query={
-            SELECT timestamp(epoch=System.TimeCreated.SystemTime) As EventTime,
-              System.Computer as Computer,
-              System.Security.UserID as SecurityID,
-              EventData.Path as Path,
-              EventData.ScriptBlockId as ScriptBlockId,
-              EventData.ScriptBlockText as ScriptBlockText,
-              System.EventRecordID as EventRecordID,
-              System.Level as Level,
-              System.Opcode as Opcode,
-              System.Task as Task
-            FROM parse_evtx(filename=FullPath)
-            WHERE System.EventID.Value = 4104
-              AND EventTime < DateBeforeTime
-              AND EventTime > DateAfterTime 
-              AND format(format="%d", args=System.Level) =~ LogLevelRegex.value[0]
-              AND if(condition=SearchStrings, 
-                  then=ScriptBlockText =~ SearchStrings,
-                  else=TRUE) 
-              AND if(condition=StringWhitelist, 
-                  then= NOT ScriptBlockText =~ StringWhitelist,
-                  else=TRUE) 
-              AND if(condition=PathWhitelist, 
-                  then= NOT Path =~ PathWhitelist,
-                  else=TRUE)
-        })
+        LET hit = SELECT *
+          FROM foreach(
+            row=files,
+            query={
+              SELECT timestamp(epoch=System.TimeCreated.SystemTime) As EventTime,
+                System.EventID.Value as EventID,
+                System.Computer as Computer,
+                System.Security.UserID as SecurityID,
+                EventData.Path as Path,
+                EventData.ScriptBlockId as ScriptBlockId,
+                EventData.ScriptBlockText as ScriptBlockText,
+                System.EventRecordID as EventRecordID,
+                System.Level as Level,
+                System.Opcode as Opcode,
+                System.Task as Task,
+                if(condition=Source, then=Source, else=FullPath) as Source
+              FROM parse_evtx(filename=FullPath)
+              WHERE System.EventID.Value = 4104
+                AND EventTime < DateBeforeTime
+                AND EventTime > DateAfterTime 
+                AND format(format="%d", args=System.Level) =~ LogLevelRegex.value[0]
+                AND if(condition=SearchStrings, 
+                    then=ScriptBlockText =~ SearchStrings,
+                    else=TRUE) 
+                AND if(condition=StringWhitelist, 
+                    then= NOT ScriptBlockText =~ StringWhitelist,
+                    else=TRUE) 
+                AND if(condition=PathWhitelist, 
+                    then= NOT Path =~ PathWhitelist,
+                    else=TRUE)
+          })
+          ORDER BY Source DESC
+
+        -- Group results for deduplication
+        LET grouped = SELECT *
+          FROM hits
+          GROUP BY EventRecordID
+
+        -- Output results
+        SELECT
+            EventTime,
+            EventID,
+            Computer,
+            SecurityID,
+            Path,
+            ScriptBlockId,
+            ScriptBlockText,
+            EventRecordID,
+            Level,
+            Opcode,
+            Task,
+            Source
+        FROM grouped

--- a/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
+++ b/artifacts/definitions/Windows/EventLogs/PowershellScriptblock.yaml
@@ -8,32 +8,37 @@ description: |
   malicious content.
   
   There are several parameter's availible for search leveraging regex. 
-    - dateAfter enables search for events after this date.  
-    - dateBefore enables search for events before this date.   
+    - DateAfter enables search for events after this date.  
+    - DateBefore enables search for events before this date.   
     - SearchStrings enables regex search over scriptblock text field.  
-    - stringWhiteList enables a regex whitelist for scriptblock text field.  
-    - pathWhitelist enables a regex whitelist for path of scriptblock. 
+    - StringWhiteList enables a regex whitelist for scriptblock text field.  
+    - PathWhitelist enables a regex whitelist for path of scriptblock. 
     - LogLevel enables searching on type of log. Default is Warning level 
       which is logged even if ScriptBlock logging is turned off when 
-      suspicious keywords detected in Powershell interpreter.   
+      suspicious keywords detected in Powershell interpreter. See second 
+      reference for list of keywords.
   
 
 author: Matt Green - @mgreen27
 
+reference:
+  - https://attack.mitre.org/techniques/T1059/001/
+  - https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs#L1781-L1943
+
 parameters:
-  - name: eventLog
+  - name: EventLog
     default: C:\Windows\system32\winevt\logs\Microsoft-Windows-PowerShell%4Operational.evtx
-  - name: dateAfter
+  - name: DateAfter
     description: "search for events after this date. YYYY-MM-DDTmm:hh:ss Z"
     type: timestamp
-  - name: dateBefore
+  - name: DateBefore
     description: "search for events before this date. YYYY-MM-DDTmm:hh:ss Z"
     type: timestamp
-  - name: searchStrings
+  - name: SearchStrings
     description: "regex search over scriptblock text field."
-  - name: stringWhitelist
+  - name: StringWhitelist
     description: "Regex of string to witelist"
-  - name: pathWhitelist
+  - name: PathWhitelist
     description: "Regex of path to whitelist."
     
   - name: LogLevel
@@ -51,20 +56,37 @@ parameters:
       All,"."
       Warning,"3"
       Verbose,"5"
-      
+  - name: SearchVSS
+    description: "Add VSS into query."
+    type: bool     
       
 sources:
-  - name: PowershellScriptBlock
-    queries:
-      - LET time <= SELECT format(format="%v", args=Regex) as value
+  - query: |
+        -- Build time bounds
+        LET DateAfterTime <= if(condition=DateAfter, 
+            then=timestamp(epoch=DateAfter), else=timestamp(epoch="1600-01-01"))
+        LET DateBeforeTime <= if(condition=DateBefore, 
+            then=timestamp(epoch=DateBefore), else=timestamp(epoch="2200-01-01"))
+
+        -- Parse Log level dropdown selection
+        LET LogLevelRegex <= SELECT format(format="%v", args=Regex) as value
             FROM parse_csv(filename=LogLevelMap, accessor="data")
             WHERE Choice=LogLevel LIMIT 1
-      - LET LogLevelRegex <= SELECT format(format="%v", args=Regex) as value
-            FROM parse_csv(filename=LogLevelMap, accessor="data")
-            WHERE Choice=LogLevel LIMIT 1
-      - LET files = SELECT * FROM glob(
-            globs=eventLog)
-      - SELECT *
+
+        -- Determine target files
+        LET files = SELECT *
+          FROM if(condition=SearchVSS,
+            then= {
+              SELECT *
+              FROM Artifact.Windows.Search.VSS(SearchFilesGlob=EventLog)
+            },
+            else= {
+              SELECT *
+              FROM glob(globs=EventLog,accessor='ntfs')
+            })
+
+        -- Main query
+        SELECT *
         FROM foreach(
           row=files,
           query={
@@ -79,30 +101,17 @@ sources:
               System.Opcode as Opcode,
               System.Task as Task
             FROM parse_evtx(filename=FullPath)
-            WHERE System.EventID.Value = 4104 and
-                if(condition=dateAfter, then=EventTime > timestamp(string=dateAfter),
-                 else=TRUE) and
-                if(condition=dateBefore, then=EventTime < timestamp(string=dateBefore),
-                 else=TRUE) and
-                format(format="%d", args=System.Level) =~ LogLevelRegex.value[0] and
-                if(condition=searchStrings, then=ScriptBlockText =~ searchStrings,
-                 else=TRUE) and
-                if(condition=stringWhitelist, then=not ScriptBlockText =~ stringWhitelist,
-                 else=TRUE) and
-                if(condition=pathWhitelist, then=not Path =~ pathWhitelist,
-                 else=TRUE)
+            WHERE System.EventID.Value = 4104
+              AND EventTime < DateBeforeTime
+              AND EventTime > DateAfterTime 
+              AND format(format="%d", args=System.Level) =~ LogLevelRegex.value[0]
+              AND if(condition=SearchStrings, 
+                  then=ScriptBlockText =~ SearchStrings,
+                  else=TRUE) 
+              AND if(condition=StringWhitelist, 
+                  then= NOT ScriptBlockText =~ StringWhitelist,
+                  else=TRUE) 
+              AND if(condition=PathWhitelist, 
+                  then= NOT Path =~ PathWhitelist,
+                  else=TRUE)
         })
-
-reports:
-  - type: HUNT
-    template: |
-      Powershell: Scriptblock
-      =======================
-      Powershell is commonly used by attackers accross all stages of the attack 
-      lifecycle.  
-      A valuable hunt is to search Scriptblock logs for signs of malicious 
-      content. Stack ranking these events can provide valuable leads from which 
-      to start an investigation.
-      
-      {{ Query "SELECT count(items=ScriptBlockText) as Count, ScriptBlockText FROM source(source='PowershellScriptBlock') GROUP BY ScriptBlockText ORDER BY Count"  | Table }}
-      


### PR DESCRIPTION
Refactor of Powershell ScriptBlock collection to include VSS capability.
Added a couple of references including the Powershell repo keywords that are used to generate loglevel 3.
Removed hunt report as this is redundant with Notebook.