### PR TITLE
Update azure.go

### DIFF
--- a/api/authenticators/azure.go
+++ b/api/authenticators/azure.go
@@ -84,7 +84,7 @@ func oauthAzureLogin(config_obj *config_proto.Config) http.Handler {
 			oauthState = generateStateOauthCookie(w)
 		}
 
-		u := azureOauthConfig.AuthCodeURL(oauthState.Value, oauth2.ApprovalForce)
+		u := azureOauthConfig.AuthCodeURL(oauthState.Value)
 		http.Redirect(w, r, u, http.StatusTemporaryRedirect)
 	})
 }


### PR DESCRIPTION
Removed ApprovalForce which forces the user to *always* consent to the application permissions even if an Azure admin has grant his/er consent to the App Registration used by Velociraptor.