### PR TITLE
Fixed bug in client comms.

### DIFF
--- a/bin/frontend.go
+++ b/bin/frontend.go
@@ -115,6 +115,14 @@ func startFrontend(sm *services.Service) (*api.Builder, error) {
 		return nil, err
 	}
 
+	// Parse extra artifacts from --definitions flag before we start
+	// any services just in case these services need to access these
+	// custom artifacts.
+	_, err = getRepository(config_obj)
+	if err != nil {
+		return nil, err
+	}
+
 	// Load any artifacts defined in the config file before the
 	// frontend services are started so they may use them.
 	err = load_config_artifacts(config_obj)
@@ -124,12 +132,6 @@ func startFrontend(sm *services.Service) (*api.Builder, error) {
 
 	// These services must start only on the frontends.
 	err = startup.StartupFrontendServices(sm)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse the artifacts database to detect errors early.
-	_, err = getRepository(config_obj)
 	if err != nil {
 		return nil, err
 	}

--- a/http_comms/sender_test.go
+++ b/http_comms/sender_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"sync"
 	"testing"
@@ -49,7 +48,8 @@ type MockHTTPConnector struct {
 }
 
 func (self *MockHTTPConnector) GetCurrentUrl(handler string) string { return "http://URL/" + handler }
-func (self *MockHTTPConnector) Post(handler string, data []byte, urgent bool) (*http.Response, error) {
+func (self *MockHTTPConnector) Post(ctx context.Context,
+	name, handler string, data []byte, urgent bool) (*bytes.Buffer, error) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
@@ -70,10 +70,7 @@ func (self *MockHTTPConnector) Post(handler string, data []byte, urgent bool) (*
 			self.received = append(self.received, item.Name)
 		})
 
-	return &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
-		StatusCode: 200,
-	}, nil
+	return &bytes.Buffer{}, nil
 }
 func (self *MockHTTPConnector) ReKeyNextServer()   {}
 func (self *MockHTTPConnector) ServerName() string { return "VelociraptorServer" }


### PR DESCRIPTION
When the client received a 503 status from the server (due to load
shedding for example) it failed to close the socket on error
paths. This resulted in a leak of a socket and presented in having
many TIME_WAIT sockets.

This PR refactors the http comms code to ensure the socket is closed
on all error paths