### PR TITLE
Solidify the rules around when tools can be upgraded.

### DIFF
--- a/api/authenticators/logging.go
+++ b/api/authenticators/logging.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/logging"
 )
@@ -36,7 +37,7 @@ func GetUserInfo(ctx context.Context,
 	config_obj *config_proto.Config) *api_proto.VelociraptorUser {
 	result := &api_proto.VelociraptorUser{}
 
-	userinfo, ok := ctx.Value("USER").(string)
+	userinfo, ok := ctx.Value(constants.GRPC_USER_CONTEXT).(string)
 	if ok {
 		data := []byte(userinfo)
 		err := json.Unmarshal(data, result)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/logging"
 )
@@ -53,7 +54,7 @@ func GetUserInfo(ctx context.Context,
 	config_obj *config_proto.Config) *api_proto.VelociraptorUser {
 	result := &api_proto.VelociraptorUser{}
 
-	userinfo, ok := ctx.Value("USER").(string)
+	userinfo, ok := ctx.Value(constants.GRPC_USER_CONTEXT).(string)
 	if ok {
 		data := []byte(userinfo)
 		err := json.Unmarshal(data, result)

--- a/api/tools.go
+++ b/api/tools.go
@@ -53,7 +53,10 @@ func (self *ApiServer) SetToolInfo(ctx context.Context,
 
 	materialize := in.Materialize
 	in.Materialize = false
-	err = services.GetInventory().AddTool(self.config, in)
+	err = services.GetInventory().AddTool(self.config, in,
+		services.ToolOptions{
+			AdminOverride: true,
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/api/upload.go
+++ b/api/upload.go
@@ -16,6 +16,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 func toolUploadHandler(
@@ -25,6 +26,8 @@ func toolUploadHandler(
 
 		// Check for acls
 		userinfo := GetUserInfo(r.Context(), config_obj)
+		utils.Debug(userinfo)
+
 		permissions := acls.ARTIFACT_WRITER
 		perm, err := acls.CheckAccess(config_obj, userinfo.Name, permissions)
 		if !perm || err != nil {
@@ -66,7 +69,6 @@ func toolUploadHandler(
 
 		tool.Filename = path.Base(handler.Filename)
 		tool.ServeLocally = true
-		tool.AdminOverride = true
 
 		file_store_factory := file_store.GetFileStore(config_obj)
 		path_manager := paths.NewInventoryPathManager(config_obj, tool)
@@ -96,7 +98,10 @@ func toolUploadHandler(
 
 		tool.Hash = hex.EncodeToString(sha_sum.Sum(nil))
 
-		err = services.GetInventory().AddTool(config_obj, tool)
+		err = services.GetInventory().AddTool(config_obj, tool,
+			services.ToolOptions{
+				AdminOverride: true,
+			})
 		if err != nil {
 			returnError(w, http.StatusInternalServerError,
 				fmt.Sprintf("Error: %v", err))

--- a/bin/gui.go
+++ b/bin/gui.go
@@ -21,7 +21,7 @@ var (
 
 	gui_command_datastore = gui_command.Flag(
 		"datastore", "Path to a datastore directory (defaults to temp)").
-		String()
+		ExistingDir()
 
 	gui_command_no_browser = gui_command.Flag(
 		"nobrowser", "Do not bring up the browser").Bool()
@@ -88,6 +88,13 @@ func doGUI() {
 		config_obj.Client.LocalBuffer.FilenameWindows = ""
 		config_obj.Client.LocalBuffer.FilenameLinux = ""
 		config_obj.Client.LocalBuffer.FilenameDarwin = ""
+
+		// Make the client use the datastore_directory for tempfiles as well.
+		tmpdir := filepath.Join(datastore_directory, "temp")
+		os.MkdirAll(tmpdir, 0700)
+		config_obj.Client.TempdirLinux = tmpdir
+		config_obj.Client.TempdirWindows = tmpdir
+		config_obj.Client.TempdirDarwin = tmpdir
 
 		config_obj.Datastore.Location = datastore_directory
 		config_obj.Datastore.FilestoreDirectory = datastore_directory
@@ -157,10 +164,12 @@ func doGUI() {
 	}
 
 	if !*gui_command_no_client {
+		*verbose_flag = true
 		logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 		logger.Info("Running client from %v", client_config_path)
 		go RunClient(ctx, sm.Wg, &client_config_path)
 	}
+
 	sm.Wg.Wait()
 }
 

--- a/bin/tools.go
+++ b/bin/tools.go
@@ -104,10 +104,9 @@ func doThirdPartyUpload() {
 	}
 
 	tool := &artifacts_proto.Tool{
-		Name:          *third_party_upload_tool_name,
-		Filename:      filename,
-		ServeLocally:  !*third_party_upload_serve_remote,
-		AdminOverride: true,
+		Name:         *third_party_upload_tool_name,
+		Filename:     filename,
+		ServeLocally: !*third_party_upload_serve_remote,
 	}
 
 	// Does the user want to scrape releases from github?
@@ -147,7 +146,10 @@ func doThirdPartyUpload() {
 	defer cancel()
 
 	// Now add the tool to the inventory with the correct hash.
-	err = services.GetInventory().AddTool(config_obj, tool)
+	err = services.GetInventory().AddTool(
+		config_obj, tool, services.ToolOptions{
+			AdminOverride: true,
+		})
 	kingpin.FatalIfError(err, "Adding tool "+tool.Name)
 
 	if *third_party_upload_download {

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -218,9 +218,6 @@ func StartHuntDispatcher(
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) error {
 
-	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
-	logger.Info("<green>Starting</> Hunt Dispatcher Service.")
-
 	result := &HuntDispatcher{
 		hunts: make(map[string]*api_proto.Hunt),
 	}
@@ -230,9 +227,14 @@ func StartHuntDispatcher(
 	go func() {
 		defer wg.Done()
 
+		// On the client we register a dummy dispatcher since
+		// there is nothing to sync from.
 		if config_obj.Datastore == nil {
 			return
 		}
+
+		logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+		logger.Info("<green>Starting</> Hunt Dispatcher Service.")
 
 		for {
 			select {

--- a/services/inventory.go
+++ b/services/inventory.go
@@ -34,6 +34,14 @@ func RegisterInventory(inventory Inventory) {
 	ginventory = inventory
 }
 
+type ToolOptions struct {
+	// Tool is being upgraded.
+	Upgrade bool
+
+	// Admin is overriding tool in inventory.
+	AdminOverride bool
+}
+
 type Inventory interface {
 	// Get a list of the entire tools database with all known tools.
 	Get() *artifacts_proto.ThirdParty
@@ -57,7 +65,8 @@ type Inventory interface {
 	// actually valid and available, they need to call
 	// GetToolInfo() after this to force the tool to be
 	// materialized.
-	AddTool(config_obj *config_proto.Config, tool *artifacts_proto.Tool) error
+	AddTool(config_obj *config_proto.Config,
+		tool *artifacts_proto.Tool, opts ToolOptions) error
 
 	// Remove the tool from the inventory.
 	RemoveTool(config_obj *config_proto.Config, tool_name string) error

--- a/services/inventory/dummy.go
+++ b/services/inventory/dummy.go
@@ -245,7 +245,23 @@ func getGithubRelease(ctx context.Context, Client HTTPClient,
 }
 
 func (self *Dummy) AddTool(config_obj *config_proto.Config,
-	tool_request *artifacts_proto.Tool) error {
+	tool_request *artifacts_proto.Tool,
+	opts services.ToolOptions) error {
+	if opts.Upgrade {
+		existing_tool, err := self.ProbeToolInfo(tool_request.Name)
+		if err == nil {
+			// Ignore the request if the existing
+			// definition is better than the new one.
+			if isDefinitionBetter(existing_tool, tool_request) {
+				return nil
+			}
+		}
+	}
+
+	if opts.AdminOverride {
+		tool_request.AdminOverride = true
+	}
+
 	self.mu.Lock()
 	defer self.mu.Unlock()
 

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -116,7 +116,11 @@ func (self *Launcher) EnsureToolsDeclared(
 			// itself.
 			logger.Info("Adding tool %v from artifact %v",
 				tool.Name, artifact.Name)
-			err = services.GetInventory().AddTool(config_obj, tool)
+			err = services.GetInventory().AddTool(
+				config_obj, tool,
+				services.ToolOptions{
+					Upgrade: true,
+				})
 			if err != nil {
 				return err
 			}

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -196,8 +196,7 @@ func (self *LauncherTestSuite) TestCompilingWithTools() {
 			ServeLocally: true,
 			Filename:     "mytool.exe",
 			Url:          tool_url,
-			//Hash:         sha_value,
-		})
+		}, services.ToolOptions{AdminOverride: true})
 	assert.NoError(self.T(), err)
 
 	status = 200

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -351,12 +351,11 @@ func compileArtifact(
 	// Make sure tools are all defined.
 	inventory := services.GetInventory()
 	for _, tool := range artifact.Tools {
-		stored_tool, err := inventory.ProbeToolInfo(tool.Name)
-		if err != nil || stored_tool == nil {
-			err = inventory.AddTool(config_obj, tool)
-			if err != nil {
-				return err
-			}
+		err := inventory.AddTool(
+			config_obj, tool,
+			services.ToolOptions{Upgrade: true})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/services/sanity/sanity.go
+++ b/services/sanity/sanity.go
@@ -201,7 +201,10 @@ func checkForServerUpgrade(
 					tool_definition.Hash = ""
 
 					err = inventory.AddTool(
-						config_obj, tool_definition)
+						config_obj, tool_definition,
+						services.ToolOptions{
+							Upgrade: true,
+						})
 					if err != nil {
 						return err
 					}

--- a/services/sanity/sanity_test.go
+++ b/services/sanity/sanity_test.go
@@ -80,12 +80,13 @@ tools:
 	tool_definition := &artifacts_proto.Tool{
 		Name: "Tool1",
 		Url:  "https://www.company.com",
-
-		// This flag signifies that an admin explicitly set
-		// this tool. We never overwrite an admin's setting.
-		AdminOverride: true,
 	}
-	err := inventory.AddTool(self.config_obj, tool_definition)
+	err := inventory.AddTool(self.config_obj, tool_definition,
+		services.ToolOptions{
+			// This flag signifies that an admin explicitly set
+			// this tool. We never overwrite an admin's setting.
+			AdminOverride: true,
+		})
 	assert.NoError(self.T(), err)
 
 	require.NoError(self.T(), self.sm.Start(StartSanityCheckService))

--- a/vql/server/inventory.go
+++ b/vql/server/inventory.go
@@ -57,12 +57,11 @@ func (self *InventoryAddFunction) Call(ctx context.Context,
 	}
 
 	tool := &artifacts_proto.Tool{
-		Name:          arg.Tool,
-		ServeLocally:  arg.ServeLocally,
-		Url:           arg.URL,
-		Filename:      arg.Filename,
-		Hash:          arg.Hash,
-		AdminOverride: true,
+		Name:         arg.Tool,
+		ServeLocally: arg.ServeLocally,
+		Url:          arg.URL,
+		Filename:     arg.Filename,
+		Hash:         arg.Hash,
 	}
 
 	if arg.File != "" {
@@ -105,7 +104,10 @@ func (self *InventoryAddFunction) Call(ctx context.Context,
 		}
 	}
 
-	err = services.GetInventory().AddTool(config_obj, tool)
+	err = services.GetInventory().AddTool(
+		config_obj, tool, services.ToolOptions{
+			AdminOverride: true,
+		})
 	if err != nil {
 		scope.Log("inventory_add: %s", err.Error())
 		return vfilter.Null{}


### PR DESCRIPTION
Tool definitions are upgraded automatically:

1. When an artifact is added and the tool is not already known.
2. Then an admin forces the tool to be updated

In the first case, the artifact may have a tool definition which
includes where the upstream url of the tool is and a hint about the
serving policy (serve locally). The artifact definition is only a
suggestion and multiple artifacts may define the same tool with
potentially conflicting data.

This PR implements the idea of a better/worse tool definition. A
better definition is one which has enough information for us to
actually fetch the tool (e.g. URL, github project).

An artifact may simply declare that its using the tool but not declare
where it should be served from - instead relying on another artifact
to specify more information.

Therefore artifacts are only upgraded opportunistically when they have
more information than previous definition.

Admin specified artifacts are always respected - an artifact
definition will never overwrite an admin specified definition. At the
same time an admin is able to override the previous definition.