### PR TITLE
Wait for event queries to terminate before interrupting client.

### DIFF
--- a/actions/events_test.go
+++ b/actions/events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,6 +133,11 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()
+
+	// Wait until the entire event table is cleaned up.
+	wg := &sync.WaitGroup{}
+	actions.InitializeEventTable(ctx, wg)
+	defer wg.Wait()
 
 	require.NoError(self.T(), client_manager.SetClientMonitoringState(
 		ctx, self.config_obj, server_state))

--- a/artifacts/definitions/Windows/ETW/ETWSessions.yaml
+++ b/artifacts/definitions/Windows/ETW/ETWSessions.yaml
@@ -1,0 +1,27 @@
+name: Windows.ETW.ETWSessions
+description: |
+  Windows Event Tracing exposes a lot of low level system information
+  and events. It is normally employed be security tools to gather
+  telemetry, however may also be used maliciously.
+
+  This artifact monitors for all new ETW sessions and reports the
+  tracing process as well as the provider that is being traced.
+
+type: CLIENT_EVENT
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+sources:
+  - query: |
+      LET PublisherGlob = '''HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Publishers\*\@'''
+
+      LET GUIDLookup(GUID) = SELECT Data.value AS Provider
+         FROM stat(accessor="registry", filename=path_join(components=[PublisherGlob, GUID, "@"]))
+
+      SELECT System.TimeStamp AS Timestamp, {
+           SELECT Name, CommandLine from pslist(pid=System.ProcessID)
+        } AS ProcessInfo ,
+        GUIDLookup(GUID=EventData.ProviderName)[0].Provider AS Provider,
+        System AS _System, EventData AS _EventData
+      FROM watch_etw(guid="{B675EC37-BDB6-4648-BC92-F3FDC74D3CA2}", any=0x400)
+      WHERE System.ID = 14

--- a/artifacts/definitions/Windows/ETW/ViewSessions.yaml
+++ b/artifacts/definitions/Windows/ETW/ViewSessions.yaml
@@ -1,0 +1,30 @@
+name: Windows.ETW.ViewSessions
+description: |
+  This artifact enumerates all ETW sessions and optionally kills dangling ones
+
+required_permissions:
+  - EXECVE
+
+precondition: SELECT OS From info() where OS = 'windows'
+parameters:
+  - name: SessionRegex
+    default: "Velociraptor"
+  - name: KillMatching
+    type: bool
+    description: If set will kill the relevant sessions.
+
+
+sources:
+  - query: |
+      SELECT * FROM foreach(row={
+         SELECT Stdout, parse_string_with_regex(string=Stdout, regex="(^[^ ]+)").g1 AS SessionName
+         from execve(argv=["logman", "query", "-ets"], sep="\n")
+         WHERE Stdout =~ "Running" AND SessionName =~ SessionRegex
+      }, query={
+         SELECT * FROM if(condition=KillMatching,
+         then={
+             SELECT SessionName, Stdout FROM execve(argv=["logman", "stop", SessionName, "-ets"])
+         }, else={
+             SELECT SessionName FROM scope()
+         })
+      })

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -314,7 +314,10 @@ func NewClientExecutor(
 	// Drain messages from server and execute them, pushing
 	// results to the output channel.
 	go func() {
-		defer close(result.Outbound)
+		// Keep this open to avoid sending on close
+		// channels. The executed queries should finish
+		// themselves when the context is done.
+		// defer close(result.Outbound)
 
 		// Do not exit until all goroutines have finished.
 		wg := &sync.WaitGroup{}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -315,8 +315,9 @@ func NewClientExecutor(
 	// results to the output channel.
 	go func() {
 		// Keep this open to avoid sending on close
-		// channels. The executed queries should finish
+		// channels. The executed queries should finish by
 		// themselves when the context is done.
+
 		// defer close(result.Outbound)
 
 		// Do not exit until all goroutines have finished.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -37,9 +37,15 @@ func (self *ExecutorTestSuite) TestCancellation() {
 		defer wg.Done()
 
 		// Wait here until the executor is fully cancelled.
-		for message := range executor.Outbound {
-			received_messages = append(
-				received_messages, message)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case message := <-executor.Outbound:
+				received_messages = append(
+					received_messages, message)
+			}
 		}
 	}()
 

--- a/executor/services.go
+++ b/executor/services.go
@@ -56,6 +56,9 @@ func StartEventTableService(
 		config_obj, &crypto_proto.VeloMessage{
 			SessionId: constants.MONITORING_WELL_KNOWN_FLOW,
 		}, exe.Outbound)
+
+	actions.InitializeEventTable(ctx, wg)
+
 	if config_obj.Writeback.EventQueries != nil {
 		actions.UpdateEventTable{}.Run(config_obj, ctx,
 			responder, config_obj.Writeback.EventQueries)

--- a/vql/windows/filesystems/registry_windows.go
+++ b/vql/windows/filesystems/registry_windows.go
@@ -362,6 +362,10 @@ func getValueInfo(key registry.Key, components []string) (*RegValueInfo, error) 
 			_components: components,
 		}}
 
+	if value_name == "@" {
+		value_name = ""
+	}
+
 	buf_size, value_type, err := key.GetValue(value_name, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes an issue where etw sessions were left behind when the
client was interrupted causing a leak of sessions.

Also added an artifact that can help to kill stray etw sessions to
clean up resources.