### PR TITLE
Low latency client connectivity discovery

### DIFF
--- a/api/clients.go
+++ b/api/clients.go
@@ -121,10 +121,6 @@ func (self *ApiServer) GetClient(
 			services.GetNotifier().IsClientConnected(ctx,
 				self.config, in.ClientId, 2) {
 			api_client.LastSeenAt = uint64(time.Now().UnixNano() / 1000)
-		} else {
-			// Warm up the cache anyway.
-			go services.GetNotifier().IsClientConnected(
-				ctx, self.config, in.ClientId, 2)
 		}
 	}
 

--- a/artifacts/definitions/Server/Internal/Pong.yaml
+++ b/artifacts/definitions/Server/Internal/Pong.yaml
@@ -1,0 +1,9 @@
+name: Server.Internal.Pong
+description: |
+  An internal queue for Ping replies
+
+type: INTERNAL
+
+column_types:
+  - name: ClientId
+  - name: Connected

--- a/datastore/memcache_file.go
+++ b/datastore/memcache_file.go
@@ -378,6 +378,37 @@ func (self *MemcacheFileDataStore) GetBuffer(
 	return bulk_data, nil
 }
 
+// Needed to support RawDataStore interface.
+func (self *MemcacheFileDataStore) SetBuffer(
+	config_obj *config_proto.Config,
+	urn api.DSPathSpec, data []byte, completion func()) error {
+
+	err := self.cache.SetData(config_obj, urn, data)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	select {
+	case <-self.ctx.Done():
+		return nil
+
+	case self.writer <- &Mutation{
+		op:         MUTATION_OP_SET_SUBJECT,
+		urn:        urn,
+		wg:         &wg,
+		data:       data,
+		completion: completion,
+	}:
+	}
+
+	if config_obj.Datastore.MemcacheWriteMutationBuffer < 0 {
+		wg.Wait()
+	}
+	return nil
+}
+
 // Recursively makes sure the directories are added to the cache. We
 // treat the file backing as authoritative, so if the dir cache is not
 // present in cache we read intermediate paths from disk.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/Velocidex/go-yara v1.1.10-0.20210726130504-d5e402efc424
 	github.com/Velocidex/grpc-go-pool v1.2.2-0.20211129003310-ece3b3fe13f4
 	github.com/Velocidex/json v0.0.0-20210402154432-68206e1293d0
-	github.com/Velocidex/ordereddict v0.0.0-20211021090706-c5d39d5aa33a
+	github.com/Velocidex/ordereddict v0.0.0-20211209041727-c8e40f18702c
 	github.com/Velocidex/pkcs7 v0.0.0-20210524015001-8d1eee94a157
 	github.com/Velocidex/sflags v0.3.1-0.20210402155316-b09f53df5162
 	github.com/Velocidex/survey v1.8.7-0.20190926071832-2ff99cc7aa49

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,9 @@ github.com/Velocidex/json v0.0.0-20210402154432-68206e1293d0/go.mod h1:ukJBuruT9
 github.com/Velocidex/ordereddict v0.0.0-20191106020901-97c468e5e403/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/ordereddict v0.0.0-20200723153557-9460a6764ab8/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/ordereddict v0.0.0-20210502082334-cf5d9045c0d1/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
-github.com/Velocidex/ordereddict v0.0.0-20211021090706-c5d39d5aa33a h1:po9Vz/VDKMyplbGyawzXjv410FPAKxRUseF+urlCkSM=
 github.com/Velocidex/ordereddict v0.0.0-20211021090706-c5d39d5aa33a/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
+github.com/Velocidex/ordereddict v0.0.0-20211209041727-c8e40f18702c h1:5t88nemfPZW9qres0nUXgE5+WcXn+h2QpESdqRWu/gM=
+github.com/Velocidex/ordereddict v0.0.0-20211209041727-c8e40f18702c/go.mod h1:pxJpvN5ISMtDwrdIdqnJ3ZrjIngCw+WT6gfNil6Zjvo=
 github.com/Velocidex/pkcs7 v0.0.0-20210524015001-8d1eee94a157 h1:cNRL6O5MZdKi4i0aQxW6+7RoT34QMHFuRKpigCIHBG8=
 github.com/Velocidex/pkcs7 v0.0.0-20210524015001-8d1eee94a157/go.mod h1:/fy/Eg4TQz9KkJduvZfGCnbWTQ/LKaknS2wYB52cU6c=
 github.com/Velocidex/sflags v0.3.1-0.20210402155316-b09f53df5162 h1:wcYgZ8Z8w0JNMqqOFcOYrucDGaNYeCMd8ScDDCo/p8w=

--- a/services/frontend.go
+++ b/services/frontend.go
@@ -36,6 +36,8 @@ func GetFrontendManager() FrontendManager {
 }
 
 type FrontendManager interface {
+	GetMinionCount() int
+
 	// Establish a gRPC connection to the master node. If we are
 	// running on the master node already then returns a
 	// fs.ErrNotExist error. If we fail to connect returns another

--- a/services/frontend/frontend.go
+++ b/services/frontend/frontend.go
@@ -180,6 +180,21 @@ func (self *MasterFrontendManager) processMetrics(ctx context.Context,
 	return nil
 }
 
+func (self *MasterFrontendManager) GetMinionCount() int {
+	res := 0
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	for node_name, metric := range self.stats {
+		if node_name != "master" {
+			if time.Now().Sub(metric.Timestamp) < 60*time.Second {
+				res++
+			}
+		}
+	}
+	return res
+}
+
 // Every 10 seconds read the cummulative stats and update the
 // Server.Monitor.Health artifact.
 func (self *MasterFrontendManager) UpdateStats(ctx context.Context) {
@@ -307,6 +322,10 @@ func (self MasterFrontendManager) Start(ctx context.Context, wg *sync.WaitGroup,
 type MinionFrontendManager struct {
 	config_obj *config_proto.Config
 	name       string
+}
+
+func (self MinionFrontendManager) GetMinionCount() int {
+	return 0
 }
 
 func (self MinionFrontendManager) IsMaster() bool {

--- a/services/journal/replication_test.go
+++ b/services/journal/replication_test.go
@@ -37,6 +37,10 @@ type MockFrontendService struct {
 	mock *mock_proto.MockAPIClient
 }
 
+func (self MockFrontendService) GetMinionCount() int {
+	return 0
+}
+
 // The minion replicates to the master node.
 func (self MockFrontendService) GetMasterAPIClient(ctx context.Context) (
 	api_proto.APIClient, func() error, error) {
@@ -152,11 +156,13 @@ type: CLIENT_EVENT
 		mu.Lock()
 		defer mu.Unlock()
 
+		// json.Dump(watched)
 		return vtesting.CompareStrings(watched, []string{
 			// Watch for ping requests from the
 			// master. This is used to let the master know
 			// if a client is connected to us.
 			"Server.Internal.Ping",
+			"Server.Internal.Pong",
 			"Server.Internal.MasterRegistrations",
 
 			// The notifications service will watch for

--- a/vql/server/monitoring/add_monitoring.go
+++ b/vql/server/monitoring/add_monitoring.go
@@ -7,7 +7,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
-	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -240,11 +239,14 @@ func (self AddServerMonitoringFunction) Call(
 		Parameters: &flows_proto.ArtifactParameters{},
 	}
 
-	params := arg.Parameters.Reduce(ctx)
-	params_dict, ok := params.(*ordereddict.Dict)
-	if !ok {
-		scope.Log("add_client_monitoring: parameters should be a dict")
-		return vfilter.Null{}
+	params_dict := ordereddict.NewDict()
+	if arg.Parameters != nil {
+		params := arg.Parameters.Reduce(ctx)
+		params_dict, ok = params.(*ordereddict.Dict)
+		if !ok {
+			scope.Log("add_client_monitoring: parameters should be a dict")
+			return vfilter.Null{}
+		}
 	}
 
 	for _, k := range params_dict.Keys() {
@@ -269,8 +271,6 @@ func (self AddServerMonitoringFunction) Call(
 		scope.Log("add_server_monitoring: %v", err)
 		return vfilter.Null{}
 	}
-
-	json.Dump(event_config)
 
 	return event_config
 }


### PR DESCRIPTION
By keeping track of the number of minions we can quickly determine when a client is not connected to anywhere without having to timeout.