### PR TITLE
Add EvtxHunter whitelist application

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
+++ b/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
@@ -96,6 +96,10 @@ sources:
                     AND str(str=EventID) =~ IdRegex
                     AND format(format='%v %v %v', args=[
                                EventData, UserData, Message]) =~ IocRegex
+                    AND if(condition=WhitelistRegex,
+                        then= NOT format(format='%v %v %v', args=[
+                               EventData, UserData, Message]) =~ WhitelistRegex,
+                        else= True)
             }
           )
 


### PR DESCRIPTION
Looks like the whitelist feature was not applied. Re-adding to enable detection use cases.