### PR TITLE
Handle empty directory in VFS refresh

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -292,7 +292,7 @@ func (self *ApiServer) ListClients(
 	result := &api_proto.SearchClientsResponse{}
 	for _, client_id := range db.SearchClients(
 		self.config, constants.CLIENT_INDEX_URN,
-		in.Query, query_type, in.Offset, limit, sort_direction) {
+		in.Query, query_type, in.Offset, 0, sort_direction) {
 		if in.NameOnly || query_type == "key" {
 			result.Names = append(result.Names, client_id)
 		} else {
@@ -313,7 +313,7 @@ func (self *ApiServer) ListClients(
 
 			result.Items = append(result.Items, api_client)
 
-			if uint64(len(result.Items)) >= in.Limit {
+			if uint64(len(result.Items)) >= limit {
 				break
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Velocidex/cgofuse v1.1.2
 	github.com/Velocidex/etw v0.0.0-20210723072214-4d0cffd1ff22 // indirect
 	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
-	github.com/Velocidex/go-yara v1.1.10-0.20210423154840-dace8239c158
+	github.com/Velocidex/go-yara v1.1.10-0.20210726130504-d5e402efc424
 	github.com/Velocidex/json v0.0.0-20210402154432-68206e1293d0
 	github.com/Velocidex/ordereddict v0.0.0-20210502082334-cf5d9045c0d1
 	github.com/Velocidex/pkcs7 v0.0.0-20210524015001-8d1eee94a157

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b h1
 github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b/go.mod h1:draN67DBVJDAVmLWDIJ85CrV0UxmIGfWZ4njukhINQs=
 github.com/Velocidex/go-yara v1.1.10-0.20210423154840-dace8239c158 h1:gvnUc2P/5i7wclLwMAFnJlXu35bZz7pDXdFV5SCfhW4=
 github.com/Velocidex/go-yara v1.1.10-0.20210423154840-dace8239c158/go.mod h1:N1A2MzBKorQm3WixuPUSm4gmzGA6i5sYrwHyUBvY5lg=
+github.com/Velocidex/go-yara v1.1.10-0.20210726130504-d5e402efc424 h1:36GhJ1iRd/9yGgvlRWREcPRrWG2H4mF2lEpOvdYP55w=
+github.com/Velocidex/go-yara v1.1.10-0.20210726130504-d5e402efc424/go.mod h1:N1A2MzBKorQm3WixuPUSm4gmzGA6i5sYrwHyUBvY5lg=
 github.com/Velocidex/json v0.0.0-20210402154432-68206e1293d0 h1:oMdYhZqDdZq0PpVFxGvjhhNhxNl6D7ycR0SuKkbEKac=
 github.com/Velocidex/json v0.0.0-20210402154432-68206e1293d0/go.mod h1:ukJBuruT9b24pdgZwWDvOaCYHeS03B7oQPCUWh25bwM=
 github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=

--- a/gui/velociraptor/src/components/vfs/file-tree.js
+++ b/gui/velociraptor/src/components/vfs/file-tree.js
@@ -280,7 +280,8 @@ class VeloFileTree extends Component {
 
                 if (response && response.data && response.data.Response) {
                     // Hold on to the raw data.
-                    node.raw_data = JSON.parse(response.data.Response);
+                    node.raw_data = JSON.parse(response.data.Response) || [];
+                    node.flow_id = response.data.flow_id;
 
                     // Extract the directory children from the raw_data
                     for (var i=0; i<node.raw_data.length; i++) {

--- a/services/vfs_service/vfs_service_test.go
+++ b/services/vfs_service/vfs_service_test.go
@@ -100,7 +100,9 @@ func (self *VFSServiceTestSuite) EmulateCollection(
 			Set("Flow", &flows_proto.ArtifactCollectorContext{
 				ClientId:             self.client_id,
 				SessionId:            self.flow_id,
-				ArtifactsWithResults: []string{artifact}})},
+				ArtifactsWithResults: []string{artifact},
+				TotalCollectedRows:   uint64(len(rows)),
+			})},
 		"System.Flow.Completion", "server", "")
 
 	return self.flow_id
@@ -171,7 +173,6 @@ func (self *VFSServiceTestSuite) TestVFSListDirectoryEmpty() {
 		db.GetSubject(self.config_obj,
 			client_path_manager.VFSPath([]string{"file", "a", "b"}),
 			resp)
-		utils.Debug(resp)
 		return resp.Timestamp > 0
 	})
 	assert.Equal(self.T(), self.getFullPath(resp), []string{})

--- a/services/vfs_service/vfs_service_test.go
+++ b/services/vfs_service/vfs_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
@@ -128,6 +129,52 @@ func (self *VFSServiceTestSuite) TestVFSListDirectory() {
 	assert.Equal(self.T(), self.getFullPath(resp), []string{
 		"/a/b/c", "/a/b/d", "/a/b/e",
 	})
+}
+
+func (self *VFSServiceTestSuite) TestVFSListDirectoryEmpty() {
+	journal, err := services.GetJournal()
+	assert.NoError(self.T(), err)
+
+	// Emulate a flow completion message coming from the flow processor.
+	artifact := "System.VFS.ListDirectory"
+	journal.PushRowsToArtifact(self.config_obj,
+		[]*ordereddict.Dict{ordereddict.NewDict().
+			Set("ClientId", self.client_id).
+			Set("FlowId", self.flow_id).
+			Set("Flow", &flows_proto.ArtifactCollectorContext{
+				ClientId:  self.client_id,
+				SessionId: self.flow_id,
+				Request: &flows_proto.ArtifactCollectorArgs{
+					Artifacts: []string{artifact},
+					Specs: []*flows_proto.ArtifactSpec{{
+						Artifact: artifact,
+						Parameters: &flows_proto.ArtifactParameters{
+							Env: []*actions_proto.VQLEnv{{
+								Key:   "Path",
+								Value: "/a/b/",
+							}, {
+								Key:   "Accessor",
+								Value: "file",
+							}},
+						},
+					}},
+				}}),
+		}, "System.Flow.Completion", "server", "")
+
+	db, err := datastore.GetDB(self.config_obj)
+	assert.NoError(self.T(), err)
+
+	client_path_manager := paths.NewClientPathManager(self.client_id)
+	resp := &flows_proto.VFSListResponse{}
+
+	vtesting.WaitUntil(2*time.Second, self.T(), func() bool {
+		db.GetSubject(self.config_obj,
+			client_path_manager.VFSPath([]string{"file", "a", "b"}),
+			resp)
+		utils.Debug(resp)
+		return resp.Timestamp > 0
+	})
+	assert.Equal(self.T(), self.getFullPath(resp), []string{})
 }
 
 func (self *VFSServiceTestSuite) TestRecursiveVFSListDirectory() {

--- a/utils/file.go
+++ b/utils/file.go
@@ -180,3 +180,14 @@ func (self *DataFileInfo) IsLink() bool {
 func (self *DataFileInfo) GetLink() (string, error) {
 	return "", errors.New("Not implemented")
 }
+
+func ReadDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+
+	return names, err
+}


### PR DESCRIPTION
If a VFS directory listing returns nothing, the job hangs thinking it
has never finished. Presents an issue when trying to enumerate an
empty directory.

Also added a link to view the collection that listed the directory in
the collection history.

Fixes: #1161