### PR TITLE
UX improvement: added show all hosts button next to search box

### DIFF
--- a/gui/static/angular-components/core/search-box-directive.js
+++ b/gui/static/angular-components/core/search-box-directive.js
@@ -57,6 +57,25 @@ SearchBoxController.prototype.submitQuery = function(e) {
     return false;
 };
 
+
+/**
+ * Updates GRR UI with wildcard query result (using legacy API).
+ *
+ * @export
+ */
+SearchBoxController.prototype.submitEmptyQuery = function(e) {
+    if (this.scope_["navigate"]) {
+        this.grrRoutingService_.go('search', {q: '*'});
+        return;
+    }
+
+    this.scope_["query"] = this.query;
+
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+};
+
 SearchBoxController.prototype.predict = function(viewValue) {
     var url = 'v1/SearchClients';
     var params = {

--- a/gui/static/angular-components/core/search-box.html
+++ b/gui/static/angular-components/core/search-box.html
@@ -1,5 +1,5 @@
 <abbr title="Type label: to open a list of possible labels completions.">
-  <form class="pull-right client-search-box">
+  <form class="pull-left client-search-box">
     <div class="form-group">
       <div class="input-group">
         <input id="client_query" autocomplete="off"
@@ -19,4 +19,13 @@
       </div>
     </div>
   </form>
+  <div class="pull-right" style="padding-left: 2em">
+    
+      <button id="show-hosts-btn"
+              type="button"
+              class="btn btn-default"
+              ng-click="controller.submitEmptyQuery()">
+              <span class="fa fa-server navicon ng-scope"></span> show all 
+        </button>
+      </div>
 </abbr>


### PR DESCRIPTION
Made the UI a bit more intuitive to beginners:
![image](https://user-images.githubusercontent.com/38898566/92534683-c860b600-f278-11ea-8a96-8ad49596f7c0.png)

The "show all" button just queries with a wild card to show all hosts.