### PR TITLE
TemplateInjection hunt improvement

### DIFF
--- a/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
+++ b/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
@@ -16,6 +16,8 @@ description: |
     hosting image files for canary files or abused for NetNTLM hash colleciton.  
     
     Change TemplateFileRegex to '\\.xml\\.rels$' for looser file selection.  
+    Change TemplateTargetRegex to '^(https?|smb|\\\\|//|mhtml|file)' for looser 
+    Target selection.  
 
 author: Matt Green - @mgreen27
 
@@ -34,7 +36,7 @@ parameters:
     default: '(document|settings)\.xml\.rels$'
   - name: TemplateTargetRegex
     description: Regex to search inside resource section.
-    default: '^(https?|smb|\\\\|//|mhtml|file)'
+    default: '^(https?|smb|\\\\|//|mhtml)'
   - name: UploadDocument
     type: bool
     description: Select to upload document on detection.

--- a/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
+++ b/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
@@ -7,6 +7,15 @@ description: |
     an office template.   
     
     The default artifact will also detect MSHTML RCE Vulnerability #CVE-2021-40444.  
+      
+    This artifact can also be modified to search for other suspicious rels files:  
+    - document.xml.rels = macros, ole objects, images  
+    - settings.xml.rels = templates  
+    - websettings.xml.rels = frames  
+    - header#.xml.rels and footer#.xml.rels and others has also been observed 
+    hosting image files for canary files or abused for NetNTLM hash colleciton.  
+    
+    Change TemplateFileRegex to '\\.xml\\.rels$' for looser file selection.  
 
 author: Matt Green - @mgreen27
 
@@ -20,9 +29,12 @@ parameters:
   - name: SearchGlob
     description: Glob to search
     default: C:\Users\**\*.{docx,dotx,xlsx,xltx,pptx,potx,ppsx,sldx}
-  - name: TemplateRegex
+  - name: TemplateFileRegex
     description: Regex to search inside resource section.
-    default: '^(https?|smb|\\\\|//|mhtml)'
+    default: '(document|settings)\.xml\.rels$'
+  - name: TemplateTargetRegex
+    description: Regex to search inside resource section.
+    default: '^(https?|smb|\\\\|//|mhtml|file)'
   - name: UploadDocument
     type: bool
     description: Select to upload document on detection.
@@ -46,7 +58,7 @@ sources:
                 FROM glob(globs=url(
                     scheme="file", path=OfficePath, fragment="/**").String,
                     accessor='zip')
-                WHERE not IsDir and Size > 0 and ZipMemberPath =~ '(document|settings).xml.rels'
+                WHERE not IsDir and Size > 0 and ZipMemberPath =~ TemplateFileRegex
             })
             
       -- parse settings file by line and extract config
@@ -81,7 +93,7 @@ sources:
                     hash(path=SectionPath,accessor='zip') as SectionHash
                 FROM stat(filename=Document)
                 WHERE
-                    TemplateTarget =~ TemplateRegex
+                    TemplateTarget =~ TemplateTargetRegex
             })
 
       -- upload hits to server


### PR DESCRIPTION
Moved File selection out to a parameter enable more generic Office *.xml.rels file targeting.
Add description after research to asssist community use of the artefact when hunting.

Windows.Detection.TemplateInjection
This content will detect injected templates in Office documents.

Template injection is a form of defence evasion where a malicious macro is loaded into an OOXML document via a resource file masquerading as an office template.

The default artifact will also detect MSHTML RCE Vulnerability #CVE-2021-40444.

This artifact can also be modified to search for other suspicious rels files:
- document.xml.rels = macros, ole objects, images
- settings.xml.rels = templates
- websettings.xml.rels = frames
- header#.xml.rels and footer#.xml.rels and others has also been observed hosting image files for canary files or abused for NetNTLM hash colleciton.

Change TemplateFileRegex to ‘\.xml\.rels$’ for looser file selection.
Change TemplateTargetRegex to ‘^(https?|smb|\\|//|mhtml|file)’ for looser Target selection.