### PR TITLE
Re-enable x86 windows binaries in github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
         export PATH=$PATH:~/go/bin/
         go run make.go -v Linux
         go run make.go -v Windows
-        echo skipping go run make.go -v Windowsx86
+        go run make.go -v Windowsx86
         go run make.go -v DarwinBase
 
     - name: StoreBinaries


### PR DESCRIPTION
Re-enables building windows x86 binaries on pull.

Doing this allow users to use a velociraptor deployment thats not necessary tied to a tagged release, but instead allow users to pick a specific commit hash and stand up a working deployment based on that.

I ran the changed action here: https://github.com/yampelo/velociraptor/actions/runs/267244143 and it generated the binaries:

```
/Users/omer.yampel/Downloads/binaries/velociraptor-v0.5.0-darwin-amd64:      Mach-O 64-bit executable x86_64
/Users/omer.yampel/Downloads/binaries/velociraptor-v0.5.0-linux-amd64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 3.2.0, BuildID[sha1]=d1b2d52a9d06c7d3c4d147c01cffdf4524a84717, stripped
/Users/omer.yampel/Downloads/binaries/velociraptor-v0.5.0-windows-386.exe:   PE32 executable (console) Intel 80386 (stripped to external PDB), for MS Windows
/Users/omer.yampel/Downloads/binaries/velociraptor-v0.5.0-windows-amd64.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```

