### PR TITLE
Force mime for notebooks

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -21,8 +21,6 @@ import (
 func toolUploadHandler(
 	config_obj *config_proto.Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("File Upload Endpoint Hit")
-
 		// Check for acls
 		userinfo := GetUserInfo(r.Context(), config_obj)
 		permissions := acls.ARTIFACT_WRITER
@@ -40,6 +38,7 @@ func toolUploadHandler(
 			returnError(w, http.StatusBadRequest, "Unsupported params")
 			return
 		}
+		defer r.MultipartForm.RemoveAll()
 
 		tool := &artifacts_proto.Tool{}
 		params, pres := r.Form["_params_"]

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	VERSION                    = "0.6.0-rc1"
+	VERSION                    = "0.6.0-rc2"
 	ENROLLMENT_WELL_KNOWN_FLOW = "E:Enrol"
 	MONITORING_WELL_KNOWN_FLOW = FLOW_PREFIX + "Monitoring"
 

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.12.0
@@ -83,9 +82,9 @@ require (
 	github.com/processout/grpc-go-pool v1.2.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
-	github.com/qri-io/starlib v0.5.0 // indirect
+	github.com/qri-io/starlib v0.5.0
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
-	github.com/robertkrimen/otto v0.0.0-20210614181706-373ff5438452 // indirect
+	github.com/robertkrimen/otto v0.0.0-20210614181706-373ff5438452
 	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/sebdah/goldie v1.0.0
 	github.com/sebdah/goldie/v2 v2.5.3
@@ -112,7 +111,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
@@ -124,7 +122,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20200722101157-37e4751dd5ca
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20210620044135-56aeed157e90
+	www.velocidex.com/golang/vfilter v0.0.0-20210621143251-8e57fc2e83c6
 	www.velocidex.com/golang/vtypes v0.0.0-20210531054645-7ec8b6e24d88
 )
 

--- a/go.sum
+++ b/go.sum
@@ -108,7 +108,6 @@ github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897/go.mod h1:xTS7Pm1p
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20201120212035-bb82daffcca2/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
-github.com/alecthomas/repr v0.0.0-20210301060118-828286944d6a h1:GY6ZI5mOHoiQ+g2ETFQGYu6fNgc6bCe4b4kr8tSrhpg=
 github.com/alecthomas/repr v0.0.0-20210301060118-828286944d6a/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/repr v0.0.0-20210611225437-1a2716eca9d6 h1:U80AUqb3eEPLw60yvrEa2WadeJw+U1N8XeCVsUREep0=
 github.com/alecthomas/repr v0.0.0-20210611225437-1a2716eca9d6/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
@@ -381,7 +380,6 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -531,7 +529,6 @@ github.com/shirou/gopsutil v3.20.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -968,9 +965,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196/go.mod h1:i
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
 www.velocidex.com/golang/vfilter v0.0.0-20210515085940-25d96b94dafb/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
-www.velocidex.com/golang/vfilter v0.0.0-20210531163909-d0a0745e41b7 h1:3xbomFv89/F/RlXE5jHDFz2aQHL9iFc+dtB/VRVaJs0=
-www.velocidex.com/golang/vfilter v0.0.0-20210531163909-d0a0745e41b7/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
-www.velocidex.com/golang/vfilter v0.0.0-20210620044135-56aeed157e90 h1:eR1lB34q/EyhoQ/xy3wtw2TsWG9ml3djxBHixI6WaGU=
-www.velocidex.com/golang/vfilter v0.0.0-20210620044135-56aeed157e90/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
+www.velocidex.com/golang/vfilter v0.0.0-20210621143251-8e57fc2e83c6 h1:EPExL5jjHBmDNn/jWd9LmDS7sgBIf9ppYf5YpH+Aw10=
+www.velocidex.com/golang/vfilter v0.0.0-20210621143251-8e57fc2e83c6/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
 www.velocidex.com/golang/vtypes v0.0.0-20210531054645-7ec8b6e24d88 h1:Fb7nzCAXBVzXbSUXO5sq5msYieB2GMfG7BGnZRDjKMM=
 www.velocidex.com/golang/vtypes v0.0.0-20210531054645-7ec8b6e24d88/go.mod h1:PIG8uSY330pJd620KPksZpTaAsX3sIMiiNJQihZph6c=

--- a/vql/server/results.go
+++ b/vql/server/results.go
@@ -71,6 +71,8 @@ func (self UploadsPlugins) Call(
 			return
 		}
 
+		ParseUploadArgsFromScope(arg, scope)
+
 		// Allow the plugin args to override the environment scope.
 		err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 		if err != nil {
@@ -104,6 +106,18 @@ func (self UploadsPlugins) Info(
 		Name:    "uploads",
 		Doc:     "Retrieve information about a flow's uploads.",
 		ArgType: type_map.AddType(scope, &UploadsPluginsArgs{}),
+	}
+}
+
+func ParseUploadArgsFromScope(arg *UploadsPluginsArgs, scope vfilter.Scope) {
+	client_id, pres := scope.Resolve("ClientId")
+	if pres {
+		arg.ClientId, _ = client_id.(string)
+	}
+
+	flow_id, pres := scope.Resolve("FlowId")
+	if pres {
+		arg.FlowId, _ = flow_id.(string)
 	}
 }
 


### PR DESCRIPTION
Notebooks and downloads used http.FileServer which has a couple of
problems:

1. It sniffs the mime type when serving files. This may lead to stored
XSS because users can upload to notebooks.
2. It allows directory listing by generating inde files.

This change stops these by forcing 404 on directory access and forcing
binary/octet-stream on all items in the notebook.