### PR TITLE
Created Server.Internal.Interrogation artifact

### DIFF
--- a/artifacts/definitions/Server/Internal/Interrogation.yaml
+++ b/artifacts/definitions/Server/Internal/Interrogation.yaml
@@ -1,0 +1,9 @@
+name: Server.Internal.Interrogation
+description: |
+  This event artifact is an internal event stream over which client
+  interrogations are sent. When the interrogation service finishes
+  updating a client record, it will send an event on this artifact.
+
+  Note: This is an automated system artifact. You do not need to start it.
+
+type: INTERNAL

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -46,9 +46,6 @@ const (
 
 	USER_AGENT = "Velociraptor - Dig Deeper!"
 
-	// Internal artifact names.
-	CLIENT_INFO_ARTIFACT = "Generic.Client.Info"
-
 	// Globals set in VQL scopes.
 	SCOPE_CONFIG        = "config"
 	SCOPE_SERVER_CONFIG = "server_config"

--- a/file_store/test_utils/testsuite.go
+++ b/file_store/test_utils/testsuite.go
@@ -37,11 +37,17 @@ type: INTERNAL
 name: Server.Internal.Notifications
 type: INTERNAL
 `, `
+name: Server.Internal.Interrogation
+type: INTERNAL
+`, `
 name: Server.Internal.Ping
 type: INTERNAL
 `, `
 name: System.Flow.Completion
 type: CLIENT_EVENT
+`, `
+name: System.Hunt.Creation
+type: SERVER_EVENT
 `, `
 name: Server.Internal.ArtifactModification
 type: SERVER_EVENT

--- a/services/client_info.go
+++ b/services/client_info.go
@@ -55,6 +55,7 @@ func (self ClientInfo) OSString() string {
 
 type ClientInfoManager interface {
 	Get(client_id string) (*ClientInfo, error)
+	Flush(client_id string)
 }
 
 func GetHostname(client_id string) string {

--- a/services/hunt_manager/hunt_manager.go
+++ b/services/hunt_manager/hunt_manager.go
@@ -72,6 +72,10 @@ import (
 	"www.velocidex.com/golang/vfilter"
 )
 
+var (
+	HuntManagerForTests *HuntManager
+)
+
 // This is the record that will be sent by the foreman to the hunt
 // manager.
 type ParticipationRecord struct {
@@ -117,6 +121,12 @@ func (self *HuntManager) Start(
 
 	err = journal.WatchQueueWithCB(ctx, config_obj, wg,
 		"Server.Internal.Label", self.ProcessLabelChange)
+	if err != nil {
+		return err
+	}
+
+	err = journal.WatchQueueWithCB(ctx, config_obj, wg,
+		"Server.Internal.Interrogation", self.ProcessInterrogation)
 	if err != nil {
 		return err
 	}
@@ -254,6 +264,22 @@ func (self *HuntManager) maybeDirectlyAssignFlow(
 	return nil
 }
 
+// Watch for an interrogate completion and check all the hunts on
+// this client in case the interrogate has more information (like
+// an OS condition).
+func (self *HuntManager) ProcessInterrogation(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	row *ordereddict.Dict) error {
+
+	client_id, pres := row.GetString("ClientId")
+	if !pres {
+		return errors.New("ClientId not found")
+	}
+
+	return self.participateInAllHunts(ctx, config_obj, client_id)
+}
+
 // Watch for all flows created by a hunt and maintain the list of hunt
 // completions.
 func (self *HuntManager) ProcessFlowCompletion(
@@ -272,16 +298,20 @@ func (self *HuntManager) ProcessFlowCompletion(
 		return err
 	}
 
-	if flow.Request == nil {
+	if flow.Request == nil || len(flow.Request.Artifacts) == 0 {
 		return nil
 	}
 
+	// We only care about flows that were launched by hunts here. The
+	// flow creator is the hunt id.
 	hunt_id := flow.Request.Creator
 	if !strings.HasPrefix(hunt_id, constants.HUNT_PREFIX) {
 		return nil
 	}
 
-	// Flow is complete so add it to the hunt stats.
+	// Flow is complete so add it to the hunt stats. We send a
+	// mutation to the hunt dispatcher to mediate internal hunt state
+	// manipulation.
 	mutation := &api_proto.HuntMutation{
 		HuntId: hunt_id,
 		Stats:  &api_proto.HuntStats{},
@@ -332,6 +362,12 @@ func (self *HuntManager) ProcessLabelChange(
 	if !pres || operation != "Add" {
 		return nil
 	}
+
+	return self.participateInAllHunts(ctx, config_obj, client_id)
+}
+
+func (self *HuntManager) participateInAllHunts(ctx context.Context,
+	config_obj *config_proto.Config, client_id string) error {
 
 	journal, err := services.GetJournal()
 	if err != nil {
@@ -462,6 +498,9 @@ func StartHuntManager(
 				Logger: logging.NewPlainLogger(config_obj, &logging.GenericComponent),
 			}),
 	}
+
+	HuntManagerForTests = result
+
 	return result.Start(ctx, config_obj, wg)
 }
 


### PR DESCRIPTION
Previously, when a hunt targets by OS, and a new client appears, the
interrogation service races the hunt service to check the client's
hunt membership. Usually the hunt manager will examine the client
immediately and since we have no information about its OS we can not
assign it to the hunt.

This PR adds a watcher to the hunt manager to check for new
interrogated clients, since these may change their OS property. In
order to determine when a client is updated this adds another internal
Server.Internal.Interrogation artifact which is guaranteed to
fire **after** the interrogation is processed.

Fixes: #1272 