### PR TITLE
Implemented file buffers for directory queue manager.

### DIFF
--- a/api/csrf.go
+++ b/api/csrf.go
@@ -27,7 +27,7 @@ func csrfProtect(config_obj *config_proto.Config,
 	_, _ = hasher.Write([]byte(config_obj.Frontend.PrivateKey))
 	token := hasher.Sum(nil)
 
-	protectionFn := csrf.Protect(token, csrf.Path("/"))
+	protectionFn := csrf.Protect(token, csrf.Path("/"), csrf.MaxAge(7*24*60*60))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		protectionFn(parent).ServeHTTP(w, r)

--- a/artifacts/definitions/Windows/Forensics/Lnk.yaml
+++ b/artifacts/definitions/Windows/Forensics/Lnk.yaml
@@ -395,9 +395,9 @@ sources:
 column_types:
   - name: Mtime
     type: timestamp
-  - name: ATime
+  - name: Atime
     type: timestamp
-  - name: CTime
+  - name: Ctime
     type: timestamp
   - name: HeaderCreationTime
     type: timestamp

--- a/executor/pool.go
+++ b/executor/pool.go
@@ -71,15 +71,18 @@ func (self *PoolClientExecutor) ReadResponse() <-chan *crypto_proto.GrrMessage {
 
 // Inspect the request and decide if we will cache it under a query.
 func getQueryName(message *crypto_proto.GrrMessage) string {
+	query_name := ""
 	if message.VQLClientAction != nil {
 		for _, query := range message.VQLClientAction.Query {
 			if query.Name != "" {
-				return query.Name
+				query_name = query.Name
 			}
 		}
+		// Cache it under the query name and the
+		serialized, _ := json.Marshal(message.VQLClientAction.Env)
+		return fmt.Sprintf("%v: %v", query_name, string(serialized))
 
 	}
-
 	return ""
 }
 

--- a/file_store/api/queues.go
+++ b/file_store/api/queues.go
@@ -10,7 +10,8 @@ import (
 // responsible for rotating the queue files as required.
 type QueueManager interface {
 	PushEventRows(path_manager PathManager, rows []*ordereddict.Dict) error
-	Watch(queue_name string) (output <-chan *ordereddict.Dict, cancel func())
+	Watch(ctx context.Context, queue_name string) (
+		output <-chan *ordereddict.Dict, cancel func())
 }
 
 type ResultSetFileProperties struct {

--- a/file_store/api/testsuite.go
+++ b/file_store/api/testsuite.go
@@ -241,7 +241,8 @@ func (self *QueueManagerTestSuite) TestPush() {
 		ordereddict.NewDict().Set("foo", 1),
 		ordereddict.NewDict().Set("foo", 2)}
 
-	output, cancel := self.manager.Watch(artifact_name)
+	ctx := context.Background()
+	output, cancel := self.manager.Watch(ctx, artifact_name)
 	defer cancel()
 
 	err := self.manager.PushEventRows(

--- a/file_store/directory/buffer.go
+++ b/file_store/directory/buffer.go
@@ -1,0 +1,239 @@
+// A ring buffer to queue messages
+
+// Similar to the client ring buffer but this one has no limit because
+// we never want to block writers.
+
+package directory
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/Velocidex/ordereddict"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
+	logging "www.velocidex.com/golang/velociraptor/logging"
+)
+
+// The below is similar to http_comms.FileBasedRingBuffer except:
+// * Size of the file is not limited.
+// * Leasing a full number of messages at once (rather than combined size).
+
+const (
+	FileMagic         = "VRB\x5e"
+	FirstRecordOffset = 50
+)
+
+type Header struct {
+	ReadPointer  int64 // Leasing will start at this file offset.
+	WritePointer int64 // Enqueue will write at this file position.
+}
+
+func (self *Header) MarshalBinary() ([]byte, error) {
+	data := make([]byte, FirstRecordOffset)
+	copy(data, FileMagic)
+
+	binary.LittleEndian.PutUint64(data[4:12], uint64(self.ReadPointer))
+	binary.LittleEndian.PutUint64(data[12:20], uint64(self.WritePointer))
+
+	return data, nil
+}
+
+func (self *Header) UnmarshalBinary(data []byte) error {
+	if len(data) < FirstRecordOffset {
+		return errors.New("Invalid header length")
+	}
+
+	if string(data[:4]) != FileMagic {
+		return errors.New("Invalid Magic")
+	}
+
+	self.ReadPointer = int64(binary.LittleEndian.Uint64(data[4:12]))
+	self.WritePointer = int64(binary.LittleEndian.Uint64(data[12:20]))
+
+	return nil
+}
+
+type FileBasedRingBuffer struct {
+	config_obj *config_proto.Config
+
+	mu sync.Mutex
+
+	fd     *os.File
+	header *Header
+
+	read_buf  []byte
+	write_buf []byte
+
+	log_ctx *logging.LogContext
+}
+
+// Enqueue the item into the ring buffer and append to the end.
+func (self *FileBasedRingBuffer) Enqueue(item interface{}) error {
+	serialized, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	// Write the new message to the end of the file at the WritePointer
+	binary.LittleEndian.PutUint64(self.write_buf, uint64(len(serialized)))
+	_, err = self.fd.WriteAt(self.write_buf, int64(self.header.WritePointer))
+	if err != nil {
+		// File is corrupt now, reset it.
+		self.Reset()
+		return err
+	}
+
+	n, err := self.fd.WriteAt(serialized, int64(self.header.WritePointer+8))
+	if err != nil {
+		self.Reset()
+		return err
+	}
+
+	self.header.WritePointer += 8 + int64(n)
+
+	// Update the header
+	serialized, err = self.header.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	_, err = self.fd.WriteAt(serialized, 0)
+	if err != nil {
+		self.Reset()
+		return err
+	}
+
+	return nil
+}
+
+// Returns some messages message from the file.
+func (self *FileBasedRingBuffer) Lease(count int) []*ordereddict.Dict {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	result := make([]*ordereddict.Dict, 0, count)
+
+	// The file contains more data.
+	for self.header.WritePointer > self.header.ReadPointer {
+
+		// Read the next chunk (length+value) from the current leased pointer.
+		n, err := self.fd.ReadAt(self.read_buf, self.header.ReadPointer)
+		if err != nil || n != len(self.read_buf) {
+			self.log_ctx.Error("Possible corruption detected: file too short.")
+			self._Truncate()
+			return nil
+		}
+
+		length := int64(binary.LittleEndian.Uint64(self.read_buf))
+		// File might be corrupt - just reset the
+		// entire file.
+		if length > constants.MAX_MEMORY*2 || length <= 0 {
+			self.log_ctx.Error("Possible corruption detected - item length is too large.")
+			self._Truncate()
+			return nil
+		}
+
+		// Unmarshal one item at a time.
+		serialized := make([]byte, length)
+		n, _ = self.fd.ReadAt(serialized, self.header.ReadPointer+8)
+		if int64(n) != length {
+			self.log_ctx.Errorf(
+				"Possible corruption detected - expected item of length %v received %v.",
+				length, n)
+			self._Truncate()
+			return nil
+		}
+
+		item := ordereddict.NewDict()
+		err = item.UnmarshalJSON(serialized)
+		if err == nil {
+			result = append(result, item)
+		}
+
+		self.header.ReadPointer += 8 + int64(n)
+		// We read up to the write pointer, we may truncate the file now.
+		if self.header.ReadPointer == self.header.WritePointer {
+			self._Truncate()
+		}
+
+		if len(result) >= count {
+			break
+		}
+	}
+
+	return result
+}
+
+// _Truncate returns the file to a virgin state. Assumes
+// FileBasedRingBuffer is already under lock.
+func (self *FileBasedRingBuffer) _Truncate() {
+	_ = self.fd.Truncate(0)
+	self.header.ReadPointer = FirstRecordOffset
+	self.header.WritePointer = FirstRecordOffset
+	serialized, _ := self.header.MarshalBinary()
+	_, _ = self.fd.WriteAt(serialized, 0)
+}
+
+func (self *FileBasedRingBuffer) Reset() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self._Truncate()
+}
+
+// Closes the underlying file and shut down the readers.
+func (self *FileBasedRingBuffer) Close() {
+	self.fd.Close()
+}
+
+func NewFileBasedRingBuffer(
+	config_obj *config_proto.Config, fd *os.File) (*FileBasedRingBuffer, error) {
+
+	log_ctx := logging.GetLogger(config_obj, &logging.FrontendComponent)
+
+	header := &Header{
+		// Pad the header a bit to allow for extensions.
+		WritePointer: FirstRecordOffset,
+		ReadPointer:  FirstRecordOffset,
+	}
+	data := make([]byte, FirstRecordOffset)
+	n, err := fd.ReadAt(data, 0)
+	if n > 0 && n < FirstRecordOffset && err == io.EOF {
+		log_ctx.Error("Possible corruption detected: file too short.")
+		err = fd.Truncate(0)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if n > 0 && (err == nil || err == io.EOF) {
+		err := header.UnmarshalBinary(data[:n])
+		// The header is not valid, truncate the file and
+		// start again.
+		if err != nil {
+			log_ctx.Errorf("Possible corruption detected: %v.", err)
+			err = fd.Truncate(0)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	result := &FileBasedRingBuffer{
+		config_obj: config_obj,
+		fd:         fd,
+		header:     header,
+		read_buf:   make([]byte, 8),
+		write_buf:  make([]byte, 8),
+		log_ctx:    log_ctx,
+	}
+
+	return result, nil
+}

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -1,21 +1,279 @@
+// A Queue manager that uses files on disk.
+
+// The queue manager is a broken between writers and readers. Writers
+// want to emit a message to a queue with minimumal delay, and have
+// the message dispatched to all readers with minimal latency.
+
+// A memory queue simply pushes the message to all reader's via a
+// buffered channel. As long as the channel buffer remains available
+// this works well with very minimal latency in broadcasting to
+// readers. However, when the channel becomes full the writers may be
+// blocked while readers are working their way through the channel.
+
+// This queue manager uses a combination of a channel and a disk file
+// to buffer messages for readers. When a writer writes to the queue
+// manager, the manager attempts to write on the channel but if it is
+// not available, then writer switches to a ring buffer file on disk.
+// A separate go routine drains the disk file into the channel
+// periodically. Therefore, we never block the writer - either the
+// message is delivered immediately to the buffered channel, or it is
+// written to disk and later delivered.
+
+// This low latency property is critical because queue managers are
+// used to deliver messages in critical code paths and can not be
+// delayed.
+
 package directory
 
 import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"time"
+
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
-	"www.velocidex.com/golang/velociraptor/file_store/memory"
 	"www.velocidex.com/golang/velociraptor/file_store/result_sets"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
-var (
-	pool = memory.NewQueuePool()
-)
+// A listener wraps a channel that our client will listen on. We send
+// the message to each listener that is subscribed to the queue.
+type Listener struct {
+	id int64
+	mu sync.Mutex
+
+	// The consumer interested in these events. The consumer may
+	// block arbitrarily.
+	output chan *ordereddict.Dict
+
+	// We receive events on this channel - we guarantee this does
+	// not block for long.
+	input chan *ordereddict.Dict
+
+	// A backup file to store extra messages.
+	file_buffer *FileBasedRingBuffer
+
+	// Name of the file_buffer
+	tmpfile string
+	cancel  func()
+}
+
+// Should not block - very fast.
+func (self *Listener) Send(item *ordereddict.Dict) {
+	self.input <- item
+}
+
+func (self *Listener) Close() {
+	self.cancel()
+	self.file_buffer.Close()
+
+	// Close the output channel so our listener will exit.
+	close(self.output)
+
+	os.Remove(self.tmpfile) // clean up file buffer
+}
+
+func (self *Listener) Debug() *ordereddict.Dict {
+	result := ordereddict.NewDict().Set("BackingFile", self.tmpfile)
+	st, _ := os.Stat(self.tmpfile)
+	result.Set("Size", int64(st.Size()))
+
+	return result
+}
+
+func NewListener(config_obj *config_proto.Config, ctx context.Context,
+	output chan *ordereddict.Dict) (*Listener, error) {
+
+	tmpfile, err := ioutil.TempFile("", "journal")
+	if err != nil {
+		return nil, err
+	}
+
+	file_buffer, err := NewFileBasedRingBuffer(config_obj, tmpfile)
+	if err != nil {
+		return nil, err
+	}
+
+	subctx, cancel := context.WithCancel(ctx)
+	self := &Listener{
+		id:          time.Now().UnixNano(),
+		cancel:      cancel,
+		input:       make(chan *ordereddict.Dict),
+		output:      output,
+		file_buffer: file_buffer,
+		tmpfile:     tmpfile.Name(),
+	}
+
+	// Pump messages from input channel and distribute to
+	// output. If output is busy we divert to the file buffer.
+	go func() {
+		defer cancel()
+
+		for {
+			select {
+			case <-subctx.Done():
+				return
+
+			case item, ok := <-self.input:
+				if !ok {
+					return
+				}
+				select {
+				case <-subctx.Done():
+					return
+
+					// If we can immediately push
+					// to the output, do so
+				case self.output <- item:
+
+					// Otherwise push to the file.
+				default:
+					self.file_buffer.Enqueue(item)
+				}
+			}
+		}
+
+	}()
+
+	// Pump messages from the file_buffer to our listeners.
+	go func() {
+		for {
+			// Wait here until the file has some data in it.
+			select {
+			case <-subctx.Done():
+				return
+
+			case <-time.After(time.Second):
+				// Get some messages from the file.
+				for _, item := range self.file_buffer.Lease(100) {
+					select {
+					case <-subctx.Done():
+						return
+					case self.output <- item:
+					}
+				}
+			}
+		}
+	}()
+
+	return self, nil
+}
+
+// A Queue manages a set of registrations at a specific queue name
+// (artifact name).
+type QueuePool struct {
+	mu sync.Mutex
+
+	config_obj *config_proto.Config
+
+	registrations map[string][]*Listener
+}
+
+func (self *QueuePool) Register(
+	ctx context.Context, vfs_path string) (<-chan *ordereddict.Dict, func()) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	output_chan := make(chan *ordereddict.Dict)
+
+	registrations := self.registrations[vfs_path]
+	new_registration, err := NewListener(self.config_obj, ctx, output_chan)
+	if err != nil {
+		close(output_chan)
+		return output_chan, func() {}
+	}
+
+	registrations = append(registrations, new_registration)
+
+	self.registrations[vfs_path] = registrations
+
+	return output_chan, func() {
+		self.unregister(vfs_path, new_registration.id)
+	}
+}
+
+// This holds a lock on the entire pool and it is used when the system
+// shuts down so not very often.
+func (self *QueuePool) unregister(vfs_path string, id int64) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	registrations, pres := self.registrations[vfs_path]
+	if pres {
+		new_registrations := make([]*Listener, 0, len(registrations))
+		for _, item := range registrations {
+			if id == item.id {
+				item.Close()
+			} else {
+				new_registrations = append(new_registrations,
+					item)
+			}
+		}
+
+		self.registrations[vfs_path] = new_registrations
+	}
+}
+
+// Make a copy of the registrations under lock and then we can take
+// our time to send them later.
+func (self *QueuePool) getRegistrations(vfs_path string) []*Listener {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	registrations, ok := self.registrations[vfs_path]
+	if ok {
+		// Make a copy of the registrations for sending this
+		// message.
+		return append([]*Listener{}, registrations...)
+	}
+
+	return nil
+}
+
+func (self *QueuePool) Broadcast(vfs_path string, row *ordereddict.Dict) {
+	// Ensure we do not hold the lock for very long here.
+	for _, item := range self.getRegistrations(vfs_path) {
+		item.Send(row)
+	}
+}
+
+func (self *QueuePool) Debug() *ordereddict.Dict {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	result := ordereddict.NewDict()
+	for k, v := range self.registrations {
+		listeners := ordereddict.NewDict()
+		for idx, l := range v {
+			listeners.Set(fmt.Sprintf("%v", idx), l.Debug())
+		}
+		result.Set(k, listeners)
+	}
+	return result
+}
+
+func NewQueuePool(config_obj *config_proto.Config) *QueuePool {
+	return &QueuePool{
+		config_obj:    config_obj,
+		registrations: make(map[string][]*Listener),
+	}
+}
 
 type DirectoryQueueManager struct {
-	FileStore api.FileStore
-	Clock     utils.Clock
+	mu sync.Mutex
+
+	queue_pool *QueuePool
+	FileStore  api.FileStore
+	config_obj *config_proto.Config
+	Clock      utils.Clock
+}
+
+func (self *DirectoryQueueManager) Debug() *ordereddict.Dict {
+	return self.queue_pool.Debug()
 }
 
 func (self *DirectoryQueueManager) PushEventRows(
@@ -32,20 +290,22 @@ func (self *DirectoryQueueManager) PushEventRows(
 		// Set a timestamp per event for easier querying.
 		row.Set("_ts", int(self.Clock.Now().Unix()))
 		rs_writer.Write(row)
-		pool.Broadcast(path_manager.GetQueueName(), row)
+		self.queue_pool.Broadcast(path_manager.GetQueueName(), row)
 	}
 	return nil
 }
 
-func (self *DirectoryQueueManager) Watch(
+func (self *DirectoryQueueManager) Watch(ctx context.Context,
 	queue_name string) (output <-chan *ordereddict.Dict, cancel func()) {
-	return pool.Register(queue_name)
+	return self.queue_pool.Register(ctx, queue_name)
 }
 
 func NewDirectoryQueueManager(config_obj *config_proto.Config,
 	file_store api.FileStore) api.QueueManager {
 	return &DirectoryQueueManager{
-		FileStore: file_store,
-		Clock:     utils.RealClock{},
+		FileStore:  file_store,
+		config_obj: config_obj,
+		queue_pool: NewQueuePool(config_obj),
+		Clock:      utils.RealClock{},
 	}
 }

--- a/file_store/directory/queue_test.go
+++ b/file_store/directory/queue_test.go
@@ -1,15 +1,34 @@
-package directory
+package directory_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/Velocidex/ordereddict"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"www.velocidex.com/golang/velociraptor/config"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/file_store/directory"
 	"www.velocidex.com/golang/velociraptor/file_store/memory"
+	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	"www.velocidex.com/golang/velociraptor/paths/artifacts"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/journal"
+	"www.velocidex.com/golang/velociraptor/services/repository"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+var (
+	monitoringArtifact = `
+name: TestQueue
+type: SERVER_EVENT
+`
 )
 
 func TestDirectoryQueueManager(t *testing.T) {
@@ -23,6 +42,121 @@ func TestDirectoryQueueManager(t *testing.T) {
 	config_obj.Datastore.FilestoreDirectory = dir
 	config_obj.Datastore.Location = dir
 
-	manager := NewDirectoryQueueManager(config_obj, memory.Test_memory_file_store)
+	manager := directory.NewDirectoryQueueManager(config_obj, memory.Test_memory_file_store)
 	suite.Run(t, api.NewQueueManagerTestSuite(config_obj, manager, memory.Test_memory_file_store))
+}
+
+type TestSuite struct {
+	suite.Suite
+	config_obj *config_proto.Config
+	client_id  string
+	sm         *services.Service
+	dir        string
+}
+
+func (self *TestSuite) SetupTest() {
+	dir, err := ioutil.TempDir("", "file_store_test")
+	assert.NoError(self.T(), err)
+	self.dir = dir
+
+	os.Setenv("temp", dir)
+
+	self.config_obj, err = new(config.Loader).WithFileLoader(
+		"../../http_comms/test_data/server.config.yaml").
+		WithRequiredFrontend().WithWriteback().
+		LoadAndValidate()
+	require.NoError(self.T(), err)
+
+	// Start essential services.
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*60)
+	self.sm = services.NewServiceManager(ctx, self.config_obj)
+
+	require.NoError(self.T(), self.sm.Start(journal.StartJournalService))
+	require.NoError(self.T(), self.sm.Start(repository.StartRepositoryManager))
+
+	self.client_id = "C.12312"
+}
+
+func (self *TestSuite) TearDownTest() {
+	self.sm.Close()
+	test_utils.GetMemoryFileStore(self.T(), self.config_obj).Clear()
+	test_utils.GetMemoryDataStore(self.T(), self.config_obj).Clear()
+	os.RemoveAll(self.dir) // clean up
+
+}
+
+func (self *TestSuite) TestQueueManager() {
+	repo_manager, err := services.GetRepositoryManager()
+	assert.NoError(self.T(), err)
+
+	repository, err := repo_manager.GetGlobalRepository(self.config_obj)
+	assert.NoError(self.T(), err)
+
+	_, err = repository.LoadYaml(monitoringArtifact, true)
+	assert.NoError(self.T(), err)
+
+	file_store := test_utils.GetMemoryFileStore(self.T(), self.config_obj)
+	manager := directory.NewDirectoryQueueManager(
+		self.config_obj, file_store).(*directory.DirectoryQueueManager)
+
+	// Push some rows to the queue manager
+	ctx := context.Background()
+
+	reader, cancel := manager.Watch(ctx, "TestQueue")
+
+	path_manager := artifacts.NewMonitoringArtifactLogPathManager(self.config_obj,
+		"C.123", "TestQueue")
+
+	// Query the state of the manager for testing.
+	dbg := manager.Debug()
+	// The initial size is zero
+	assert.Equal(self.T(), int64(0), utils.GetInt64(dbg, "TestQueue.0.Size"))
+
+	// Push some rows without reading - this should write to the
+	// file buffer and not block.
+	for i := 0; i < 10; i++ {
+		err = manager.PushEventRows(path_manager, []*ordereddict.Dict{
+			ordereddict.NewDict().
+				Set("Foo", "Bar"),
+		})
+		assert.NoError(self.T(), err)
+	}
+
+	// The file should contain all the rows now.
+	dbg = manager.Debug()
+
+	// File size is not accurate due to timestamps
+	assert.Greater(self.T(), utils.GetInt64(dbg, "TestQueue.0.Size"), int64(300))
+
+	// Now read all the rows from the file.
+	count := 0
+	for row := range reader {
+		count++
+		assert.Equal(self.T(), "Bar", utils.GetString(row, "Foo"))
+
+		// Break on the 10th row
+		if count >= 10 {
+			break
+		}
+	}
+
+	// Now check the file - it should be truncated since we read all messages.
+	dbg = manager.Debug()
+	assert.Equal(self.T(), int64(50), utils.GetInt64(dbg, "TestQueue.0.Size"))
+
+	// Now cancel the watcher - further reads from the channel
+	// should not block - the channel is closed.
+	cancel()
+
+	for range reader {
+	}
+
+	// Now make sure the tempfile is removed.
+	tempfile := utils.GetString(dbg, "TestQueue.0.BackingFile")
+	_, err = os.Stat(tempfile)
+	assert.Error(self.T(), err)
+}
+
+func TestFileBasedQueueManager(t *testing.T) {
+	suite.Run(t, &TestSuite{})
 }

--- a/file_store/mysql/queue.go
+++ b/file_store/mysql/queue.go
@@ -30,6 +30,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync"
@@ -242,7 +243,8 @@ func (self *MysqlQueueManager) PushEventRows(
 	return err
 }
 
-func (self *MysqlQueueManager) Watch(queue_name string) (<-chan *ordereddict.Dict, func()) {
+func (self *MysqlQueueManager) Watch(
+	ctx context.Context, queue_name string) (<-chan *ordereddict.Dict, func()) {
 	return pool.Register(queue_name)
 }
 

--- a/file_store/result_sets/events_test.go
+++ b/file_store/result_sets/events_test.go
@@ -177,10 +177,9 @@ func (self *TimedResultSetTestSuite) TestTimedResultSets() {
 	clock := &utils.MockClock{MockNow: now}
 
 	// Start off by writing some events on a queue.
-	qm := &directory.DirectoryQueueManager{
-		FileStore: self.file_store,
-		Clock:     clock,
-	}
+	qm := directory.NewDirectoryQueueManager(
+		self.config_obj, self.file_store).(*directory.DirectoryQueueManager)
+	qm.Clock = clock
 
 	path_manager := artifacts.NewArtifactPathManager(
 		self.config_obj,

--- a/flows/foreman.go
+++ b/flows/foreman.go
@@ -134,6 +134,10 @@ func ForemanProcessMessage(
 			return err
 		}
 
+		notifier := services.GetNotifier()
+		if notifier == nil {
+			return errors.New("Notifier not configured")
+		}
 		return services.GetNotifier().NotifyListener(config_obj, client_id)
 	})
 }

--- a/gui/velociraptor/src/components/core/api-service.js
+++ b/gui/velociraptor/src/components/core/api-service.js
@@ -38,6 +38,13 @@ const get = function(url, params, cancel_token) {
         url: api_handlers + url,
         params: params,
         cancelToken: cancel_token,
+    }).then(response=>{
+        // Update the csrf token.
+        let token = response.headers["x-csrf-token"];
+        if (token && token.length > 0) {
+            window.CsrfToken = token;
+        }
+        return response;
     }).catch(handle_error);
 };
 

--- a/gui/velociraptor/src/components/forms/validated_int.js
+++ b/gui/velociraptor/src/components/forms/validated_int.js
@@ -21,9 +21,13 @@ export default class ValidatedInteger extends React.Component {
 
     render() {
         let value = this.props.value;
+
+        // Need to set the initial value to '' to tell React this is a
+        // controlled component.
         if (_.isUndefined(value)) {
-            value = 0;
+            value = '';
         }
+
         return (
             <>
               <Form.Control placeholder={this.props.placeholder || ""}

--- a/gui/velociraptor/src/components/vfs/file-list.js
+++ b/gui/velociraptor/src/components/vfs/file-list.js
@@ -176,13 +176,17 @@ class VeloFileList extends Component {
 
         // To recursively download files we launch an artifact
         // collection.
-        let path = this.props.node.path || [];
-        if (path.length < 1) {
+
+        //  full_path is the client side path as told by the client's
+        //  VFSListDirectory.
+        let full_path = this.props.node && this.props.node.full_path;
+        if (!full_path || !node.path) {
             return;
         }
 
-        let accessor = path[0];
-        let search_path = Join(path.slice(1));
+        // path is a list of components starting with the accessor
+        let accessor = node.path[0];
+        let search_path = full_path;
         api.post("v1/CollectArtifact", {
             urgent: true,
             client_id: this.props.client.client_id,

--- a/gui/velociraptor/src/components/vfs/file-text-view.js
+++ b/gui/velociraptor/src/components/vfs/file-text-view.js
@@ -34,9 +34,11 @@ export default class FileTextView extends React.Component {
         // 1. Selected node changes (file list was selected).
         // 2. VFS path changes (tree navigated away).
         // 3. node version changes (file was refreshed).
+        // 4. page is changed
         if (prevProps.node.selected !== this.props.node.selected ||
             !_.isEqual(prevProps.node.path, this.props.node.path) ||
-            prevProps.node.version !== this.props.node.version) {
+            prevProps.node.version !== this.props.node.version ||
+            prevState.page != this.state.page) {
             this.fetchText_(this.state.page);
         };
     }

--- a/gui/velociraptor/src/components/vfs/file-tree.js
+++ b/gui/velociraptor/src/components/vfs/file-tree.js
@@ -294,6 +294,7 @@ class VeloFileTree extends Component {
                             children.push({
                                 name: file_info.Name,
                                 path: path_components,
+                                full_path: file_info._FullPath,
                                 children: [],
                             });
                         }

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -372,7 +372,7 @@ func StartClientMonitoringService(
 		return err
 	}
 
-	events, cancel := journal.Watch("Server.Internal.ArtifactModification")
+	events, cancel := journal.Watch(ctx, "Server.Internal.ArtifactModification")
 
 	wg.Add(1)
 	go func() {

--- a/services/interrogation/interrogation.go
+++ b/services/interrogation/interrogation.go
@@ -49,7 +49,7 @@ func (self *EnrollmentService) Start(
 		return err
 	}
 
-	events, cancel := journal.Watch("Server.Internal.Enrollment")
+	events, cancel := journal.Watch(ctx, "Server.Internal.Enrollment")
 
 	wg.Add(1)
 	go func() {

--- a/services/interrogation/utils.go
+++ b/services/interrogation/utils.go
@@ -30,7 +30,7 @@ func watchForFlowCompletion(
 		return err
 	}
 
-	events, cancel := journal.Watch("System.Flow.Completion")
+	events, cancel := journal.Watch(ctx, "System.Flow.Completion")
 	manager, err := services.GetRepositoryManager()
 	if err != nil {
 		return err

--- a/services/journal.go
+++ b/services/journal.go
@@ -15,6 +15,7 @@ package services
 // in real time from client event artifacts.
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -52,7 +53,8 @@ type JournalService interface {
 	// Watch the artifact named by queue_name for new rows. This
 	// only makes sense for artifacts of type CLIENT_EVENT and
 	// SERVER_EVENT
-	Watch(queue_name string) (output <-chan *ordereddict.Dict, cancel func())
+	Watch(ctx context.Context,
+		queue_name string) (output <-chan *ordereddict.Dict, cancel func())
 
 	// Push the rows into the datastore in the location give by
 	// the path manager.

--- a/services/journal/journal.go
+++ b/services/journal/journal.go
@@ -27,7 +27,8 @@ type JournalService struct {
 	qm api.QueueManager
 }
 
-func (self *JournalService) Watch(queue_name string) (
+func (self *JournalService) Watch(
+	ctx context.Context, queue_name string) (
 	output <-chan *ordereddict.Dict, cancel func()) {
 
 	if self == nil || self.qm == nil {
@@ -35,7 +36,7 @@ func (self *JournalService) Watch(queue_name string) (
 		return nil, func() {}
 	}
 
-	return self.qm.Watch(queue_name)
+	return self.qm.Watch(ctx, queue_name)
 }
 
 func (self *JournalService) PushRowsToArtifact(

--- a/services/labels/labels.go
+++ b/services/labels/labels.go
@@ -370,7 +370,7 @@ func (self *Labeler) Start(ctx context.Context,
 		return err
 	}
 
-	events, cancel := journal.Watch("Server.Internal.Label")
+	events, cancel := journal.Watch(ctx, "Server.Internal.Label")
 
 	wg.Add(1)
 	go func() {

--- a/services/notifications/notifications.go
+++ b/services/notifications/notifications.go
@@ -60,7 +60,7 @@ func StartNotificationService(
 	if err != nil {
 		return err
 	}
-	events, cancel := journal.Watch("Server.Internal.Notifications")
+	events, cancel := journal.Watch(ctx, "Server.Internal.Notifications")
 
 	wg.Add(1)
 	go func() {
@@ -74,6 +74,7 @@ func StartNotificationService(
 			self.notification_pool.Shutdown()
 			self.notification_pool = nil
 		}()
+		defer logger.Info("Exiting notification service!")
 
 		for {
 			select {
@@ -90,7 +91,6 @@ func StartNotificationService(
 					continue
 				}
 
-				self.pool_mu.Lock()
 				if target == "Regex" {
 					regex_str, ok := event.GetString("Regex")
 					if ok {
@@ -109,7 +109,6 @@ func StartNotificationService(
 				} else {
 					self.notification_pool.Notify(target)
 				}
-				self.pool_mu.Unlock()
 			}
 		}
 	}()

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -47,6 +47,9 @@ func (self *EventTable) Close() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
+	logger.Info("Closing Server Monitoring Event table")
+
 	// Close the old table.
 	if self.cancel != nil {
 		self.cancel()
@@ -117,6 +120,7 @@ func (self *EventTable) Update(
 
 	// Run each collection separately in parallel.
 	for _, vql_request := range vql_requests {
+
 		err = self.RunQuery(ctx, config_obj, self.wg, vql_request)
 		if err != nil {
 			return err
@@ -197,7 +201,6 @@ func (self *EventTable) RunQuery(
 		for _, query := range vql_request.Query {
 			vql, err := vfilter.Parse(query.VQL)
 			if err != nil {
-				scope.Log("server_monitoring: %v", err)
 				return
 			}
 
@@ -217,7 +220,6 @@ func (self *EventTable) RunQuery(
 					rs_writer.Write(vfilter.RowToDict(ctx, scope, row).
 						Set("_ts", self.Clock.Now().Unix()))
 					rs_writer.Flush()
-
 				}
 			}
 		}

--- a/services/services.go
+++ b/services/services.go
@@ -19,6 +19,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -52,6 +53,7 @@ type Service struct {
 }
 
 func (self *Service) Close() {
+	fmt.Printf("Closing services\n")
 	self.cancel()
 
 	// Wait for services to exit.

--- a/services/test_utils.go
+++ b/services/test_utils.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"sync"
 
 	"github.com/Velocidex/ordereddict"
@@ -28,7 +29,8 @@ func GetPublishedEvents(
 		if err != nil {
 			return
 		}
-		events, cancel := journal.Watch(artifact)
+		ctx := context.Background()
+		events, cancel := journal.Watch(ctx, artifact)
 		defer cancel()
 
 		// Wait here until we are set up.

--- a/services/vfs_service/utils.go
+++ b/services/vfs_service/utils.go
@@ -31,12 +31,15 @@ func watchForFlowCompletion(
 		return err
 	}
 
-	events, cancel := journal.Watch("System.Flow.Completion")
+	events, cancel := journal.Watch(ctx, "System.Flow.Completion")
+
+	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		defer cancel()
+		defer logger.Info("Stopping watch for %v", artifact_name)
 
 		builder := services.ScopeBuilder{
 			Config:     config_obj,

--- a/services/vfs_service/vfs_service.go
+++ b/services/vfs_service/vfs_service.go
@@ -64,6 +64,8 @@ func (self *VFSService) ProcessDownloadFile(
 	ts, _ := row.GetInt64("_ts")
 
 	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	logger.Info("VFSService: Processing System.VFS.DownloadFile from %v", client_id)
+
 	flow_path_manager := paths.NewFlowPathManager(client_id, flow_id)
 
 	path_manager := artifacts.NewArtifactPathManager(config_obj,
@@ -127,6 +129,8 @@ func (self *VFSService) ProcessListDirectory(
 	ts, _ := row.GetInt64("_ts")
 
 	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	logger.Info("VFSService: Processing System.VFS.ListDirectory from %v", client_id)
+
 	path_manager := artifacts.NewArtifactPathManager(config_obj,
 		client_id, flow_id, "System.VFS.ListDirectory")
 
@@ -141,6 +145,7 @@ func (self *VFSService) ProcessListDirectory(
 	var current_vfs_components []string = nil
 
 	for row := range row_chan {
+		utils.Debug(row)
 		full_path, _ := row.GetString("_FullPath")
 		accessor, _ := row.GetString("_Accessor")
 		name, _ := row.GetString("Name")

--- a/utils/dict.go
+++ b/utils/dict.go
@@ -8,11 +8,11 @@ import (
 
 // Returns the containing dict for a nested dict. This allows fetching
 // a key using dot notation.
-func _get(dict *ordereddict.Dict, key string) *ordereddict.Dict {
+func _get(dict *ordereddict.Dict, key string) (*ordereddict.Dict, string) {
 	components := strings.Split(key, ".")
 	// Only a single component, return the dict.
 	if len(components) == 1 {
-		return dict
+		return dict, components[0]
 	}
 
 	// Iterate over all but the last component fetching the nested
@@ -21,26 +21,26 @@ func _get(dict *ordereddict.Dict, key string) *ordereddict.Dict {
 	for _, member := range components[:len(components)-1] {
 		result, pres := dict.Get(member)
 		if !pres {
-			return ordereddict.NewDict()
+			return ordereddict.NewDict(), ""
 		}
 		nested, ok := result.(*ordereddict.Dict)
 		if !ok {
-			return ordereddict.NewDict()
+			return ordereddict.NewDict(), ""
 		}
 		dict = nested
 	}
 
-	return dict
+	return dict, components[len(components)-1]
 }
 
 func GetString(dict *ordereddict.Dict, key string) string {
-	dict = _get(dict, key)
-	res, _ := dict.GetString(key)
+	subdict, last := _get(dict, key)
+	res, _ := subdict.GetString(last)
 	return res
 }
 
 func GetInt64(dict *ordereddict.Dict, key string) int64 {
-	dict = _get(dict, key)
-	res, _ := dict.GetInt64(key)
+	subdict, last := _get(dict, key)
+	res, _ := subdict.GetInt64(last)
 	return res
 }

--- a/vql/common/for.go
+++ b/vql/common/for.go
@@ -64,6 +64,56 @@ func (self ForPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfil
 	}
 }
 
+type RangePluginArgs struct {
+	Start int64 `vfilter:"required,field=start,doc=Start index (0 based)"`
+	End   int64 `vfilter:"required,field=end,doc=End index (0 based)"`
+	Step  int64 `vfilter:"required,field=step,doc=End index (0 based)"`
+}
+
+type RangePlugin struct{}
+
+func (self RangePlugin) Call(
+	ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) <-chan vfilter.Row {
+	output_chan := make(chan vfilter.Row)
+
+	go func() {
+		defer close(output_chan)
+
+		arg := &RangePluginArgs{}
+		err := vfilter.ExtractArgs(scope, args, arg)
+		if err != nil {
+			scope.Log("range: %v", err)
+			return
+		}
+
+		if arg.Step == 0 {
+			arg.Step = 1
+		}
+
+		for i := arg.Start; i < arg.End; i += arg.Step {
+			select {
+			case <-ctx.Done():
+				return
+
+			case output_chan <- ordereddict.NewDict().Set("_value", i):
+			}
+		}
+	}()
+
+	return output_chan
+}
+
+func (self RangePlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.PluginInfo {
+	return &vfilter.PluginInfo{
+		Name:    "range",
+		Doc:     "Iterate over range.",
+		ArgType: type_map.AddType(scope, &RangePluginArgs{}),
+	}
+}
+
 func init() {
+	vql_subsystem.RegisterPlugin(&RangePlugin{})
 	vql_subsystem.RegisterPlugin(&ForPlugin{})
 }

--- a/vql/server/monitoring.go
+++ b/vql/server/monitoring.go
@@ -155,7 +155,7 @@ func (self WatchMonitoringPlugin) Call(
 		}
 
 		// Ask the journal service to watch the event queue for us.
-		qm_chan, cancel := journal.Watch(arg.Artifact)
+		qm_chan, cancel := journal.Watch(ctx, arg.Artifact)
 		defer cancel()
 
 		for row := range qm_chan {


### PR DESCRIPTION
Previously, the queue manager was in memory only, pushing events
through memory channels to consumers. This means if a consumer was too
slow, events were accumulating in memory until the channel was
full. At this point, the back pressure on the senders would cause
server lockup since queues are often read in the critical path.

This change creates an overflow buffer file for each queue
listener. If the listener is not available to read from the channel
immediately, the queue manager will write the data to a file, and
return immediately to the writer.

Therefore it is no longer possible to block on queue writes which
ensures stability under high load.