### PR TITLE
GUI artifact form was ignoring the friendly name attribute

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -24,6 +24,7 @@ parameters:
     default: "."
 
   - name: Flag
+    friendly_name: A Flag with a name
     type: bool
     default: Y
 

--- a/gui/velociraptor/src/components/forms/form.js
+++ b/gui/velociraptor/src/components/forms/form.js
@@ -76,6 +76,7 @@ export default class VeloForm extends React.Component {
 
     render() {
         let param = this.props.param;
+        let name = param.friendly_name || param.name;
 
         switch(param.type) {
         case "hidden":
@@ -154,7 +155,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>
@@ -187,7 +188,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>
@@ -219,7 +220,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>
@@ -269,7 +270,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>
@@ -295,7 +296,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>
@@ -324,7 +325,7 @@ export default class VeloForm extends React.Component {
                       delay={{show: 250, hide: 400}}
                       overlay={(props)=>renderToolTip(props, param)}>
                       <div>
-                        {param.name}
+                        {name}
                       </div>
                     </OverlayTrigger>
                   </Form.Label>

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -345,12 +345,15 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 	}
 
 	if is_relevant() {
-		err := self.setClientMonitoringState(ctx, config_obj, "", self.state)
+		err := self.load_from_file(ctx, config_obj)
 		if err != nil {
 			logger := logging.GetLogger(
 				config_obj, &logging.FrontendComponent)
 			logger.Error("self.setClientMonitoringState: %v", err)
 		}
+
+		// Update version to reflect the new time.
+		self.state.Version = uint64(self.Clock.Now().UnixNano())
 	}
 }
 
@@ -415,6 +418,9 @@ func (self *ClientEventTable) load_from_file(
 
 		return self.setClientMonitoringState(ctx, config_obj, "", self.state)
 	}
+
+	// Update the new version
+	self.state.Version = uint64(self.Clock.Now().UnixNano())
 
 	clear_caches(self.state)
 	return self.compileState(ctx, config_obj, self.state)

--- a/services/launcher/compiler.go
+++ b/services/launcher/compiler.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	artifact_in_query_regex = regexp.MustCompile(`Artifact\.([^\s\(]+)\(`)
-	escape_regex            = regexp.MustCompile("(^[0-9]|[\"' ])")
+	escape_regex            = regexp.MustCompile("(^[0-9]|[\"' .-])")
 )
 
 func escape_name(name string) string {


### PR DESCRIPTION
This attribute allows a parameter to have a longer user friendly name
to appear in the form.

Also fixed a bug in client monitoring service: When using with a
minion the server and minion could fail by updating each other for new
event monitoring queries.