### PR TITLE
Reuse VQL http client in server inventory.

### DIFF
--- a/services/inventory/inventory.go
+++ b/services/inventory/inventory.go
@@ -38,7 +38,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"path"
 	"sync"
@@ -55,6 +54,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vql/networking"
 )
 
 type HTTPClient interface {
@@ -345,20 +345,8 @@ func StartInventoryService(
 		Clock:    utils.RealClock{},
 		binaries: &artifacts_proto.ThirdParty{},
 		db:       datastore.NewTestDataStore(),
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout:   300 * time.Second,
-					KeepAlive: 300 * time.Second,
-					DualStack: true,
-				}).DialContext,
-				MaxIdleConns:          100,
-				IdleConnTimeout:       300 * time.Second,
-				TLSHandshakeTimeout:   100 * time.Second,
-				ExpectContinueTimeout: 10 * time.Second,
-				ResponseHeaderTimeout: 100 * time.Second,
-			},
-		},
+		// Use the VQL http client so it can accept the same certs.
+		Client: networking.GetHttpClient(config_obj.Client, nil),
 	}
 
 	db, err := datastore.GetDB(config_obj)


### PR DESCRIPTION
The client's VQL implementation takes into account self signed SSL
deployments and allows server signed by the Velociraptor CA, but the
inventory service was making its own http client. This could cause
discrepency in inventory not being able to download tools hosted on
the Velociraptor server.