### PR TITLE
Pass types to dependent artifacts in request.

### DIFF
--- a/flows/artifacts.go
+++ b/flows/artifacts.go
@@ -485,12 +485,19 @@ func FailIfError(
 
 	// Update the hunt stats if this is a hunt.
 	if constants.HuntIdRegex.MatchString(collection_context.Request.Creator) {
-		err := services.GetHuntDispatcher().ModifyHunt(
+		dispatcher := services.GetHuntDispatcher()
+		if dispatcher == nil {
+			return errors.New("Hunt dispatcher not ready")
+		}
+
+		err := dispatcher.ModifyHunt(
 			collection_context.Request.Creator,
 			func(hunt *api_proto.Hunt) error {
 				if hunt != nil && hunt.Stats != nil {
 					hunt.Stats.TotalClientsWithErrors++
 				}
+				// We pretty much always modify the
+				// stats here.
 				return nil
 			})
 		if err != nil {

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -111,9 +111,9 @@ func (self *HuntDispatcher) ModifyHunt(
 		if hunt_obj.StartTime > self.GetLastTimestamp() {
 			atomic.StoreUint64(&self.last_timestamp, hunt_obj.StartTime)
 		}
-
 		self.dirty = true
 	}
+
 	return err
 }
 
@@ -131,6 +131,7 @@ func (self *HuntDispatcher) _flush_stats(config_obj *config_proto.Config) error 
 		return err
 	}
 
+	// Only write the updated stats
 	for _, hunt_obj := range self.hunts {
 		hunt_path_manager := paths.NewHuntPathManager(hunt_obj.HuntId)
 		err = db.SetSubject(config_obj,
@@ -163,9 +164,8 @@ func (self *HuntDispatcher) Refresh(config_obj *config_proto.Config) error {
 	// is OK because we will get those clients on the next foreman
 	// update - the important thing is that foreman checks are not
 	// blocked by this.
-	atomic.StoreUint64(&self.last_timestamp, 0)
+	last_timestamp := atomic.SwapUint64(&self.last_timestamp, 0)
 
-	var last_timestamp uint64
 	defer func() {
 		atomic.StoreUint64(&self.last_timestamp, last_timestamp)
 	}()

--- a/services/launcher/compiler.go
+++ b/services/launcher/compiler.go
@@ -34,7 +34,7 @@ func maybeEscape(name string) string {
 }
 
 func CompileSingleArtifact(config_obj *config_proto.Config,
-	repository services.Repository, artifact *artifacts_proto.Artifact,
+	artifact *artifacts_proto.Artifact,
 	result *actions_proto.VQLCollectorArgs) error {
 	for _, parameter := range artifact.Parameters {
 		value := parameter.Default
@@ -118,12 +118,11 @@ LET %v <= if(
 		}
 	}
 
-	return mergeSources(config_obj, repository, artifact, result)
+	return mergeSources(config_obj, artifact, result)
 }
 
 func mergeSources(
-	config_obj *config_proto.Config,
-	repository services.Repository, artifact *artifacts_proto.Artifact,
+	config_obj *config_proto.Config, artifact *artifacts_proto.Artifact,
 	result *actions_proto.VQLCollectorArgs) error {
 
 	scope := vql_subsystem.MakeScope()
@@ -335,6 +334,7 @@ func PopulateArtifactsVQLCollectorArgs(
 				filtered_parameters = append(filtered_parameters,
 					&artifacts_proto.ArtifactParameter{
 						Name:    param.Name,
+						Type:    param.Type,
 						Default: param.Default,
 					})
 			}

--- a/services/launcher/fixtures/TestParameterTypesDeps.golden
+++ b/services/launcher/fixtures/TestParameterTypesDeps.golden
@@ -12,6 +12,6 @@
    }
   ],
   "BoolValue": true,
-  "BoolValue2": "Y"
+  "BoolValue2": true
  }
 ]

--- a/services/launcher/fixtures/TestParameterTypesDepsQuery.golden
+++ b/services/launcher/fixtures/TestParameterTypesDepsQuery.golden
@@ -25,7 +25,8 @@
    {
     "Foo": 2
    }
-  ]
+  ],
+  "BoolValue": true
  },
  {
   "IntValue": 5

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -148,7 +148,7 @@ func (self *Launcher) getVQLCollectorArgs(
 	should_obfuscate bool) (*actions_proto.VQLCollectorArgs, error) {
 
 	vql_collector_args := &actions_proto.VQLCollectorArgs{}
-	err := CompileSingleArtifact(config_obj, repository, artifact, vql_collector_args)
+	err := CompileSingleArtifact(config_obj, artifact, vql_collector_args)
 	if err != nil {
 		return nil, err
 	}

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -112,7 +112,7 @@ name: Test.Artifact.Types
 parameters:
 - name: IntValue
   type: int
-  default: 5
+  default: "5"
 
 - name: CSVValue
   type: csv
@@ -781,7 +781,9 @@ func (self *LauncherTestSuite) TestParameterTypesDepsQuery() {
 		"SELECT BoolValue FROM Artifact.Test.Artifact.Types(BoolValue=TRUE)",
 		"SELECT BoolValue FROM Artifact.Test.Artifact.Types(BoolValue='N')",
 		"SELECT BoolValue FROM Artifact.Test.Artifact.Types(BoolValue='Y')",
-		"SELECT CSVValue FROM Artifact.Test.Artifact.Types(CSVValue=[dict(Foo=1), dict(Foo=2)])",
+
+		// Check that default parameters on artifact plugin call are properly parsed.
+		"SELECT CSVValue, BoolValue FROM Artifact.Test.Artifact.Types(CSVValue=[dict(Foo=1), dict(Foo=2)])",
 		"SELECT IntValue FROM Artifact.Test.Artifact.Types(IntValue=5)",
 		"SELECT TimestampValue FROM Artifact.Test.Artifact.Types(TimestampValue=timestamp(epoch=1608714807))",
 	}

--- a/services/services.go
+++ b/services/services.go
@@ -19,7 +19,6 @@ package services
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -53,7 +52,6 @@ type Service struct {
 }
 
 func (self *Service) Close() {
-	fmt.Printf("Closing services\n")
 	self.cancel()
 
 	// Wait for services to exit.


### PR DESCRIPTION
This is needed to properly convert default types for dependencies.

When calling the client we attach a distilled version of the artifact
definition of dependent artifacts (i.e. those referenced from within
the VQL). This allows the client to resolve dependencies at runtime.

While args passed directly to dependent args have the correct type
already, defaults are always strings and need to be converted. In
order to do that correctly the client needs to know about their types.

NOTE: This might cause erros on older clients - usually not critical
errors. This happens because current artifacts assume parameters are
already converted to their correct types and if the client is not
doing this correctly they will fail.