### PR TITLE
Offline Collector cloud upload test before collecting. 

### DIFF
--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -118,46 +118,27 @@ parameters:
   - name: S3Collection
     type: hidden
     default: |
-      // Add all the tools we are going to use to the inventory.
-      LET _ <= SELECT inventory_add(tool=ToolName, hash=ExpectedHash)
-      FROM parse_csv(filename="/inventory.csv", accessor="me")
-      WHERE log(message="Adding tool " + ToolName)
-
-      LET Artifacts <= parse_json_array(data=Artifacts)
-      LET Parameters <= parse_json(data=Parameters)
-      LET baseline <= SELECT Fqdn FROM info()
-      LET TargetArgs <= parse_json(data=target_args)
-
-      // Make the filename safe on windows.
-      LET filename <= regex_replace(
-          source=format(format="Collection-%s-%s",
-                        args=[baseline[0].Fqdn, timestamp(epoch=now())]),
-          re="[^0-9A-Za-z\\-.]", replace="_")
-
-      LET _ <= log(message="Will collect package " + filename +
-         " and upload to s3 bucket " + TargetArgs.bucket)
-
-      SELECT upload_s3(file=Container,
+      // A utility function to upload the file.
+      LET upload_file(filename) = upload_s3(file=filename,
           bucket=TargetArgs.bucket,
-          name=filename + ".zip",
+          name=filename,
           credentialskey=TargetArgs.credentialsKey,
           credentialssecret=TargetArgs.credentialsSecret,
           region=TargetArgs.region,
           endpoint=TargetArgs.endpoint,
-          noverifycert=TargetArgs.noverifycert) AS Upload,
-       upload_s3(file=Report,
-          bucket=TargetArgs.bucket,
-          name=filename + ".html",
-          credentialskey=TargetArgs.credentialsKey,
-          credentialssecret=TargetArgs.credentialsSecret,
-          region=TargetArgs.region,
-          endpoint=TargetArgs.endpoint,
-          noverifycert=TargetArgs.noverifycert) AS ReportUpload
-      FROM collect(artifacts=Artifacts, report=tempfile(extension=".html"),
-          args=Parameters, output=tempfile(extension=".zip"), template=Template,
-          password=Password)
+          noverifycert=TargetArgs.noverifycert)
 
   - name: GCSCollection
+    type: hidden
+    default: |
+      // A utility function to upload the file.
+      LET upload_file(filename) = upload_gcs(file=filename,
+          bucket=TargetArgs.bucket,
+          project=GCSBlob.project_id,
+          name=filename,
+          credentials=TargetArgs.GCSKey)
+
+  - name: CloudCollection
     type: hidden
     default: |
       // Add all the tools we are going to use to the inventory.
@@ -167,9 +148,14 @@ parameters:
 
       LET Artifacts <= parse_json_array(data=Artifacts)
       LET Parameters <= parse_json(data=Parameters)
-      LET baseline <= SELECT Fqdn FROM info()
+      LET baseline <= SELECT Fqdn, basename(path=Exe) AS Exe FROM info()
       LET TargetArgs <= parse_json(data=target_args)
-      LET GCSBlob <= parse_json(data=TargetArgs.GCSKey)
+
+
+      // Try to upload the log file now to see if we are even able to
+      // upload at all - we do this to avoid having to collect all the
+      // data and then failing the upload step.
+      LET upload_test <= upload_file(filename=baseline[0].Exe + ".log")
 
       // Make the filename safe on windows.
       LET filename <= regex_replace(
@@ -178,23 +164,21 @@ parameters:
           re="[^0-9A-Za-z\\-.]", replace="_")
 
       LET _ <= log(message="Will collect package " + filename +
-         " and upload to GCS bucket " + TargetArgs.bucket)
+         " and upload to cloud bucket " + TargetArgs.bucket)
 
-      SELECT upload_gcs(file=Container,
-          bucket=TargetArgs.bucket,
-          project=GCSBlob.project_id,
-          name=filename + ".zip",
-          credentials=TargetArgs.GCSKey
-      ) AS Upload,
-      upload_gcs(file=Report,
-          bucket=TargetArgs.bucket,
-          project=GCSBlob.project_id,
-          name=filename + ".html",
-          credentials=TargetArgs.GCSKey
-      ) AS ReportUpload
-      FROM collect(artifacts=Artifacts, report=tempfile(extension=".html"),
-          args=Parameters, output=tempfile(extension=".zip"), template=Template,
+      LET collect_and_upload = SELECT upload_file(filename=Container) AS Upload,
+          upload_file(filename=Report) AS ReportUpload,
+          upload_file(filename=baseline[0].Exe + ".log") AS LogUpload
+      FROM collect(artifacts=Artifacts,
+          report=tempfile(extension=".html"),
+          args=Parameters,
+          output=tempfile(extension=".zip"),
+          template=Template,
           password=Password)
+
+      SELECT * FROM if(condition=upload_test.Path,
+          then=collect_and_upload,
+          else={SELECT log(message="Aborting collection: Failed to upload to cloud bucket!") FROM scope()})
 
   - name: PackageToolsArtifact
     description: Collects and uploads third party binaries.
@@ -226,6 +210,7 @@ parameters:
           SELECT upload(file=temp, name="inventory.csv") FROM scope()
 
   - name: FetchBinaryOverride
+    type: hidden
     description: |
        A replacement for Generic.Utils.FetchBinary which
        grabs files from the local archive.
@@ -291,8 +276,8 @@ sources:
 
       LET CollectionArtifact <= SELECT Value FROM switch(
         a = { SELECT StandardCollection AS Value FROM scope() WHERE target = "ZIP" },
-        b = { SELECT S3Collection AS Value  FROM scope() WHERE target = "S3" },
-        c = { SELECT GCSCollection AS Value  FROM scope() WHERE target = "GCS" },
+        b = { SELECT S3Collection + CloudCollection AS Value  FROM scope() WHERE target = "S3" },
+        c = { SELECT GCSCollection + CloudCollection AS Value  FROM scope() WHERE target = "GCS" },
         d = { SELECT "" AS Value  FROM scope() WHERE log(message="Unknown collection type " + target) }
       )
 

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -119,9 +119,9 @@ parameters:
     type: hidden
     default: |
       // A utility function to upload the file.
-      LET upload_file(filename) = upload_s3(file=filename,
+      LET upload_file(filename, name) = upload_s3(file=filename,
           bucket=TargetArgs.bucket,
-          name=filename,
+          name=name,
           credentialskey=TargetArgs.credentialsKey,
           credentialssecret=TargetArgs.credentialsSecret,
           region=TargetArgs.region,
@@ -132,10 +132,10 @@ parameters:
     type: hidden
     default: |
       // A utility function to upload the file.
-      LET upload_file(filename) = upload_gcs(file=filename,
+      LET upload_file(filename, name) = upload_gcs(file=filename,
           bucket=TargetArgs.bucket,
           project=GCSBlob.project_id,
-          name=filename,
+          name=name,
           credentials=TargetArgs.GCSKey)
 
   - name: CloudCollection
@@ -151,24 +151,26 @@ parameters:
       LET baseline <= SELECT Fqdn, basename(path=Exe) AS Exe FROM info()
       LET TargetArgs <= parse_json(data=target_args)
 
-
-      // Try to upload the log file now to see if we are even able to
-      // upload at all - we do this to avoid having to collect all the
-      // data and then failing the upload step.
-      LET upload_test <= upload_file(filename=baseline[0].Exe + ".log")
-
       // Make the filename safe on windows.
       LET filename <= regex_replace(
           source=format(format="Collection-%s-%s",
                         args=[baseline[0].Fqdn, timestamp(epoch=now())]),
           re="[^0-9A-Za-z\\-.]", replace="_")
 
+      // Try to upload the log file now to see if we are even able to
+      // upload at all - we do this to avoid having to collect all the
+      // data and then failing the upload step.
+      LET _ <= log(message="Uploading to " + filename + ".log")
+      LET upload_test <= upload_file(filename=baseline[0].Exe + ".log",
+          name=filename + ".log")
+
       LET _ <= log(message="Will collect package " + filename +
          " and upload to cloud bucket " + TargetArgs.bucket)
 
-      LET collect_and_upload = SELECT upload_file(filename=Container) AS Upload,
-          upload_file(filename=Report) AS ReportUpload,
-          upload_file(filename=baseline[0].Exe + ".log") AS LogUpload
+      LET collect_and_upload = SELECT
+          upload_file(filename=Container, name=filename+".zip") AS Upload,
+          upload_file(filename=Report, name=filename+".html") AS ReportUpload,
+          upload_file(filename=baseline[0].Exe + ".log", name=filename+".log") AS LogUpload
       FROM collect(artifacts=Artifacts,
           report=tempfile(extension=".html"),
           args=Parameters,
@@ -178,7 +180,8 @@ parameters:
 
       SELECT * FROM if(condition=upload_test.Path,
           then=collect_and_upload,
-          else={SELECT log(message="Aborting collection: Failed to upload to cloud bucket!") FROM scope()})
+          else={SELECT log(message="Aborting collection: Failed to upload to cloud bucket!")
+                FROM scope()})
 
   - name: PackageToolsArtifact
     description: Collects and uploads third party binaries.

--- a/gui/velociraptor/src/components/flows/offline-collector.js
+++ b/gui/velociraptor/src/components/flows/offline-collector.js
@@ -93,9 +93,9 @@ class OfflineCollectorParameters  extends React.Component {
                       <Col sm="8">
                         <Form.Control as="textarea" rows={3}
                                       placeholder="Bucket name"
-                                      value={this.props.parameters.target_args.gcs_bucket}
+                                      value={this.props.parameters.target_args.bucket}
                                       onChange={e => {
-                                          this.props.parameters.target_args.gcs_bucket = e.target.value;
+                                          this.props.parameters.target_args.bucket = e.target.value;
                                           this.props.setParameters(this.props.parameters);
                                       }}
                         />
@@ -107,9 +107,9 @@ class OfflineCollectorParameters  extends React.Component {
                       <Col sm="8">
                         <Form.Control as="textarea" rows={3}
                                       placeholder="GCS Blob"
-                                      value={this.props.parameters.target_args.gcs_key_blob}
+                                      value={this.props.parameters.target_args.GCSKey}
                                       onChange={e => {
-                                          this.props.parameters.target_args.gcs_key_blob = e.target.value;
+                                          this.props.parameters.target_args.GCSKey = e.target.value;
                                           this.props.setParameters(this.props.parameters);
                                       }}
                         />
@@ -117,6 +117,77 @@ class OfflineCollectorParameters  extends React.Component {
                     </Form.Group> </>
 
                   }
+                  { this.props.parameters.target === "S3" && <>
+                    <Form.Group as={Row}>
+                      <Form.Label column sm="3">S3 Bucket </Form.Label>
+                      <Col sm="8">
+                        <Form.Control as="textarea" rows={3}
+                                      placeholder="Bucket name"
+                                      value={this.props.parameters.target_args.bucket}
+                                      onChange={e => {
+                                          this.props.parameters.target_args.bucket = e.target.value;
+                                          this.props.setParameters(this.props.parameters);
+                                      }}
+                        />
+                      </Col>
+                    </Form.Group>
+
+                    <Form.Group as={Row}>
+                      <Form.Label column sm="3">Credentials Key</Form.Label>
+                      <Col sm="8">
+                        <Form.Control as="textarea" rows={3}
+                                      placeholder="Credentials Key"
+                                      value={this.props.parameters.target_args.credentialsKey}
+                                      onChange={e => {
+                                          this.props.parameters.target_args.credentialsKey = e.target.value;
+                                          this.props.setParameters(this.props.parameters);
+                                      }}
+                        />
+                      </Col>
+                    </Form.Group>
+
+                    <Form.Group as={Row}>
+                      <Form.Label column sm="3">Credentials Secret</Form.Label>
+                      <Col sm="8">
+                        <Form.Control as="textarea" rows={3}
+                                      placeholder="Credentials Secret"
+                                      value={this.props.parameters.target_args.credentialsSecret}
+                                      onChange={e => {
+                                          this.props.parameters.target_args.credentialsSecret = e.target.value;
+                                          this.props.setParameters(this.props.parameters);
+                                      }}
+                        />
+                      </Col>
+                    </Form.Group>
+                    <Form.Group as={Row}>
+                      <Form.Label column sm="3">Region</Form.Label>
+                      <Col sm="8">
+                        <Form.Control as="textarea" rows={3}
+                                      placeholder="Region"
+                                      value={this.props.parameters.target_args.region}
+                                      onChange={e => {
+                                          this.props.parameters.target_args.region = e.target.value;
+                                          this.props.setParameters(this.props.parameters);
+                                      }}
+                        />
+                      </Col>
+                    </Form.Group>
+                    <Form.Group as={Row}>
+                      <Form.Label column sm="3">Endpoint</Form.Label>
+                      <Col sm="8">
+                        <Form.Control as="textarea" rows={3}
+                                      placeholder="Endpoint (blank for AWS)"
+                                      value={this.props.parameters.target_args.endpoint}
+                                      onChange={e => {
+                                          this.props.parameters.target_args.endpoint = e.target.value;
+                                          this.props.setParameters(this.props.parameters);
+                                      }}
+                        />
+                      </Col>
+                    </Form.Group>
+                    </>
+                  }
+
                 </Form>
               </Modal.Body>
               <Modal.Footer>
@@ -144,8 +215,17 @@ export default class OfflineCollectorWizard extends React.Component {
             target_os: "Windows",
             target: "ZIP",
             target_args: {
-                gcs_bucket: "",
-                gcs_key_blob: "",
+                // Common
+                bucket: "",
+
+                // For GCS Buckets
+                GCSKey: "",
+
+                // For S3 buckets.
+                credentialsKey: "",
+                credentialsSecret: "",
+                region: "",
+                endpoint: "",
             },
             template: "Reporting.Default",
             password: "",
@@ -177,7 +257,7 @@ export default class OfflineCollectorWizard extends React.Component {
             this.state.collector_parameters.target_args)});
         env.push({key: "opt_verbose", value: "Y"});
         env.push({key: "opt_banner", value: "Y"});
-        env.push({key: "opt_prompt", value: "Y"});
+        env.push({key: "opt_prompt", value: "N"});
         env.push({key: "opt_admin", value: "Y"});
 
         return request;

--- a/gui/velociraptor/src/components/tools/tool-viewer.js
+++ b/gui/velociraptor/src/components/tools/tool-viewer.js
@@ -350,8 +350,8 @@ export default class ToolViewer extends React.Component {
                               <InputGroup.Text
                                 className={classNames({"disabled": !this.state.tool_file})}
                                 onClick={this.uploadFile}>
-                                { this.state.inflight ?
-                                  <FontAwesomeIcon icon="spinner" spin/> :
+                                { this.state.loading ?
+                                  <FontAwesomeIcon icon="spinner" spin /> :
                                   "Upload" }
                               </InputGroup.Text>
                             </InputGroup.Prepend>


### PR DESCRIPTION
Sometimes the cloud upload fails due to factors beyond our
control (e.g. clock skew or invalid creds). In that case it is
annoying to only find out about it after collecting a ton of
data. This change uploads a small file first and then aborts the
collecting if the file can not be uploaded before collecting all the
artifacts.

This change also uploads the collection log file to the cloud.