### PR TITLE
Allow listener to not use file buffer.

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -4174,7 +4174,21 @@
     required: true
   category: windows
 - name: unhex
-  description: Apply hex decoding to the string.
+  description: |
+    Apply hex decoding to the string.
+
+    A hex encoded string consists of two hex digits per byte -
+    therefore valid hex encoded strings have an even length.
+
+    For example: "01230F0a"
+
+    Note: If you need to encode a string as hex encoded string you can
+    use the format function:
+
+    ```vql
+    format(format="%02x", args="Hello") -> "48656c6c6f"
+    ```
+
   type: Function
   args:
   - name: string

--- a/file_store/directory/listener_test.go
+++ b/file_store/directory/listener_test.go
@@ -12,7 +12,8 @@ import (
 
 func (self *TestSuite) TestListener() {
 	listener, err := directory.NewListener(
-		self.ConfigObj, self.Sm.Ctx, "TestListener")
+		self.ConfigObj, self.Sm.Ctx, "TestListener",
+		directory.QueueOptions{})
 	assert.NoError(self.T(), err)
 
 	events := []int64{}
@@ -61,7 +62,8 @@ func (self *TestSuite) TestListener() {
 // the buffer file.
 func (self *TestSuite) TestListenerPreserveTypes() {
 	listener, err := directory.NewListener(
-		self.ConfigObj, self.Sm.Ctx, "TestListener")
+		self.ConfigObj, self.Sm.Ctx, "TestListener",
+		directory.QueueOptions{})
 	assert.NoError(self.T(), err)
 
 	// TODO: Figure out how to preserve time.Time properly.

--- a/services/broadcast.go
+++ b/services/broadcast.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/file_store/directory"
 )
 
 // The broadcast service allows VQL to implement fan out
@@ -65,6 +66,6 @@ func GetBroadcastService() (BroadcastService, error) {
 
 type BroadcastService interface {
 	RegisterGenerator(input <-chan *ordereddict.Dict, name string) error
-	Watch(ctx context.Context, name string) (
+	Watch(ctx context.Context, name string, options directory.QueueOptions) (
 		output <-chan *ordereddict.Dict, cancel func(), err error)
 }

--- a/services/broadcast/broadcast.go
+++ b/services/broadcast/broadcast.go
@@ -62,7 +62,8 @@ func (self *BroadcastService) unregister(name string) {
 	delete(self.listener_closers, name)
 }
 
-func (self *BroadcastService) Watch(ctx context.Context, name string) (
+func (self *BroadcastService) Watch(
+	ctx context.Context, name string, options directory.QueueOptions) (
 	output <-chan *ordereddict.Dict, cancel func(), err error) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
@@ -72,7 +73,7 @@ func (self *BroadcastService) Watch(ctx context.Context, name string) (
 		return nil, nil, fmt.Errorf("No generator registered for %v", name)
 	}
 
-	output_chan, cancel := self.pool.Register(ctx, name)
+	output_chan, cancel := self.pool.Register(ctx, name, options)
 	// If closers in nil we create a new slice.
 	closers, _ := self.listener_closers[name]
 	closers = append(closers, cancel)


### PR DESCRIPTION
In some cases it is more efficient to skip the file buffer and just
allow direct communication over the Listener channel - for example in
the Generator implementation.