### PR TITLE
Fix AWS Managed Services SFTP File Upload Failure

### DIFF
--- a/vql/tools/sftp_upload.go
+++ b/vql/tools/sftp_upload.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/Velocidex/ordereddict"
@@ -188,7 +189,7 @@ func upload_SFTP(ctx context.Context, scope vfilter.Scope,
 	}
 
 	fpath := filepath.Join(path, name)
-	file, err := client.Create(fpath)
+	file, err := client.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
 		return &api.UploadResponse{
 			Error: err.Error(),

--- a/vql/tools/sftp_upload.go
+++ b/vql/tools/sftp_upload.go
@@ -195,13 +195,13 @@ func upload_SFTP(ctx context.Context, scope vfilter.Scope,
 			Error: err.Error(),
 		}, err
 	}
-	defer file.Close()
 	if _, err := file.ReadFrom(reader); err != nil {
 		return &api.UploadResponse{
 			Error: err.Error(),
 		}, err
 	}
 
+	file.Close()
 	check, err := client.Lstat(fpath)
 	if err != nil {
 		return &api.UploadResponse{


### PR DESCRIPTION
Made the following changes to SFTP uploads to avoid errors on AWS Managed Services SFTP servers caused by AWS limitations on concurrent read and write operations.

- Open files in write-only mode for uploads
- Close uploaded files before performing read operations (lstat)

The "Linux Build All Arches" action was executed on this branch, the results can be found [here](https://github.com/davidjmaria/velociraptor/actions/runs/596884620). 
I have manually tested SFTP uploads with the resulting binaries using an AWS managed services SFTP server, as well as on a traditional OpenSSH SFTP server. 