### PR TITLE
A few small fixes for better usability 

### DIFF
--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -217,7 +217,11 @@ func installLogoff(config_obj *config_proto.Config, mux *http.ServeMux) {
 			Value:   "",
 			Expires: time.Unix(0, 0),
 		})
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		fmt.Fprintf(w, `
+			<html><body>
+			You have successfully logged off!
+			</body></html>
+		`)
 	}))
 }
 
@@ -232,6 +236,7 @@ func authenticateUserHandle(config_obj *config_proto.Config,
 			logger := logging.GetLogger(config_obj, &logging.Audit)
 			logger.WithFields(logrus.Fields{
 				"remote": r.RemoteAddr,
+				"error":  err.Error(),
 			}).Error("OAuth2 Redirect")
 
 			// Not authorized - redirect to logon screen.

--- a/gui/velociraptor/src/components/artifacts/artifacts.css
+++ b/gui/velociraptor/src/components/artifacts/artifacts.css
@@ -31,7 +31,7 @@
 }
 
 .artifact-search-panel {
-    position: fixed;
+    position: static;
     width: 100%;
     overflow-x: auto;
     height: -webkit-fill-available;


### PR DESCRIPTION
f205d05
 Added 2 little fixes:
* `Sign off` message to avoid a re-auth loop
* Error message in Logger

c408652
Firefox cuts off artifact-search-report and does not show any data with `position: fixed`, changed to `static`

observed before:
![ff](https://user-images.githubusercontent.com/9745163/99289467-aa4d9e00-2845-11eb-865f-37ea73cdf557.jpg)
