### PR TITLE
Add CommonName to connections/alias netstat to connections

### DIFF
--- a/vql/linux/connections.go
+++ b/vql/linux/connections.go
@@ -18,6 +18,7 @@
 package linux
 
 import (
+	"fmt"
 	"github.com/Velocidex/ordereddict"
 	"github.com/shirou/gopsutil/net"
 	"www.velocidex.com/golang/velociraptor/acls"
@@ -25,28 +26,68 @@ import (
 	"www.velocidex.com/golang/vfilter"
 )
 
+var (
+	CommonName = map[string]string{
+		"11":  "UNIX_SOCK|SOCK_STREAM",
+		"12":  "UNIX_SOCK|SOCK_DGRAM",
+		"15":  "UNIX_SOCK|SOCK_SEQPACKET",
+		"21":  "tcp",
+		"22":  "udp",
+		"101": "tcp6",
+		"102": "udp6",
+	}
+)
+
+type ConnectionStatEnhanced struct {
+	Fd         uint32   `json:"fd"`
+	Family     uint32   `json:"family"`
+	Type       uint32   `json:"type"`
+	CommonName string   `json:"commonname"`
+	Laddr      net.Addr `json:"localaddr"`
+	Raddr      net.Addr `json:"remoteaddr"`
+	Status     string   `json:"status"`
+	Uids       []int32  `json:"uids"`
+	Pid        int32    `json:"pid"`
+}
+
+func get_conns(
+	scope vfilter.Scope,
+	args *ordereddict.Dict) []vfilter.Row {
+	var result []vfilter.Row
+
+	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
+	if err != nil {
+		scope.Log("connections: %s", err)
+		return result
+	}
+
+	if cons, err := net.Connections("all"); err == nil {
+		for _, item := range cons {
+			match_string := fmt.Sprintf("%d%d", item.Family, item.Type)
+			common_name, ok := CommonName[match_string]
+			if !ok {
+				scope.Log("Unknown Family/Type: %d %d", item.Family, item.Type)
+				common_name = "UNKNOWN"
+			}
+			conn := ConnectionStatEnhanced{item.Fd, item.Family, item.Type, common_name,
+				item.Laddr, item.Raddr, item.Status, item.Uids, item.Pid}
+			result = append(result, conn)
+		}
+	}
+	return result
+}
+
 func init() {
 	vql_subsystem.RegisterPlugin(
 		&vfilter.GenericListPlugin{
 			PluginName: "connections",
-			Function: func(
-				scope vfilter.Scope,
-				args *ordereddict.Dict) []vfilter.Row {
-				var result []vfilter.Row
-
-				err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
-				if err != nil {
-					scope.Log("connections: %s", err)
-					return result
-				}
-
-				if cons, err := net.Connections("all"); err == nil {
-					for _, item := range cons {
-						result = append(result, item)
-					}
-				}
-				return result
-			},
-			Doc: "List all active connections",
+			Function:   get_conns,
+			Doc:        "List all active connections",
+		})
+	vql_subsystem.RegisterPlugin(
+		&vfilter.GenericListPlugin{
+			PluginName: "netstat",
+			Function:   get_conns,
+			Doc:        "List all active connections (alias to connections)",
 		})
 }


### PR DESCRIPTION
This  change gives a common name to type/family combinations to make them more readable. It also aliases netstat to connections in order to not break existing artifacts that depend on connections. 