### PR TITLE
Firefox history parser

### DIFF
--- a/artifacts/definitions/Windows/Applications/Firefox/History.yaml
+++ b/artifacts/definitions/Windows/Applications/Firefox/History.yaml
@@ -1,0 +1,39 @@
+name: Windows.Application.Firefox.History
+description: |
+  Enumerate the users Firefox history.
+author: Zach Stanford @svch0st
+parameters:
+  - name: placesGlobs
+    default: \AppData\Roaming\Mozilla\Firefox\Profiles\*\places.sqlite
+  - name: urlSQLQuery
+    default: |
+        SELECT *,url as url_visited FROM moz_historyvisits, moz_places WHERE moz_historyvisits.place_id=moz_places.id
+  - name: userRegex
+    default: .
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+sources:
+  - queries:
+      - |
+        LET places_files = SELECT * from foreach(
+          row={
+             SELECT Uid, Name AS User, Directory
+             FROM Artifact.Windows.Sys.Users()
+             WHERE Name =~ userRegex
+          },
+          query={
+             SELECT User, FullPath, Mtime from glob(
+               globs=Directory + placesGlobs)
+          })
+
+      - |
+        SELECT * FROM foreach(row=places_files,
+          query={
+            SELECT User, FullPath,
+                   timestamp(epoch=visit_date/1000000) as visit_time,
+                   place_id,url_visited,title,rev_host,visit_count,hidden,typed,description
+            FROM sqlite(
+              file=FullPath,
+              query=urlSQLQuery)
+          })


### PR DESCRIPTION
Joins the two tables moz_historyvisits, moz_places from the Firefox places.sqlite database.