### PR TITLE
removed L

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Timeline.yaml
+++ b/artifacts/definitions/Windows/Forensics/Timeline.yaml
@@ -15,7 +15,7 @@ parameters:
     description: If specified only show executions after this time.
 
   - name: Win10TimelineGlob
-    default: C:\Users\*\AppData\Local\ConnectedDevicesPlatform\L.*\ActivitiesCache.db
+    default: C:\Users\*\AppData\Local\ConnectedDevicesPlatform\.*\ActivitiesCache.db
 
 precondition: SELECT OS From info() where OS = 'windows'
 


### PR DESCRIPTION
\L.*\ will only capture the activities cache from Local Microsoft accounts and not AAD accounts (Which start with AAD). There's another one I cant recall the prefix for.