### PR TITLE
Golden improvments

### DIFF
--- a/bin/artifacts.go
+++ b/bin/artifacts.go
@@ -109,11 +109,12 @@ func getRepository(config_obj *config_proto.Config) (services.Repository, error)
 
 	repository, err := manager.GetGlobalRepository(config_obj)
 	kingpin.FatalIfError(err, "Artifact GetGlobalRepository ")
+
 	if *artifact_definitions_dir != "" {
 		logging.GetLogger(config_obj, &logging.ToolComponent).
 			Info("Loading artifacts from %s",
 				*artifact_definitions_dir)
-		_, err := repository.LoadDirectory(*artifact_definitions_dir)
+		_, err := repository.LoadDirectory(config_obj, *artifact_definitions_dir)
 		if err != nil {
 			logging.GetLogger(config_obj, &logging.ToolComponent).
 				Error("Artifact LoadDirectory: %v ", err)

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -224,10 +224,6 @@ func doGolden() {
 	logger := logging.GetLogger(config_obj, &logging.ToolComponent)
 	logger.Info("Starting golden file test.")
 
-	globs, err := filepath.Glob(fmt.Sprintf("%s/**/*.in.yaml", *golden_command_prefix))
-	logger.Info("Found the following golden files: %s", globs)
-	kingpin.FatalIfError(err, "Glob")
-
 	failures := []string{}
 
 	err = filepath.Walk(*golden_command_prefix, func(file_path string, info os.FileInfo, err error) error {

--- a/services/repository.go
+++ b/services/repository.go
@@ -76,7 +76,7 @@ type ScopeBuilder struct {
 // An artifact repository holds definitions for artifacts.
 type Repository interface {
 	// Load an entire directory recursively.
-	LoadDirectory(dirname string) (int, error)
+	LoadDirectory(config_obj *config_proto.Config, dirname string) (int, error)
 
 	// Make a copy of this repository.
 	Copy() Repository

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -63,7 +63,7 @@ func (self *Repository) Copy() services.Repository {
 	return result
 }
 
-func (self *Repository) LoadDirectory(dirname string) (int, error) {
+func (self *Repository) LoadDirectory(config_obj *config_proto.Config, dirname string) (int, error) {
 	self.mu.Lock()
 
 	count := 0
@@ -75,6 +75,7 @@ func (self *Repository) LoadDirectory(dirname string) (int, error) {
 
 	self.mu.Unlock()
 
+	logger := logging.GetLogger(config_obj, &logging.GenericComponent)
 	err := filepath.Walk(dirname,
 		func(file_path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -85,13 +86,15 @@ func (self *Repository) LoadDirectory(dirname string) (int, error) {
 				strings.HasSuffix(info.Name(), ".yml")) {
 				data, err := ioutil.ReadFile(file_path)
 				if err != nil {
-					return errors.Wrap(err, "While reading "+info.Name())
+					logger.Error("Could not load %s: %s", info.Name(), err)
+					return nil
 				}
 				_, err = self.LoadYaml(string(data), false)
 				if err != nil {
-					return errors.Wrap(err, "While reading "+info.Name())
+					logger.Error("Could not load %s: %s", info.Name(), err)
+					return nil
 				}
-
+				logger.Info("Loaded %s", file_path)
 				count += 1
 			}
 			return nil


### PR DESCRIPTION
Adds support for the `--definitions` flag in the golden command as well as makes golden recursively look for in.yaml files in the source folder:

If my folder structure is

```
vql
   - tests
       - basetest.in.yaml
       - windows
            - test1.in.yaml
            - test2.in.yaml
```

```
output/velociraptor-v0.5.0-darwin-amd64 golden --definitions=../vql/artifacts/ ../vql/tests/Windows/
```

will run `test1.in.yaml, test2.in.yaml`

```
output/velociraptor-v0.5.0-darwin-amd64 golden --definitions=../vql/artifacts/ ../vql/tests/
```

will run `basetest.in.yaml, test1.in.yaml, test2.in.yaml`

Closes #635 


