### PR TITLE
Added hunt_add() VQL function.

### DIFF
--- a/bin/installer_windows.go
+++ b/bin/installer_windows.go
@@ -543,6 +543,7 @@ func NewVelociraptorService(name string) (*VelociraptorService, error) {
 	go func() {
 		for {
 			runOnce(result, elog)
+			time.Sleep(10 * time.Second)
 		}
 	}()
 

--- a/reporting/container.go
+++ b/reporting/container.go
@@ -419,6 +419,9 @@ func (self *Container) maybeCollectSparseFile(
 }
 
 func (self *Container) Close() error {
+	self.Lock()
+	defer self.Unlock()
+
 	if self.current_writers != 0 {
 		for _, i := range self.backtraces {
 			fmt.Println(i)

--- a/vql/acls.go
+++ b/vql/acls.go
@@ -36,6 +36,7 @@ type ServerACLManager struct {
 	Token     *acl_proto.ApiClientACL
 }
 
+// Token must have *ALL* the specified permissions.
 func (self *ServerACLManager) CheckAccess(
 	permissions ...acls.ACL_PERMISSION) (bool, error) {
 	for _, permission := range permissions {

--- a/vql/server/hunt.go
+++ b/vql/server/hunt.go
@@ -29,6 +29,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/services"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
 	"www.velocidex.com/golang/velociraptor/grpc_client"
@@ -118,6 +119,66 @@ func (self ScheduleHuntFunction) Info(scope *vfilter.Scope, type_map *vfilter.Ty
 	}
 }
 
+type AddToHuntFunctionArg struct {
+	ClientId string `vfilter:"required,field=ClientId"`
+	HuntId   string `vfilter:"required,field=HuntId"`
+}
+
+type AddToHuntFunction struct{}
+
+func (self *AddToHuntFunction) Call(ctx context.Context,
+	scope *vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_CLIENT)
+	if err != nil {
+		scope.Log("hunt_add: %s", err)
+		return vfilter.Null{}
+	}
+
+	arg := &AddToHuntFunctionArg{}
+	err = vfilter.ExtractArgs(scope, args, arg)
+	if err != nil {
+		scope.Log("hunt_add: %s", err.Error())
+		return vfilter.Null{}
+	}
+
+	config_obj, ok := artifacts.GetServerConfig(scope)
+	if !ok {
+		scope.Log("Command can only run on the server")
+		return vfilter.Null{}
+	}
+
+	journal := services.GetJournal()
+	if journal == nil {
+		return vfilter.Null{}
+	}
+
+	err = journal.PushRowsToArtifact(config_obj,
+		[]*ordereddict.Dict{ordereddict.NewDict().
+			Set("HuntId", arg.HuntId).
+			Set("ClientId", arg.ClientId).
+			Set("Override", true).
+			Set("Participate", true)},
+		"System.Hunt.Participation", arg.ClientId, "")
+	if err != nil {
+		scope.Log("hunt_add: %s", err.Error())
+		return vfilter.Null{}
+	}
+
+	return arg.ClientId
+}
+
+func (self AddToHuntFunction) Info(scope *vfilter.Scope,
+	type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:    "hunt_add",
+		Doc:     "Assign a client to a hunt.",
+		ArgType: type_map.AddType(scope, &AddToHuntFunctionArg{}),
+	}
+}
+
 func init() {
 	vql_subsystem.RegisterFunction(&ScheduleHuntFunction{})
+	vql_subsystem.RegisterFunction(&AddToHuntFunction{})
 }


### PR DESCRIPTION
This allows VQL to directly add a client to a hunt. The client will be
immediately scheduled regardless of label matches. This works even if
the hunt is paused or expired.