### PR TITLE
Add Windows.Detection.Yara.NTFS

### DIFF
--- a/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
+++ b/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
@@ -26,13 +26,11 @@ parameters:
   - name: PathRegex
     description: Only file names that match this regular expression will be scanned.
     default: Windows/System32/kernel32\.dll$
-  - name: SearchMFT
-    description: "Target drive MFT. Default is a C:"
-    default: "C:/$MFT"
+  - name: DriveLetter
+    description: "Target drive. Default is a C:"
+    default: "C:"
   - name: SizeMax
-    default:
   - name: SizeMin
-    default:
   - name: AllDrives
     type: bool
   - name: UploadHits
@@ -76,11 +74,11 @@ sources:
                 then= { SELECT ShortHandYara as Content FROM scope() },
                 else= { SELECT YaraRule as Content FROM scope() }))
             
-      -- first find all files with relevant extention in mft
+      -- first find all matching files mft
       LET files = SELECT IsDir,
             split(string=MFTPath,sep='\\$')[0] +  FullPath as FullPath
-        FROM Artifact.Windows.NTFS.MFT(MFTFilename=SearchMFT,AllDrives=AllDrives,
-                PathRegex=PathRegex,SizeMax=SizeMax, SizeMin=SizeMin)
+        FROM Artifact.Windows.NTFS.MFT(MFTFilename=DriveLetter + "/$MFT", AllDrives=AllDrives,
+                PathRegex=PathRegex, SizeMax=SizeMax, SizeMin=SizeMin)
         WHERE NOT IsDir
           AND if(condition=EarliestSILastChanged,
             then= LastRecordChange0x10 > EarliestSILastChanged,

--- a/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
+++ b/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
@@ -1,0 +1,120 @@
+name: Windows.Detection.Yara.NTFS
+author: Matt Green - @mgreen27
+description: |
+  This artifact searches the MFT, returns a list of target files then runs Yara 
+  over the target list.  
+    
+  There are 3 kinds of Yara rules that can be deployed:   
+   &nbsp;1. Url link to a yara rule.   
+   &nbsp;2. Shorthand yara in the format "wide nocase ascii:string1,string2,string3".  
+   &nbsp;3. or a Standard Yara rule attached as a parameter.  
+  Only one method of Yara will be applied and search order is as above.  
+  
+  The artifact leverages Windows.NTFS.MFT so similar regex filters can be applied 
+  including Path, Size and date. The artifact also has an option to search across 
+  all attached drives and upload any files with Yara hits.  
+    
+  Some examples of path regex may include:  
+   &nbsp;Extension at a path: Windows/System32/.+\\.dll$  
+   &nbsp;More wildcards: Windows/.+/.+\\.dll$  
+   &nbsp;Specific file: Windows/System32/kernel32\.dll$  
+   &nbsp;Multiple extentions: \.(php|aspx|resx|asmx)$  
+  Note: no drive and forward slashes.
+  
+type: CLIENT
+parameters:
+  - name: PathRegex
+    description: Only file names that match this regular expression will be scanned.
+    default: Windows/System32/kernel32\.dll$
+  - name: SearchMFT
+    description: "Target drive MFT. Default is a C:"
+    default: "C:/$MFT"
+  - name: SizeMax
+    default:
+  - name: SizeMin
+    default:
+  - name: AllDrives
+    type: bool
+  - name: UploadHits
+    type: bool
+  - name: EarliestSILastChanged
+    type: timestamp
+  - name: LatestSILastChanged
+    type: timestamp
+  - name: EarliestFNCreation
+    type: timestamp
+  - name: LatestFNCreation
+    type: timestamp
+  - name: YaraUrl
+    description: If configured will attempt to download Yara rules form Url
+    default:
+  - name: ShortHandYara
+    description: Second option Yara choice is a Velociraptor shorthand Yara rule
+    default: 
+  - name: YaraRule
+    description: Final Yara option and the default if no other options provided.
+    default: |
+        rule IsPE:TestRule {
+           meta:
+              author = "the internet"
+              date = "2021-03-04"
+              description = "A simple PE rule to test yara features"
+          condition:
+             uint16(0) == 0x5A4D and
+             uint32(uint32(0x3C)) == 0x00004550
+        }
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+      -- check which Yara to use
+      LET yara = SELECT * FROM if(condition=YaraUrl,
+            then= { SELECT Content FROM http_client( url=YaraUrl, method='GET') },
+            else= if(condition=ShortHandYara,
+                then= { SELECT ShortHandYara as Content FROM scope() },
+                else= { SELECT YaraRule as Content FROM scope() }))
+            
+      -- first find all files with relevant extention in mft
+      LET files = SELECT IsDir,
+            split(string=MFTPath,sep='\\$')[0] +  FullPath as FullPath
+        FROM Artifact.Windows.NTFS.MFT(MFTFilename=SearchMFT,AllDrives=AllDrives,
+                PathRegex=PathRegex,SizeMax=SizeMax, SizeMin=SizeMin)
+        WHERE NOT IsDir
+          AND if(condition=EarliestSILastChanged,
+            then= LastRecordChange0x10 > EarliestSILastChanged,
+            else= True)
+          AND if(condition=LatestSILastChanged,
+            then= LastRecordChange0x10 < LatestSILastChanged,
+            else= True)
+          AND if(condition=EarliestFNCreated,
+            then= Created0x30 > EarliestFNCreation,
+            else= True)
+          AND if(condition=LatestFNCreated,
+            then= Created0x30 < LatestFNCreation,
+            else= True)
+          
+      -- scan files and only report a single hit.
+      LET hits = SELECT * FROM foreach(row=files,
+            query={
+                SELECT 
+                    FileName as FullPath,
+                    File.Size AS Size,
+                    File.ModTime AS ModTime,
+                    Rule, Tags, Meta, 
+                    str(str=String.Data) AS HitContext,
+                    String.Offset AS HitOffset
+                FROM yara(rules=yara.Content[0],files=FullPath)
+                LIMIT 1
+            })
+      
+      -- upload files that have hit
+      LET upload_hits=SELECT *, 
+            upload(file=FullPath) AS Upload 
+        FROM hits
+
+      -- return rows
+      SELECT * FROM if(condition=UploadHits,
+        then=upload_hits,
+        else=hits)

--- a/artifacts/testdata/server/testcases/yara_detection.in.yaml
+++ b/artifacts/testdata/server/testcases/yara_detection.in.yaml
@@ -1,0 +1,47 @@
+Parameters:
+  IsPE: |
+      rule IsPE:TestRule {
+        meta:
+          author = "the internet"
+          date = "2021-03-04"
+          description = "A simple PE rule to test yara features"
+        condition:
+          uint16(0) == 0x5A4D and
+          uint32(uint32(0x3C)) == 0x00004550
+      }
+
+Queries:
+  # Setup our mocks --MFT needs to be mocked as below to pass srcDir
+  - |
+    LET _ <= SELECT
+          mock(plugin='info', results=[dict(OS='windows')]),
+          mock(plugin='http_client', results=[
+             dict(Url='http://remote',
+                  Content=RemoteYara, Response=200)]),
+          -- First call to Windows.NTFS.MFT reveal target dll info
+          -- srcDir needs to be used to align fields
+          mock(artifact=Artifact.Windows.NTFS.MFT, results=[
+             dict(
+              EntryNumber=42344,
+              InUse = true,
+              ParentEntryNumber = 3589,
+              MFTPath = srcDir + "$MFT",
+              FullPath = "artifacts/testdata/files/wkscli.dll",
+              FileName = "wkscli.dll",
+              FileSize = 764976,
+              ReferenceCount = 2,
+              IsDir = false,
+              Created0x10 = "2020-11-19T02:48:46.9885373Z",
+              Created0x30 = "2021-01-24T06:57:36.7073284Z",
+              LastModified0x10 = "2020-11-19T02:48:47.0041758Z",
+              LastModified0x30 = "2021-01-24T06:57:39.5353986Z",
+              LastRecordChange0x10 = "2021-01-24T06:59:40.7021579Z",
+              LastRecordChange0x30 = "2021-01-24T06:57:39.5353986Z",
+              LastAccess0x10 = "2021-03-05T13:44:04.1999087Z",
+              LastAccess0x30 = "2021-01-24T06:57:36.7073284Z")
+          ])
+    FROM scope()
+
+  # Test NTFS yara outputs from shorthand and standard yara
+  - SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')
+  - SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)

--- a/artifacts/testdata/server/testcases/yara_detection.in.yaml
+++ b/artifacts/testdata/server/testcases/yara_detection.in.yaml
@@ -43,5 +43,6 @@ Queries:
     FROM scope()
 
   # Test NTFS yara outputs from shorthand and standard yara
-  - SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')
-  - SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)
+  - SELECT relpath(path=FullPath, base=srcDir) as TestPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')
+  - SELECT relpath(path=FullPath, base=srcDir) as TestPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)
+

--- a/artifacts/testdata/server/testcases/yara_detection.out.yaml
+++ b/artifacts/testdata/server/testcases/yara_detection.out.yaml
@@ -26,18 +26,18 @@ LET _ <= SELECT
           LastAccess0x30 = "2021-01-24T06:57:36.7073284Z")
       ])
 FROM scope()
-[]SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')[
+[]SELECT relpath(path=FullPath, base=srcDir) as TestPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')[
  {
-  "FullPath": "d:\\a\\velociraptor\\velociraptor\\artifacts/testdata/files/wkscli.dll",
+  "TestPath": "artifacts\\testdata\\files\\wkscli.dll",
   "Size": 9728,
   "Rule": "X",
   "Meta": {},
   "HitContext": "MZ",
   "HitOffset": 0
  }
-]SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)[
+]SELECT relpath(path=FullPath, base=srcDir) as TestPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)[
  {
-  "FullPath": "d:\\a\\velociraptor\\velociraptor\\artifacts/testdata/files/wkscli.dll",
+  "TestPath": "artifacts\\testdata\\files\\wkscli.dll",
   "Size": 9728,
   "Rule": "IsPE",
   "Meta": {

--- a/artifacts/testdata/server/testcases/yara_detection.out.yaml
+++ b/artifacts/testdata/server/testcases/yara_detection.out.yaml
@@ -1,0 +1,51 @@
+LET _ <= SELECT
+      mock(plugin='info', results=[dict(OS='windows')]),
+      mock(plugin='http_client', results=[
+         dict(Url='http://remote',
+              Content=RemoteYara, Response=200)]),
+      -- First call to Windows.NTFS.MFT reveal target dll info
+      -- srcDir needs to be used to align fields
+      mock(artifact=Artifact.Windows.NTFS.MFT, results=[
+         dict(
+          EntryNumber=42344,
+          InUse = true,
+          ParentEntryNumber = 3589,
+          MFTPath = srcDir + "$MFT",
+          FullPath = "artifacts/testdata/files/wkscli.dll",
+          FileName = "wkscli.dll",
+          FileSize = 764976,
+          ReferenceCount = 2,
+          IsDir = false,
+          Created0x10 = "2020-11-19T02:48:46.9885373Z",
+          Created0x30 = "2021-01-24T06:57:36.7073284Z",
+          LastModified0x10 = "2020-11-19T02:48:47.0041758Z",
+          LastModified0x30 = "2021-01-24T06:57:39.5353986Z",
+          LastRecordChange0x10 = "2021-01-24T06:59:40.7021579Z",
+          LastRecordChange0x30 = "2021-01-24T06:57:39.5353986Z",
+          LastAccess0x10 = "2021-03-05T13:44:04.1999087Z",
+          LastAccess0x30 = "2021-01-24T06:57:36.7073284Z")
+      ])
+FROM scope()
+[]SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll',ShortHandYara='wide ascii:MZ')[
+ {
+  "FullPath": "d:\\a\\velociraptor\\velociraptor\\artifacts/testdata/files/wkscli.dll",
+  "Size": 9728,
+  "Rule": "X",
+  "Meta": {},
+  "HitContext": "MZ",
+  "HitOffset": 0
+ }
+]SELECT FullPath,Size,Rule,Rule,Meta,HitContext,HitOffset FROM Artifact.Windows.Detection.Yara.NTFS(PathRegex='wkscli.dll', YaraRule=IsPE)[
+ {
+  "FullPath": "d:\\a\\velociraptor\\velociraptor\\artifacts/testdata/files/wkscli.dll",
+  "Size": 9728,
+  "Rule": "IsPE",
+  "Meta": {
+   "author": "the internet",
+   "date": "2021-03-04",
+   "description": "A simple PE rule to test yara features"
+  },
+  "HitContext": "Null",
+  "HitOffset": null
+ }
+]


### PR DESCRIPTION
Add Windows.Detection.Yara.NTFS and test.
 This artifact searches the MFT, returns a list of target files then runs Yara  over the target list.  