### PR TITLE
Implemented generate() VQL function

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,7 +83,7 @@ jobs:
         CGO_ENABLED: "0"
 
       run: |
-        go test -race -v ./... --tags server_vql
+        go test -v ./... --tags server_vql
 
     - name: Test Golden Generic
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,7 +83,7 @@ jobs:
         CGO_ENABLED: "0"
 
       run: |
-        go test -v ./... --tags server_vql
+        go test -race -v ./... --tags server_vql
 
     - name: Test Golden Generic
       shell: cmd

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ auto:
 	go run make.go -v auto
 
 test:
-	go test -v --tags server_vql ./...
+	go test -race -v --tags server_vql ./...
 
 golden:
 	./output/velociraptor -v --config artifacts/testdata/windows/test.config.yaml golden artifacts/testdata/server/testcases/ --env srcDir=`pwd` --filter=${GOLDEN}

--- a/actions/events.go
+++ b/actions/events.go
@@ -207,7 +207,11 @@ func (self UpdateEventTable) Run(
 
 	// Cancel the context when the cancel channel is closed.
 	go func() {
-		<-table.Done
+		mu.Lock()
+		done := table.Done
+		mu.Unlock()
+
+		<-done
 		logger.Info("UpdateEventTable: Closing all contexts")
 		cancel()
 	}()
@@ -253,7 +257,7 @@ func (self UpdateEventTable) Run(
 			if name != "" {
 				logger.Info("Finished monitoring query %s", name)
 			}
-		}(event)
+		}(proto.Clone(event).(*actions_proto.VQLCollectorArgs))
 	}
 
 	err = update_writeback(config_obj, arg)

--- a/actions/query_log.go
+++ b/actions/query_log.go
@@ -10,12 +10,27 @@ var (
 )
 
 type QueryLogEntry struct {
+	mu       sync.Mutex
 	Query    string
 	Start    time.Time
 	Duration int64
 }
 
+func (self *QueryLogEntry) Copy() QueryLogEntry {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	return QueryLogEntry{
+		Query:    self.Query,
+		Start:    self.Start,
+		Duration: self.Duration,
+	}
+}
+
 func (self *QueryLogEntry) Close() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	self.Duration = time.Now().UnixNano() - self.Start.UnixNano()
 }
 
@@ -56,7 +71,7 @@ func (self *QueryLogType) Get() []QueryLogEntry {
 	// Return a copy of the logs
 	result := make([]QueryLogEntry, 0, len(self.Queries))
 	for _, q := range self.Queries {
-		result = append(result, *q)
+		result = append(result, q.Copy())
 	}
 
 	return result

--- a/artifacts/testdata/server/testcases/generator.in.yaml
+++ b/artifacts/testdata/server/testcases/generator.in.yaml
@@ -6,7 +6,7 @@ Queries:
   - SELECT * FROM combine(
     a={
       SELECT _value FROM Generator
-      WHERE sleep(ms=100)
+      WHERE sleep(ms=500)
     }, b={
       SELECT _value FROM Generator
     })

--- a/artifacts/testdata/server/testcases/generator.in.yaml
+++ b/artifacts/testdata/server/testcases/generator.in.yaml
@@ -1,0 +1,13 @@
+Queries:
+  - LET Generator = generate(query={
+      SELECT * FROM range(start=0, end=10, step=1)
+      })
+
+  - SELECT * FROM combine(
+    a={
+      SELECT _value FROM Generator
+      WHERE sleep(ms=100)
+    }, b={
+      SELECT _value FROM Generator
+    })
+    ORDER BY _value

--- a/artifacts/testdata/server/testcases/generator.out.yaml
+++ b/artifacts/testdata/server/testcases/generator.out.yaml
@@ -1,0 +1,62 @@
+LET Generator = generate(query={ SELECT * FROM range(start=0, end=10, step=1) })[]SELECT * FROM combine( a={ SELECT _value FROM Generator WHERE sleep(ms=100) }, b={ SELECT _value FROM Generator }) ORDER BY _value[
+ {
+  "_value": 0
+ },
+ {
+  "_value": 0
+ },
+ {
+  "_value": 1
+ },
+ {
+  "_value": 1
+ },
+ {
+  "_value": 2
+ },
+ {
+  "_value": 2
+ },
+ {
+  "_value": 3
+ },
+ {
+  "_value": 3
+ },
+ {
+  "_value": 4
+ },
+ {
+  "_value": 4
+ },
+ {
+  "_value": 5
+ },
+ {
+  "_value": 5
+ },
+ {
+  "_value": 6
+ },
+ {
+  "_value": 6
+ },
+ {
+  "_value": 7
+ },
+ {
+  "_value": 7
+ },
+ {
+  "_value": 8
+ },
+ {
+  "_value": 8
+ },
+ {
+  "_value": 9
+ },
+ {
+  "_value": 9
+ }
+]

--- a/artifacts/testdata/server/testcases/generator.out.yaml
+++ b/artifacts/testdata/server/testcases/generator.out.yaml
@@ -1,4 +1,4 @@
-LET Generator = generate(query={ SELECT * FROM range(start=0, end=10, step=1) })[]SELECT * FROM combine( a={ SELECT _value FROM Generator WHERE sleep(ms=100) }, b={ SELECT _value FROM Generator }) ORDER BY _value[
+LET Generator = generate(query={ SELECT * FROM range(start=0, end=10, step=1) })[]SELECT * FROM combine( a={ SELECT _value FROM Generator WHERE sleep(ms=500) }, b={ SELECT _value FROM Generator }) ORDER BY _value[
  {
   "_value": 0
  },

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -28,6 +28,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 var (
@@ -144,11 +145,13 @@ func GetDB(config_obj *config_proto.Config) (DataStore, error) {
 
 		// Sanitize the FilestoreDirectory parameter so we
 		// have a consistent filename in the test datastore.
-		config_obj.Datastore.Location = strings.TrimSuffix(
-			config_obj.Datastore.Location, "/")
-		config_obj.Datastore.Location = strings.TrimSuffix(
-			config_obj.Datastore.Location, "\\")
-
+		if config_obj.Datastore.Location != "" {
+			utils.Debug(config_obj.Datastore.Location)
+			config_obj.Datastore.Location = strings.TrimSuffix(
+				config_obj.Datastore.Location, "/")
+			config_obj.Datastore.Location = strings.TrimSuffix(
+				config_obj.Datastore.Location, "\\")
+		}
 		return gTestDatastore, nil
 
 	default:

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -28,7 +28,6 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
-	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 var (
@@ -146,7 +145,6 @@ func GetDB(config_obj *config_proto.Config) (DataStore, error) {
 		// Sanitize the FilestoreDirectory parameter so we
 		// have a consistent filename in the test datastore.
 		if config_obj.Datastore.Location != "" {
-			utils.Debug(config_obj.Datastore.Location)
 			config_obj.Datastore.Location = strings.TrimSuffix(
 				config_obj.Datastore.Location, "/")
 			config_obj.Datastore.Location = strings.TrimSuffix(

--- a/datastore/memory.go
+++ b/datastore/memory.go
@@ -224,7 +224,7 @@ func (self *TestDataStore) SetSubject(
 	filename := pathSpecToPath(urn, config_obj)
 	self.Trace("SetSubject", filename)
 
-	self.Subjects[filename] = message
+	self.Subjects[filename] = proto.Clone(message)
 	self.Components[filename] = urn.Components()
 
 	return nil

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -247,6 +247,10 @@
       async=TRUE)
     ```
   type: Plugin
+  args:
+  - name: async
+    type: bool
+    description: If specified we run all queries asynchronously and combine the output.
   category: plugin
 - name: client_delete
   description: |
@@ -503,6 +507,10 @@
     type: string
     description: One of more regular expressions that will include columns.
     repeated: true
+- name: combine
+  description: Combine the output of several queries into the same result set.A convenience
+    plugin acting like chain(async=TRUE).
+  type: Plugin
 - name: compress
   description: |
     Compress a file.
@@ -1250,6 +1258,44 @@
     type: string
     description: The credentials to use
     required: true
+- name: generate
+  description: |
+    Create a named generator that receives rows from the query.
+
+    This plugin allow multiple queries to efficiently filter rows from
+    the same query. For example:
+
+    ```vql
+    LET SystemLog = generate(query={
+       SELECT * FROM parse_evtx(filename='''C:\Windows\system32\winevt\logs\System.evtx''')
+    })
+
+    SELECT timestamp(epoch=System.TimeCreated.SystemTime) AS Timestamp,
+       Type, EventData
+    FROM combine(
+    a={
+      SELECT *, "Kernel Driver Install" AS Type
+      FROM SystemLog
+      WHERE System.EventID.Value = 7045 AND EventData.ServiceType =~ "kernel"
+    }, b={
+      SELECT *, "Log File Cleared" AS Type,
+                UserData.LogFileCleared AS EventData
+      FROM SystemLog
+      WHERE System.EventID.Value = 104
+    })
+    ```
+
+  type: Function
+  args:
+  - name: name
+    type: string
+    description: Name to call the generator
+  - name: query
+    type: StoredQuery
+    description: Run this query to generator rows.
+  - name: delay
+    type: int64
+    description: Wait before starting the query
 - name: geoip
   description: |
     Lookup an IP Address using the MaxMind GeoIP database. You can get
@@ -3350,6 +3396,9 @@
   - name: time
     type: int64
     description: The number of seconds to sleep
+  - name: ms
+    type: int64
+    description: The number of ms to sleep
   category: basic
 - name: slice
   description: Slice an array.
@@ -3990,11 +4039,9 @@
   - name: credentialskey
     type: string
     description: The AWS key credentials to use
-    required: true
   - name: credentialssecret
     type: string
     description: The AWS secret credentials to use
-    required: true
   - name: endpoint
     type: string
     description: The Endpoint to use
@@ -4496,4 +4543,3 @@
     type: string
     description: If set use this key to cache the  yara rules.
   category: plugin
-

--- a/file_store/directory/buffer.go
+++ b/file_store/directory/buffer.go
@@ -70,6 +70,11 @@ type FileBasedRingBuffer struct {
 	write_buf []byte
 
 	log_ctx *logging.LogContext
+
+	// Keep track of how many messages are leased. When we lease
+	// messages this wg is added, then callers can decrement it as
+	// needed.
+	Wg sync.WaitGroup
 }
 
 // Enqueue the item into the ring buffer and append to the end.
@@ -170,6 +175,7 @@ func (self *FileBasedRingBuffer) Lease(count int) []*ordereddict.Dict {
 		}
 	}
 
+	self.Wg.Add(len(result))
 	return result
 }
 

--- a/file_store/directory/buffer.go
+++ b/file_store/directory/buffer.go
@@ -126,7 +126,9 @@ func (self *FileBasedRingBuffer) Lease(count int) []*ordereddict.Dict {
 		// Read the next chunk (length+value) from the current leased pointer.
 		n, err := self.fd.ReadAt(self.read_buf, self.header.ReadPointer)
 		if err != nil || n != len(self.read_buf) {
-			self.log_ctx.Error("Possible corruption detected: file too short.")
+			self.log_ctx.Error(
+				"Possible corruption detected: file too short Writer %v, Reader %v.",
+				self.header.WritePointer, self.header.ReadPointer)
 			self._Truncate()
 			return nil
 		}

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -218,7 +218,7 @@ func (self *QueuePool) Register(
 		close(output_chan)
 		cancel()
 
-		return output_chan, func() {}
+		return output_chan, cancel
 	}
 
 	registrations = append(registrations, new_registration)
@@ -229,6 +229,8 @@ func (self *QueuePool) Register(
 		found := self.unregister(vfs_path, new_registration.id)
 		if found {
 			cancel()
+
+			fmt.Printf("QueuePool cancelling listener context\n")
 			close(output_chan)
 		}
 	}
@@ -239,6 +241,8 @@ func (self *QueuePool) Register(
 func (self *QueuePool) unregister(vfs_path string, id int64) (found bool) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	fmt.Printf("QueuePool unregistering listener id %v\n", id)
 
 	registrations, pres := self.registrations[vfs_path]
 	if pres {

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -85,7 +85,8 @@ func (self *Listener) FlushFile() {
 		for _, item := range items {
 			select {
 			case <-self.ctx.Done():
-				return
+				// We still need to release this item from the wg.
+				self.file_buffer.Wg.Done()
 
 			case self.output <- item:
 				self.file_buffer.Wg.Done()
@@ -179,7 +180,8 @@ func NewListener(config_obj *config_proto.Config, ctx context.Context,
 				for _, item := range items {
 					select {
 					case <-ctx.Done():
-						return
+						self.file_buffer.Wg.Done()
+
 					case output <- item:
 						self.file_buffer.Wg.Done()
 					}

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -83,7 +83,11 @@ func (self *Listener) Close() {
 		}
 
 		for _, item := range items {
-			self.output <- item
+			select {
+			case <-self.ctx.Done():
+				return
+			case self.output <- item:
+			}
 		}
 	}
 	self.file_buffer.Close()

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -213,10 +213,10 @@ func (self *QueuePool) Register(
 	self.registrations[vfs_path] = registrations
 
 	return output_chan, func() {
+		cancel()
 		found := self.unregister(vfs_path, new_registration.id)
 		if found {
 			close(output_chan)
-			cancel()
 		}
 	}
 }

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -229,6 +229,8 @@ func (self *QueuePool) Register(
 		found := self.unregister(vfs_path, new_registration.id)
 		if found {
 			cancel()
+
+			fmt.Printf("QueuePool cancelling listener context\n")
 			close(output_chan)
 		}
 	}
@@ -239,6 +241,8 @@ func (self *QueuePool) Register(
 func (self *QueuePool) unregister(vfs_path string, id int64) (found bool) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	fmt.Printf("QueuePool unregistering listener id %v\n", id)
 
 	registrations, pres := self.registrations[vfs_path]
 	if pres {

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -229,8 +229,6 @@ func (self *QueuePool) Register(
 		found := self.unregister(vfs_path, new_registration.id)
 		if found {
 			cancel()
-
-			fmt.Printf("QueuePool cancelling listener context\n")
 			close(output_chan)
 		}
 	}
@@ -241,8 +239,6 @@ func (self *QueuePool) Register(
 func (self *QueuePool) unregister(vfs_path string, id int64) (found bool) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
-
-	fmt.Printf("QueuePool unregistering listener id %v\n", id)
 
 	registrations, pres := self.registrations[vfs_path]
 	if pres {

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -43,7 +43,7 @@ import (
 // A listener wraps a channel that our client will listen on. We send
 // the message to each listener that is subscribed to the queue.
 type Listener struct {
-	id int64
+	id uint64
 
 	// The consumer interested in these events. The consumer may
 	// block arbitrarily.
@@ -127,7 +127,7 @@ func NewListener(config_obj *config_proto.Config, ctx context.Context,
 	}
 
 	self := &Listener{
-		id:          time.Now().UnixNano(),
+		id:          utils.GetId(),
 		ctx:         ctx,
 		input:       make(chan *ordereddict.Dict),
 		output:      output,
@@ -238,7 +238,7 @@ func (self *QueuePool) Register(
 
 // This holds a lock on the entire pool and it is used when the system
 // shuts down so not very often.
-func (self *QueuePool) unregister(vfs_path string, id int64) (found bool) {
+func (self *QueuePool) unregister(vfs_path string, id uint64) (found bool) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 

--- a/file_store/memory/memory.go
+++ b/file_store/memory/memory.go
@@ -37,8 +37,10 @@ func NewMemoryFileStore(config_obj *config_proto.Config) *MemoryFileStore {
 	}
 
 	// Sanitize the FilestoreDirectory
-	config_obj.Datastore.FilestoreDirectory = strings.TrimSuffix(
-		config_obj.Datastore.FilestoreDirectory, "/")
+	if config_obj.Datastore.FilestoreDirectory != "" {
+		config_obj.Datastore.FilestoreDirectory = strings.TrimSuffix(
+			config_obj.Datastore.FilestoreDirectory, "/")
+	}
 
 	return Test_memory_file_store
 }

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20200722101157-37e4751dd5ca
 	www.velocidex.com/golang/oleparse v0.0.0-20190327031422-34195d413196
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20210826152205-95ca08f5dfde
+	www.velocidex.com/golang/vfilter v0.0.0-20210913135640-226d766334af
 	www.velocidex.com/golang/vtypes v0.0.0-20210728123451-f085971da113
 )
 

--- a/go.sum
+++ b/go.sum
@@ -984,5 +984,7 @@ www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:
 www.velocidex.com/golang/vfilter v0.0.0-20210515085940-25d96b94dafb/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
 www.velocidex.com/golang/vfilter v0.0.0-20210826152205-95ca08f5dfde h1:MBGxqavpHupcWdnKYeWK+LriJ99yrquoPaxoVT94j8U=
 www.velocidex.com/golang/vfilter v0.0.0-20210826152205-95ca08f5dfde/go.mod h1:KB724xBNYh4lgipyGwsvx0/5hXRqsKjmrMrkSjGESvU=
+www.velocidex.com/golang/vfilter v0.0.0-20210913135640-226d766334af h1:JVVzwj+2LdufD4bjwvkdKfhrtwxtO3c6en+8vFv/2tc=
+www.velocidex.com/golang/vfilter v0.0.0-20210913135640-226d766334af/go.mod h1:eEFMhAmoFHWGCKF39j+iOhTH8REpqBndc3OsdPsxqo8=
 www.velocidex.com/golang/vtypes v0.0.0-20210728123451-f085971da113 h1:IXya95AX2bUPIbgi4vEWeer6MoNdKC3nRRtxsulcAuQ=
 www.velocidex.com/golang/vtypes v0.0.0-20210728123451-f085971da113/go.mod h1:PIG8uSY330pJd620KPksZpTaAsX3sIMiiNJQihZph6c=

--- a/search/index.go
+++ b/search/index.go
@@ -191,6 +191,15 @@ func getChildren(
 	metricLRUMiss.Inc()
 	db, _ := datastore.GetDB(config_obj)
 	children, err := db.ListChildren(config_obj, root.SetTag("Index"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep the listing sorted in cache.
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].Base() < children[j].Base()
+	})
+
 	cached_entry := &lruEntry{
 		ts:       now,
 		children: children,
@@ -234,10 +243,6 @@ func walkIndexWithPrefix(ctx context.Context,
 
 			next_partitions = partitions[1:]
 		}
-
-		sort.Slice(children, func(i, j int) bool {
-			return children[i].Base() < children[j].Base()
-		})
 
 		// First add any non-directories that exist in this directory.
 		for _, child := range children {

--- a/search/index_test.go
+++ b/search/index_test.go
@@ -191,7 +191,6 @@ func (self *TestSuite) TestEnumerateIndex() {
 	}
 
 	current_op_count = getIndexListings(self.T())
-	utils.Debug(current_op_count - initial_op_count)
 	assert.True(self.T(), 50 > current_op_count-initial_op_count)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/golang/mock/gomock"
@@ -168,6 +169,9 @@ func (self *ServerTestSuite) TestClientEventTable() {
 
 	// The version of the currently installed table.
 	version := services.ClientEventManager().GetClientMonitoringState().Version
+
+	// Wait a bit.
+	time.Sleep(time.Second)
 
 	// Send a foreman checkin message from client with old event
 	// table version.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/golang/mock/gomock"
@@ -17,7 +16,6 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/api"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
-	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
 	crypto_client "www.velocidex.com/golang/velociraptor/crypto/client"
@@ -36,25 +34,42 @@ import (
 	"www.velocidex.com/golang/velociraptor/services/client_monitoring"
 	"www.velocidex.com/golang/velociraptor/services/hunt_dispatcher"
 	"www.velocidex.com/golang/velociraptor/services/interrogation"
-	"www.velocidex.com/golang/velociraptor/services/inventory"
-	"www.velocidex.com/golang/velociraptor/services/journal"
-	"www.velocidex.com/golang/velociraptor/services/labels"
-	"www.velocidex.com/golang/velociraptor/services/launcher"
-	"www.velocidex.com/golang/velociraptor/services/notifications"
-	"www.velocidex.com/golang/velociraptor/services/repository"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 
 	_ "www.velocidex.com/golang/velociraptor/result_sets/simple"
 	_ "www.velocidex.com/golang/velociraptor/result_sets/timed"
 )
 
+var (
+	mock_definitions = []string{`
+name: Windows.Remediation.QuarantineMonitor
+type: SERVER_EVENT
+`, `
+name: System.Hunt.Creation
+type: SERVER_EVENT
+`, `
+name: System.Flow.Archive
+type: SERVER
+`, `
+name: Server.Internal.Enrollment
+type: INTERNAL
+`, `
+name: Generic.Client.Info
+type: CLIENT
+sources:
+- name: BasicInformation
+  query: SELECT * FROM info()
+- name: Users
+  precondition: SELECT OS From info() where OS = 'windows'
+  query: SELECT * FROM info()
+`}
+)
+
 type ServerTestSuite struct {
-	suite.Suite
+	test_utils.TestSuite
 	server        *server.Server
 	client_crypto *crypto_client.ClientCryptoManager
-	config_obj    *config_proto.Config
 	client_id     string
-	sm            *services.Service
 }
 
 type MockAPIClientFactory struct {
@@ -69,56 +84,26 @@ func (self MockAPIClientFactory) GetAPIClient(
 
 func (self *ServerTestSuite) SetupTest() {
 	var err error
+	self.TestSuite.SetupTest()
+	self.LoadArtifacts(mock_definitions)
 
-	self.config_obj, err = new(config.Loader).WithFileLoader(
-		"../http_comms/test_data/server.config.yaml").
-		WithVerbose(true).
-		WithWriteback(). //  The writeback is actually embedded in the config above.
-		LoadAndValidate()
-	require.NoError(self.T(), err)
+	require.NoError(self.T(), self.Sm.Start(client_monitoring.StartClientMonitoringService))
+	require.NoError(self.T(), self.Sm.Start(hunt_dispatcher.StartHuntDispatcher))
+	require.NoError(self.T(), self.Sm.Start(interrogation.StartInterrogationService))
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*60)
-	self.sm = services.NewServiceManager(ctx, self.config_obj)
-
-	require.NoError(self.T(), self.sm.Start(journal.StartJournalService))
-	require.NoError(self.T(), self.sm.Start(notifications.StartNotificationService))
-	require.NoError(self.T(), self.sm.Start(inventory.StartInventoryService))
-	require.NoError(self.T(), self.sm.Start(repository.StartRepositoryManager))
-	require.NoError(self.T(), self.sm.Start(launcher.StartLauncherService))
-	require.NoError(self.T(), self.sm.Start(labels.StartLabelService))
-	require.NoError(self.T(), self.sm.Start(client_monitoring.StartClientMonitoringService))
-	require.NoError(self.T(), self.sm.Start(interrogation.StartInterrogationService))
-
-	// Load all the standard artifacts.
-	manager, err := services.GetRepositoryManager()
-	assert.NoError(self.T(), err)
-
-	manager.GetGlobalRepository(self.config_obj)
-
-	self.server, err = server.NewServer(self.sm.Ctx, self.config_obj, self.sm.Wg)
+	self.server, err = server.NewServer(self.Sm.Ctx, self.ConfigObj, self.Sm.Wg)
 	require.NoError(self.T(), err)
 
 	self.client_crypto, err = crypto_client.NewClientCryptoManager(
-		self.config_obj, []byte(self.config_obj.Writeback.PrivateKey))
+		self.ConfigObj, []byte(self.ConfigObj.Writeback.PrivateKey))
 	require.NoError(self.T(), err)
 
 	_, err = self.client_crypto.AddCertificate([]byte(
-		self.config_obj.Frontend.Certificate))
+		self.ConfigObj.Frontend.Certificate))
 
 	require.NoError(self.T(), err)
 
 	self.client_id = self.client_crypto.ClientId
-}
-
-func (self *ServerTestSuite) TearDownTest() {
-	// Reset the data store.
-	db, err := datastore.GetDB(self.config_obj)
-	require.NoError(self.T(), err)
-
-	db.Close()
-	test_utils.GetMemoryFileStore(self.T(), self.config_obj).Clear()
-
-	self.sm.Close()
 }
 
 func (self *ServerTestSuite) TestEnrollment() {
@@ -132,19 +117,19 @@ func (self *ServerTestSuite) TestEnrollment() {
 
 	wg.Add(1)
 	services.GetPublishedEvents(
-		self.config_obj, "Server.Internal.Enrollment", wg, 1, &messages)
+		self.ConfigObj, "Server.Internal.Enrollment", wg, 1, &messages)
 
 	self.server.ProcessSingleUnauthenticatedMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
 			CSR: &crypto_proto.Certificate{Pem: csr_message}})
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(self.T(), err)
 
 	pub_key := &crypto_proto.PublicKey{}
 	err = db.GetSubject(
-		self.config_obj,
+		self.ConfigObj,
 		paths.NewClientPathManager(self.client_id).Key(),
 		pub_key)
 
@@ -165,19 +150,15 @@ func (self *ServerTestSuite) TestEnrollment() {
 func (self *ServerTestSuite) TestClientEventTable() {
 	t := self.T()
 
-	// Start some services.
-	require.NoError(t, self.sm.Start(client_monitoring.StartClientMonitoringService))
-	require.NoError(t, self.sm.Start(hunt_dispatcher.StartHuntDispatcher))
-
 	ctrl := gomock.NewController(self.T())
 	defer ctrl.Finish()
 
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	defer runner.Close()
 
 	// Set a new event monitoring table
 	err := services.ClientEventManager().SetClientMonitoringState(
-		context.Background(), self.config_obj,
+		context.Background(), self.ConfigObj,
 		&flows_proto.ClientEventTable{
 			Artifacts: &flows_proto.ArtifactCollectorArgs{
 				Artifacts: []string{"Generic.Client.Stats"},
@@ -198,10 +179,10 @@ func (self *ServerTestSuite) TestClientEventTable() {
 				LastEventTableVersion: 0,
 			},
 		})
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(self.T(), err)
 
-	tasks, err := db.GetClientTasks(self.config_obj,
+	tasks, err := db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 1)
@@ -219,21 +200,18 @@ func (self *ServerTestSuite) TestClientEventTable() {
 // LastHuntTimestamp = 0 and will receive the UpdateForeman message.
 func (self *ServerTestSuite) TestForeman() {
 	t := self.T()
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	defer runner.Close()
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(self.T(), err)
-
-	err = self.sm.Start(hunt_dispatcher.StartHuntDispatcher)
-	require.NoError(t, err)
 
 	// The hunt will launch the Generic.Client.Info on the client.
 	expected := api.MakeCollectorRequest(
 		self.client_id, "Generic.Client.Info")
 
 	hunt_id, err := flows.CreateHunt(
-		context.Background(), self.config_obj,
+		context.Background(), self.ConfigObj,
 		vql_subsystem.NullACLManager{},
 		&api_proto.Hunt{
 			State:        api_proto.Hunt_RUNNING,
@@ -244,7 +222,7 @@ func (self *ServerTestSuite) TestForeman() {
 	// Check for hunt object in the data store.
 	hunt := &api_proto.Hunt{}
 	hunt_path_manager := paths.NewHuntPathManager(hunt_id)
-	err = db.GetSubject(self.config_obj, hunt_path_manager.Path(), hunt)
+	err = db.GetSubject(self.ConfigObj, hunt_path_manager.Path(), hunt)
 	require.NoError(t, err)
 
 	assert.NotNil(t, hunt.StartRequest.CompiledCollectorArgs)
@@ -273,7 +251,7 @@ func (self *ServerTestSuite) TestForeman() {
 		})
 
 	// Server should schedule the new hunt on the client.
-	tasks, err := db.GetClientTasks(self.config_obj,
+	tasks, err := db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 1)
@@ -284,16 +262,16 @@ func (self *ServerTestSuite) TestForeman() {
 	assert.Equal(t, tasks[0].UpdateForeman.LastHuntTimestamp, services.GetHuntDispatcher().
 		GetLastTimestamp())
 
-	path_manager, err := artifacts.NewArtifactPathManager(self.config_obj,
+	path_manager, err := artifacts.NewArtifactPathManager(self.ConfigObj,
 		self.client_id, "", "System.Hunt.Participation")
 	assert.NoError(t, err)
 
 	rows := []*ordereddict.Dict{}
-	file_store_factory := file_store.GetFileStore(self.config_obj)
+	file_store_factory := file_store.GetFileStore(self.ConfigObj)
 	rs_reader, err := result_sets.NewResultSetReader(
 		file_store_factory, path_manager.Path())
 	assert.NoError(t, err)
-	for row := range rs_reader.Rows(self.sm.Ctx) {
+	for row := range rs_reader.Rows(self.Sm.Ctx) {
 		rows = append(rows, row)
 	}
 	assert.Equal(t, len(rows), 1)
@@ -302,10 +280,10 @@ func (self *ServerTestSuite) TestForeman() {
 func (self *ServerTestSuite) RequiredFilestoreContains(
 	filename file_store_api.FSPathSpec, regex string) {
 
-	file_store_factory := test_utils.GetMemoryFileStore(self.T(), self.config_obj)
+	file_store_factory := test_utils.GetMemoryFileStore(self.T(), self.ConfigObj)
 
 	value, pres := file_store_factory.Get(filename.AsFilestoreFilename(
-		self.config_obj))
+		self.ConfigObj))
 	if !pres {
 		self.T().FailNow()
 	}
@@ -316,7 +294,7 @@ func (self *ServerTestSuite) RequiredFilestoreContains(
 // Receiving a response from the server to the monitoring flow will
 // write the rows into a csv file in the client's monitoring area.
 func (self *ServerTestSuite) TestMonitoring() {
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -335,18 +313,18 @@ func (self *ServerTestSuite) TestMonitoring() {
 		})
 	runner.Close()
 
-	path_manager, err := artifacts.NewArtifactPathManager(self.config_obj,
+	path_manager, err := artifacts.NewArtifactPathManager(self.ConfigObj,
 		self.client_id, constants.MONITORING_WELL_KNOWN_FLOW,
 		"System.Hunt.Participation")
 	assert.NoError(self.T(), err)
 
 	self.RequiredFilestoreContains(path_manager.Path(), self.client_id)
-	test_utils.GetMemoryFileStore(self.T(), self.config_obj).Debug()
+	test_utils.GetMemoryFileStore(self.T(), self.ConfigObj).Debug()
 }
 
 // Monitoring queries which upload data.
 func (self *ServerTestSuite) TestMonitoringWithUpload() {
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -378,7 +356,7 @@ func (self *ServerTestSuite) TestLog() {
 
 	// Emulate log messages from client to flow delivered in
 	// separate POST.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -410,7 +388,7 @@ func (self *ServerTestSuite) TestLog() {
 // gracefully.
 func (self *ServerTestSuite) TestLogToUnknownFlow() {
 	// Emulate a log message from client to flow.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -423,16 +401,16 @@ func (self *ServerTestSuite) TestLogToUnknownFlow() {
 	runner.Close()
 
 	t := self.T()
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
 
 	// Cancellation message should never be sent due to log.
-	tasks, err := db.GetClientTasks(self.config_obj,
+	tasks, err := db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 0)
 
-	runner = flows.NewFlowRunner(self.config_obj)
+	runner = flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -443,12 +421,12 @@ func (self *ServerTestSuite) TestLogToUnknownFlow() {
 	runner.Close()
 
 	// Cancellation message should never be sent due to status.
-	tasks, err = db.GetClientTasks(self.config_obj,
+	tasks, err = db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 0)
 
-	runner = flows.NewFlowRunner(self.config_obj)
+	runner = flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -460,7 +438,7 @@ func (self *ServerTestSuite) TestLogToUnknownFlow() {
 
 	// Cancellation message should be sent due to response
 	// messages.
-	tasks, err = db.GetClientTasks(self.config_obj,
+	tasks, err = db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 1)
@@ -476,7 +454,7 @@ func (self *ServerTestSuite) TestScheduleCollection() {
 	manager, err := services.GetRepositoryManager()
 	assert.NoError(self.T(), err)
 
-	repository, err := manager.GetGlobalRepository(self.config_obj)
+	repository, err := manager.GetGlobalRepository(self.ConfigObj)
 	require.NoError(t, err)
 
 	launcher, err := services.GetLauncher()
@@ -484,24 +462,24 @@ func (self *ServerTestSuite) TestScheduleCollection() {
 
 	flow_id, err := launcher.ScheduleArtifactCollection(
 		context.Background(),
-		self.config_obj,
+		self.ConfigObj,
 		vql_subsystem.NullACLManager{},
 		repository,
 		request)
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
 
 	// Launching the artifact will schedule one query on the client.
 	tasks, err := db.GetClientTasks(
-		self.config_obj, self.client_id,
+		self.ConfigObj, self.client_id,
 		true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 2)
 
 	collection_context := &flows_proto.ArtifactCollectorContext{}
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.NoError(t, err)
 
 	assert.Equal(t, collection_context.Request, request)
@@ -512,7 +490,7 @@ func (self *ServerTestSuite) createArtifactCollection() (string, error) {
 	manager, err := services.GetRepositoryManager()
 	assert.NoError(self.T(), err)
 
-	repository, err := manager.GetGlobalRepository(self.config_obj)
+	repository, err := manager.GetGlobalRepository(self.ConfigObj)
 	require.NoError(self.T(), err)
 
 	// Schedule a flow in the database.
@@ -521,7 +499,7 @@ func (self *ServerTestSuite) createArtifactCollection() (string, error) {
 
 	flow_id, err := launcher.ScheduleArtifactCollection(
 		context.Background(),
-		self.config_obj,
+		self.ConfigObj,
 		vql_subsystem.NullACLManager{},
 		repository,
 		&flows_proto.ArtifactCollectorArgs{
@@ -541,7 +519,7 @@ func (self *ServerTestSuite) TestUploadBuffer() {
 	require.NoError(t, err)
 
 	// Emulate a response from this flow.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -578,7 +556,7 @@ func (self *ServerTestSuite) TestVQLResponse() {
 	require.NoError(t, err)
 
 	// Emulate a response from this flow.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -597,7 +575,7 @@ func (self *ServerTestSuite) TestVQLResponse() {
 		})
 	runner.Close()
 
-	flow_path_manager, err := artifacts.NewArtifactPathManager(self.config_obj,
+	flow_path_manager, err := artifacts.NewArtifactPathManager(self.ConfigObj,
 		self.client_id, flow_id, "Generic.Client.Info")
 	assert.NoError(self.T(), err)
 
@@ -613,7 +591,7 @@ func (self *ServerTestSuite) TestErrorMessage() {
 	require.NoError(t, err)
 
 	// Emulate a response from this flow.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	runner.ProcessSingleMessage(
 		context.Background(),
 		&crypto_proto.VeloMessage{
@@ -628,7 +606,7 @@ func (self *ServerTestSuite) TestErrorMessage() {
 		})
 	runner.Close()
 
-	db, _ := datastore.GetDB(self.config_obj)
+	db, _ := datastore.GetDB(self.ConfigObj)
 
 	// A log is generated
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
@@ -636,7 +614,7 @@ func (self *ServerTestSuite) TestErrorMessage() {
 
 	// The collection_context is marked as errored.
 	collection_context := &flows_proto.ArtifactCollectorContext{}
-	err = db.GetSubject(self.config_obj, path_manager.Path(),
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(),
 		collection_context)
 	require.NoError(t, err)
 
@@ -656,7 +634,7 @@ func (self *ServerTestSuite) TestCompletions() {
 	require.NoError(t, err)
 
 	// Emulate a response from this flow.
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 
 	// Generic.Client.Info sends two requests, lets complete them both.
 	runner.ProcessSingleMessage(
@@ -671,12 +649,12 @@ func (self *ServerTestSuite) TestCompletions() {
 		})
 	runner.Close()
 
-	db, _ := datastore.GetDB(self.config_obj)
+	db, _ := datastore.GetDB(self.ConfigObj)
 
 	// The collection_context is marked as errored.
 	collection_context := &flows_proto.ArtifactCollectorContext{}
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.NoError(t, err)
 
 	// Flow not complete yet - still an outstanding request.
@@ -696,7 +674,7 @@ func (self *ServerTestSuite) TestCompletions() {
 	runner.Close()
 
 	// Flow should be complete now that second response arrived.
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.NoError(t, err)
 
 	require.Equal(self.T(), flows_proto.ArtifactCollectorContext_FINISHED,
@@ -711,7 +689,7 @@ func (self *ServerTestSuite) TestCancellation() {
 
 	t := self.T()
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
 
 	// Schedule a flow in the database.
@@ -719,22 +697,23 @@ func (self *ServerTestSuite) TestCancellation() {
 	require.NoError(t, err)
 
 	// One task is scheduled for the client.
-	tasks, err := db.GetClientTasks(self.config_obj,
+	tasks, err := db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
+
 	// Generic.Client.Info has two source preconditions in parallel
 	assert.Equal(t, len(tasks), 2)
 
 	// Cancelling the flow will notify the client immediately.
 	response, err := flows.CancelFlow(
 		context.Background(),
-		self.config_obj, self.client_id, flow_id, "username")
+		self.ConfigObj, self.client_id, flow_id, "username")
 	require.NoError(t, err)
 	require.Equal(t, response.FlowId, flow_id)
 
 	// Cancelling a flow simply schedules a cancel message for the
 	// client and removes all pending tasks.
-	tasks, err = db.GetClientTasks(self.config_obj,
+	tasks, err = db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 1)
@@ -747,7 +726,7 @@ func (self *ServerTestSuite) TestCancellation() {
 	// The flow must be marked as cancelled with an error.
 	collection_context := &flows_proto.ArtifactCollectorContext{}
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.NoError(t, err)
 
 	require.Regexp(t, regexp.MustCompile("Cancelled by username"),
@@ -762,10 +741,10 @@ func (self *ServerTestSuite) TestCancellation() {
 func (self *ServerTestSuite) TestUnknownFlow() {
 	t := self.T()
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
 
-	runner := flows.NewFlowRunner(self.config_obj)
+	runner := flows.NewFlowRunner(self.ConfigObj)
 	defer runner.Close()
 
 	// Send a message to a random non-existant flow from client.
@@ -779,7 +758,7 @@ func (self *ServerTestSuite) TestUnknownFlow() {
 		})
 
 	// This should send a cancellation message to the client.
-	tasks, err := db.GetClientTasks(self.config_obj,
+	tasks, err := db.GetClientTasks(self.ConfigObj,
 		self.client_id, true /* do_not_lease */)
 	assert.NoError(t, err)
 	assert.Equal(t, len(tasks), 1)
@@ -792,7 +771,7 @@ func (self *ServerTestSuite) TestUnknownFlow() {
 	// The flow does not exist - make sure it still does not.
 	collection_context := &flows_proto.ArtifactCollectorContext{}
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.Error(t, err, os.ErrNotExist)
 }
 
@@ -800,7 +779,7 @@ func (self *ServerTestSuite) TestUnknownFlow() {
 func (self *ServerTestSuite) TestFlowArchives() {
 	t := self.T()
 
-	db, err := datastore.GetDB(self.config_obj)
+	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
 
 	// Schedule a flow in the database.
@@ -809,7 +788,7 @@ func (self *ServerTestSuite) TestFlowArchives() {
 
 	// Attempt to archive a running flow.
 	_, err = flows.ArchiveFlow(
-		self.config_obj, self.client_id, flow_id, "username")
+		self.ConfigObj, self.client_id, flow_id, "username")
 	require.Error(t, err)
 
 	// Cancelling the flow will notify the client immediately.
@@ -817,20 +796,20 @@ func (self *ServerTestSuite) TestFlowArchives() {
 	// Now cancel the same flow.
 	response, err := flows.CancelFlow(
 		context.Background(),
-		self.config_obj, self.client_id, flow_id, "username")
+		self.ConfigObj, self.client_id, flow_id, "username")
 	require.NoError(t, err)
 	require.Equal(t, response.FlowId, flow_id)
 
 	// Now archive the flow - should work because the flow is terminated.
 	res, err := flows.ArchiveFlow(
-		self.config_obj, self.client_id, flow_id, "username")
+		self.ConfigObj, self.client_id, flow_id, "username")
 	require.NoError(t, err)
 	require.Equal(t, res.FlowId, flow_id)
 
 	// The flow must be marked as archived.
 	collection_context := &flows_proto.ArtifactCollectorContext{}
 	path_manager := paths.NewFlowPathManager(self.client_id, flow_id)
-	err = db.GetSubject(self.config_obj, path_manager.Path(), collection_context)
+	err = db.GetSubject(self.ConfigObj, path_manager.Path(), collection_context)
 	require.NoError(t, err)
 
 	require.Regexp(t, regexp.MustCompile("Archived by username"),

--- a/services/broadcast.go
+++ b/services/broadcast.go
@@ -1,0 +1,70 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/Velocidex/ordereddict"
+)
+
+// The broadcast service allows VQL to implement fan out
+// behavior. This is useful for multiple queries that need to operate
+// on the result of a single query efficiently.
+//
+// An event generator is a query which produces rows and has a
+// name. Users can use the source() plugin to receive events from the
+// query or pull events directly from the generator.
+//
+// LET Generator <= generate(name="MyGenerator", query={
+//    SELECT * FROM parse_mft(...)
+//  }, delay=2)
+//
+//
+//  SELECT * FROM chain(
+//   a={ SELECT * FROM source(name="MyGenerator") WHERE X = 1 },
+//   b={ SELECT * FROM Generator WHERE X = 2 },
+//   c={ SELECT * FROM Generator WHERE X = 3 },
+//   async=TRUE)
+//
+// In the above:
+
+// 1. A Generator object is created with the name MyGenerator. The
+//    generator will wait 2 seconds before starting the query to
+//    produce rows.
+
+// 2. In the next query, the chain() plugin starts several queries,
+//    all drawing events from the same generator. Each event will be
+//    duplicated to all members and the results will be combined. Due
+//    to the async=TRUE option, the queries will all run in parallel.
+
+var (
+	broadcast_mu     sync.Mutex
+	broadcastService BroadcastService
+
+	AlreadyRegisteredError = errors.New("Already Registered")
+)
+
+func RegisterBroadcast(b BroadcastService) {
+	broadcast_mu.Lock()
+	defer broadcast_mu.Unlock()
+
+	broadcastService = b
+}
+
+func GetBroadcastService() (BroadcastService, error) {
+	broadcast_mu.Lock()
+	defer broadcast_mu.Unlock()
+
+	if broadcastService == nil {
+		return nil, errors.New("Broadcast service not ready")
+	}
+
+	return broadcastService, nil
+}
+
+type BroadcastService interface {
+	RegisterGenerator(input <-chan *ordereddict.Dict, name string) error
+	Watch(ctx context.Context, name string) (
+		output <-chan *ordereddict.Dict, cancel func(), err error)
+}

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -1,0 +1,93 @@
+package broadcast
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Velocidex/ordereddict"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store/directory"
+	"www.velocidex.com/golang/velociraptor/services"
+)
+
+type BroadcastService struct {
+	pool *directory.QueuePool
+
+	mu sync.Mutex
+
+	generators       map[string]<-chan *ordereddict.Dict
+	listener_closers map[string][]func()
+}
+
+func (self *BroadcastService) RegisterGenerator(
+	input <-chan *ordereddict.Dict, name string) error {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	_, pres := self.generators[name]
+	if pres {
+		return services.AlreadyRegisteredError
+	}
+
+	self.generators[name] = input
+
+	go func() {
+		defer self.unregister(name)
+
+		// Read items from the input channel and broadcast them to all
+		// listeners.
+		for item := range input {
+			self.pool.Broadcast(name, item)
+		}
+	}()
+
+	return nil
+}
+
+// Remove the generator and close off all listeners.
+func (self *BroadcastService) unregister(name string) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	delete(self.generators, name)
+	closers, ok := self.listener_closers[name]
+	if ok {
+		for _, closer := range closers {
+			closer()
+		}
+	}
+
+	delete(self.listener_closers, name)
+}
+
+func (self *BroadcastService) Watch(ctx context.Context, name string) (
+	output <-chan *ordereddict.Dict, cancel func(), err error) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	_, pres := self.generators[name]
+	if !pres {
+		return nil, nil, fmt.Errorf("No generator registered for %v", name)
+	}
+
+	output_chan, cancel := self.pool.Register(ctx, name)
+	closers, _ := self.listener_closers[name]
+	closers = append(closers, cancel)
+	self.listener_closers[name] = closers
+
+	return output_chan, cancel, nil
+}
+
+func StartBroadcastService(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	config_obj *config_proto.Config) error {
+	services.RegisterBroadcast(&BroadcastService{
+		pool:             directory.NewQueuePool(config_obj),
+		generators:       make(map[string]<-chan *ordereddict.Dict),
+		listener_closers: make(map[string][]func()),
+	})
+
+	return nil
+}

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -55,6 +55,7 @@ func (self *BroadcastService) unregister(name string) {
 
 	if ok {
 		for _, closer := range closers {
+			fmt.Printf("Closing\n")
 			closer()
 		}
 	}

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -57,6 +57,7 @@ func (self *BroadcastService) unregister(name string) {
 	fmt.Printf("unregister %v with %v closers\n", name, len(closers))
 	if ok {
 		for _, closer := range closers {
+			fmt.Printf("Closing\n")
 			closer()
 		}
 	}

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -38,7 +38,6 @@ func (self *BroadcastService) RegisterGenerator(
 		// Read items from the input channel and broadcast them to all
 		// listeners.
 		for item := range input {
-			fmt.Printf("Broadcasting item %v\n", item)
 			self.pool.Broadcast(name, item)
 		}
 	}()
@@ -54,10 +53,8 @@ func (self *BroadcastService) unregister(name string) {
 	delete(self.generators, name)
 	closers, ok := self.listener_closers[name]
 
-	fmt.Printf("unregister %v with %v closers\n", name, len(closers))
 	if ok {
 		for _, closer := range closers {
-			fmt.Printf("Closing\n")
 			closer()
 		}
 	}

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -38,6 +38,7 @@ func (self *BroadcastService) RegisterGenerator(
 		// Read items from the input channel and broadcast them to all
 		// listeners.
 		for item := range input {
+			fmt.Printf("Broadcasting item %v\n", item)
 			self.pool.Broadcast(name, item)
 		}
 	}()
@@ -52,6 +53,8 @@ func (self *BroadcastService) unregister(name string) {
 
 	delete(self.generators, name)
 	closers, ok := self.listener_closers[name]
+
+	fmt.Printf("unregister %v with %v closers\n", name, len(closers))
 	if ok {
 		for _, closer := range closers {
 			closer()

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -55,7 +55,6 @@ func (self *BroadcastService) unregister(name string) {
 
 	if ok {
 		for _, closer := range closers {
-			fmt.Printf("Closing\n")
 			closer()
 		}
 	}

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -75,6 +75,17 @@ type ClientEventTable struct {
 	id string
 }
 
+func (self *ClientEventTable) SetClock(clock utils.Clock) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.Clock = clock
+}
+
+func (self ClientEventTable) GetClock() utils.Clock {
+	return self.Clock
+}
+
 // Checks to see if we need to update the client event table. Each
 // client's table version is the timestamp when it received the event
 // table update. Clients need to renew their table if:
@@ -199,8 +210,8 @@ func (self *ClientEventTable) setClientMonitoringState(
 		state.Artifacts = &flows_proto.ArtifactCollectorArgs{}
 	}
 
-	self.state = state
-	state.Version = uint64(self.Clock.Now().UnixNano())
+	self.state = proto.Clone(state).(*flows_proto.ClientEventTable)
+	self.state.Version = uint64(self.Clock.Now().UnixNano())
 
 	// Store the new table in the data store.
 	db, err := datastore.GetDB(config_obj)

--- a/services/journal/buffer.go
+++ b/services/journal/buffer.go
@@ -77,6 +77,12 @@ type BufferFile struct {
 	log_ctx *logging.LogContext
 }
 
+func (self *BufferFile) GetHeader() Header {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+	return *self.Header
+}
+
 // Enqueue the item into the ring buffer and append to the end.
 func (self *BufferFile) Enqueue(item *api_proto.PushEventRequest) error {
 	serialized, err := proto.Marshal(item)

--- a/services/labels/labels.go
+++ b/services/labels/labels.go
@@ -67,6 +67,13 @@ type Labeler struct {
 	Clock utils.Clock
 }
 
+func (self *Labeler) SetClock(c utils.Clock) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.Clock = c
+}
+
 // If an explicit record does not exist, we retrieve it from searching the index.
 func (self *Labeler) getRecordFromIndex(
 	config_obj *config_proto.Config, client_id string) (*CachedLabels, error) {

--- a/services/repository/plugin.go
+++ b/services/repository/plugin.go
@@ -215,7 +215,7 @@ func (self *ArtifactRepositoryPlugin) Call(
 				// Add the scope args
 				child_scope.AppendVars(env)
 
-				ok, err = actions.CheckPreconditions(ctx, scope, request)
+				ok, err := actions.CheckPreconditions(ctx, scope, request)
 				if err != nil {
 					scope.Log("While evaluating preconditions: %v", err)
 					return

--- a/services/repository/plugin_test.go
+++ b/services/repository/plugin_test.go
@@ -145,7 +145,12 @@ func (self *PluginTestSuite) TestArtifactPluginWithPrecondition() {
 
 	queries := []string{
 		"SELECT * FROM Artifact.CallArtifactWithFalsePrecondition()",
-		"SELECT * FROM Artifact.CallArtifactWithFalsePrecondition(precondition=TRUE)",
+
+		// Preconditions are **not** enforced on the sub artifact
+		// because we only ask the top artifact to honor them, but it
+		// is **not** also passing the preconditions requirement to
+		// its sub artifact.
+		"SELECT * FROM Artifact.CallArtifactWithFalsePrecondition(preconditions=TRUE)",
 	}
 
 	results := ordereddict.NewDict()

--- a/services/repository/testdata/TestArtifactPluginWithPrecondition.golden
+++ b/services/repository/testdata/TestArtifactPluginWithPrecondition.golden
@@ -5,5 +5,10 @@
    "_Source": "CallArtifactWithFalsePrecondition"
   }
  ],
- "SELECT * FROM Artifact.CallArtifactWithFalsePrecondition(precondition=TRUE)": []
+ "SELECT * FROM Artifact.CallArtifactWithFalsePrecondition(preconditions=TRUE)": [
+  {
+   "A": 1,
+   "_Source": "CallArtifactWithFalsePrecondition"
+  }
+ ]
 }

--- a/services/server_monitoring/tracer.go
+++ b/services/server_monitoring/tracer.go
@@ -22,6 +22,9 @@ func (self *QueryTracer) Clear(query string) {
 }
 
 func (self *QueryTracer) Dump() []string {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	result := []string{}
 	for k := range self.current_queries {
 		result = append(result, k)

--- a/startup/startup.go
+++ b/startup/startup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/broadcast"
 	"www.velocidex.com/golang/velociraptor/services/client_info"
 	"www.velocidex.com/golang/velociraptor/services/client_monitoring"
 	"www.velocidex.com/golang/velociraptor/services/ddclient"
@@ -60,6 +61,14 @@ func StartupEssentialServices(sm *services.Service) error {
 	j, _ := services.GetJournal()
 	if j == nil {
 		err := sm.Start(journal.StartJournalService)
+		if err != nil {
+			return err
+		}
+	}
+
+	b, _ := services.GetBroadcastService()
+	if b == nil {
+		err := sm.Start(broadcast.StartBroadcastService)
 		if err != nil {
 			return err
 		}

--- a/utils/counter.go
+++ b/utils/counter.go
@@ -1,0 +1,11 @@
+package utils
+
+import "sync/atomic"
+
+var (
+	idx uint64
+)
+
+func GetId() uint64 {
+	return atomic.AddUint64(&idx, 1)
+}

--- a/utils/panic.go
+++ b/utils/panic.go
@@ -17,7 +17,7 @@ func CheckForPanic(msg string, vals ...interface{}) {
 	}
 }
 
-func RecoverVQL(scope vfilter.Scope) {
+func RecoverVQL(scope vfilter.Scope) error {
 	r := recover()
 	if r != nil {
 		scope.Log("PANIC: %v\n", r)
@@ -25,4 +25,9 @@ func RecoverVQL(scope vfilter.Scope) {
 		n := runtime.Stack(buffer, false /* all */)
 		scope.Log("%s", buffer[:n])
 	}
+	err, ok := r.(error)
+	if ok {
+		return fmt.Errorf("PANIC: %v", err)
+	}
+	return nil
 }

--- a/vql/functions/sleep.go
+++ b/vql/functions/sleep.go
@@ -13,6 +13,7 @@ import (
 
 type SleepArgs struct {
 	Sleep int64 `vfilter:"optional,field=time,doc=The number of seconds to sleep"`
+	MS    int64 `vfilter:"optional,field=ms,doc=The number of ms to sleep"`
 }
 
 type SleepFunction struct{}
@@ -27,12 +28,17 @@ func (self *SleepFunction) Call(ctx context.Context,
 		return false
 	}
 
+	ms := arg.MS
+	if ms == 0 {
+		ms = arg.Sleep * 1000
+	}
+
 	select {
 	// Cancellation should abort the sleep.
 	case <-ctx.Done():
 		break
 
-	case <-time.After(time.Duration(arg.Sleep) * time.Second):
+	case <-time.After(time.Duration(ms) * time.Millisecond):
 		break
 	}
 

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Velocidex/ordereddict"
@@ -116,6 +117,7 @@ func (self *GeneratorFunction) Call(ctx context.Context,
 		}
 
 		for item := range arg.Query.Eval(sub_ctx, scope) {
+			fmt.Printf("Pushing item %v\n", item)
 			select {
 			case <-sub_ctx.Done():
 				return

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -1,0 +1,140 @@
+package golang
+
+import (
+	"context"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/services"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+type Generator struct {
+	name string
+}
+
+// Give Generator the vfilter.StoredQuery interface so it can return
+// events.
+
+func (self Generator) Eval(ctx context.Context, scope types.Scope) <-chan types.Row {
+	result := make(chan vfilter.Row)
+
+	b, err := services.GetBroadcastService()
+	if err != nil {
+		scope.Log("generate: %v", err)
+		close(result)
+		return result
+	}
+
+	output_chan, cancel, err := b.Watch(ctx, self.name)
+	if err != nil {
+		scope.Log("generate: %v", err)
+		close(result)
+		return result
+	}
+
+	scope.AddDestructor(func() {
+		cancel()
+	})
+
+	go func() {
+		defer close(result)
+
+		for item := range output_chan {
+			select {
+			case <-ctx.Done():
+				return
+			case result <- item:
+			}
+		}
+	}()
+
+	return result
+}
+
+type GeneratorArgs struct {
+	Name  string            `vfilter:"optional,field=name,doc=Name to call the generator"`
+	Query types.StoredQuery `vfilter:"optional,field=query,doc=Run this query to generator rows."`
+	Delay int64             `vfilter:"optional,field=delay,doc=Wait before starting the query"`
+}
+
+type GeneratorFunction struct{}
+
+func (self *GeneratorFunction) Call(ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+	arg := &GeneratorArgs{}
+	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+	if err != nil {
+		scope.Log("generate: %s", err.Error())
+		return false
+	}
+
+	if arg.Name == "" {
+		arg.Name = types.ToString(arg.Query, scope)
+	}
+
+	b, err := services.GetBroadcastService()
+	if err != nil {
+		scope.Log("generate: %v", err)
+		return types.Null{}
+	}
+
+	output_chan := make(chan *ordereddict.Dict)
+
+	// Try to register this generator but if it is already registered
+	// just wrap the existing one and return it.
+	err = b.RegisterGenerator(output_chan, arg.Name)
+	if err == services.AlreadyRegisteredError {
+		return Generator{arg.Name}
+	}
+
+	scope.Log("generate: registered new query for %v: %v",
+		arg.Name, types.ToString(arg.Query, scope))
+
+	sub_ctx, cancel := context.WithCancel(ctx)
+
+	// Remove the generator when the scope destroys.
+	scope.AddDestructor(func() {
+		scope.Log("generate: Removing generator %v", arg.Name)
+		cancel()
+	})
+
+	go func() {
+		defer close(output_chan)
+
+		if arg.Delay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-time.After(time.Duration(arg.Delay) * time.Millisecond):
+			}
+		}
+
+		for item := range arg.Query.Eval(sub_ctx, scope) {
+			select {
+			case <-sub_ctx.Done():
+				return
+			case output_chan <- vfilter.MaterializedLazyRow(ctx, item, scope):
+			}
+		}
+	}()
+
+	return Generator{arg.Name}
+}
+
+func (self GeneratorFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:    "generate",
+		Doc:     "Create a named generator that receives rows from the query.",
+		ArgType: type_map.AddType(scope, &GeneratorArgs{}),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&GeneratorFunction{})
+}

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Velocidex/ordereddict"
@@ -37,13 +36,10 @@ func (self Generator) Eval(ctx context.Context, scope types.Scope) <-chan types.
 		return result
 	}
 
-	/*
-		scope.AddDestructor(func() {
-			cancel()
-		})
-	*/
 	go func() {
 		defer close(result)
+
+		// Remove the watcher when we are done.
 		defer cancel()
 
 		for item := range output_chan {
@@ -120,7 +116,6 @@ func (self *GeneratorFunction) Call(ctx context.Context,
 		}
 
 		for item := range arg.Query.Eval(sub_ctx, scope) {
-			fmt.Printf("Pushing item %v\n", item)
 			select {
 			case <-sub_ctx.Done():
 				return

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -36,8 +36,14 @@ func (self Generator) Eval(ctx context.Context, scope types.Scope) <-chan types.
 		return result
 	}
 
+	/*
+		scope.AddDestructor(func() {
+			cancel()
+		})
+	*/
 	go func() {
 		defer close(result)
+		defer cancel()
 
 		// Remove the watcher when we are done.
 		defer cancel()

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -37,17 +37,20 @@ func (self Generator) Eval(ctx context.Context, scope types.Scope) <-chan types.
 		return result
 	}
 
-	scope.AddDestructor(func() {
-		cancel()
-	})
-
+	/*
+		scope.AddDestructor(func() {
+			cancel()
+		})
+	*/
 	go func() {
 		defer close(result)
+		defer cancel()
 
 		for item := range output_chan {
 			select {
 			case <-ctx.Done():
 				return
+
 			case result <- item:
 			}
 		}

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -36,15 +36,8 @@ func (self Generator) Eval(ctx context.Context, scope types.Scope) <-chan types.
 		return result
 	}
 
-	/*
-		scope.AddDestructor(func() {
-			cancel()
-		})
-	*/
 	go func() {
 		defer close(result)
-		defer cancel()
-
 		// Remove the watcher when we are done.
 		defer cancel()
 

--- a/vql/parsers/sqlite_test.go
+++ b/vql/parsers/sqlite_test.go
@@ -16,45 +16,16 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/jmoiron/sqlx"
 	"github.com/sebdah/goldie"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"www.velocidex.com/golang/velociraptor/config"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
-	"www.velocidex.com/golang/velociraptor/services/repository"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
 )
 
 type TestSuite struct {
-	suite.Suite
-	config_obj *config_proto.Config
-	sm         *services.Service
-}
-
-func (self *TestSuite) SetupTest() {
-	var err error
-	self.config_obj, err = new(config.Loader).WithFileLoader(
-		"../../http_comms/test_data/server.config.yaml").
-		WithRequiredFrontend().WithWriteback().WithVerbose(true).
-		LoadAndValidate()
-	require.NoError(self.T(), err)
-
-	self.config_obj.Frontend.DoNotCompressArtifacts = true
-
-	// Start essential services.
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*60)
-	self.sm = services.NewServiceManager(ctx, self.config_obj)
-
-	require.NoError(self.T(), self.sm.Start(repository.StartRepositoryManager))
-}
-
-func (self *TestSuite) TearDownTest() {
-	self.sm.Close()
-	test_utils.GetMemoryFileStore(self.T(), self.config_obj).Clear()
-	test_utils.GetMemoryDataStore(self.T(), self.config_obj).Clear()
+	test_utils.TestSuite
 }
 
 func (self *TestSuite) createSqliteFile(filename string) error {
@@ -88,7 +59,7 @@ func (self *TestSuite) TestSQLite() {
 	log_buffer := &strings.Builder{}
 
 	builder := services.ScopeBuilder{
-		Config:     self.config_obj,
+		Config:     self.ConfigObj,
 		ACLManager: vql_subsystem.NullACLManager{},
 		Logger:     log.New(log_buffer, "vql: ", 0),
 		Env:        ordereddict.NewDict(),

--- a/vql/readers/paged.go
+++ b/vql/readers/paged.go
@@ -99,6 +99,20 @@ type AccessorReader struct {
 	lru_size int
 }
 
+func (self *AccessorReader) SetLifetime(l time.Duration) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.Lifetime = l
+}
+
+func (self *AccessorReader) GetLifetime() time.Duration {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	return self.Lifetime
+}
+
 func (self *AccessorReader) Size() int {
 	return 1
 }
@@ -180,7 +194,7 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 
 				// Close the file after its lifetime
 				// is exhausted.
-			case <-time.After(self.Lifetime):
+			case <-time.After(self.GetLifetime()):
 				self.Close()
 			}
 		}()

--- a/vql/readers/paged_reader_test.go
+++ b/vql/readers/paged_reader_test.go
@@ -105,13 +105,16 @@ func (self *TestSuite) TestPagedReader() {
 	}
 
 	// Make the reader's timeout very short.
-	reader.Lifetime = 10 * time.Millisecond
+	reader.SetLifetime(10 * time.Millisecond)
 	reader.Close()
 	reader.ReadAt(buff, 0)
 	assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 
 	// Wait here until the reader closes itself by itself.
 	vtesting.WaitUntil(time.Second, self.T(), func() bool {
+		reader.mu.Lock()
+		defer reader.mu.Unlock()
+
 		return reader.reader == nil
 	})
 

--- a/vql/tools/collector_test.go
+++ b/vql/tools/collector_test.go
@@ -113,6 +113,14 @@ type TestSuite struct {
 	test_utils.TestSuite
 }
 
+func (self *TestSuite) SetupTest() {
+	self.TestSuite.SetupTest()
+	self.LoadArtifactFiles(
+		"../../artifacts/definitions/Demo/Plugins/GUI.yaml",
+		"../../artifacts/definitions/Reporting/Default.yaml",
+	)
+}
+
 func (self *TestSuite) TestSimpleCollection() {
 	scope := vql_subsystem.MakeScope()
 


### PR DESCRIPTION
The generate() function allows to efficiently process the same query
using multiple VQL queries. It is essentially a fan-out mechanism that
allows each row to be processed by multiple queries.