### PR TITLE
Add AMCache detection base

### DIFF
--- a/artifacts/definitions/Windows/Detection/AMCache.yaml
+++ b/artifacts/definitions/Windows/Detection/AMCache.yaml
@@ -1,0 +1,110 @@
+name: Windows.Detection.Amcache
+author: Matt Green - @mgreen27
+description: |
+    This artifact collects AMCache entries with a SHA1 hash to enable threat 
+    detection.  
+    
+    AmCache is an artifact which stores metadata related to PE execution and 
+    program installation on Windows 7 and Server 2008 R2 and above. This artifact 
+    includes EntryName, EntryPath and SHA1 as great data points for IOC collection. 
+    Secondary datapoints include publisher/company, BinaryType and OriginalFileName.  
+    
+    Available filters include:  
+    
+      - SHA1regex - regex entries to filter by SHA1.   
+      - PathRegex - filter on path if available. 
+      - NameRegex - filter on EntryName / binary.
+      
+    NOTE:   
+    
+      - Secondary fields are not consistent across AMCache types and some legacy 
+      versions do not return these fields. 
+      - Some enrichment has occured but any secondary fields should be treated as 
+      guidance only.  
+      - This artifact collects only entries with a SHA1, for complete AMCache 
+      analysis please download raw artifact sets.
+
+reference:
+  - https://www.ssi.gouv.fr/uploads/2019/01/anssi-coriin_2019-analysis_amcache.pdf
+  
+parameters:
+  - name: AMCacheGlob
+    default: "%SYSTEMROOT%/appcompat/Programs/Amcache.hve"
+    description: AMCache hive path
+  - name: KeyPathGlob
+    default: /Root/{Inventory, File}**
+    type: hidden
+    description: Registry key path glob
+  - name: SHA1Regex
+    default: .
+    description: Regex of SHA1s to filter
+  - name: PathRegex
+    description: Regex of recorded path.
+  - name: NameRegex
+    description: Regex of entry / binary name
+    
+
+sources:
+  - queries:
+      - |
+        LET files <= SELECT FullPath FROM glob(globs=expand(path=AMCacheGlob))
+        
+        SELECT * FROM foreach(row=files, 
+                query={
+                    SELECT
+                      url(parse=Key.FullPath).Path As HivePath,
+                      url(parse=Key.FullPath).Fragment as EntryKey,
+                      Key.ModTime as KeyMTime,
+                      parse_string_with_regex(string=Key.FullPath,
+                          regex='%5CRoot%5C(\\w+)%5C').g1 as EntryType,
+                      if(condition= FileId,
+                          then = strip(string=FileId,prefix='0000'),
+                      else= if(condition= `101`,
+                          then= strip(string=`101`,prefix='0000'),
+                      else= if(condition= DriverId,
+                          then= strip(string=DriverId,prefix='0000')))) as SHA1,
+                      if(condition=Name,
+                          then=Name,
+                          else= if(condition=FriendlyName,
+                              then=FriendlyName,
+                              else=if(condition=`15`,
+                                  then=split(string=str(str=`15`), sep='\\\\')[-1],
+                                  else= if(condition=DriverName,
+                                    then=DriverName)))) as EntryName,
+                      if(condition=LowerCaseLongPath,
+                          then=LowerCaseLongPath,
+                          else= if(condition=`15`,
+                              then=`15`,
+                          else=if(condition=AddinCLSID,
+                              then=AddinCLSID))) as EntryPath,
+                      if(condition=Publisher,
+                          then=Publisher,
+                          else=if(condition=Provider,
+                              then=Provider,
+                              else= if(condition=DriverCompany,
+                                  then=DriverCompany))) as Publisher,
+                      OriginalFileName,
+                      if(condition =BinaryType,
+                          then= BinaryType,
+                          else=if(condition=AddInType,
+                              then=AddinType + ' ' + OfficeArchitecture,
+                          else= if(condition=Key.FullPath=~ 'InventoryDevicePnp',
+                              then='DevicePnp',
+                              else=if(condition=Key.FullPath=~'InventoryDriverBinary',
+                                  then='DriverBinary')))) as BinaryType
+  
+                    FROM read_reg_key(globs=url(scheme='file', path=FullPath,
+                                 fragment=KeyPathGlob).String,accessor='raw_reg')
+                    WHERE SHA1
+                        AND SHA1 =~ SHA1Regex
+                        AND if(condition= NameRegex,
+                            then= EntryName =~ NameRegex,
+                            else= True)
+                        AND if(condition= PathRegex,
+                            then= EntryPath =~ PathRegex,
+                            else= True)
+            })
+
+        
+        
+        

--- a/artifacts/testdata/server/testcases/amcache.in.yaml
+++ b/artifacts/testdata/server/testcases/amcache.in.yaml
@@ -1,0 +1,142 @@
+Parameters:
+  ReadRegMock: |
+    [{
+        "Key": {
+          "FullPath": "file:///C:/Windows/appcompat/Programs/Amcache.hve#%5CRoot%5CInventoryDevicePnp%5C%22pci/ven_8086&dev_10d3&subsys_07d015ad&rev_00/000c29ffff23301200%22",
+          "Size": 0,
+          "Mode": 2147484141,
+          "ModeStr": "drwxr-xr-x",
+          "ModTime": "2021-04-09T21:47:09Z",
+          "Sys": null,
+          "Mtime": "2021-04-09T21:47:09Z",
+          "Ctime": "2021-04-09T21:47:09Z",
+          "Atime": "2021-04-09T21:47:09Z"
+        },
+        "Model": "Intel(R) 82574L Gigabit Network Connection",
+        "Manufacturer": "Intel Corporation",
+        "DriverName": "e1i65x64.sys",
+        "ParentId": "pci\\ven_15ad&dev_07a0&subsys_07a015ad&rev_01\\3&18d45aa6&0&a8",
+        "MatchingID": "pci\\ven_8086&dev_10d3",
+        "Class": "net",
+        "ClassGuid": "{4d36e972-e325-11ce-bfc1-08002be10318}",
+        "Description": "Intel(R) 82574L Gigabit Network Connection",
+        "Enumerator": "pci",
+        "Service": "e1i65x64",
+        "InstallState": "0",
+        "DeviceState": "32",
+        "Inf": "net1ic64.inf",
+        "DriverVerDate": 6,
+        "InstallDate": 1,
+        "FirstInstallDate": 1,
+        "DriverPackageStrongName": "net1ic64.inf_amd64_5f033e913d34d111",
+        "DriverVerVersion": "12.17.10.8",
+        "ContainerId": "{1fe39919-d4cc-915c-c431-581af43bd7d9}",
+        "ProblemCode": "0",
+        "Provider": "Microsoft",
+        "DriverId": "000022a9b6e2023b86e51419c8a43ce567b28093c037",
+        "BusReportedDescription": "Ethernet Controller",
+        "HWID": "pci\\ven_8086&dev_10d3&subsys_07d015ad&rev_00,pci\\ven_8086&dev_10d3&subsys_07d015ad,pci\\ven_8086&dev_10d3&cc_020000,pci\\ven_8086&dev_10d3&cc_0200",
+        "ExtendedInfs": "",
+        "COMPID": "pci\\ven_8086&dev_10d3&rev_00,pci\\ven_8086&dev_10d3,pci\\ven_8086&cc_020000,pci\\ven_8086&cc_0200,pci\\ven_8086,pci\\cc_020000&dt_0,pci\\cc_020000,pci\\cc_0200&dt_0,pci\\cc_0200",
+        "STACKID": "\\driver\\e1i65x64,\\driver\\acpi,\\driver\\pci",
+        "UpperClassFilters": "",
+        "LowerClassFilters": "",
+        "UpperFilters": "",
+        "LowerFilters": "",
+        "DeviceInterfaceClasses": ""
+      },
+      {
+        "Key": {
+          "FullPath": "file:///C:/Windows/appcompat/Programs/Amcache.hve#%5CRoot%5CInventoryApplicationFile%5C7z.exe%7C1e434041bd08abf9",
+          "Size": 0,
+          "Mode": 2147484141,
+          "ModeStr": "drwxr-xr-x",
+          "ModTime": "2021-01-26T00:44:14Z",
+          "Sys": null,
+          "Mtime": "2021-01-26T00:44:14Z",
+          "Ctime": "2021-01-26T00:44:14Z",
+          "Atime": "2021-01-26T00:44:14Z"
+        },
+        "ProgramId": "00067b31013cb72675f1a817efcfb27ba23900000904",
+        "FileId": "000012345678d435163ae3945cbef30ef6b9872a4591",
+        "LowerCaseLongPath": "c:\\programdata\\7-zip\\bin\\x64\\7z.exe",
+        "LongPathHash": "7z.exe|1e434041bd08abf9",
+        "Name": "7z.exe",
+        "OriginalFileName": "7z.exe",
+        "Publisher": "igor pavlov",
+        "Version": "19.00",
+        "BinFileVersion": "19.0.0.0",
+        "BinaryType": "pe64_amd64",
+        "ProductName": "7-zip",
+        "ProductVersion": "19.00",
+        "LinkDate": "02/21/2019 16:00:00",
+        "BinProductVersion": "19.0.0.0",
+        "AppxPackageFullName": "",
+        "AppxPackageRelativeId": "",
+        "Size": 468992,
+        "Language": 1033,
+        "Usn": 106933632
+      },  
+      {
+        "Key": {
+          "FullPath": "file:///C:/Windows/appcompat/Programs/Amcache.hve#%5CRoot%5CInventoryApplicationFile%5C1.exe%7Ce7ecb4ace0d41711",
+          "Size": 0,
+          "Mode": 2147484141,
+          "ModeStr": "drwxr-xr-x",
+          "ModTime": "2021-03-30T21:26:02Z",
+          "Sys": null,
+          "Mtime": "2021-03-30T21:26:02Z",
+          "Ctime": "2021-03-30T21:26:02Z",
+          "Atime": "2021-03-30T21:26:02Z"
+        },
+        "ProgramId": "000692269d6891c785cd9c35a6fa1ed61a8a0000ffff",
+        "FileId": "000012345678611028f3328f52f1f136907d9cb6a701",
+        "LowerCaseLongPath": "C:\\Users\\Public\\1.exe",
+        "LongPathHash": "1.exe|e7ecb4ace0d41711",
+        "Name": "1.exe",
+        "OriginalFileName": "",
+        "Publisher": "",
+        "Version": "",
+        "BinFileVersion": "",
+        "BinaryType": "pe64_amd64",
+        "ProductName": "",
+        "ProductVersion": "",
+        "LinkDate": "03/21/2021 14:06:42",
+        "BinProductVersion": "",
+        "AppxPackageFullName": "",
+        "AppxPackageRelativeId": "",
+        "Size": 45657088,
+        "Language": 0,
+        "Usn": 420745216
+      },
+      {
+        "15": "C:\\Users\\Public\\a.exe",
+        "16": 1,
+        "17": 132593741561422880,
+        "101": "00001234567890abcdef00001234567890abcdefffff",
+        "Key": {
+          "FullPath": "file:///C:/Windows/AppCompat/Programs/Amcache.hve#%5CRoot%5CFile%5C3d4ad068-875c-4d05-915d-80dbc131d854%5C4800002f315",
+          "Size": 0,
+          "Mode": 2147484141,
+          "ModeStr": "drwxr-xr-x",
+          "ModTime": "2021-03-18T23:03:12Z",
+          "Sys": null,
+          "Mtime": "2021-03-18T23:03:12Z",
+          "Ctime": "2021-03-18T23:03:12Z",
+          "Atime": "2021-03-18T23:03:12Z"
+        }
+    }]
+
+Queries:
+  # Mock out the info plugin just for fun.
+  - LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict(OS='windows', foo='baz')] ),
+      mock(plugin='glob', results=[dict(FullPath='C:\\Windows\\AppCompat\\Programs\\Amcache.hve')] ),
+      mock(plugin='read_reg_key', results=parse_json_array(data=ReadRegMock))
+      FROM scope()
+
+  # This artifact uses the raw registry parser.
+  - SELECT * FROM Artifact.Windows.Detection.Amcache(SHA1Regex = '1234567890abcdef00001234567890abcdefffff')
+  - SELECT * FROM Artifact.Windows.Detection.Amcache(PathRegex = 'C:\\\\Users\\\\Public\\\\')
+  - SELECT * FROM Artifact.Windows.Detection.Amcache(NameRegex = '^a\\.exe$')
+  - SELECT * FROM Artifact.Windows.Detection.Amcache()
+

--- a/artifacts/testdata/server/testcases/amcache.out.yaml
+++ b/artifacts/testdata/server/testcases/amcache.out.yaml
@@ -1,0 +1,109 @@
+LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict(OS='windows', foo='baz')] ), mock(plugin='glob', results=[dict(FullPath='C:\\Windows\\AppCompat\\Programs\\Amcache.hve')] ), mock(plugin='read_reg_key', results=parse_json_array(data=ReadRegMock)) FROM scope()[]SELECT * FROM Artifact.Windows.Detection.Amcache(SHA1Regex = '1234567890abcdef00001234567890abcdefffff')[
+ {
+  "HivePath": "/C:/Windows/AppCompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\File\\3d4ad068-875c-4d05-915d-80dbc131d854\\4800002f315",
+  "KeyMTime": "2021-03-18T23:03:12Z",
+  "EntryType": "File",
+  "SHA1": "1234567890abcdef00001234567890abcdefffff",
+  "EntryName": "a.exe",
+  "EntryPath": "C:\\Users\\Public\\a.exe",
+  "Publisher": null,
+  "OriginalFileName": null,
+  "BinaryType": null,
+  "_Source": "Windows.Detection.Amcache"
+ }
+]SELECT * FROM Artifact.Windows.Detection.Amcache(PathRegex = 'C:\\\\Users\\\\Public\\\\')[
+ {
+  "HivePath": "/C:/Windows/appcompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\InventoryApplicationFile\\1.exe|e7ecb4ace0d41711",
+  "KeyMTime": "2021-03-30T21:26:02Z",
+  "EntryType": "InventoryApplicationFile",
+  "SHA1": "12345678611028f3328f52f1f136907d9cb6a701",
+  "EntryName": "1.exe",
+  "EntryPath": "C:\\Users\\Public\\1.exe",
+  "Publisher": null,
+  "OriginalFileName": "",
+  "BinaryType": "pe64_amd64",
+  "_Source": "Windows.Detection.Amcache"
+ },
+ {
+  "HivePath": "/C:/Windows/AppCompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\File\\3d4ad068-875c-4d05-915d-80dbc131d854\\4800002f315",
+  "KeyMTime": "2021-03-18T23:03:12Z",
+  "EntryType": "File",
+  "SHA1": "1234567890abcdef00001234567890abcdefffff",
+  "EntryName": "a.exe",
+  "EntryPath": "C:\\Users\\Public\\a.exe",
+  "Publisher": null,
+  "OriginalFileName": null,
+  "BinaryType": null,
+  "_Source": "Windows.Detection.Amcache"
+ }
+]SELECT * FROM Artifact.Windows.Detection.Amcache(NameRegex = '^a\\.exe$')[
+ {
+  "HivePath": "/C:/Windows/AppCompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\File\\3d4ad068-875c-4d05-915d-80dbc131d854\\4800002f315",
+  "KeyMTime": "2021-03-18T23:03:12Z",
+  "EntryType": "File",
+  "SHA1": "1234567890abcdef00001234567890abcdefffff",
+  "EntryName": "a.exe",
+  "EntryPath": "C:\\Users\\Public\\a.exe",
+  "Publisher": null,
+  "OriginalFileName": null,
+  "BinaryType": null,
+  "_Source": "Windows.Detection.Amcache"
+ }
+]SELECT * FROM Artifact.Windows.Detection.Amcache()[
+ {
+  "HivePath": "/C:/Windows/appcompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\InventoryDevicePnp\\\"pci/ven_8086\u0026dev_10d3\u0026subsys_07d015ad\u0026rev_00/000c29ffff23301200\"",
+  "KeyMTime": "2021-04-09T21:47:09Z",
+  "EntryType": "InventoryDevicePnp",
+  "SHA1": "22a9b6e2023b86e51419c8a43ce567b28093c037",
+  "EntryName": "e1i65x64.sys",
+  "EntryPath": null,
+  "Publisher": "Microsoft",
+  "OriginalFileName": null,
+  "BinaryType": "DevicePnp",
+  "_Source": "Windows.Detection.Amcache"
+ },
+ {
+  "HivePath": "/C:/Windows/appcompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\InventoryApplicationFile\\7z.exe|1e434041bd08abf9",
+  "KeyMTime": "2021-01-26T00:44:14Z",
+  "EntryType": "InventoryApplicationFile",
+  "SHA1": "12345678d435163ae3945cbef30ef6b9872a4591",
+  "EntryName": "7z.exe",
+  "EntryPath": "c:\\programdata\\7-zip\\bin\\x64\\7z.exe",
+  "Publisher": "igor pavlov",
+  "OriginalFileName": "7z.exe",
+  "BinaryType": "pe64_amd64",
+  "_Source": "Windows.Detection.Amcache"
+ },
+ {
+  "HivePath": "/C:/Windows/appcompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\InventoryApplicationFile\\1.exe|e7ecb4ace0d41711",
+  "KeyMTime": "2021-03-30T21:26:02Z",
+  "EntryType": "InventoryApplicationFile",
+  "SHA1": "12345678611028f3328f52f1f136907d9cb6a701",
+  "EntryName": "1.exe",
+  "EntryPath": "C:\\Users\\Public\\1.exe",
+  "Publisher": null,
+  "OriginalFileName": "",
+  "BinaryType": "pe64_amd64",
+  "_Source": "Windows.Detection.Amcache"
+ },
+ {
+  "HivePath": "/C:/Windows/AppCompat/Programs/Amcache.hve",
+  "EntryKey": "\\Root\\File\\3d4ad068-875c-4d05-915d-80dbc131d854\\4800002f315",
+  "KeyMTime": "2021-03-18T23:03:12Z",
+  "EntryType": "File",
+  "SHA1": "1234567890abcdef00001234567890abcdefffff",
+  "EntryName": "a.exe",
+  "EntryPath": "C:\\Users\\Public\\a.exe",
+  "Publisher": null,
+  "OriginalFileName": null,
+  "BinaryType": null,
+  "_Source": "Windows.Detection.Amcache"
+ }
+]


### PR DESCRIPTION
This artifact collects AMCache entries with a SHA1 hash to enable threat detection.  

AmCache is an artifact which stores metadata related to PE execution and program installation on Windows 7 and Server 2008 R2 and above. This artifact includes EntryName, EntryPath and SHA1 as great data points for IOC collection.  Secondary datapoints include publisher/company, BinaryType and OriginalFileName.  
    
Available filters include:  
      SHA1regex - regex entries to filter by SHA1.   
      PathRegex - filter on path if available. 
      NameRegex - filter on EntryName / binary.
      
NOTE:   
    Secondary fields are not consistent across AMCache types and some legacy versions do not return these fields. 
    Some enrichment has occured but any secondary fields should be treated as guidance only.  
    This artifact collects only entries with a SHA1, for complete AMCache analysis please download raw artifact sets.

reference:
  - https://www.ssi.gouv.fr/uploads/2019/01/anssi-coriin_2019-analysis_amcache.pdf