### PR TITLE
Add Linux and MacOS PacketCapture artifacts

### DIFF
--- a/artifacts/definitions/Linux/Network/PacketCapture.yaml
+++ b/artifacts/definitions/Linux/Network/PacketCapture.yaml
@@ -1,0 +1,36 @@
+name: Linux.Network.PacketCapture
+author: Wes Lambert, @therealwlambert
+description: | 
+  description: | 
+  This artifact leverages tcpdump to natively capture packets.
+  
+  The `Duration` parameter is used to define how long (in seconds) the capture should be.  Specific interfaces can be defined using the `Interface` parameter, otherwise the artifact defaults to an interface assignment of `any`.  
+  
+  A `BPF` can also be supplied to filter the captured traffic as desired.
+  
+parameters:
+    - name: Duration
+      type: integer
+      description: Duration (in seconds) of PCAP to be recorded.
+      default: 10
+      
+    - name: Interface
+      type: string
+      default: any
+
+    - name: BPF
+      type: string
+      default:
+    
+sources:
+    - queries:
+        - |
+            LET pcap <= tempfile(extension=".pcap")
+        - |
+            LET record_pcap = 
+                    SELECT * FROM execve(argv=['bash', '-c',  '(tcpdump -nni ' + Interface + ' -w ' + pcap + ' ' + '\'' + BPF + '\') & sleep ' + Duration + '; kill $!']) 
+        - |
+            SELECT * FROM chain (
+              a={SELECT * FROM record_pcap},
+              b={SELECT upload(file=pcap) AS Upload FROM scope()}
+            )

--- a/artifacts/definitions/MacOS/Network/PacketCapture.yaml
+++ b/artifacts/definitions/MacOS/Network/PacketCapture.yaml
@@ -1,0 +1,36 @@
+name: MacOS.Network.PacketCapture
+author: Wes Lambert, @therealwlambert
+description: | 
+  description: | 
+  This artifact leverages tcpdump to natively capture packets.
+  
+  The `Duration` parameter is used to define how long (in seconds) the capture should be.  Specific interfaces can be defined using the `Interface` parameter, otherwise the artifact defaults to an interface assignment of `any`.  
+  
+  A `BPF` can also be supplied to filter the captured traffic as desired.
+  
+parameters:
+    - name: Duration
+      type: integer
+      description: Duration (in seconds) of PCAP to be recorded.
+      default: 10
+      
+    - name: Interface
+      type: string
+      default: any
+
+    - name: BPF
+      type: string
+      default:
+    
+sources:
+    - queries:
+        - |
+            LET pcap <= tempfile(extension=".pcap")
+        - |
+            LET record_pcap = 
+                    SELECT * FROM execve(argv=['bash', '-c',  '(tcpdump -nni ' + Interface + ' -w ' + pcap + ' ' + '\'' + BPF + '\') & sleep ' + Duration + '; kill $!']) 
+        - |
+            SELECT * FROM chain (
+              a={SELECT * FROM record_pcap},
+              b={SELECT upload(file=pcap) AS Upload FROM scope()}
+            )


### PR DESCRIPTION
Adds a Linux and macOS artifact for endpoint packet capture via tcpdump, allowing for a capture duration, and a BPF to be set.