### PR TITLE
New Windows.EventLogs.Evtx artifact

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/Evtx.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Evtx.yaml
@@ -56,37 +56,43 @@ parameters:
 
 sources:
   - queries:
-      - LET evtxglobs <= SELECT FullPath FROM glob(globs=expand(path=EvtxGlob))
-
-      - LET files = 
+      # expand provided glob into a list of paths on the file system (fs)
+      - LET fspaths <= 
+          SELECT FullPath FROM glob(globs=expand(path=EvtxGlob))
+          WHERE FullPath =~ PathRegex
+      
+      # function returning list of VSS paths corresponding to path
+      - LET vsspaths(path) = 
+          SELECT FullPath FROM Artifact.Windows.Search.VSS(SearchFilesGlob=path)
+          WHERE FullPath =~ PathRegex
+      
+      # function returning parsed evtx from list of paths
+      - LET evtxsearch(pathList) = 
           SELECT * FROM foreach(
-            row=evtxglobs,
+            row=pathList,
             query={
-              SELECT * 
-              FROM if(condition=SearchVSS,
-                      then={SELECT * FROM Artifact.Windows.Search.VSS(SearchFilesGlob=FullPath)},
-                      else={SELECT * FROM glob(globs=FullPath)})
+              SELECT *,
+                timestamp(epoch=int(int=System.TimeCreated.SystemTime)) AS TimeCreated,
+                System.Channel as Channel,
+                System.EventRecordID as EventRecordID,
+                System.EventID.Value as EventID,
+                FullPath
+              FROM parse_evtx(filename=FullPath)
+              WHERE
+                if(condition=StartDate, then=TimeCreated >= timestamp(string=StartDate), else=true)
+                AND if(condition=EndDate, then=TimeCreated <= timestamp(string=EndDate), else=true)
+                AND Channel =~ ChannelRegex
+                AND str(str=EventID) =~ IDRegex
             }
           )
-          WHERE FullPath =~ PathRegex
-          ORDER BY FullPath DESC
-
-      # Parse all target files and de-duplicate with GROUP BY
-      - SELECT * FROM foreach(
-          row=files,
-          query={
-            SELECT *,
-              timestamp(epoch=int(int=System.TimeCreated.SystemTime)) AS TimeCreated,
-              System.Channel as Channel,
-              System.EventRecordID as EventRecordID,
-              System.EventID.Value as EventID,
-              FullPath
-            FROM parse_evtx(filename=FullPath)
-            WHERE
-              if(condition=StartDate, then=TimeCreated >= timestamp(string=StartDate), else=true)
-              AND if(condition=EndDate, then=TimeCreated <= timestamp(string=EndDate), else=true)
-              AND Channel =~ ChannelRegex
-              AND str(str=EventID) =~ IDRegex
-          }
-        )
-        GROUP BY EventRecordID,Channel
+        
+      # only de-duplicate using GROUP BY when searching VSS
+      # de-duplicate file-by-file to reduce memory impact
+      - SELECT * FROM if(condition=SearchVSS, then={
+          SELECT * FROM foreach(row=fspaths, query={
+            SELECT * FROM evtxsearch(pathList={SELECT FullPath FROM vsspaths(path=FullPath)})
+            GROUP BY EventRecordID,Channel
+          })
+        }, else={
+          SELECT * FROM evtxsearch(pathList={select FullPath FROM fspaths})
+        })

--- a/artifacts/definitions/Windows/EventLogs/Evtx.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Evtx.yaml
@@ -22,6 +22,9 @@ description: |
   
   - Parsing and aggregating may use high amounts of CPU on the client. Consider
   reducing the ops/second or narrowing the glob/path regex if necessary.
+  - Parsing may use significant memory and time when searching VSS volumes and
+  deduplicating events. This is proportional to the evtx file size and number
+  of VSS copies. Consider whether the extra events are worth the resources.
   - Parsing many event logs may take longer than the default timeout.  When
   parsing all log files and searching VSS, consider doubling the default or 
   more (especially with reduced ops/second, or if targets have high-volume 
@@ -94,5 +97,5 @@ sources:
             GROUP BY EventRecordID,Channel
           })
         }, else={
-          SELECT * FROM evtxsearch(pathList={select FullPath FROM fspaths})
+          SELECT * FROM evtxsearch(pathList={SELECT FullPath FROM fspaths})
         })

--- a/artifacts/definitions/Windows/EventLogs/Evtx.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Evtx.yaml
@@ -1,0 +1,92 @@
+name: Windows.EventLogs.Evtx
+
+description: |
+  Parses and returns events from Windows evtx logs.
+  
+  Each event is returned in full, but results can be narrowed using a glob 
+  pattern for evtx files, a timespan, and regexes to match the evtx path, event 
+  channel, and/or event ID:
+  
+  - EvtxGlob: glob of event log files (evtx) to target
+  - StartDate: earliest event created timestamp to target 
+  - EndDate: latest event created timestamp to target
+  - PathRegex: a regex to match against paths returned from EvtxGlob
+  - ChannelRegex: a regex to match against the event channel
+  - IDRegex: a regex to match against the event ID  
+  
+  Gathering these logs enables VQL analysis (_e.g._, via notebooks) and bulk
+  export (_e.g._, to elasticsearch) for additional processing.  It can also be 
+  used as the basis for custom artifacts with more in-depth filtering.
+  
+  **Note: This artifact can be resource intensive.**  
+  
+  - Parsing and aggregating may use high amounts of CPU on the client. Consider
+  reducing the ops/second or narrowing the glob/path regex if necessary.
+  - Parsing many event logs may take longer than the default timeout.  When
+  parsing all log files and searching VSS, consider doubling the default or 
+  more (especially with reduced ops/second, or if targets have high-volume 
+  3rd-party log sources such as Sysmon).
+  - The artifact routinely produces hundreds of thousands of rows per host. 
+  Consider filtering results using path, channel, and ID regexes if necessary.
+
+  Inspired by others in `Windows.EventLogs.*`, many by Matt Green (@mgreen27).
+    
+author: Chris Hendricks (chris@counteractive.net)
+
+precondition: SELECT OS FROM info() WHERE OS = 'windows'
+
+parameters:
+  - name: EvtxGlob
+    default: '%SystemRoot%\System32\winevt\Logs\*.evtx'
+  - name: SearchVSS
+    description: "Search VSS for EvtxGlob as well."
+    type: bool
+  - name: StartDate
+    type: timestamp
+    description: "Parse events on or after this date (YYYY-MM-DDTmm:hh:ssZ)"
+  - name: EndDate
+    type: timestamp
+    description: "Parse events on or before this date (YYYY-MM-DDTmm:hh:ssZ)"
+  - name: PathRegex
+    default: "."
+  - name: ChannelRegex
+    default: "."
+  - name: IDRegex
+    default: "."
+
+sources:
+  - queries:
+      - LET evtxglobs <= SELECT FullPath FROM glob(globs=expand(path=EvtxGlob))
+
+      - LET files = 
+          SELECT * FROM foreach(
+            row=evtxglobs,
+            query={
+              SELECT * 
+              FROM if(condition=SearchVSS,
+                      then={SELECT * FROM Artifact.Windows.Search.VSS(SearchFilesGlob=FullPath)},
+                      else={SELECT * FROM glob(globs=FullPath)})
+            }
+          )
+          WHERE FullPath =~ PathRegex
+          ORDER BY FullPath DESC
+
+      # Parse all target files and de-duplicate with GROUP BY
+      - SELECT * FROM foreach(
+          row=files,
+          query={
+            SELECT *,
+              timestamp(epoch=int(int=System.TimeCreated.SystemTime)) AS TimeCreated,
+              System.Channel as Channel,
+              System.EventRecordID as EventRecordID,
+              System.EventID.Value as EventID,
+              FullPath
+            FROM parse_evtx(filename=FullPath)
+            WHERE
+              if(condition=StartDate, then=TimeCreated >= timestamp(string=StartDate), else=true)
+              AND if(condition=EndDate, then=TimeCreated <= timestamp(string=EndDate), else=true)
+              AND Channel =~ ChannelRegex
+              AND str(str=EventID) =~ IDRegex
+          }
+        )
+        GROUP BY EventRecordID,Channel


### PR DESCRIPTION
This is a version of a custom artifact we use to grab and parse evtx "in bulk," as discussed in discord - just polished for wider use.  It's basically just a convenience wrapper around the `parse_evtx()` VQL plugin (hence the name), and lets you do some nice things like specify event IDs and channels via regex.  Feedback welcome, and thanks again for a great project and community.