### PR TITLE
API service bugfix: Call scope destructors before closing channel.

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -96,13 +96,13 @@ func streamQuery(
 
 	// Now execute the query.
 	scope := manager.BuildScope(builder)
-	defer scope.Close()
 
 	// Throttle the query if required.
 	vfilter.InstallThrottler(scope, vfilter.NewTimeThrottler(float64(rate)))
 
 	go func() {
 		defer close(response_channel)
+		defer scope.Close()
 
 		scope.Log("Starting query execution.")
 
@@ -118,7 +118,7 @@ func streamQuery(
 			// All the queries will use the same scope. This allows one
 			// query to define functions for the next query in order.
 			for query_idx, vql := range statements {
-				fmt.Printf("Running %v\n", vql.ToString(scope))
+				logger.Info("Query: Running %v\n", vql.ToString(scope))
 
 				result_chan := vfilter.GetResponseChannel(
 					vql, stream.Context(), scope,

--- a/artifacts/definitions/Windows/NTFS/MFT.yaml
+++ b/artifacts/definitions/Windows/NTFS/MFT.yaml
@@ -1,23 +1,23 @@
 name: Windows.NTFS.MFT
 description: |
-  This artifact parses $MFT files and returns rows of each in scope  MFT record. 
-  This artifact can be used as the basis for other artifacts where the MFT needs 
+  This artifact parses $MFT files and returns rows of each in scope  MFT record.
+  This artifact can be used as the basis for other artifacts where the MFT needs
   to be queried or for deleted file recovery.
-  
-  For deleted file recovery: Take the MFT ID of a file of interest and provide 
-  it to the Windows.NTFS.Recover artifact.  
-  
-  To query all attached ntfs drives: check the AllDrives switch.  
 
-  I have added several filters to uplift search capabilities from the original 
-  MFT artifact. Due to the multi-drive features, the MFTPath will output the MFT 
-  path of the entry.  
+  For deleted file recovery: Take the MFT ID of a file of interest and provide
+  it to the Windows.NTFS.Recover artifact.
 
-  Available filters include:  
-  - FullPath regex  
-  - FileName regex  
-  - Time bounds to select files with a timestamp within time ranges   
-  - FileSize bounds 
+  To query all attached ntfs drives: check the AllDrives switch.
+
+  I have added several filters to uplift search capabilities from the original
+  MFT artifact. Due to the multi-drive features, the MFTPath will output the MFT
+  path of the entry.
+
+  Available filters include:
+  - FullPath regex
+  - FileName regex
+  - Time bounds to select files with a timestamp within time ranges
+  - FileSize bounds
 
 author: "Matt Green - @mgreen27"
 
@@ -52,9 +52,9 @@ parameters:
 sources:
   - query: |
       -- firstly set timebounds for performance
-      LET DateAfterTime <= if(condition=DateAfter, 
+      LET DateAfterTime <= if(condition=DateAfter,
             then=DateAfter, else="1600-01-01")
-      LET DateBeforeTime <= if(condition=DateBefore, 
+      LET DateBeforeTime <= if(condition=DateBefore,
             then=DateBefore, else="2200-01-01")
 
 
@@ -71,32 +71,32 @@ sources:
         FROM parse_mft(filename=MFTPath, accessor=Accessor)
         WHERE FullPath =~ PathRegex
             AND FileName =~ FileRegex
-            AND Created0x10 < DateBeforeTime 
-            AND Created0x10 > DateAfterTime 
-            AND Created0x30 < DateBeforeTime 
-            AND Created0x30 > DateAfterTime 
-            AND LastModified0x10 < DateBeforeTime  
-            AND LastModified0x10 > DateAfterTime 
-            AND LastModified0x30 < DateBeforeTime  
-            AND LastModified0x30 > DateAfterTime 
-            AND LastRecordChange0x10 < DateBeforeTime  
-            AND LastRecordChange0x10 > DateAfterTime 
-            AND LastRecordChange0x30 < DateBeforeTime  
-            AND LastRecordChange0x30 > DateAfterTime 
-            AND LastAccess0x10 < DateBeforeTime  
-            AND LastAccess0x10 > DateAfterTime 
-            AND LastAccess0x30 < DateBeforeTime  
+            AND Created0x10 < DateBeforeTime
+            AND Created0x10 > DateAfterTime
+            AND Created0x30 < DateBeforeTime
+            AND Created0x30 > DateAfterTime
+            AND LastModified0x10 < DateBeforeTime
+            AND LastModified0x10 > DateAfterTime
+            AND LastModified0x30 < DateBeforeTime
+            AND LastModified0x30 > DateAfterTime
+            AND LastRecordChange0x10 < DateBeforeTime
+            AND LastRecordChange0x10 > DateAfterTime
+            AND LastRecordChange0x30 < DateBeforeTime
+            AND LastRecordChange0x30 > DateAfterTime
+            AND LastAccess0x10 < DateBeforeTime
+            AND LastAccess0x10 > DateAfterTime
+            AND LastAccess0x30 < DateBeforeTime
             AND LastAccess0x30 > DateAfterTime
-            AND if(condition=SizeMax, 
+            AND if(condition=SizeMax,
                 then=FileSize < atoi(string=SizeMax),
                 else=TRUE)
-            AND if(condition=SizeMin, 
+            AND if(condition=SizeMin,
                 then=FileSize > atoi(string=SizeMin),
                 else=TRUE)
-      
-      
+
+
       -- include all attached drives
-      LET all_drives = SELECT * FROM foreach(row=ntfs_drives, 
+      LET all_drives = SELECT * FROM foreach(row=ntfs_drives,
             query={
                 SELECT *
                 FROM mftsearch(MFTPath=Path)
@@ -105,8 +105,6 @@ sources:
 
 
       -- return rows
-      SELECT * FROM if(condition=AllDrives, 
+      SELECT * FROM if(condition=AllDrives,
         then= all_drives,
-        else= mftsearch(MFTPath=MFTFilename)
-        )
-            
+        else= { SELECT * FROM mftsearch(MFTPath=MFTFilename) })

--- a/bin/query.go
+++ b/bin/query.go
@@ -174,10 +174,12 @@ func doRemoteQuery(
 
 		switch format {
 		case "json":
-			fmt.Println(json.MarshalIndent(rows))
+			fmt.Println(string(json.MustMarshalIndent(rows)))
 
 		case "jsonl":
-			fmt.Println(json.MarshalJsonl(rows))
+			for _, row := range rows {
+				fmt.Println(json.MustMarshalString(row))
+			}
 
 		case "csv":
 			scope := vql_subsystem.MakeScope()


### PR DESCRIPTION
If the scope destructor wants to send a log message, the channel needs
to be available.