### PR TITLE
Added procdump and procdump64

### DIFF
--- a/artifacts/definitions/Windows/Detection/BinaryRename.yaml
+++ b/artifacts/definitions/Windows/Detection/BinaryRename.yaml
@@ -58,7 +58,9 @@ parameters:
         XXXXX,MEGAcmdShell.exe,MEGAcmdShell,MEGAcmdShell
         XXXXX,pCloud.exe,pCloud.exe,pCloud cloud storage
         XXXXX,,pCloud Drive.exe,pCloud setup
-
+        procdump.exe,ProcDump,procdump,Sysinternals process dump utility
+        procdump64.exe,ProcDump,procdump,Sysinternals process dump utility
+        
 sources:
   - query: |
       LET bins <= SELECT


### PR DESCRIPTION
Procdump is used by threat actors repeatedly and is often renamed to appear less obvious.
Also: https://twitter.com/mrd0x/status/1460597833917251595