### PR TITLE
Add automatic type convertion for artifact parameters.

### DIFF
--- a/artifacts/definitions/Triage/Collection/UploadTable.yaml
+++ b/artifacts/definitions/Triage/Collection/UploadTable.yaml
@@ -23,9 +23,7 @@ sources:
 
       - |
         SELECT * FROM foreach(
-         row={
-           SELECT * FROM parse_csv(filename=triageTable, accessor='data')
-         },
+         row=triageTable,
          query={
            SELECT FullPath, Size, Modifed, Type,
                FileDetails.Path AS ZipPath,

--- a/artifacts/definitions/Windows/Attack/ParentProcess.yaml
+++ b/artifacts/definitions/Windows/Attack/ParentProcess.yaml
@@ -28,7 +28,6 @@ parameters:
 sources:
      - queries:
        # Build up some cached queries for speed.
-       - LET lookup <= SELECT * FROM parse_csv(filename=lookupTable, accessor='data')
        - LET processes <= SELECT Name, Pid, Ppid, CommandLine, CreateTime, Exe FROM pslist()
        - LET processes_lookup <= SELECT Name As ProcessName, Pid As ProcID FROM processes
        - |
@@ -52,6 +51,6 @@ sources:
                     ActualParentName,
                     Pid, Ppid, CommandLine, CreateTime, Exe,
                     ParentRegex as ExpectedParentName
-             FROM lookup
+             FROM lookupTable
              WHERE ActualProcessName =~ ProcessName AND NOT ActualParentName =~ ParentRegex
          })

--- a/artifacts/definitions/Windows/Attack/Prefetch.yaml
+++ b/artifacts/definitions/Windows/Attack/Prefetch.yaml
@@ -58,7 +58,7 @@ reports:
       could potentially mean.
 
       {{ define "query" }}
-         LET lookup <= SELECT * FROM parse_csv(filename=lookupTable, accessor='data')
+         LET lookup <= SELECT * FROM lookupTable
       {{ end }}
 
       {{ define "data"}}

--- a/artifacts/definitions/Windows/Collectors/File.yaml
+++ b/artifacts/definitions/Windows/Collectors/File.yaml
@@ -25,7 +25,7 @@ sources:
      queries:
       # Generate the collection globs for each device
       - LET specs = SELECT RootDevice + "\\" + Glob AS Glob
-            FROM parse_csv(filename=collectionSpec, accessor="data")
+            FROM collectionSpec
             WHERE log(message="Processing Device " + RootDevice + " With " + Accessor)
 
       # Join all the collection rules into a single Glob plugin. This ensure we

--- a/artifacts/definitions/Windows/Collectors/VSS.yaml
+++ b/artifacts/definitions/Windows/Collectors/VSS.yaml
@@ -42,8 +42,8 @@ sources:
             WHERE Name = "\\\\.\\" + RootDevice
 
       # Generate the collection globs for each device
-      - LET specs = SELECT Device + Glob AS Glob FROM parse_csv(
-            filename=collectionSpec, accessor="data")
+      - LET specs = SELECT Device + Glob AS Glob
+            FROM collectionSpec
             WHERE log(message="Processing Device " + Device + " With " + Accessor)
 
       # Join all the collection rules into a single Glob plugin. This ensure we

--- a/artifacts/definitions/Windows/Detection/RemoteYara/Process.yaml
+++ b/artifacts/definitions/Windows/Detection/RemoteYara/Process.yaml
@@ -82,7 +82,7 @@ sources:
         LET me <= SELECT Pid FROM pslist(pid=getpid())
       - |
         LET whitelist <= SELECT upcase(string=Path) AS Path
-                FROM parse_csv(filename=pathWhitelist, accessor='data')
+                FROM pathWhitelist
       - |
         LET processes <= SELECT Name as ProcessName, CommandLine, Pid
             FROM pslist()

--- a/artifacts/definitions/Windows/Forensics/LocalHashes/Query.yaml
+++ b/artifacts/definitions/Windows/Forensics/LocalHashes/Query.yaml
@@ -39,7 +39,7 @@ sources:
       LET hashes = SELECT Hash FROM chain(
       a={
         SELECT lowcase(string=strip(string=Hash)) AS Hash
-        FROM parse_csv(filename=Hashes, accessor="data")
+        FROM Hashes
       }, b={
         SELECT * FROM foreach(row=split(string=CommaDelimitedHashes, sep=","),
         query={

--- a/artifacts/definitions/Windows/Persistence/PermanentWMIEvents.yaml
+++ b/artifacts/definitions/Windows/Persistence/PermanentWMIEvents.yaml
@@ -21,8 +21,7 @@ sources:
    queries:
      - LET FilterToConsumerBinding = SELECT * FROM foreach(
         row={
-                SELECT *
-                FROM parse_csv(filename=namespaces, accessor='data')
+                SELECT * FROM namespaces
         },
         query={
                 SELECT parse_string_with_regex(string=Consumer,
@@ -34,8 +33,7 @@ sources:
 
      - SELECT * FROM foreach(
             row={
-                    SELECT *
-                    FROM parse_csv(filename=namespaces, accessor='data')
+                    SELECT * FROM namespaces
             },
             query={
                  SELECT {

--- a/artifacts/definitions/Windows/Remediation/Quarantine.yaml
+++ b/artifacts/definitions/Windows/Remediation/Quarantine.yaml
@@ -71,7 +71,7 @@ sources:
                   SrcAddr,SrcMask,SrcPort,
                   DstAddr,DstMask,DstPort,
                   Protocol,Mirrored,Description
-              FROM parse_csv(filename=RuleLookupTable, accessor='data')
+              FROM RuleLookupTable
 
         // Parse a URL to get domain name.
         LET get_domain(URL) = parse_string_with_regex(

--- a/artifacts/definitions/Windows/Remediation/Sinkhole.yaml
+++ b/artifacts/definitions/Windows/Remediation/Sinkhole.yaml
@@ -1,25 +1,25 @@
 name: Windows.Remediation.Sinkhole
 description: |
-   **Apply a Sinkhole via Windows hosts file modification**  
-   This content will modify the Windows hosts file by a configurable 
-   lookup table.  
+   **Apply a Sinkhole via Windows hosts file modification**
+   This content will modify the Windows hosts file by a configurable
+   lookup table.
 
-   On application, the original configuration is backed up.  
-   When reapplying a sinkhole, the original configuration is restored then 
-   changes applied to maintain integrity of the restore process.  
-   If RestoreBackup is selected the artifact will restore the backup 
+   On application, the original configuration is backed up.
+   When reapplying a sinkhole, the original configuration is restored then
+   changes applied to maintain integrity of the restore process.
+   If RestoreBackup is selected the artifact will restore the backup
    configuration, then delete the backup with no further processing.
-   
+
    NOTE:
-   Modifying the hosts file may cause network communication issues. I have 
-   disabled any sinkhole settings on the Velociraptor agent configuration 
+   Modifying the hosts file may cause network communication issues. I have
+   disabled any sinkhole settings on the Velociraptor agent configuration
    but there are no rail guards on other domains. Use with caution.
 
 author: Matt Green - @mgreen27
 
 required_permissions:
   - EXECVE
-  
+
 type: CLIENT
 
 parameters:
@@ -49,13 +49,13 @@ sources:
 
     query: |
       -- Extract sink hole requirements from table
-      LET changes <= SELECT 
+      LET changes <= SELECT
                 Domain,
                 Sinkhole,
                 if(condition=Description,
                   then= CommentPrefix + ': ' + Description,
                   else= CommentPrefix) as Description
-            FROM parse_csv(filename=SinkholeTable, accessor='data') 
+            FROM SinkholeTable
 
       -- Check for backup to determine if sinkhole applied
       LET check_backup = SELECT FullPath FROM stat(filename=HostsFileBackup)
@@ -67,10 +67,10 @@ sources:
       LET restore = SELECT * FROM chain(
             a=copy(filename=HostsFileBackup,dest=HostsFile),
             b={
-                SELECT * 
+                SELECT *
                 FROM if(condition=RestoreBackup,
                     then={
-                        SELECT * 
+                        SELECT *
                         FROM execve(argv=['cmd.exe', '/c',
                             'del','/F',HostsFileBackup])
                     })
@@ -78,11 +78,11 @@ sources:
 
       -- Write hosts file
       LET write(DataBlob) = copy(filename=DataBlob,dest=HostsFile,accessor='data')
-      
+
       -- FlushDNS
-      LET flushdns = SELECT * 
+      LET flushdns = SELECT *
         FROM execve(argv=['cmd.exe', '/c','ipconfig','/flushdns'])
-                
+
       -- Find existing entries to modify
       LET existing = SELECT
             parse_string_with_regex(
@@ -93,8 +93,8 @@ sources:
             ]) as Record,
             Line
         FROM parse_lines(filename=HostsFile)
-        WHERE 
-            Line 
+        WHERE
+            Line
             AND NOT Line =~ '^#'
 
       -- Parse a URL to get domain name.
@@ -127,7 +127,7 @@ sources:
       -- Add new hostsfile entries
       LET find_newline = SELECT * FROM foreach(row=changes,
             query={
-                SELECT 
+                SELECT
                     format(format='\t%v\t\t%v\t\t# %v',
                         args=[Sinkhole,Domain,Description]) as Line,
                     Domain,
@@ -139,12 +139,12 @@ sources:
             })
 
       -- Determine which lines should stay the same
-      LET find_line= SELECT 
+      LET find_line= SELECT
                 Line,
                 Record.Hostname as Domain,
                 'old entry' as Type
             FROM existing
-            WHERE 
+            WHERE
                 NOT Domain in find_modline.Domain
                 AND NOT Domain in find_newline.Domain
 
@@ -154,7 +154,7 @@ sources:
             b=find_newline,
             c=find_line
       )
-      
+
       -- Join lines from staging object
       LET HostsData = join(array=build_lines.Line,sep='\r\n')
 
@@ -172,16 +172,16 @@ sources:
                             },
                         else= backup)
                 )
-                
+
       -- Do kick off logic
-      LET do_it <= SELECT * FROM if(condition= NOT RestoreBackup, 
+      LET do_it <= SELECT * FROM if(condition= NOT RestoreBackup,
             then= {
                 SELECT * FROM chain(
                     a= log(message='Adding hosts entries.'),
                     b= write(DataBlob=HostsData),
                     c= flushdns
-                    
+
                 )})
-                
+
       -- Finally show resultant HostsFile
       SELECT * FROM Artifact.Windows.System.HostsFile()

--- a/artifacts/definitions/Windows/System/CriticalServices.yaml
+++ b/artifacts/definitions/Windows/System/CriticalServices.yaml
@@ -27,11 +27,9 @@ parameters:
        wuauserv
 
 sources:
-     - queries:
-       - LET lookup <= SELECT * FROM parse_csv(filename=lookupTable, accessor='data')
-       - |
+     - query: |
          SELECT Name, DisplayName, Created, State, {
-            SELECT * FROM lookup WHERE Name =~ ServiceName
+            SELECT * FROM lookupTable WHERE Name =~ ServiceName
          } AS Critical
          FROM Artifact.Windows.System.Services()
          WHERE Critical AND State != "Running"

--- a/artifacts/testdata/windows/remediation.in.yaml
+++ b/artifacts/testdata/windows/remediation.in.yaml
@@ -17,7 +17,7 @@ Queries:
     WHERE Line =~ "evil.com"
 
   # Test rolling back sinkhole - output none and check hosts file at end.
-  - SELECT * FROM Artifact.Windows.Remediation.Sinkhole(RestoreBackup="True")
+  - SELECT * FROM Artifact.Windows.Remediation.Sinkhole(RestoreBackup=True)
 
   # Should not have evil.com in it any more.
   - SELECT Line from parse_lines(filename=HostFile)

--- a/artifacts/testdata/windows/remediation.out.yaml
+++ b/artifacts/testdata/windows/remediation.out.yaml
@@ -9,4 +9,4 @@ SELECT Line from parse_lines(filename=HostFile) WHERE Line =~ "evil.com"[]SELECT
  {
   "Line": "\t127.0.0.1\t\tevil.com\t\t# Velociraptor sinkhole: Evilcorp C2 domain"
  }
-]SELECT * FROM Artifact.Windows.Remediation.Sinkhole(RestoreBackup="True")[]SELECT Line from parse_lines(filename=HostFile) WHERE Line =~ "evil.com"[]
+]SELECT * FROM Artifact.Windows.Remediation.Sinkhole(RestoreBackup=True)[]SELECT Line from parse_lines(filename=HostFile) WHERE Line =~ "evil.com"[]

--- a/artifacts/testdata/windows/vss.in.yaml
+++ b/artifacts/testdata/windows/vss.in.yaml
@@ -11,8 +11,8 @@ Queries:
   # even though the logs were cleared.
   - SELECT EventID,ServiceName,Source FROM Artifact.Windows.EventLogs.ServiceCreationComspec(
        EventLog="C:\\Windows\\system32\\winevt\\logs\\System.evtx",
-       SearchVSS="True")
+       SearchVSS=True)
 
   # Find cleared event logs - should show 2 times.
   - SELECT EventID, Channel, Message=~ 'Clear',Source FROM Artifact.Windows.EventLogs.Cleared(
-       SearchVSS="True")
+       SearchVSS=True)

--- a/artifacts/testdata/windows/vss.out.yaml
+++ b/artifacts/testdata/windows/vss.out.yaml
@@ -18,7 +18,7 @@ SELECT FullPath, SHA1, Source, Deduped FROM Artifact.Windows.Search.VSS(SearchFi
   "Source": "C:",
   "Deduped": true
  }
-]SELECT EventID,ServiceName,Source FROM Artifact.Windows.EventLogs.ServiceCreationComspec( EventLog="C:\\Windows\\system32\\winevt\\logs\\System.evtx", SearchVSS="True")[
+]SELECT EventID,ServiceName,Source FROM Artifact.Windows.EventLogs.ServiceCreationComspec( EventLog="C:\\Windows\\system32\\winevt\\logs\\System.evtx", SearchVSS=True)[
  {
   "EventID": 7045,
   "ServiceName": "TestingDetection1",
@@ -29,7 +29,7 @@ SELECT FullPath, SHA1, Source, Deduped FROM Artifact.Windows.Search.VSS(SearchFi
   "ServiceName": "TestingDetection2",
   "Source": "C:"
  }
-]SELECT EventID, Channel, Message=~ 'Clear',Source FROM Artifact.Windows.EventLogs.Cleared( SearchVSS="True")[
+]SELECT EventID, Channel, Message=~ 'Clear',Source FROM Artifact.Windows.EventLogs.Cleared( SearchVSS=True)[
  {
   "EventID": 104,
   "Channel": "System",

--- a/file_store/memory/memory.go
+++ b/file_store/memory/memory.go
@@ -48,6 +48,7 @@ type MemoryWriter struct {
 func (self *MemoryWriter) Size() (int64, error) {
 	return int64(len(self.buf)), nil
 }
+
 func (self *MemoryWriter) Write(data []byte) (int, error) {
 	self.buf = append(self.buf, data...)
 	return len(data), nil

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/ZachtimusPrime/Go-Splunk-HTTP v0.0.0-20200420213219-094ff9e8d788
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/chroma v0.7.2
-	github.com/alecthomas/participle v0.6.0
-	github.com/alecthomas/repr v0.0.0-20201006074542-804e374aceb1 // indirect
+	github.com/alecthomas/participle v0.7.1
+	github.com/alecthomas/repr v0.0.0-20201120212035-bb82daffcca2 // indirect
 	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
 	github.com/aws/aws-sdk-go v1.26.7
 	github.com/bi-zone/etw v0.0.0-20200916105032-b215904fae4f
@@ -121,7 +121,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20200722101157-37e4751dd5ca
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20201009013914-88dce699d74e
+	www.velocidex.com/golang/vfilter v0.0.0-20201207041817-0a52513015ec
 	www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -89,12 +89,16 @@ github.com/alecthomas/kong v0.2.4/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq
 github.com/alecthomas/participle v0.4.4/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/participle v0.6.0 h1:Pvo8XUCQKgIywVjz/+Ci3IsjGg+g/TdKkMcfgghKCEw=
 github.com/alecthomas/participle v0.6.0/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
+github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
+github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c h1:MVVbswUlqicyj8P/JljoocA7AyCo62gzD0O7jfvrhtE=
 github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20201006074542-804e374aceb1 h1:ncv/2kzkBh4MtnP6YYN+L0GOWKutnFwzq/X9Xtk3V6I=
 github.com/alecthomas/repr v0.0.0-20201006074542-804e374aceb1/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/alecthomas/repr v0.0.0-20201120212035-bb82daffcca2 h1:G5TeG64Ox4OWq2YwlsxS7nOedU8vbGgNRTRDAjGvDCk=
+github.com/alecthomas/repr v0.0.0-20201120212035-bb82daffcca2/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -797,5 +801,7 @@ www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiA
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
 www.velocidex.com/golang/vfilter v0.0.0-20201009013914-88dce699d74e h1:b52ELePcwuPHkHOVSvN78RiktExbT911s/AYbEmv9vU=
 www.velocidex.com/golang/vfilter v0.0.0-20201009013914-88dce699d74e/go.mod h1:XlUeViBwZxeefhxbkxW2oGUVcB/oQfxtBgnxL9jLryg=
+www.velocidex.com/golang/vfilter v0.0.0-20201207041817-0a52513015ec h1:1thCFMv0Kh8EdoskNvDrIhssOp0XK/ND6lu+U/p17eE=
+www.velocidex.com/golang/vfilter v0.0.0-20201207041817-0a52513015ec/go.mod h1:XlUeViBwZxeefhxbkxW2oGUVcB/oQfxtBgnxL9jLryg=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b h1:z5v5o1dhtzaxvlWm6qSTYZ4OTr56Ol2JpM1Y5Wu9zQE=
 www.velocidex.com/golang/vtypes v0.0.0-20180924145839-b0d509f8925b/go.mod h1:tXxIx8UJuI81Hoxcv0DTq2a1Pi1H6l1uCf4dhqUSUkw=

--- a/services/launcher/fixtures/TestParameterTypes.golden
+++ b/services/launcher/fixtures/TestParameterTypes.golden
@@ -1,0 +1,39 @@
+[
+ {
+  "IntValue": 9,
+  "CSVValue": [
+   {
+    "Col1": "Value1",
+    "Col2": "Value2"
+   },
+   {
+    "Col1": "Value3",
+    "Col2": "Value4"
+   }
+  ],
+  "TimestampValue": "2020-10-01T09:20:00Z",
+  "TimestampValue.Unix": 1601544000,
+  "timestamp(epoch=TimestampValue)": "2020-10-01T09:20:00Z",
+  "TimestampValueUnset": "0001-01-01T00:00:00Z",
+  "TimestampValueUnset.Unix": -62135596800,
+  "DateAfterTime": "1600-01-01T00:00:00Z",
+  "DateBeforeTime": "2020-10-01T09:20:00Z",
+  "BoolValue": false,
+  "BoolValue2": true,
+  "BoolValueUnset": false,
+  "BoolValue = \"Y\"": false,
+  "BoolValue != \"Y\"": true,
+  "BoolValue2 = \"Y\"": true,
+  "BoolValue2 != \"Y\"": false,
+  "{ SELECT * FROM CSVValue }": [
+   {
+    "Col1": "Value1",
+    "Col2": "Value2"
+   },
+   {
+    "Col1": "Value3",
+    "Col2": "Value4"
+   }
+  ]
+ }
+]

--- a/services/vfs_service/vfs_service_test.go
+++ b/services/vfs_service/vfs_service_test.go
@@ -184,9 +184,12 @@ func (self *VFSServiceTestSuite) TestVFSDownload() {
 			makeStat("/a/b", "B"),
 		})
 
-	// Simulate and upload was received by our System.VFS.DownloadFile collection.
+	// Simulate an upload that was received by our System.VFS.DownloadFile collection.
 	file_store := self.GetMemoryFileStore()
-	file_store.Data[flow_path_manager.GetUploadsFile("file", "/a/b/B").Path()] = []byte("Data")
+	fd, err := file_store.WriteFile(flow_path_manager.GetUploadsFile("file", "/a/b/B").Path())
+	assert.NoError(self.T(), err)
+	fd.Write([]byte("Data"))
+	fd.Close()
 
 	self.EmulateCollection(
 		"System.VFS.DownloadFile", []*ordereddict.Dict{

--- a/vql/functions/time.go
+++ b/vql/functions/time.go
@@ -28,7 +28,7 @@ func (self cachedTime) Size() int {
 type _TimestampArg struct {
 	Epoch       vfilter.Any `vfilter:"optional,field=epoch"`
 	CocoaTime   int64       `vfilter:"optional,field=cocoatime"`
-	MacTime   int64       `vfilter:"optional,field=mactime,doc=HFS+"`
+	MacTime     int64       `vfilter:"optional,field=mactime,doc=HFS+"`
 	WinFileTime int64       `vfilter:"optional,field=winfiletime"`
 	String      string      `vfilter:"optional,field=string,doc=Guess a timestamp from a string"`
 	UsStyle     bool        `vfilter:"optional,field=us_style,doc=US Style Month/Day/Year"`
@@ -52,7 +52,7 @@ func (self _Timestamp) Call(ctx context.Context, scope *vfilter.Scope,
 		scope.Log("timestamp: %s", err.Error())
 		return vfilter.Null{}
 	}
-	 
+
 	if arg.CocoaTime > 0 {
 		return time.Unix((arg.CocoaTime + 978307200), 0)
 	}
@@ -60,7 +60,7 @@ func (self _Timestamp) Call(ctx context.Context, scope *vfilter.Scope,
 	if arg.MacTime > 0 {
 		return time.Unix((arg.MacTime - 2082844800), 0)
 	}
-	
+
 	if arg.WinFileTime > 0 {
 		return time.Unix((arg.WinFileTime/10000000)-11644473600, 0)
 	}
@@ -87,6 +87,11 @@ func TimeFromAny(scope *vfilter.Scope, timestamp vfilter.Any) (time.Time, error)
 		dec = int64(dec_f * 1e9)
 
 	case string:
+		// If there is no input return an empty timestamp
+		// (unix epoch)
+		if t == "" {
+			return time.Time{}, nil
+		}
 		return parse_time_from_string(scope, t)
 
 	case time.Time:


### PR DESCRIPTION
Since all artifact parameters are sent to the client as strings, they
need to be converted into proper types in VQL. This change does this
automatically in the VQL compiler, leaving artifact writers to specify
their required types directly.