### PR TITLE
Start the server service when installing on windows.

### DIFF
--- a/bin/server_service_windows.go
+++ b/bin/server_service_windows.go
@@ -200,7 +200,7 @@ func installServiceServerService(
 		},
 
 		// Executable will be started with this command line args:
-		"service", "run")
+		"server_service", "run")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Although not supported it is possible to install the server on Windows
using
`velociraptor.exe --config server.config.yaml server_service install`

This was broken but now it should be fixed.