### PR TITLE
Fix bug in Windows DLLs and Services

### DIFF
--- a/artifacts/definitions/Windows/System/DLLs.yaml
+++ b/artifacts/definitions/Windows/System/DLLs.yaml
@@ -30,7 +30,7 @@ sources:
                      ModuleBaseAddress+ModuleBaseSize]) AS Range,
                 ModuleName, ExePath,
                 if(condition=Calculate_Hash,
-                  then=hash(path=ExePath,
+                  then=hash(path=expand(path=ExePath),
                             accessor=file)) AS Hash,
                 if(condition=CertificateInfo,
                   then=authenticode(filename=ExePath)) AS Certinfo

--- a/artifacts/definitions/Windows/System/Services.yaml
+++ b/artifacts/definitions/Windows/System/Services.yaml
@@ -26,7 +26,7 @@ sources:
                  FROM stat(filename=servicesKeyGlob + Name, accessor='reg')
                } AS Created,
                {
-                 SELECT ServiceDll FROM read_reg_key(globs=servicesKeyGlob + Name + "\\Parameters")
+                 SELECT expand(path=ServiceDll) FROM read_reg_key(globs=servicesKeyGlob + Name + "\\Parameters")
                } AS ServiceDll,
                {
                  SELECT FailureCommand FROM read_reg_key(globs=servicesKeyGlob + Name)
@@ -39,12 +39,12 @@ sources:
         SELECT *,
                  if(condition=Calculate_hashes,
                     then=hash(path=AbsoluteExePath,
-                           accessor=file)) AS HashServiceExe,
+                           accessor="file")) AS HashServiceExe,
                  if(condition=CertificateInfo,
                     then=authenticode(filename=AbsoluteExePath)) AS CertinfoServiceExe,
                  if(condition=Calculate_hashes,
                     then=hash(path=ServiceDll,
-                           accessor=file)) AS HashServiceDll,
+                           accessor="file")) AS HashServiceDll,
                  if(condition=CertificateInfo,
                     then=authenticode(filename=ServiceDll)) AS CertinfoServiceDll
         FROM service


### PR DESCRIPTION
This fixes a typo in Windows.System.Services from the accessor being `file` to `"file"`. This also makes sure that paths in both Services and DLLs are expanded so we don't get complaints like `hash %systemroot%\...: Unable to open raw device`