### PR TITLE
Deduplicate event query table when no change is detected.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,8 @@ name: Linux Build All Arches
 on:
   pull_request:
     types: [closed]
-    branches:
-      - master
+#    branches:
+#      - master
 
 jobs:
   build:

--- a/artifacts/definitions/Windows/EventLogs/Kerbroasting.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Kerbroasting.yaml
@@ -14,42 +14,31 @@ description: |
   Kerbroasting can be used for privilege escalation or persistence by adding a
   SPN attribute to an unexpected account.
 
-  Log Source: Windows Security Event Log (Domain Controllers).  
-  Event ID: 4769 
-  Status: 0x0 (Audit Success)  
-  Ticket Encryption: 0x17 (RC4)  
-  Service Name: NOT krbtgt or NOT a system account (account name ends in $)  
-  TargetUserName: NOT a system account (*$@*)  
+  Log Source: Windows Security Event Log (Domain Controllers).
+  Event ID: 4769
+  Status: 0x0 (Audit Success)
+  Ticket Encryption: 0x17 (RC4)
+  Service Name: NOT krbtgt or NOT a system account (account name ends in $)
+  TargetUserName: NOT a system account (*$@*)
 
   Monitor and alert on unusual events with these conditions from an unexpected
-  IP.  
+  IP.
   Note: There are potential false positives so whitelist normal source IPs and
-  manage risk of insecure ticket generation.  
+  manage risk of insecure ticket generation.
 
 reference:
   - https://attack.mitre.org/techniques/T1208/
   - https://www.trustedsec.com/blog/art_of_kerberoast/
-  
+
 parameters:
   - name: EvtxGlob
     default: '%SystemRoot%\System32\winevt\logs\Security.evtx'
   - name: SearchVSS
     description: "Add VSS into query."
     type: bool
-    
+
 sources:
   - query: |
-      -- firstly set timebounds for performance
-      LET DateAfterTime <= if(condition=DateAfter,
-        then=timestamp(epoch=DateAfter), else=timestamp(epoch="1600-01-01"))
-      LET DateBeforeTime <= if(condition=DateBefore,
-        then=timestamp(epoch=DateBefore), else=timestamp(epoch="2200-01-01"))
-        
-      -- Parse Log level dropdown selection
-      LET LogLevelRegex <= SELECT format(format="%v", args=Regex) as value
-        FROM parse_csv(filename=LogLevelMap, accessor="data")
-        WHERE Choice=LogLevel LIMIT 1
-
       -- expand provided glob into a list of paths on the file system (fs)
       LET fspaths <= SELECT FullPath
         FROM glob(globs=expand(path=EvtxGlob))
@@ -78,14 +67,14 @@ sources:
                     EventData.IpPort as IpPort,
                     FullPath
                 FROM parse_evtx(filename=FullPath)
-                WHERE 
+                WHERE
                     System.EventID.Value = 4769
                     AND EventData.TicketEncryptionType = 23
                     AND EventData.Status = 0
                     AND NOT EventData.ServiceName =~ "krbtgt|\\$$"
                     AND NOT EventData.TargetUserName =~ "\\$@"
           })
-    
+
 
       -- include VSS in calculation and deduplicate with GROUP BY by file
       LET include_vss = SELECT * FROM foreach(row=fspaths,

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -39,6 +39,7 @@ import (
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/hunt_dispatcher"
 	"www.velocidex.com/golang/velociraptor/startup"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/tools"
@@ -146,6 +147,9 @@ func runTest(fixture *testFixture,
 		return "", err
 	}
 	defer sm.Close()
+
+	err = sm.Start(hunt_dispatcher.StartHuntDispatcher)
+	kingpin.FatalIfError(err, "Starting services")
 
 	_, err = getRepository(config_obj)
 	kingpin.FatalIfError(err, "Loading extra artifacts")

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -365,7 +365,7 @@ func (self inMemoryLogWriter) Write(p []byte) (n int, err error) {
 
 	// Truncate too many logs
 	if len(memory_logs) > 1000 {
-		prelogs = nil
+		memory_logs = nil
 	}
 
 	memory_logs = append(memory_logs, string(p))

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -3,6 +3,11 @@
 // the GUI at any time.
 //
 // This service maintains access to the global event table.
+
+// NOTE: The client's event table will be updated when the client's
+// table's version is after:
+// 1. The global event table state was modified.
+// 2. Any label was updated for that client.
 package client_monitoring
 
 import (
@@ -80,13 +85,14 @@ func (self *ClientEventTable) CheckClientEventsVersion(
 	version := self.state.Version
 	self.mu.Unlock()
 
+	if client_version < version {
+		return true
+	}
+
+	// Now check the label group
 	labeler := services.GetLabeler()
 	if labeler == nil {
 		return false
-	}
-
-	if client_version < version {
-		return true
 	}
 
 	// If the client's labels have changed after their table
@@ -278,7 +284,7 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 	defer self.mu.Unlock()
 
 	modified_name, pres := event.GetString("artifact")
-	if !pres || modified_name == "" {
+	if !pres || modified_name != "ClientEventTable" {
 		return
 	}
 
@@ -286,7 +292,7 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 
 	// Determine if the modified artifact affects us.
 	is_relevant := func() bool {
-		// Ignore events that we sent.
+		// Ignore events that we sent ourselves.
 		if setter == self.id {
 			return false
 		}
@@ -295,13 +301,10 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 	}
 
 	if is_relevant() {
-		// Recompile artifacts and update the version.
-		self.state.Version = uint64(self.clock.Now().UnixNano())
-
-		clear_caches(self.state)
-		err := self.compileState(ctx, config_obj, self.state)
+		err := self.load_from_file(ctx, config_obj)
 		if err != nil {
-			logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+			logger := logging.GetLogger(
+				config_obj, &logging.FrontendComponent)
 			logger.Error("compileState: %v", err)
 		}
 	}
@@ -329,7 +332,13 @@ func (self *ClientEventTable) LoadFromFile(
 		return errors.New("Frontend not configured")
 	}
 
+	return self.load_from_file(ctx, config_obj)
+}
+
+func (self *ClientEventTable) load_from_file(
+	ctx context.Context, config_obj *config_proto.Config) error {
 	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	logger.Info("Reloading client monitoring tables from datastore\n")
 	db, err := datastore.GetDB(config_obj)
 	if err != nil {
 		return err

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -284,7 +284,7 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 	defer self.mu.Unlock()
 
 	modified_name, pres := event.GetString("artifact")
-	if !pres || modified_name != "ClientEventTable" {
+	if !pres || modified_name == "" {
 		return
 	}
 
@@ -297,6 +297,12 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 			return false
 		}
 
+		// We could try to figure out if the artifact actually
+		// changed anythign but this is hard to know - not
+		// only do we need to look at the artifact in the
+		// event table but all dependencies as well. So for
+		// now we just recompile the event table when any
+		// artifact is changed.
 		return true
 	}
 

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -109,14 +109,6 @@ func StartupEssentialServices(sm *services.Service) error {
 		}
 	}
 
-	if services.GetHuntDispatcher() == nil {
-		// Hunt dispatcher manages client's hunt membership.
-		err := sm.Start(hunt_dispatcher.StartHuntDispatcher)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -144,6 +136,14 @@ func StartupFrontendServices(sm *services.Service) error {
 	// Updates DynDNS records if needed. Frontends need to maintain their IP addresses.
 	if spec.DynDns {
 		err := sm.Start(ddclient.StartDynDNSService)
+		if err != nil {
+			return err
+		}
+	}
+
+	if spec.HuntDispatcher {
+		// Hunt dispatcher manages client's hunt membership.
+		err := sm.Start(hunt_dispatcher.StartHuntDispatcher)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The server may refresh the client's event table when no change is
actually needed (for example when the client's labels change but these
do not affect the label group assignment).

In this case the client may restart its event queries needlessly. This
change ensures that the queries are not refreshed if they didnt
actually change.