### PR TITLE
Allow all commands to override configs.

### DIFF
--- a/bin/artifacts.go
+++ b/bin/artifacts.go
@@ -124,7 +124,7 @@ func getRepository(config_obj *config_proto.Config) (services.Repository, error)
 func doArtifactCollect() {
 	checkAdmin()
 
-	config_obj, err := DefaultConfigLoader.WithNullLoader().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
 	sm, err := startEssentialServices(config_obj)
@@ -191,7 +191,7 @@ func getFilterRegEx(pattern string) (*regexp.Regexp, error) {
 }
 
 func doArtifactShow() {
-	config_obj, err := DefaultConfigLoader.WithNullLoader().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
 	sm, err := startEssentialServices(config_obj)
@@ -212,7 +212,7 @@ func doArtifactShow() {
 }
 
 func doArtifactList() {
-	config_obj, err := DefaultConfigLoader.WithNullLoader().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
 	sm, err := startEssentialServices(config_obj)

--- a/bin/client.go
+++ b/bin/client.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	"www.velocidex.com/golang/velociraptor/config"
 	crypto_client "www.velocidex.com/golang/velociraptor/crypto/client"
 	crypto_utils "www.velocidex.com/golang/velociraptor/crypto/utils"
 	"www.velocidex.com/golang/velociraptor/executor"
@@ -43,16 +42,10 @@ func RunClient(
 	config_path *string) {
 
 	// Include the writeback in the client's configuration.
-	config_obj, err := new(config.Loader).
-		WithVerbose(*verbose_flag).
-		WithFileLoader(*config_path).
-		WithEmbedded().
-		WithEnvLoader("VELOCIRAPTOR_CONFIG").
-		WithCustomValidator(initFilestoreAccessor).
-		WithCustomValidator(initDebugServer).
-		WithLogFile(*logging_flag).
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().
 		WithRequiredLogging().
+		WithFileLoader(*config_path).
 		WithWriteback().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 

--- a/bin/config.go
+++ b/bin/config.go
@@ -94,7 +94,7 @@ var (
 )
 
 func doShowConfig() {
-	config_obj, err := DefaultConfigLoader.LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	if *config_show_command_json {
@@ -205,7 +205,7 @@ func doGenerateConfigNonInteractive() {
 }
 
 func doRotateKeyConfig() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	logger := logging.GetLogger(config_obj, &logging.ToolComponent)
@@ -239,7 +239,7 @@ func doRotateKeyConfig() {
 }
 
 func doReissueServerKeys() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	logger := logging.GetLogger(config_obj, &logging.ToolComponent)
@@ -286,7 +286,7 @@ func getClientConfig(config_obj *config_proto.Config) *config_proto.Config {
 }
 
 func doDumpClientConfig() {
-	config_obj, err := DefaultConfigLoader.WithRequiredClient().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredClient().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	client_config := getClientConfig(config_obj)
@@ -298,7 +298,7 @@ func doDumpClientConfig() {
 }
 
 func doDumpApiClientConfig() {
-	config_obj, err := DefaultConfigLoader.WithRequiredCA().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredCA().
 		WithRequiredUser().
 		LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")

--- a/bin/config_frontend.go
+++ b/bin/config_frontend.go
@@ -31,7 +31,7 @@ func reportCurrentSetup(config_obj *config_proto.Config) string {
 }
 
 func doConfigFrontend() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	doit := false

--- a/bin/csv.go
+++ b/bin/csv.go
@@ -21,7 +21,7 @@ var (
 )
 
 func doCSV() {
-	config_obj, err := DefaultConfigLoader.WithNullLoader().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
 	sm, err := startEssentialServices(config_obj)

--- a/bin/debian.go
+++ b/bin/debian.go
@@ -129,7 +129,7 @@ func doServerDeb() {
 	// deb on the same system where the logs should go.
 	_ = config.ValidateClientConfig(&config_proto.Config{})
 
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
 	// Debian packages always use the "velociraptor" user.
@@ -225,7 +225,7 @@ func doClientDeb() {
 	// deb on the same system where the logs should go.
 	_ = config.ValidateClientConfig(&config_proto.Config{})
 
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 

--- a/bin/frontend.go
+++ b/bin/frontend.go
@@ -40,7 +40,7 @@ var (
 )
 
 func doFrontend() {
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
 		WithRequiredLogging().LoadAndValidate()

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -226,7 +226,7 @@ func doGolden() {
 	_, cancel := makeCtxWithTimeout(120)
 	defer cancel()
 
-	config_obj, err := DefaultConfigLoader.LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Can not load configuration.")
 
 	logger := logging.GetLogger(config_obj, &logging.ToolComponent)

--- a/bin/grant.go
+++ b/bin/grant.go
@@ -49,7 +49,7 @@ var (
 )
 
 func doGrant() {
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
 		LoadAndValidate()
@@ -102,7 +102,7 @@ func doGrant() {
 }
 
 func doShow() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config.")
 
 	sm, err := startEssentialServices(config_obj)

--- a/bin/gui.go
+++ b/bin/gui.go
@@ -45,10 +45,9 @@ func doGUI() {
 	client_config_path := filepath.Join(datastore_directory, "client.config.yaml")
 
 	// Try to open the config file from there
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithVerbose(true).
-		WithFileLoader(server_config_path).
-		LoadAndValidate()
+		WithFileLoader(server_config_path).LoadAndValidate()
 	if err != nil || config_obj.Frontend == nil {
 
 		// Need to generate a new config. This config is not

--- a/bin/installer_darwin.go
+++ b/bin/installer_darwin.go
@@ -45,7 +45,7 @@ var (
 )
 
 func doRemove() error {
-	config_obj, err := DefaultConfigLoader.WithRequiredClient().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredClient().
 		WithWriteback().LoadAndValidate()
 	if err != nil {
 		return errors.Wrap(err, "Unable to load config file")
@@ -65,7 +65,7 @@ func doRemove() error {
 }
 
 func doInstall() error {
-	config_obj, err := DefaultConfigLoader.WithRequiredClient().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredClient().
 		WithWriteback().LoadAndValidate()
 	if err != nil {
 		return errors.Wrap(err, "Unable to load config file")

--- a/bin/installer_windows.go
+++ b/bin/installer_windows.go
@@ -36,7 +36,6 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 	"golang.org/x/sys/windows/svc/mgr"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_client "www.velocidex.com/golang/velociraptor/crypto/client"
 	crypto_utils "www.velocidex.com/golang/velociraptor/crypto/utils"
@@ -295,7 +294,7 @@ func removeService(name string) error {
 }
 
 func doRemove() {
-	config_obj, err := DefaultConfigLoader.LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
 	logger := logging.GetLogger(config_obj, &logging.ClientComponent)
@@ -346,12 +345,9 @@ func loadClientConfig() (*config_proto.Config, error) {
 		config_path = &config_target_path
 	}
 
-	config_obj, err := new(config.Loader).WithVerbose(*verbose_flag).
-		WithEmbedded().
-		WithFileLoader(*config_path).
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().
-		WithWriteback().
-		LoadAndValidate()
+		WithWriteback().LoadAndValidate()
 	if err != nil {
 		// Config obj is not valid here, we can not actually
 		// log anything since we dont know where to send it so
@@ -558,7 +554,7 @@ func init() {
 		var err error
 		switch command {
 		case installl_command.FullCommand():
-			config_obj, err := DefaultConfigLoader.LoadAndValidate()
+			config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 			kingpin.FatalIfError(err, "Unable to load config file")
 			logger := logging.GetLogger(config_obj, &logging.ClientComponent)
 
@@ -588,26 +584,26 @@ func init() {
 			}
 
 		case start_command.FullCommand():
-			config_obj, err := DefaultConfigLoader.LoadAndValidate()
+			config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 			kingpin.FatalIfError(err, "Unable to load config file")
 			err = startService(config_obj.Client.WindowsInstaller.ServiceName)
 
 		case stop_command.FullCommand():
-			config_obj, err := DefaultConfigLoader.LoadAndValidate()
+			config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 			kingpin.FatalIfError(err, "Unable to load config file")
 			err = controlService(
 				config_obj.Client.WindowsInstaller.ServiceName,
 				svc.Stop, svc.Stopped)
 
 		case pause_command.FullCommand():
-			config_obj, err := DefaultConfigLoader.LoadAndValidate()
+			config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 			kingpin.FatalIfError(err, "Unable to load config file")
 			err = controlService(
 				config_obj.Client.WindowsInstaller.ServiceName,
 				svc.Pause, svc.Paused)
 
 		case continue_command.FullCommand():
-			config_obj, err := DefaultConfigLoader.LoadAndValidate()
+			config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 			kingpin.FatalIfError(err, "Unable to load config file")
 			err = controlService(
 				config_obj.Client.WindowsInstaller.ServiceName,

--- a/bin/notebook.go
+++ b/bin/notebook.go
@@ -18,7 +18,7 @@ var (
 )
 
 func doExportNotebook() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
 	sm, err := startEssentialServices(config_obj)

--- a/bin/pool.go
+++ b/bin/pool.go
@@ -77,7 +77,7 @@ func doPoolClient() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client_config, err := DefaultConfigLoader.
+	client_config, err := makeDefaultConfigLoader().
 		WithRequiredClient().
 		WithVerbose(*verbose_flag).
 		LoadAndValidate()

--- a/bin/report_archive.go
+++ b/bin/report_archive.go
@@ -36,7 +36,7 @@ var (
 )
 
 func doReportArchive() {
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -167,7 +167,7 @@ func doClientRPM() {
 	// deb on the same system where the logs should go.
 	_ = config.ValidateClientConfig(&config_proto.Config{})
 
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
@@ -269,7 +269,7 @@ func doClientSysVRPM() {
 	// deb on the same system where the logs should go.
 	_ = config.ValidateClientConfig(&config_proto.Config{})
 
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 

--- a/bin/tools.go
+++ b/bin/tools.go
@@ -53,7 +53,7 @@ var (
 )
 
 func doThirdPartyShow() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
@@ -77,7 +77,7 @@ func doThirdPartyShow() {
 }
 
 func doThirdPartyRm() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 
@@ -90,7 +90,7 @@ func doThirdPartyRm() {
 }
 
 func doThirdPartyUpload() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config ")
 

--- a/bin/unzip.go
+++ b/bin/unzip.go
@@ -32,7 +32,7 @@ var (
 )
 
 func doUnzip() {
-	config_obj, err := DefaultConfigLoader.WithNullLoader().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
 	kingpin.FatalIfError(err, "Load Config")
 
 	sm, err := startEssentialServices(config_obj)

--- a/bin/users.go
+++ b/bin/users.go
@@ -53,7 +53,7 @@ var (
 )
 
 func doAddUser() {
-	config_obj, err := DefaultConfigLoader.
+	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
@@ -106,7 +106,7 @@ func doAddUser() {
 }
 
 func doShowUser() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
 	sm, err := startEssentialServices(config_obj)
@@ -123,7 +123,7 @@ func doShowUser() {
 }
 
 func doLockUser() {
-	config_obj, err := DefaultConfigLoader.WithRequiredFrontend().LoadAndValidate()
+	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 
 	sm, err := startEssentialServices(config_obj)

--- a/reporting/cell_test.go
+++ b/reporting/cell_test.go
@@ -19,16 +19,31 @@ SELECT 1 / 2 FROM info()
 /* c
 
 # This is markdown
+with multiple lines
+/*
+This is still a comment!
 
 */
 
 SELECT * FROM glob()
+`}, {"Comments in VQL", `
+SELECT * FROM glob(globs='C:/Windows/*/*.exe')
+`}, {"Comments within lines", `
+SELECT * FROM glob(/* Foobar */globs='C:/Windows/*/*.exe')
+`}, {"Multi line VQL", `
+SELECT *, count() AS Count
+FROM certificates()
 `},
 }
 
 func TestVQL2MarkdownConversion(t *testing.T) {
 	result := ordereddict.NewDict()
 	for _, testcase := range TestCases {
+		/*
+			tokens, err := parser.Lex(bytes.NewReader([]byte(testcase.Input)))
+			utils.Debug(tokens)
+			utils.Debug(err)
+		*/
 		parsed, err := ConvertVQLCellToContent(testcase.Input)
 		assert.NoError(t, err)
 

--- a/reporting/cells.go
+++ b/reporting/cells.go
@@ -9,8 +9,8 @@ import (
 var (
 	def = lexer.Must(stateful.New(stateful.Rules{
 		"Root": {
-			{`VQLText`, `(?ms)([^/]|/[^*])+`, nil},
-			{"CommentStart", `(?ms)/[*]`, stateful.Push("Comment")},
+			{"CommentStart", `^ */[*]`, stateful.Push("Comment")},
+			{`VQLText`, `(?ms)^([^\n]+|\n)`, nil},
 		},
 		"Comment": {
 			{`CommentText`, `(?ms)([^*]|[*][^/])+`, nil},
@@ -29,9 +29,41 @@ type Content struct {
 	Fragments []Fragment ` @@* `
 }
 
+func (self *Content) PushVQL(vql string) {
+	last_idx := len(self.Fragments) - 1
+
+	if len(self.Fragments) == 0 || self.Fragments[last_idx].VQL == "" {
+		self.Fragments = append(self.Fragments, Fragment{VQL: vql})
+	} else {
+		self.Fragments[last_idx].VQL += vql
+	}
+}
+
+func (self *Content) PushComment(c string) {
+	last_idx := len(self.Fragments) - 1
+
+	if len(self.Fragments) == 0 || self.Fragments[last_idx].Comment == "" {
+		self.Fragments = append(self.Fragments, Fragment{Comment: c})
+	} else {
+		self.Fragments[last_idx].Comment += c
+	}
+}
+
 // A VQL cell consists of an interleaved set of markdown and VQL.
 func ConvertVQLCellToContent(content string) (*Content, error) {
+	parsed := &Content{}
+	err := parser.ParseString(content, parsed)
+	if err != nil {
+		return nil, err
+	}
+
 	result := &Content{}
-	err := parser.ParseString(content, result)
+	for _, fragment := range parsed.Fragments {
+		if fragment.VQL != "" {
+			result.PushVQL(fragment.VQL)
+		} else if fragment.Comment != "" {
+			result.PushComment(fragment.Comment)
+		}
+	}
 	return result, err
 }

--- a/reporting/fixtures/VQL2MarkdownConversion.golden
+++ b/reporting/fixtures/VQL2MarkdownConversion.golden
@@ -7,10 +7,34 @@
       },
       {
         "VQL": "",
-        "Comment": " c\n\n# This is markdown\n\n"
+        "Comment": " c\n\n# This is markdown\nwith multiple lines\n/*\nThis is still a comment!\n\n"
       },
       {
         "VQL": "\n\nSELECT * FROM glob()\n",
+        "Comment": ""
+      }
+    ]
+  },
+  "Comments in VQL": {
+    "Fragments": [
+      {
+        "VQL": "\nSELECT * FROM glob(globs='C:/Windows/*/*.exe')\n",
+        "Comment": ""
+      }
+    ]
+  },
+  "Comments within lines": {
+    "Fragments": [
+      {
+        "VQL": "\nSELECT * FROM glob(/* Foobar */globs='C:/Windows/*/*.exe')\n",
+        "Comment": ""
+      }
+    ]
+  },
+  "Multi line VQL": {
+    "Fragments": [
+      {
+        "VQL": "\nSELECT *, count() AS Count\nFROM certificates()\n",
         "Comment": ""
       }
     ]

--- a/vql/parsers/crypto/bigint.go
+++ b/vql/parsers/crypto/bigint.go
@@ -1,0 +1,32 @@
+package crypto
+
+import (
+	"errors"
+	"math/big"
+
+	"www.velocidex.com/golang/velociraptor/json"
+)
+
+// The default bigint marshaller uses a long integer but this may not
+// be properly parsed - to be safe we just emit a string.
+func MarshalBigInt(v interface{}, opts *json.EncOpts) ([]byte, error) {
+	bint, ok := v.(*big.Int)
+	if !ok {
+		return nil, errors.New("Not a bigint")
+	}
+
+	encoded, err := bint.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]byte, len(encoded)+2)
+	res[0] = '"'
+	res[len(res)-1] = '"'
+	copy(res[1:], encoded)
+	return res, nil
+}
+
+func init() {
+	json.RegisterCustomEncoder(&big.Int{}, MarshalBigInt)
+}


### PR DESCRIPTION
Previously this was only enabled on the frontend. This PR allows all
commands to override config - for example:

velociraptor --config client.config.yaml --config.client-server-urls=https://1.1.1.1/ client -v