### PR TITLE
Fixed bug in GUI

### DIFF
--- a/gui/velociraptor/src/components/sidebar/navigator.js
+++ b/gui/velociraptor/src/components/sidebar/navigator.js
@@ -7,6 +7,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from "classnames";
 import { NavLink } from "react-router-dom";
 
+import { EncodePathInURL } from '../utils/paths.js';
+
 class VeloNavigator extends Component {
     static propTypes = {
         client: PropTypes.object.isRequired,
@@ -129,7 +131,7 @@ class VeloNavigator extends Component {
                       </NavLink>
 
                       <NavLink className={disabled}
-                               to={"/vfs/" + this.props.client.client_id + vfs_path }>
+                               to={"/vfs/" + EncodePathInURL(this.props.client.client_id + vfs_path) }>
                         <ul className="nav nav-pills navigator">
                           <li className={classNames({
                               "nav-link": true,

--- a/gui/velociraptor/src/components/utils/paths.js
+++ b/gui/velociraptor/src/components/utils/paths.js
@@ -110,3 +110,15 @@ export const Join = function(components) {
 
     return result;
 };
+
+
+// Work around encoding bugs in react router.
+export const EncodePathInURL = function(path) {
+    path = path.replace(/-/g, "%2d");
+    return encodeURI(path).replace(/%/g, "-");
+};
+
+
+export const DecodePathInURL = function(path) {
+    return decodeURI(path.replace(/-/g, "%"));
+};

--- a/gui/velociraptor/src/components/vfs/file-list.js
+++ b/gui/velociraptor/src/components/vfs/file-list.js
@@ -12,7 +12,7 @@ import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Modal from 'react-bootstrap/Modal';
 
-import { Join } from '../utils/paths.js';
+import { Join, EncodePathInURL } from '../utils/paths.js';
 import api from '../core/api-service.js';
 import axios from 'axios';
 
@@ -112,8 +112,8 @@ class VeloFileList extends Component {
         // Update the router with the new path.
         let vfs_path = [...path];
         vfs_path.push(row.Name);
-        this.props.history.push("/vfs/" + this.props.client.client_id +
-                                Join(vfs_path));
+        this.props.history.push(
+           EncodePathInURL("/vfs/"+ this.props.client.client_id + Join(vfs_path)));
     }
 
     startRecursiveVfsRefreshOperation = () => {

--- a/gui/velociraptor/src/components/vfs/file-tree.js
+++ b/gui/velociraptor/src/components/vfs/file-tree.js
@@ -14,6 +14,8 @@ import { withRouter }  from "react-router-dom";
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { EncodePathInURL, DecodePathInURL } from '../utils/paths.js';
+
 const text_color = "#8f8f8f";
 const background_color = '#f5f5f5';
 const active_background_color = "#dee0ff";
@@ -154,7 +156,7 @@ class VeloFileTree extends Component {
             let router_vfs_path = this.props.match && this.props.match.params &&
                 this.props.match.params.vfs_path;
             if (router_vfs_path) {
-                vfs_path = SplitPathComponents(router_vfs_path);
+                vfs_path = SplitPathComponents(DecodePathInURL(router_vfs_path));
 
                 // We need to distinguish between navigating to the
                 // tree directory generally and navigating to
@@ -350,7 +352,7 @@ class VeloFileTree extends Component {
 
         // When clicking the tree the user navigates to the directory
         // - file pane is unselected.
-        this.props.history.push("/vfs/" + client_id + path + "/");
+        this.props.history.push(EncodePathInURL("/vfs/" + client_id + path +"/"));
 
         node.known = false;
         this.updateComponent(node, node.path, []);

--- a/gui/velociraptor/src/components/vfs/vfs-setter.js
+++ b/gui/velociraptor/src/components/vfs/vfs-setter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { withRouter }  from "react-router-dom";
 
-import { SplitPathComponents } from '../utils/paths.js';
+import { SplitPathComponents, DecodePathInURL } from '../utils/paths.js';
 
 // A component that syncs a client id to a client record.
 class VFSSetterFromRoute extends Component {
@@ -25,7 +25,7 @@ class VFSSetterFromRoute extends Component {
             return;
         }
 
-        let url_vfs = SplitPathComponents(this.props.match.params.vfs_path || "");
+        let url_vfs = SplitPathComponents(DecodePathInURL(this.props.match.params.vfs_path || ""));
         let props_vfs = this.props.vfs_path;
 
         if (!_.isEqual(url_vfs, props_vfs)) {


### PR DESCRIPTION
Due to react router escaping bugs we need to custom encode VFS paths
in the history object. Otherwise GUI would crash when navigating into
a vfs path with % in the filename.