### PR TITLE
Bugfix: Client queue manage sometimes produced same TaskID 

### DIFF
--- a/actions/events.go
+++ b/actions/events.go
@@ -152,6 +152,7 @@ func update(
 	GlobalEventTable.version = table.Version
 	GlobalEventTable.Done = make(chan bool)
 	GlobalEventTable.config_obj = config_obj
+	GlobalEventTable.service_wg = &sync.WaitGroup{}
 
 	return GlobalEventTable, nil, true /* changed */
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
@@ -120,6 +122,63 @@ func (self BaseTestSuite) TestIndexes() {
 	hits = self.datastore.SearchClients(self.config_obj, constants.CLIENT_INDEX_URN,
 		"*foo", "", 0, 100, SORT_UP)
 	assert.Equal(self.T(), []string{client_id}, hits)
+}
+
+func (self BaseTestSuite) TestQueueMessages() {
+	client_id := "C.1236"
+
+	message1 := &crypto_proto.VeloMessage{Source: "Server", SessionId: "1"}
+	err := self.datastore.QueueMessageForClient(self.config_obj, client_id, message1)
+	assert.NoError(self.T(), err)
+
+	// Now retrieve all messages.
+	tasks, err := self.datastore.GetClientTasks(
+		self.config_obj, client_id, true /* do_not_lease */)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), 1, len(tasks))
+	assert.True(self.T(), proto.Equal(tasks[0], message1))
+
+	// We did not lease, so the tasks are not removed, but this
+	// time we will lease.
+	tasks, err = self.datastore.GetClientTasks(
+		self.config_obj, client_id, false /* do_not_lease */)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), len(tasks), 1)
+
+	// No tasks available.
+	tasks, err = self.datastore.GetClientTasks(
+		self.config_obj, client_id, false /* do_not_lease */)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), len(tasks), 0)
+}
+
+func (self BaseTestSuite) TestFastQueueMessages() {
+	client_id := "C.1235"
+
+	written := []*crypto_proto.VeloMessage{}
+
+	for i := 0; i < 10; i++ {
+		message := &crypto_proto.VeloMessage{Source: "Server", SessionId: fmt.Sprintf("%d", i)}
+		err := self.datastore.QueueMessageForClient(self.config_obj, client_id, message)
+		assert.NoError(self.T(), err)
+
+		written = append(written, message)
+	}
+
+	// Now retrieve all messages.
+	tasks, err := self.datastore.GetClientTasks(
+		self.config_obj, client_id, true /* do_not_lease */)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), 10, len(tasks))
+
+	// Does not have to return in sorted form.
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].SessionId < tasks[j].SessionId
+	})
+
+	for i := 0; i < 10; i++ {
+		assert.True(self.T(), proto.Equal(tasks[i], written[i]))
+	}
 }
 
 func benchmarkSearchClient(b *testing.B,

--- a/datastore/filebased_test.go
+++ b/datastore/filebased_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -12,7 +13,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/config"
 	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/paths"
-	"www.velocidex.com/golang/velociraptor/vtesting"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 type FilebasedTestSuite struct {
@@ -31,7 +32,7 @@ func TestFilebasedDatabase(t *testing.T) {
 
 	suite.Run(t, &FilebasedTestSuite{BaseTestSuite{
 		datastore: &FileBaseDataStore{
-			clock: vtesting.RealClock{},
+			clock: utils.MockClock{MockNow: time.Unix(100, 0)},
 		},
 		config_obj: config_obj,
 	}})
@@ -42,7 +43,7 @@ func benchmarkSearchClientCount(b *testing.B, count int, sort_direction SortingS
 	defer os.RemoveAll(dir) // clean up
 
 	db := &FileBaseDataStore{
-		clock: vtesting.RealClock{},
+		clock: utils.RealClock{},
 	}
 
 	config_obj := config.GetDefaultConfig()

--- a/datastore/memory.go
+++ b/datastore/memory.go
@@ -16,7 +16,6 @@ import (
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/utils"
-	"www.velocidex.com/golang/velociraptor/vtesting"
 )
 
 var (
@@ -30,7 +29,7 @@ type TestDataStore struct {
 	Subjects    map[string]proto.Message
 	ClientTasks map[string][]*crypto_proto.VeloMessage
 
-	clock vtesting.Clock
+	clock utils.Clock
 }
 
 func NewTestDataStore() *TestDataStore {

--- a/flows/artifacts.go
+++ b/flows/artifacts.go
@@ -680,6 +680,8 @@ func (self *FlowRunner) ProcessSingleMessage(
 	ctx context.Context,
 	job *crypto_proto.VeloMessage) {
 
+	// json.TraceMessage(job.Source+"_job", job)
+
 	// Foreman messages are related to hunts.
 	if job.ForemanCheckin != nil {
 		err := ForemanProcessMessage(

--- a/json/debug.go
+++ b/json/debug.go
@@ -1,6 +1,10 @@
 package json
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+)
 
 func Debug(v interface{}) {
 	fmt.Println(StringIndent(v))
@@ -8,4 +12,18 @@ func Debug(v interface{}) {
 
 func Dump(v interface{}) {
 	fmt.Println(StringIndent(v))
+}
+
+var g_idx uint64
+
+// Write each message into its own file.
+func TraceMessage(filename string, message interface{}) {
+	idx := atomic.AddUint64(&g_idx, 1)
+	file, err := os.OpenFile(fmt.Sprintf("%s_%v.json", filename, idx),
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700)
+	if err != nil {
+		panic(err)
+	}
+	file.Write(MustMarshalIndent(message))
+	file.Close()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -268,6 +268,8 @@ func (self *Server) Process(
 	drain_requests_for_client bool) (
 	[]byte, int, error) {
 
+	// json.TraceMessage(message_info.Source, message_info)
+
 	runner := flows.NewFlowRunner(self.config)
 	defer runner.Close()
 
@@ -295,6 +297,12 @@ func (self *Server) Process(
 			message_list.Job,
 			self.DrainRequestsForClient(message_info.Source)...)
 	}
+
+	/*
+		for i := 0; i < len(message_list.Job); i++ {
+			json.TraceMessage(message_info.Source+"_out", message_list.Job[i])
+		}
+	*/
 
 	// Messages sent to clients are typically small and we do not
 	// benefit from compression.

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -18,7 +18,9 @@
 */
 package utils
 
-import "github.com/davecgh/go-spew/spew"
+import (
+	"github.com/davecgh/go-spew/spew"
+)
 
 func Debug(arg interface{}) {
 	spew.Dump(arg)

--- a/vtesting/helpers.go
+++ b/vtesting/helpers.go
@@ -38,20 +38,6 @@ func ReadFile(t *testing.T, filename string) []byte {
 	return result
 }
 
-type Clock interface {
-	Now() time.Time
-	After(d time.Duration) <-chan time.Time
-}
-
-type RealClock struct{}
-
-func (self RealClock) Now() time.Time {
-	return time.Now()
-}
-func (self RealClock) After(d time.Duration) <-chan time.Time {
-	return time.After(d)
-}
-
 // Compares lists of strings regardless of order.
 func CompareStrings(expected []string, watched []string) bool {
 	if len(expected) != len(watched) {


### PR DESCRIPTION
Task ID was derived from UnixNano() so under load it was sometimes
issuing the same task id to multiple jobs. This caused one job to be
overwritten in random.

The observable issue was that enrolments were often failing.