### PR TITLE
Conditionally specify the mtime to upload depending on version.

### DIFF
--- a/artifacts/definitions/Windows/Collectors/File.yaml
+++ b/artifacts/definitions/Windows/Collectors/File.yaml
@@ -48,19 +48,26 @@ sources:
       - SELECT * FROM all_results
 
    - name: Uploads
-     queries:
-      # Upload the files
-      - LET uploaded_files = SELECT * FROM foreach(row=all_results,
+     query: |
+       -- Upload the files
+       LET uploaded_files = SELECT * FROM foreach(row=all_results,
         workers=30,
         query={
             SELECT Created, LastAccessed, Modified, SourceFile, Size,
-               upload(file=SourceFile, accessor=Accessor, name=SourceFile,
-                      mtime=Modified) AS Upload
+               -- Support older clients which do not have the mtime field.
+               if(condition=version(function="upload") > 0,
+                  then=upload(
+                    file=SourceFile,
+                    accessor=Accessor, name=SourceFile,
+                    mtime=Modified),
+                  else=upload(
+                    file=SourceFile,
+                    accessor=Accessor, name=SourceFile)) AS Upload
             FROM scope()
         })
 
-      # Separate the hashes into their own column.
-      - SELECT now() AS CopiedOnTimestamp, SourceFile, Upload.Path AS DestinationFile,
+       -- Separate the hashes into their own column.
+       SELECT now() AS CopiedOnTimestamp, SourceFile, Upload.Path AS DestinationFile,
                Size AS FileSize, Upload.sha256 AS SourceFileSha256,
                Created, Modified, LastAccessed
-        FROM uploaded_files
+       FROM uploaded_files

--- a/vql/networking/upload.go
+++ b/vql/networking/upload.go
@@ -134,6 +134,7 @@ func (self UploadFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) 
 			"client this will upload the file into the flow and store " +
 			"it in the server's file store.",
 		ArgType: type_map.AddType(scope, &UploadFunctionArgs{}),
+		Version: 2,
 	}
 }
 


### PR DESCRIPTION
0.6.2 introduced the mtime arg to the upload version and started using
for e.g. Windows.KapeFile.Targets - this breaks collection from older
clients which do not support this arg.

This PR checks the version of the upload() function and specifies the
correct parameters.