### PR TITLE
Notify currently connected clients on new hunts

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -218,17 +218,18 @@ func (self *ApiServer) CollectArtifact(
 	}
 
 	flow_id, err := launcher.ScheduleArtifactCollection(
-		ctx, self.config, acl_manager, repository, in)
+		ctx, self.config, acl_manager, repository, in,
+		func() {
+			notifier := services.GetNotifier()
+			if notifier != nil {
+				notifier.NotifyListener(self.config, in.ClientId)
+			}
+		})
 	if err != nil {
 		return nil, err
 	}
 
 	result.FlowId = flow_id
-
-	err = services.GetNotifier().NotifyListener(self.config, in.ClientId)
-	if err != nil {
-		return nil, err
-	}
 
 	// Log this event as an Audit event.
 	logging.GetLogger(self.config, &logging.Audit).

--- a/clients/tasks.go
+++ b/clients/tasks.go
@@ -79,7 +79,8 @@ func currentTaskId() uint64 {
 func QueueMessageForClient(
 	config_obj *config_proto.Config,
 	client_id string,
-	req *crypto_proto.VeloMessage) error {
+	req *crypto_proto.VeloMessage,
+	completion func()) error {
 
 	// Task ID is related to time.
 	req.TaskId = currentTaskId()
@@ -90,6 +91,7 @@ func QueueMessageForClient(
 	}
 
 	client_path_manager := paths.NewClientPathManager(client_id)
-	return db.SetSubject(config_obj,
-		client_path_manager.Task(req.TaskId), req)
+	return db.SetSubjectWithCompletion(config_obj,
+		client_path_manager.Task(req.TaskId),
+		req, completion)
 }

--- a/clients/tasks_test.go
+++ b/clients/tasks_test.go
@@ -23,7 +23,7 @@ func (self *ClientTasksTestSuite) TestQueueMessages() {
 	client_id := "C.1236"
 
 	message1 := &crypto_proto.VeloMessage{Source: "Server", SessionId: "1"}
-	err := clients.QueueMessageForClient(self.ConfigObj, client_id, message1)
+	err := clients.QueueMessageForClient(self.ConfigObj, client_id, message1, nil)
 	assert.NoError(self.T(), err)
 
 	// Now retrieve all messages.
@@ -54,7 +54,8 @@ func (self *ClientTasksTestSuite) TestFastQueueMessages() {
 
 	for i := 0; i < 10; i++ {
 		message := &crypto_proto.VeloMessage{Source: "Server", SessionId: fmt.Sprintf("%d", i)}
-		err := clients.QueueMessageForClient(self.ConfigObj, client_id, message)
+		err := clients.QueueMessageForClient(
+			self.ConfigObj, client_id, message, nil)
 		assert.NoError(self.T(), err)
 
 		written = append(written, message)

--- a/crypto/server/manager.go
+++ b/crypto/server/manager.go
@@ -150,8 +150,8 @@ func (self *serverPublicKeyResolver) SetPublicKey(
 		Pem:        crypto_utils.PublicKeyToPem(key),
 		EnrollTime: uint64(time.Now().Unix()),
 	}
-	return db.SetSubject(self.config_obj,
-		client_path_manager.Key(), pem)
+	return db.SetSubjectWithCompletion(self.config_obj,
+		client_path_manager.Key(), pem, nil)
 }
 
 func (self *serverPublicKeyResolver) Clear() {}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -70,9 +70,9 @@ type DataStore interface {
 		urn api.DSPathSpec,
 		message proto.Message) error
 
-	// SetSubject writes the data to the datastore. The data is
-	// written asynchronously and may not be immediately visible by
-	// other nodes.
+	// SetSubject writes the data to the datastore synchronously. The
+	// data is written synchronously and when complete will be visible
+	// to other nodes as long as the data is not in their caches.
 	SetSubject(
 		config_obj *config_proto.Config,
 		urn api.DSPathSpec,
@@ -80,7 +80,7 @@ type DataStore interface {
 
 	// Writes the data asynchronously and fires the completion
 	// callback when the data hits the disk and will become visibile
-	// to other nodes.
+	// to other nodes this may be a long time in the future.
 	SetSubjectWithCompletion(
 		config_obj *config_proto.Config,
 		urn api.DSPathSpec,

--- a/datastore/remote.go
+++ b/datastore/remote.go
@@ -4,6 +4,7 @@ package datastore
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -62,12 +63,17 @@ func (self *RemoteDataStore) GetSubject(
 	return err
 }
 
+// Write the data synchronously.
 func (self *RemoteDataStore) SetSubject(
 	config_obj *config_proto.Config,
 	urn api.DSPathSpec,
 	message proto.Message) error {
 
-	return self.SetSubjectWithCompletion(config_obj, urn, message, nil)
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	wg.Add(1)
+	return self.SetSubjectWithCompletion(config_obj, urn, message, wg.Done)
 }
 
 func (self *RemoteDataStore) SetSubjectWithCompletion(

--- a/flows/api.go
+++ b/flows/api.go
@@ -254,12 +254,12 @@ func CancelFlow(
 		&crypto_proto.VeloMessage{
 			Cancel:    &crypto_proto.Cancel{},
 			SessionId: flow_id,
+		}, func() {
+			notifier := services.GetNotifier()
+			if notifier != nil {
+				notifier.NotifyListener(config_obj, client_id)
+			}
 		})
-	if err != nil {
-		return nil, err
-	}
-
-	err = services.GetNotifier().NotifyListener(config_obj, client_id)
 	if err != nil {
 		return nil, err
 	}

--- a/flows/artifacts_test.go
+++ b/flows/artifacts_test.go
@@ -117,7 +117,7 @@ func (self *TestSuite) TestGetFlow() {
 		flow_id, err := launcher.ScheduleArtifactCollection(
 			ctx, self.config_obj,
 			vql_subsystem.NullACLManager{},
-			repository, request1)
+			repository, request1, nil)
 		assert.NoError(self.T(), err)
 
 		flow_ids = append(flow_ids, flow_id)
@@ -125,7 +125,7 @@ func (self *TestSuite) TestGetFlow() {
 		flow_id, err = launcher.ScheduleArtifactCollection(
 			ctx, self.config_obj,
 			vql_subsystem.NullACLManager{},
-			repository, request2)
+			repository, request2, nil)
 		assert.NoError(self.T(), err)
 
 		flow_ids = append(flow_ids, flow_id)
@@ -179,7 +179,7 @@ func (self *TestSuite) TestRetransmission() {
 	flow_id, err := launcher.ScheduleArtifactCollection(
 		ctx, self.config_obj,
 		vql_subsystem.NullACLManager{},
-		repository, request)
+		repository, request, nil)
 	assert.NoError(self.T(), err)
 
 	// Send one row.
@@ -242,7 +242,7 @@ func (self *TestSuite) TestResourceLimits() {
 		ctx,
 		self.config_obj,
 		vql_subsystem.NullACLManager{},
-		repository, request)
+		repository, request, nil)
 	assert.NoError(self.T(), err)
 
 	// Drain messages to the client.

--- a/flows/foreman.go
+++ b/flows/foreman.go
@@ -84,7 +84,7 @@ func ForemanProcessMessage(
 		err := QueueMessageForClient(
 			config_obj, client_id,
 			client_event_manager.GetClientUpdateEventTableMessage(
-				config_obj, client_id))
+				config_obj, client_id), nil)
 		if err != nil {
 			return err
 		}
@@ -170,5 +170,5 @@ func ForemanProcessMessage(
 			UpdateForeman: &actions_proto.ForemanCheckin{
 				LastHuntTimestamp: latest_timestamp,
 			},
-		})
+		}, nil)
 }

--- a/flows/hunts_test.go
+++ b/flows/hunts_test.go
@@ -1,4 +1,4 @@
-package flows
+package flows_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	"www.velocidex.com/golang/velociraptor/flows"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -97,7 +98,8 @@ sources:
 	}
 
 	acl_manager := vql_subsystem.NullACLManager{}
-	hunt_id, err := CreateHunt(self.ctx, self.config_obj, acl_manager, request)
+	hunt_id, err := flows.CreateHunt(
+		self.ctx, self.config_obj, acl_manager, request)
 
 	assert.NoError(self.T(), err)
 

--- a/flows/limits.go
+++ b/flows/limits.go
@@ -65,7 +65,7 @@ func cancelCollection(config_obj *config_proto.Config, client_id, flow_id string
 		&crypto_proto.VeloMessage{
 			Cancel:    &crypto_proto.Cancel{},
 			SessionId: flow_id,
-		})
+		}, nil)
 	if err != nil {
 		return err
 	}

--- a/flows/utils.go
+++ b/flows/utils.go
@@ -69,8 +69,9 @@ func ProduceBackwardCompatibleVeloMessage(req *crypto_proto.VeloMessage) *crypto
 func QueueMessageForClient(
 	config_obj *config_proto.Config,
 	client_id string,
-	req *crypto_proto.VeloMessage) error {
+	req *crypto_proto.VeloMessage,
+	completion func()) error {
 
 	req = ProduceBackwardCompatibleVeloMessage(req)
-	return clients.QueueMessageForClient(config_obj, client_id, req)
+	return clients.QueueMessageForClient(config_obj, client_id, req, completion)
 }

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -31,6 +31,17 @@ func NewNotificationPool() *NotificationPool {
 	}
 }
 
+func (self *NotificationPool) ListClients() []string {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	result := make([]string, 0, len(self.clients))
+	for k := range self.clients {
+		result = append(result, k)
+	}
+	return result
+}
+
 func (self *NotificationPool) IsClientConnected(client_id string) bool {
 	self.mu.Lock()
 	_, pres := self.clients[client_id]

--- a/search/index.go
+++ b/search/index.go
@@ -282,7 +282,7 @@ func SetIndex(
 	}
 
 	path := path_manager.IndexTerm(term, client_id)
-	return db.SetSubject(config_obj, path, record)
+	return db.SetSubjectWithCompletion(config_obj, path, record, nil)
 }
 
 func UnsetIndex(

--- a/search/mru.go
+++ b/search/mru.go
@@ -23,6 +23,6 @@ func UpdateMRU(
 		FirstSeenAt: uint64(time.Now().Unix()),
 	}
 
-	return db.SetSubject(
-		config_obj, path_manager.MRUClient(client_id), item)
+	return db.SetSubjectWithCompletion(
+		config_obj, path_manager.MRUClient(client_id), item, nil)
 }

--- a/search/simple.go
+++ b/search/simple.go
@@ -34,7 +34,8 @@ func SetSimpleIndex(
 		// they are user provided.
 		keyword = strings.ToLower(keyword)
 		subject := index_urn.AddChild(keyword, entity)
-		err := db.SetSubject(config_obj, subject, &empty.Empty{})
+		err := db.SetSubjectWithCompletion(
+			config_obj, subject, &empty.Empty{}, nil)
 		if err != nil {
 			return err
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -449,7 +449,7 @@ func (self *ServerTestSuite) TestScheduleCollection() {
 		self.ConfigObj,
 		vql_subsystem.NullACLManager{},
 		repository,
-		request)
+		request, nil)
 
 	db, err := datastore.GetDB(self.ConfigObj)
 	require.NoError(t, err)
@@ -489,7 +489,7 @@ func (self *ServerTestSuite) createArtifactCollection() (string, error) {
 		&flows_proto.ArtifactCollectorArgs{
 			ClientId:  self.client_id,
 			Artifacts: []string{"Generic.Client.Info"},
-		})
+		}, nil)
 
 	return flow_id, err
 }

--- a/services/client_info/client_info.go
+++ b/services/client_info/client_info.go
@@ -104,6 +104,7 @@ func (self *CachedInfo) Flush() error {
 
 	// Nothing to do
 	if !self.dirty {
+		self.mu.Unlock()
 		return nil
 	}
 
@@ -122,9 +123,13 @@ func (self *CachedInfo) Flush() error {
 		return err
 	}
 
+	// A blind write will eventually hit the disk.
 	client_path_manager := paths.NewClientPathManager(client_id)
-	return db.SetSubject(
-		self.owner.config_obj, client_path_manager.Ping(), ping_client_info)
+	db.SetSubjectWithCompletion(
+		self.owner.config_obj, client_path_manager.Ping(),
+		ping_client_info, nil)
+
+	return nil
 }
 
 type ClientInfoManager struct {

--- a/services/hunt_dispatcher.go
+++ b/services/hunt_dispatcher.go
@@ -46,6 +46,10 @@ const (
 	// all frontends.
 	HuntPropagateChanges
 
+	// Hunt was changed - all other hunt dispatchers should trigger
+	// participation for this hunt. Used when a hunt is started.
+	HuntTriggerParticipation
+
 	// Just write to data store but do not propagate (good for very
 	// frequent changes).
 	HuntFlushToDatastore

--- a/services/hunt_dispatcher/hunt_dispatcher_test.go
+++ b/services/hunt_dispatcher/hunt_dispatcher_test.go
@@ -1,0 +1,173 @@
+package hunt_dispatcher
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	"www.velocidex.com/golang/velociraptor/datastore"
+	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	"www.velocidex.com/golang/velociraptor/paths"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/frontend"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vtesting"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+
+	_ "www.velocidex.com/golang/velociraptor/result_sets/timed"
+)
+
+type HuntDispatcherTestSuite struct {
+	test_utils.TestSuite
+
+	hunt_id string
+
+	master_dispatcher *HuntDispatcher
+	minion_dispatcher *HuntDispatcher
+}
+
+func (self *HuntDispatcherTestSuite) SetupTest() {
+	self.TestSuite.SetupTest()
+	self.LoadArtifacts([]string{`
+name: Server.Internal.HuntUpdate
+type: INTERNAL
+`})
+
+	Clock = &utils.IncClock{}
+
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	for i := 0; i < 5; i++ {
+		now := Clock.Now().Unix()
+		hunt_obj := &api_proto.Hunt{
+			HuntId:    fmt.Sprintf("H.%d", i),
+			State:     api_proto.Hunt_RUNNING,
+			Version:   now,
+			StartTime: uint64(now),
+		}
+		hunt_path_manager := paths.NewHuntPathManager(hunt_obj.HuntId)
+		assert.NoError(self.T(),
+			db.SetSubject(self.ConfigObj,
+				hunt_path_manager.Path(), hunt_obj))
+	}
+
+	require.NoError(self.T(), self.Sm.Start(frontend.StartFrontendService))
+
+	// Make a master and minion dispatchers.
+	require.NoError(self.T(), self.Sm.Start(StartHuntDispatcher))
+	self.master_dispatcher = services.GetHuntDispatcher().(*HuntDispatcher)
+	self.master_dispatcher.i_am_master = true
+
+	require.NoError(self.T(), self.Sm.Start(StartHuntDispatcher))
+	self.minion_dispatcher = services.GetHuntDispatcher().(*HuntDispatcher)
+	self.minion_dispatcher.i_am_master = false
+
+	// Wait until the hunt dispatchers are fully loaded.
+	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		hunt, pres := self.master_dispatcher.GetHunt("H.4")
+		return pres && hunt.HuntId == "H.4"
+	})
+
+	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		hunt, pres := self.minion_dispatcher.GetHunt("H.4")
+		return pres && hunt.HuntId == "H.4"
+	})
+}
+
+func (self *HuntDispatcherTestSuite) TestLoadingFromDisk() {
+	// All hunts are now running.
+	hunts := self.getAllHunts()
+	assert.Equal(self.T(), len(hunts), 5)
+	for _, h := range hunts {
+		assert.Equal(self.T(), h.State, api_proto.Hunt_RUNNING)
+	}
+}
+
+func (self *HuntDispatcherTestSuite) TestModifyingHuntFlushToDatastore() {
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	// Modify a hunt and flush to datastore immediately
+	modification := self.master_dispatcher.ModifyHunt("H.1",
+		func(hunt *api_proto.Hunt) services.HuntModificationAction {
+			hunt.State = api_proto.Hunt_STOPPED
+			return services.HuntFlushToDatastore
+		})
+
+	// Changes should be visible in the data store immediately.
+	assert.Equal(self.T(), modification, services.HuntFlushToDatastore)
+
+	hunt_path_manager := paths.NewHuntPathManager("H.1")
+	hunt_obj := &api_proto.Hunt{}
+	err = db.GetSubject(self.ConfigObj, hunt_path_manager.Path(), hunt_obj)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), hunt_obj.State, api_proto.Hunt_STOPPED)
+
+	// Should also be visible in master
+	hunt_obj, pres := self.master_dispatcher.GetHunt("H.1")
+	assert.True(self.T(), pres)
+	assert.Equal(self.T(), hunt_obj.State, api_proto.Hunt_STOPPED)
+
+	// But not immediately visible in minion
+	hunt_obj, pres = self.minion_dispatcher.GetHunt("H.1")
+	assert.True(self.T(), pres)
+	assert.Equal(self.T(), hunt_obj.State, api_proto.Hunt_RUNNING)
+}
+
+func (self *HuntDispatcherTestSuite) TestModifyingHuntPropagateChanges() {
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	// Now modify a hunt with services.HuntPropagateChanges
+	modification := self.master_dispatcher.ModifyHunt("H.2",
+		func(hunt *api_proto.Hunt) services.HuntModificationAction {
+			hunt.State = api_proto.Hunt_STOPPED
+			return services.HuntPropagateChanges
+		})
+
+	// Changes are not visible in the data store immediately.
+	assert.Equal(self.T(), modification, services.HuntPropagateChanges)
+	hunt_path_manager := paths.NewHuntPathManager("H.2")
+	hunt_obj := &api_proto.Hunt{}
+	err = db.GetSubject(self.ConfigObj, hunt_path_manager.Path(), hunt_obj)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), hunt_obj.State, api_proto.Hunt_RUNNING)
+
+	// But they should be visible in master
+	hunt_obj, pres := self.master_dispatcher.GetHunt("H.2")
+	assert.True(self.T(), pres)
+	assert.Equal(self.T(), hunt_obj.State, api_proto.Hunt_STOPPED)
+
+	// And eventually also visible in minion
+	vtesting.WaitUntil(time.Second, self.T(), func() bool {
+		hunt_obj, pres = self.minion_dispatcher.GetHunt("H.2")
+		return pres && hunt_obj.State == api_proto.Hunt_STOPPED
+	})
+}
+
+func (self *HuntDispatcherTestSuite) getAllHunts() []*api_proto.Hunt {
+	// Get the list of all hunts
+	hunts := []*api_proto.Hunt{}
+	err := self.master_dispatcher.ApplyFuncOnHunts(
+		func(hunt *api_proto.Hunt) error {
+			hunts = append(hunts, hunt)
+			return nil
+		})
+	assert.NoError(self.T(), err)
+
+	sort.Slice(hunts, func(i, j int) bool {
+		return hunts[i].HuntId < hunts[j].HuntId
+	})
+	return hunts
+}
+
+func TestHuntDispatcherTestSuite(t *testing.T) {
+	suite.Run(t, &HuntDispatcherTestSuite{
+		hunt_id: "H.1234",
+	})
+}

--- a/services/journal.go
+++ b/services/journal.go
@@ -69,7 +69,8 @@ type JournalService interface {
 		rows []*ordereddict.Dict, name, client_id, flows_id string) error
 
 	// Push the rows to the event artifact queue with a potential
-	// unspecified delay.
+	// unspecified delay. Internally these rows will be batched until
+	// a convenient time to send them.
 	PushRowsToArtifactAsync(config_obj *config_proto.Config,
 		row *ordereddict.Dict, name string)
 }

--- a/services/journal/replication.go
+++ b/services/journal/replication.go
@@ -166,7 +166,7 @@ func (self *ReplicationService) Start(
 	self.api_client = api_client
 	self.closer = closer
 	self.ctx = ctx
-	self.sender = make(chan *api_proto.PushEventRequest, 100)
+	self.sender = make(chan *api_proto.PushEventRequest, 10000)
 	self.SetRetryDuration(time.Second)
 
 	self.tmpfile, err = ioutil.TempFile("", "replication")

--- a/services/journal/replication_test.go
+++ b/services/journal/replication_test.go
@@ -2,6 +2,7 @@ package journal_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -215,8 +216,14 @@ func (self *ReplicationTestSuite) TestSendingEvents() {
 		assert.NoError(self.T(), err)
 	}
 
+	// Wait for events to move from the channel buffer in memory to
+	// the disk buffer.
+	time.Sleep(time.Second)
+
 	// Make sure we wrote something to the buffer file.
-	assert.True(self.T(), replicator.Buffer.GetHeader().WritePointer > 2000)
+	ptr := replicator.Buffer.GetHeader().WritePointer
+	assert.True(self.T(),
+		ptr > 2000, fmt.Sprintf("WritePointer %v", ptr))
 
 	// Wait a while to allow events to be delivered.
 	time.Sleep(time.Second)

--- a/services/labels/labels.go
+++ b/services/labels/labels.go
@@ -179,13 +179,13 @@ func (self *Labeler) notifyClient(
 		return err
 	}
 
-	return journal.PushRowsToArtifact(config_obj,
-		[]*ordereddict.Dict{
-			ordereddict.NewDict().
-				Set("client_id", client_id).
-				Set("Operation", operation).
-				Set("Label", new_label),
-		}, "Server.Internal.Label", client_id, "")
+	journal.PushRowsToArtifactAsync(config_obj,
+		ordereddict.NewDict().
+			Set("client_id", client_id).
+			Set("Operation", operation).
+			Set("Label", new_label),
+		"Server.Internal.Label")
+	return nil
 }
 
 func (self *Labeler) SetClientLabel(
@@ -215,8 +215,8 @@ func (self *Labeler) SetClientLabel(
 	}
 
 	client_path_manager := paths.NewClientPathManager(client_id)
-	err = db.SetSubject(config_obj,
-		client_path_manager.Labels(), cached.record)
+	err = db.SetSubjectWithCompletion(config_obj,
+		client_path_manager.Labels(), cached.record, nil)
 	if err != nil {
 		return err
 	}
@@ -264,8 +264,8 @@ func (self *Labeler) RemoveClientLabel(
 	}
 
 	client_path_manager := paths.NewClientPathManager(client_id)
-	err = db.SetSubject(config_obj,
-		client_path_manager.Labels(), cached.record)
+	err = db.SetSubjectWithCompletion(config_obj,
+		client_path_manager.Labels(), cached.record, nil)
 	if err != nil {
 		return err
 	}

--- a/services/launcher.go
+++ b/services/launcher.go
@@ -133,5 +133,6 @@ type Launcher interface {
 		config_obj *config_proto.Config,
 		acl_manager vql_subsystem.ACLManager,
 		repository Repository,
-		collector_request *flows_proto.ArtifactCollectorArgs) (string, error)
+		collector_request *flows_proto.ArtifactCollectorArgs,
+		completion func()) (string, error)
 }

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -66,12 +66,15 @@ type Notifier interface {
 	// Notify in the near future - no guarantee of delivery.
 	NotifyListenerAsync(config_obj *config_proto.Config, id string)
 
-	// Check if there is someone listening for the specified
-	// id. This method queries all nodes to check if the client is
-	// connected.
+	// Check if there is someone listening for the specified id. This
+	// method queries all minion nodes to check if the client is
+	// connected anywhere - It may take up to 2 seconds to find out.
 	IsClientConnected(ctx context.Context,
 		config_obj *config_proto.Config,
 		client_id string, timeout int) bool
+
+	// Returns a list of all clients directly connected at present.
+	ListClients() []string
 
 	// Check only the current node if the client is connected.
 	IsClientDirectlyConnected(client_id string) bool

--- a/services/notifications/notifications.go
+++ b/services/notifications/notifications.go
@@ -231,6 +231,10 @@ func (self *Notifier) IsClientDirectlyConnected(client_id string) bool {
 	return self.notification_pool.IsClientConnected(client_id)
 }
 
+func (self *Notifier) ListClients() []string {
+	return self.notification_pool.ListClients()
+}
+
 func (self *Notifier) IsClientConnected(
 	ctx context.Context,
 	config_obj *config_proto.Config,

--- a/services/server_artifacts/server_artifacts.go
+++ b/services/server_artifacts/server_artifacts.go
@@ -135,7 +135,8 @@ func (self *contextManager) Save() error {
 	if err != nil {
 		return err
 	}
-	return db.SetSubject(self.config_obj, self.path_manager.Path(), self.context)
+	return db.SetSubjectWithCompletion(
+		self.config_obj, self.path_manager.Path(), self.context, nil)
 }
 
 type serverLogger struct {

--- a/services/server_artifacts/server_artifacts_test.go
+++ b/services/server_artifacts/server_artifacts_test.go
@@ -85,7 +85,7 @@ func (self *ServerArtifactsTestSuite) ScheduleAndWait(
 			Creator:   user,
 			ClientId:  "server",
 			Artifacts: []string{name},
-		})
+		}, nil)
 	assert.NoError(self.T(), err)
 
 	// Notify it about the new job

--- a/timelines/supertimeline.go
+++ b/timelines/supertimeline.go
@@ -164,7 +164,8 @@ func (self *SuperTimelineWriter) Close() {
 	if err != nil {
 		return
 	}
-	db.SetSubject(self.config_obj, self.path_manager.Path(), self.SuperTimeline)
+	db.SetSubjectWithCompletion(
+		self.config_obj, self.path_manager.Path(), self.SuperTimeline, nil)
 }
 
 func (self *SuperTimelineWriter) AddChild(name string) (*TimelineWriter, error) {

--- a/utils/completer.go
+++ b/utils/completer.go
@@ -4,6 +4,31 @@ import (
 	"sync"
 )
 
+/*
+  The Completer is a helper that is used to ensure a completion
+  funciton is called when several asynchronous operations are
+  finished. Only when all operations are done, the completion function
+  will be called.
+
+  Suppose we have a number of concurrent asynchronous operations we
+  need to perform. This is the common usage pattern.
+
+  func doStuff() {
+    completer := NewCompleter(func() {
+      fmt.Printf("I am called once")
+    })
+
+    // This ensures the completer is not called until we leave this
+    // function.
+    defer completer.GetCompletionFunc()()
+
+    err := db.SetSubjectWithCompletion(...., completer.GetCompletionFunc())
+    ...
+    err := db.SetSubjectWithCompletion(...., completer.GetCompletionFunc())
+  }
+
+*/
+
 type Completer struct {
 	mu         sync.Mutex
 	count      int
@@ -19,6 +44,7 @@ func NewCompleter(completion func()) *Completer {
 func (self *Completer) GetCompletionFunc() func() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
 	self.count++
 
 	return func() {
@@ -26,7 +52,7 @@ func (self *Completer) GetCompletionFunc() func() {
 		defer self.mu.Unlock()
 
 		self.count--
-		if self.count == 0 {
+		if self.count == 0 && self.completion != nil {
 			self.completion()
 		}
 	}

--- a/vql/server/artifacts.go
+++ b/vql/server/artifacts.go
@@ -142,14 +142,14 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 	}
 
 	flow_id, err := launcher.ScheduleArtifactCollection(
-		ctx, config_obj, acl_manager, repository, request)
-	if err != nil {
-		scope.Log("collect_client: %v", err)
-		return vfilter.Null{}
-	}
-
-	// Notify the client about it.
-	err = services.GetNotifier().NotifyListener(config_obj, arg.ClientId)
+		ctx, config_obj, acl_manager, repository, request,
+		func() {
+			// Notify the client about it.
+			notifier := services.GetNotifier()
+			if notifier != nil {
+				notifier.NotifyListener(config_obj, arg.ClientId)
+			}
+		})
 	if err != nil {
 		scope.Log("collect_client: %v", err)
 		return vfilter.Null{}

--- a/vql/server/kill.go
+++ b/vql/server/kill.go
@@ -57,13 +57,12 @@ func (self *KillClientFunction) Call(ctx context.Context,
 		&crypto_proto.VeloMessage{
 			KillKillKill: &crypto_proto.Cancel{},
 			SessionId:    constants.MONITORING_WELL_KNOWN_FLOW,
+		}, func() {
+			notifier := services.GetNotifier()
+			if notifier != nil {
+				notifier.NotifyListener(config_obj, arg.ClientId)
+			}
 		})
-	if err != nil {
-		scope.Log("killkillkill: %s", err.Error())
-		return vfilter.Null{}
-	}
-
-	err = services.GetNotifier().NotifyListener(config_obj, arg.ClientId)
 	if err != nil {
 		scope.Log("killkillkill: %s", err.Error())
 		return vfilter.Null{}


### PR DESCRIPTION
When a hunt is started we used to notify all the clients, but this
creates unnecessary churn on the system. In this PR we specifically
forward all connected clients to the hunt manager instead of notifying
all clients. This keeps clients connected and avoids a thundering herd
condition.

The PR also adds completion function to QueueMessageForClient() so it
can be notified after the message is queued.