### PR TITLE
Add TemplateInjection improvement

### DIFF
--- a/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
+++ b/artifacts/definitions/Windows/Detection/TemplateInjection.yaml
@@ -96,6 +96,8 @@ sources:
                 FROM stat(filename=Document)
                 WHERE
                     TemplateTarget =~ TemplateTargetRegex
+                     AND (( Section=~'/document.xml.rels$' AND TemplateTarget=~'^mhtml:' ) 
+                            OR NOT Section=~'/document.xml.rels$' )
             })
 
       -- upload hits to server


### PR DESCRIPTION
Add optimisation to filter out more common FPs in document.xml.rels.
Currently artifact will only return Target entries in document.xml.rels that have mhtml prefix - CVE-2021-40444.