### PR TITLE
Fix SFTP Upload with write-only permissions

### DIFF
--- a/vql/tools/sftp_upload.go
+++ b/vql/tools/sftp_upload.go
@@ -203,7 +203,13 @@ func upload_SFTP(ctx context.Context, scope vfilter.Scope,
 
 	file.Close()
 	check, err := client.Lstat(fpath)
-	if err != nil {
+	if e, ok := err.(*sftp.StatusError); ok && e.FxCode() == sftp.ErrSSHFxPermissionDenied {
+		scope.Log("upload_SFTP: Unable to verify size of uploaded file due to insufficient read permissions.")
+		response := &api.UploadResponse{
+			Path: fpath,
+		}
+		return response, nil
+	} else if err != nil {
 		return &api.UploadResponse{
 			Error: err.Error(),
 		}, err


### PR DESCRIPTION
Made change to catch ErrSSHFxPermissionDenied error when uploading files using an account without read permissions. Whenever an upload is attempted when read permissions are not available, the ErrSSHFxPermissionDenied error will be caught and the user will be warned that the size of the uploaded file cannot be verified.

I have manually tested SFTP uploads with the resulting binaries using an AWS managed services SFTP server, as well as on a traditional OpenSSH SFTP server.
Fixes: #950 