### PR TITLE
Fix crash on windows service.

### DIFF
--- a/bin/installer_windows.go
+++ b/bin/installer_windows.go
@@ -352,8 +352,10 @@ func loadClientConfig() (*config_proto.Config, error) {
 		WithWriteback().
 		LoadAndValidate()
 	if err != nil {
-		logger := logging.GetLogger(config_obj, &logging.ClientComponent)
-		logger.Info("Failed to load %v will try again soon.\n", *config_path)
+		// Config obj is not valid here, we can not actually
+		// log anything since we dont know where to send it so
+		// prelog instead.
+		logging.Prelog("Failed to load %v will try again soon.\n", *config_path)
 
 		return nil, err
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -87,6 +87,11 @@ func Prelog(format string, v ...interface{}) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	// Truncate too many logs
+	if len(prelogs) > 10000 {
+		prelogs = nil
+	}
+
 	prelogs = append(prelogs, fmt.Sprintf(format, v...))
 }
 


### PR DESCRIPTION
When a config file is missing, the service attempts to log but logging
is not yet available.