### PR TITLE
Add Artifact to collect KapeFile targets on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ lint:
 	golangci-lint run
 
 KapeFilesSync:
-	python3 scripts/kape_files.py ~/projects/KapeFiles/ > artifacts/definitions/Windows/KapeFiles/Targets.yaml
+	python3 scripts/kape_files.py -t win ~/projects/KapeFiles/ > artifacts/definitions/Windows/KapeFiles/Targets.yaml
+	python3 scripts/kape_files.py -t nix ~/projects/KapeFiles/ > artifacts/definitions/Linux/KapeFiles/CollectFromDirectory.yaml
 
 # Do this after fetching the build artifacts with `gh run download <RunID>`
 UpdateCIArtifacts:

--- a/artifacts/definitions/Generic/Collectors/File.yaml
+++ b/artifacts/definitions/Generic/Collectors/File.yaml
@@ -1,4 +1,4 @@
-name: Windows.Collectors.File
+name: Generic.Collectors.File
 description: |
    Collects files using a set of globs. All globs must be on the same
    device. The globs will be searched in one pass - so you can provide
@@ -8,26 +8,36 @@ parameters:
   - name: collectionSpec
     description: |
        A CSV file with a Glob column with all the globs to collect.
-       NOTE: Globs must not have a leading device since the device
-       will depend on the VSS.
+       NOTE: Globs must not have a leading device.
     type: csv
     default: |
        Glob
        Users\*\NTUser.dat
-  - name: RootDevice
-    description: The device to apply all the glob on.
+  - name: Root
+    description: |
+      On Windows, this is the device to apply all the glob on. On *NIX,
+      this should be a path to a subdirectory but must not be a real
+      device from /dev.
     default: "C:"
   - name: Accessor
     default: lazy_ntfs
+    description: |
+      On Windows, this can be left on `lazy_ntfs'. For *NIX, this value
+      must be set to `file' since the ntfs accessors are not available.
+  - name: Separator
+    description: |
+      The path separator used to construct the final globs from the root
+      and the partial globs in `collectionSpec'.
+    default: "\\"
 
 sources:
    - name: All Matches Metadata
      queries:
       # Generate the collection globs for each device
-      - LET specs = SELECT RootDevice + "\\" + Glob AS Glob
+      - LET specs = SELECT Root + Separator + Glob AS Glob
             FROM collectionSpec
-            WHERE log(message=format(format="Processing Device %v with %v",
-                      args=[RootDevice, Accessor]))
+            WHERE log(message=format(format="Processing Device %v with %v: %v",
+                      args=[Root, Accessor, Glob]))
 
       # Join all the collection rules into a single Glob plugin. This ensure we
       # only make one pass over the filesystem. We only want LFNs.
@@ -40,7 +50,6 @@ sources:
         WHERE NOT IsDir AND log(message="Found " + SourceFile)
 
       # Create a unique key to group by - modification time and path name.
-      # Order by device name so we get C:\ above the VSS device.
       - LET all_results <= SELECT Created, LastAccessed,
               Modified, Size, SourceFile
         FROM hits

--- a/artifacts/definitions/Linux/KapeFiles/CollectFromDirectory.yaml
+++ b/artifacts/definitions/Linux/KapeFiles/CollectFromDirectory.yaml
@@ -1,0 +1,2075 @@
+name: Linux.KapeFiles.CollectFromDirectory
+description: |
+
+    Kape is a popular bulk collector tool for triaging a system
+    quickly. While KAPE itself is not an opensource tool, the logic it
+    uses to decide which files to collect is encoded in YAML files
+    hosted on the KapeFiles project
+    (https://github.com/EricZimmerman/KapeFiles) and released under an
+    MIT license.
+
+    This artifact is automatically generated from these YAML files,
+    contributed and maintained by the community. This artifact only
+    encapsulates the KAPE "Targets" - basically a bunch of glob
+    expressions used for collecting files on the endpoint. We do not
+    do any post processing these files - we just collect them.
+
+    We recommend that timeouts and upload limits be used
+    conservatively with this artifact because we can upload really
+    vast quantities of data very quickly.
+
+reference:
+  - https://www.kroll.com/en/insights/publications/cyber/kroll-artifact-parser-extractor-kape
+  - https://github.com/EricZimmerman/KapeFiles
+
+type: client
+
+parameters:
+  - name: Device
+    description: Path from where to start the search.
+    default: "/mnt/windows_mount"
+
+  - name: _BasicCollection
+    description: "Basic Collection (by Phill Moore): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Desktop LNK Files, Desktop LNK Files XP, Event logs Win7+, Event logs Win7+, Event logs XP, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, PowerShell Console Log, Prefetch, Prefetch, RECYCLER - WinXP, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, Restore point LNK Files XP, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), Thumbcache DB, UsrClass.dat registry hive, UsrClass.dat registry transaction files, WindowsIndexSearch, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt"
+    type: bool
+  - name: _SANS_Triage
+    description: "SANS Triage Collection (by Mark Hallman): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, ActivitiesCache.db, Addons, Addons XP, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, Bookmarks, Bookmarks, Box Drive Application Metadata, Box Sync Application Metadata, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Cisco Jabber Database, ComboFix, Cookies, Cookies, Cookies XP, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, Desktop LNK Files, Desktop LNK Files XP, Discord Cache Files, Discord Local Storage LevelDB Files, Downloads, Downloads XP, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Emsisoft Scan Logs, Event logs Win7+, Event logs Win7+, Event logs XP, Extensions, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, Favicons, Favicons XP, Form history, Form history XP, Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata, HexChat Chat Logs, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, IceChat Chat Logs, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, Mattermost - Chat Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11), NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, OneDrive Metadata Logs, OneDrive Metadata Settings, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, Preferences, Prefetch, Prefetch, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RECYCLER - WinXP, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, Restore point LNK Files XP, Roaming Internet Explorer folder, RogueKiller Reports, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SUM Database (.mdb files), SUPERAntiSpyware Logs, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Search, Search XP, SecureAge Antvirus Logs, SentinelOne EDR Log, Sessionstore, Sessionstore Folder, Sessionstore XP, Signal Attachments cache, Signal Database, Signal Logs, Signal config.json, Signons, Signons XP, Skype for Destkop v8+ Chromium Cache, Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage, Sophos Logs, Sophos Logs (XP), Storage Sync, Supremo Connection Logs, Supremo File Transfer Inbox, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, Telegram app folder, Telegram downloaded files, Thumbcache DB, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, UsrClass.dat registry hive, UsrClass.dat registry transaction files, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache, WBEM, WBEM, Webappstore, Webappstore XP, Webroot Program Data, WhatsApp Cache, WhatsApp Local Storage, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Protect Folder, Windows Protect Folder, Windows Protect Folder, WindowsIndexSearch, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, ccSubSDK Database, leveldb (Skype for Desktop +v8), mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+), mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings, main.db (App <v12), main.db Win7+, main.db XP, registrationInfo.xml, s4l-[username].db (App +v8), skype.db (App +v12)"
+    type: bool
+  - name: _Boot
+    description: "$Boot (by Eric Zimmerman): $Boot"
+    type: bool
+  - name: _J
+    description: "$J (by Eric Zimmerman and Andrew Rathbun): $J, $J, $Max, $Max"
+    type: bool
+  - name: _LogFile
+    description: "$LogFile (by Eric Zimmerman): $LogFile"
+    type: bool
+  - name: _MFT
+    description: "$MFT (by Eric Zimmerman): $MFT"
+    type: bool
+  - name: _MFTMirr
+    description: "$MFTMirr (by Teo Kia Meng): $MFTMirr"
+    type: bool
+  - name: _T
+    description: "$T (by Eric Zimmerman and Andrew Rathbun): $T, $T"
+    type: bool
+  - name: 1Password
+    description: "1Password Password Manager (by Matt Dawson): 1Password Backup Databases, 1Password Database, 1Password Logs"
+    type: bool
+  - name: 4KVideoDownloader
+    description: "4K Video Downloader (by Andrew Rathbun): 4K Video Downloader"
+    type: bool
+  - name: AVG
+    description: "AVG Antivirus Data (by Kirtan Shah): AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs"
+    type: bool
+  - name: AceText
+    description: "AceText (by Andrew Rathbun): AceText - Clipboard History"
+    type: bool
+  - name: AcronisTrueImage
+    description: "Acronis True Image (by Andrew Rathbun): Acronis True Image - Database Files, Acronis True Image - Logs, Acronis True Image - Scripts Folder"
+    type: bool
+  - name: Amcache
+    description: "Amcache.hve (by Eric Zimmerman): Amcache, Amcache, Amcache transaction files, Amcache transaction files"
+    type: bool
+  - name: Ammyy
+    description: "Ammyy Data (by Drew Ervin): Ammyy Program Data"
+    type: bool
+  - name: Antivirus
+    description: "Antivirus (by Andrew Rathbun): AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, ComboFix, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Emsisoft Scan Logs, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, RogueKiller Reports, SUPERAntiSpyware Logs, SecureAge Antvirus Logs, SentinelOne EDR Log, Sophos Logs, Sophos Logs (XP), Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Webroot Program Data, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, ccSubSDK Database, registrationInfo.xml"
+    type: bool
+  - name: AnyDesk
+    description: "AnyDesk (by Andrew Rathbun, Scott Hanson, and Nicole Jao): AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos"
+    type: bool
+  - name: ApacheAccessLog
+    description: "Apache Access Log (by Hadar Yudovich): Apache Access Log"
+    type: bool
+  - name: AppData
+    description: "AppData (by Phill Moore): AppData"
+    type: bool
+  - name: ApplicationEvents
+    description: "Windows Application Event Log (by Drew Ervin): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP"
+    type: bool
+  - name: AsperaConnect
+    description: "Aspera Connect Log Files (by Dennis Reneau): Aspera Client Logs, Aspera Server Logs"
+    type: bool
+  - name: Avast
+    description: "Avast Antivirus Data (by Drew Ervin): Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs"
+    type: bool
+  - name: AviraAVLogs
+    description: "Avira Logs (by Fabian Murer): Avira Activity Logs"
+    type: bool
+  - name: BCD
+    description: "Boot Configuration Files (by Troy Larson): BCD, BCD Logs"
+    type: bool
+  - name: BITS
+    description: "Microsoft BITS (Background Intelligent Transer Service) persistent files (by Jos Clephas): BITS files"
+    type: bool
+  - name: BitTorrent
+    description: "BitTorrent (by Banaanhangwagen): TorrentClients - BitTorrent"
+    type: bool
+  - name: Bitdefender
+    description: "Bitdefender Antivirus Data (by Drew Ervin, Ahmed Elshaer): Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files"
+    type: bool
+  - name: BoxDrive_Metadata
+    description: "Box Cloud Storage Metadata (by Chad Tilbury): Box Drive Application Metadata, Box Sync Application Metadata"
+    type: bool
+  - name: BoxDrive_UserFiles
+    description: "Box Cloud Storage Files (by Chad Tilbury): Box Drive User Files, Box Sync User Files"
+    type: bool
+  - name: BrowserCache
+    description: "Browser Caches (by Bjorn Vanhaeren): Chrome Cache Folder, Edge WebcacheV01.dat, Firefox Cache Folder, IE 11 Cache, IE 9/10 Cache, IE Index.dat temp internet files"
+    type: bool
+  - name: CertUtil
+    description: "Certutil (by NVISO (@NVISOsecurity)): INetCache, System CryptnetUrlCache, User CryptnetUrlCache"
+    type: bool
+  - name: Chrome
+    description: "Chrome (by Eric Zimmerman and Andrew Rathbun): Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Windows Protect Folder"
+    type: bool
+  - name: ChromeExtensions
+    description: "Chrome Extension Files (by piesecurity): Chrome Extension Files, Chrome Extension Files XP"
+    type: bool
+  - name: ChromeFileSystem
+    description: "Chrome HTML5 File System Contents (by Chad Tilbury): Chrome HTML5 File System Folder"
+    type: bool
+  - name: CiscoJabber
+    description: "Jabber (by Andrew Bannon): Cisco Jabber Database"
+    type: bool
+  - name: ClipboardMaster
+    description: "ClipboardMaster (by Andrew Rathbun): ClipboardMaster - Clipboard History - Backups, ClipboardMaster - Clipboard History - Images, ClipboardMaster - Clipboard History - Text"
+    type: bool
+  - name: CloudStorage_All
+    description: "Cloud Storage Contents and Metadata (by Chad Tilbury and Andrew Rathbun): Box Drive Application Metadata, Box Drive User Files, Box Sync Application Metadata, Box Sync User Files, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox User Files, Google Drive Backup and Sync Metadata, Google Drive Backup and Sync User Files, Google Drive for Desktop Metadata, OneDrive Metadata Logs, OneDrive Metadata Settings, OneDrive User Files, SugarSync - My SugarSync (Default Location), SugarSync - Shared Folders (Default Location), SugarSync Log File, Windows Protect Folder, pCloud Database, pCloud Database Shared Memory File, pCloud Database WAL File"
+    type: bool
+  - name: CloudStorage_Metadata
+    description: "Cloud Storage Metadata (by Chad Tilbury and Andrew Rathbun): Box Drive Application Metadata, Box Sync Application Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata, OneDrive Metadata Logs, OneDrive Metadata Settings, Windows Protect Folder"
+    type: bool
+  - name: CombinedLogs
+    description: "Collect Event logs, Trace logs, Windows Firewall and PowerShell console (by Mike Cary, Mark Hallman added the USBDevicelogs target): Delivery Optimization Trace Logs, Energy-NTKL Trace Logs, Event logs Win7+, Event logs Win7+, Event logs XP, PowerShell Console Log, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, SleepStudy Trace Logs, SleepStudy Trace Logs, WDI Trace Logs 1, WDI Trace Logs 1, WDI Trace Logs 2, WDI Trace Logs 2, WMI Trace Logs, WMI Trace Logs, Windows Firewall Logs, Windows Firewall Logs"
+    type: bool
+  - name: ComboFix
+    description: "ComboFix Antivirus Data (by Drew Ervin): ComboFix"
+    type: bool
+  - name: ConfluenceLogs
+    description: "Confluence Log Files (by Eric Capuano): Confluence Wiki Log Files, Confluence Wiki Log Files"
+    type: bool
+  - name: Cybereason
+    description: "Cybereason Sensor/Detection Logs (by piesecurity): Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs"
+    type: bool
+  - name: DC__
+    description: "DC++ (by Andrew Rathbun): DC++ Chat Logs"
+    type: bool
+  - name: Debian
+    description: "Debian on Windows Subsystem for Linux (by Matt Dawson): Debian WSL .bash_history, Debian WSL .bashrc, Debian WSL .profile, Debian WSL /etc/bash.bashrc, Debian WSL /etc/crontab, Debian WSL /etc/debian_version, Debian WSL /etc/fstab, Debian WSL /etc/group, Debian WSL /etc/hostname, Debian WSL /etc/hosts, Debian WSL /etc/os-release, Debian WSL /etc/passwd, Debian WSL /etc/profile, Debian WSL /etc/shadow, Debian WSL /etc/timezone, Debian WSL Apt Logs, Debian WSL User Crontabs"
+    type: bool
+  - name: DirectoryOpus
+    description: "Directory Opus (by Andrew Rathbun): Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus"
+    type: bool
+  - name: DirectoryTraversal_AudioFiles
+    description: "Find audio files covering a multitude of formats (by Andrew Rathbun): Audio files"
+    type: bool
+  - name: DirectoryTraversal_ExcelDocuments
+    description: "Find Excel and Excel alternative documents (by Andrew Rathbun): Excel and Excel-like Documents"
+    type: bool
+  - name: DirectoryTraversal_PDFDocuments
+    description: "Find PDF and PDF alternative documents (by Andrew Rathbun): PDF and PDF-like Documents"
+    type: bool
+  - name: DirectoryTraversal_PictureFiles
+    description: "Find picture files covering a multitude of formats (by Andrew Rathbun): Picture files"
+    type: bool
+  - name: DirectoryTraversal_SQLiteDatabases
+    description: "Find files with common SQLite file extensions (by Andrew Rathbun): SQLite Files (.db* and .sqlite*)"
+    type: bool
+  - name: DirectoryTraversal_VideoFiles
+    description: "Find video files covering a multitude of formats (by Andrew Rathbun): Video files"
+    type: bool
+  - name: DirectoryTraversal_WildCardExample
+    description: "Find zip archives (by Eric Zimmerman): Zips"
+    type: bool
+  - name: DirectoryTraversal_WordDocuments
+    description: "Find Word and Word alternative documents (by Andrew Rathbun): Word and Word-like Documents"
+    type: bool
+  - name: Discord
+    description: "Discord Cache and LevelDB Files (by Christian Johansen and Matt Dawson): Discord Cache Files, Discord Local Storage LevelDB Files"
+    type: bool
+  - name: DoubleCommander
+    description: "Double Commander (by Andrew Rathbun): Double Commander - FTP Log, Double Commander - doublecmd.xml, Double Commander - history.xml"
+    type: bool
+  - name: Dropbox_Metadata
+    description: "Dropbox Cloud Storage Metadata (by Chad Tilbury and Andrew Rathbun): Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Windows Protect Folder"
+    type: bool
+  - name: Dropbox_UserFiles
+    description: "Dropbox Cloud Storage Files (by Chad Tilbury): Dropbox User Files"
+    type: bool
+  - name: EFCommander
+    description: "EF Commander (by Andrew Rathbun): EF Commander - .ini File"
+    type: bool
+  - name: ESET
+    description: "ESET Antivirus Data (by Drew Ervin): ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP)"
+    type: bool
+  - name: Edge
+    description: "Edge (by Phill Moore): Edge folder"
+    type: bool
+  - name: EdgeChromium
+    description: "Microsoft Edge Chromium Artifacts (by Chad Tilbury): Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Windows Protect Folder"
+    type: bool
+  - name: Emsisoft
+    description: "Emsisoft Antivirus Logs (by blueskycyber): Emsisoft Scan Logs"
+    type: bool
+  - name: EncapsulationLogging
+    description: "EncapsulationLogging (by Troy Larson): EncapsulationLogging, EncapsulationLogging, EncapsulationLogging Logs, EncapsulationLogging Logs"
+    type: bool
+  - name: EventLogs_RDP
+    description: "Collect Win7+ RDP related Event logs (by Mark Hallman): Event logs Win7+, Event logs Win7+, Event logs Win7+, Event logs Win7+, Event logs Win7+, Event logs Win7+"
+    type: bool
+  - name: EventLogs
+    description: "Event logs (by Eric Zimmerman): Event logs Win7+, Event logs Win7+, Event logs XP"
+    type: bool
+  - name: EventTraceLogs
+    description: "Event Trace Logs (by Mark Hallman): Delivery Optimization Trace Logs, Energy-NTKL Trace Logs, SleepStudy Trace Logs, SleepStudy Trace Logs, WDI Trace Logs 1, WDI Trace Logs 1, WDI Trace Logs 2, WDI Trace Logs 2, WMI Trace Logs, WMI Trace Logs"
+    type: bool
+  - name: EventTranscriptDB
+    description: "EventTranscript.db (and other files related to Telemetry and Diagnostic Data) (by Andrew Rathbun and Josh Mitchell): EventTranscript.db, EventTranscript.db, Microsoft Office Diagnostic Logs"
+    type: bool
+  - name: Evernote
+    description: "Evernote (by Matt Dawson): Evernote Accounts, Evernote Notebook Snippets, Evernote Notebooks"
+    type: bool
+  - name: Everything__VoidTools_
+    description: "Everything (VoidTools) (by Andrew Rathbun): Everything (VoidTools), Everything (VoidTools) - Run History, Everything (VoidTools) - Search History"
+    type: bool
+  - name: EvidenceOfExecution
+    description: "Evidence of execution related files (by Eric Zimmerman): Amcache, Amcache, Amcache transaction files, Amcache transaction files, Prefetch, Prefetch, RecentFileCache, RecentFileCache, Syscache, Syscache transaction files"
+    type: bool
+  - name: Exchange
+    description: "Exchange Log Files (by Keith Twombley): Exchange TransportRoles log files, Exchange client access log files"
+    type: bool
+  - name: ExchangeClientAccess
+    description: "Exchange Client Access Log Files (by Keith Twombley): Exchange client access log files"
+    type: bool
+  - name: ExchangeCve_2021_26855
+    description: "Exchange Server Vulnerability *.Compiled Files (by Dennis Reneau): Exchange Server Modified Compiled Files, Exchange Server Modified Compiled Files, Exchange Server Modified Compiled Files, Exchange Server Modified Compiled Files"
+    type: bool
+  - name: ExchangeTransport
+    description: "Exchange Transport Log Files (by Keith Twombley): Exchange TransportRoles log files"
+    type: bool
+  - name: FSecure
+    description: "F-Secure Antivirus Data (by Drew Ervin): F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs"
+    type: bool
+  - name: FTPClients
+    description: "FTP Clients (by Andrew Rathbun): FileZilla Log Files, FileZilla SQLite3 Log Files, FileZilla Server XML Log Files, FileZilla XML Log Files, WinSCP (.ini file)"
+    type: bool
+  - name: Fences
+    description: "Fences (by Andrew Rathbun): Fences - Desktop Screenshots"
+    type: bool
+  - name: FileExplorerReplacements
+    description: "File Explorer Replacements (by Andrew Rathbun): Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Double Commander - FTP Log, Double Commander - doublecmd.xml, Double Commander - history.xml, EF Commander - .ini File, Free Commander - Backup Settings, Free Commander - FTP Log, Free Commander - FTP Related Information, Free Commander - FreeCommander.fav.xml, Free Commander - FreeCommander.ftp.ini, Free Commander - FreeCommander.hist.ini, Free Commander - FreeCommander.ini, Midnight Commander -- All Configuation Files, Multi Commander - Application Folder, Multi Commander - Config Folder, Multi Commander - Log File, Multi Commander - Log Folder, Multi Commander - UserData Folder, One Commander - All Configuration Files, One Commander - Other Configuration Files, Q-Dir - .ini File, Q-Dir - .qdr file, SpeedCommander - .ini File, Tablacus Explorer - remember.xml, Tablacus Explorer - window.xml, Tablacus Explorer - window1.xml, Total Commander - .ini File, Total Commander - FTP .ini File, Total Commander - FTP Logs, Total Commander - File Tree, Total Commander - Log File, Total Commander - Temp Files Created During Folder Traversal, XYplorer - .dat files, XYplorer - .ini file, XYplorer - .ini file for each respective pane, XYplorer - AutoBackup folder"
+    type: bool
+  - name: FileSystem
+    description: "File system metadata (by Eric Zimmerman): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T"
+    type: bool
+  - name: FileZillaClient
+    description: "FileZilla XML and SQLite Log Files (by Dennis Reneau): FileZilla SQLite3 Log Files, FileZilla XML Log Files"
+    type: bool
+  - name: FileZillaServer
+    description: "FileZilla Server Logs (by Andrew Rathbun): FileZilla Log Files, FileZilla Server XML Log Files"
+    type: bool
+  - name: Firefox
+    description: "Firefox (by Eric Zimmerman and Andrew Rathbun): Addons, Addons XP, Bookmarks, Bookmarks, Cookies, Cookies, Cookies XP, Downloads, Downloads XP, Extensions, Favicons, Favicons XP, Form history, Form history XP, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, Preferences, Protections, Search, Search XP, Sessionstore, Sessionstore Folder, Sessionstore XP, Signons, Signons XP, Storage Sync, Webappstore, Webappstore XP"
+    type: bool
+  - name: FreeCommander
+    description: "FreeCommander XE (by Andrew Rathbun): Free Commander - Backup Settings, Free Commander - FTP Log, Free Commander - FTP Related Information, Free Commander - FreeCommander.fav.xml, Free Commander - FreeCommander.ftp.ini, Free Commander - FreeCommander.hist.ini, Free Commander - FreeCommander.ini"
+    type: bool
+  - name: FreeDownloadManager
+    description: "Free Download Manager (by Matt Dawson): FDM Backup Info, FDM Database, FDM Database (userdata.zip)"
+    type: bool
+  - name: FreeFileSync
+    description: "FreeFileSync (by Andrew Rathbun): FreeFileSync"
+    type: bool
+  - name: Freenet
+    description: "Freenet (by Charlie Rubisoff): Freenet, Freenet, Freenet, Freenet, Freenet"
+    type: bool
+  - name: FrostWire
+    description: "FrostWire (by Andrew Rathbun): FrostWire AppData, FrostWire AppData, FrostWire Downloads"
+    type: bool
+  - name: Gigatribe
+    description: "Gigatribe Files (by Linus Nissi): Gigatribe Files Windows Vista/7/8/10, Gigatribe Files Windows XP, Gigatribe Files Windows XP"
+    type: bool
+  - name: GoogleDriveBackupSync_UserFiles
+    description: "Google Backup and Sync Storage Files (by Chad Tilbury): Google Drive Backup and Sync User Files"
+    type: bool
+  - name: GoogleDrive_Metadata
+    description: "Google Drive Metadata (by Chad Tilbury): Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata"
+    type: bool
+  - name: GroupPolicy
+    description: "Current Group Policy Enforcement (by piesecurity): Local Group Policy Files - Registry Policy Files, Local Group Policy Files - Registry Policy Files, Local Group Policy Files - Startup/Shutdown Scripts, Local Group Policy Files - Startup/Shutdown Scripts, Local Group Policy INI Files, Local Group Policy INI Files"
+    type: bool
+  - name: HeidiSQL
+    description: "HeidiSQL (by Hyun Yi @hyuunnn): HeidiSQL (tabs.ini), HeidiSQL Backup files (*.sql)"
+    type: bool
+  - name: HexChat
+    description: "HexChat (by Andrew Rathbun): HexChat Chat Logs"
+    type: bool
+  - name: HitmanPro
+    description: "HitmanPro Antivirus Data (by Drew Ervin): HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs"
+    type: bool
+  - name: IISLogFiles
+    description: "IIS Log Files (by Troy Larson): IIS log files, IIS log files, IIS log files, IIS log files, IIS log files"
+    type: bool
+  - name: IRCClients
+    description: "IRC Clients (by Andrew Rathbun): HexChat Chat Logs, IceChat Chat Logs, mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+)"
+    type: bool
+  - name: IceChat
+    description: "IceChat (by Andrew Rathbun): IceChat Chat Logs"
+    type: bool
+  - name: InternetExplorer
+    description: "Internet Explorer (by Eric Zimmerman): IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Local Internet Explorer folder, Roaming Internet Explorer folder"
+    type: bool
+  - name: IrfanView
+    description: "IrfanView (by Andrew Rathbun): IrfanView Configuration File"
+    type: bool
+  - name: JDownloader2
+    description: "JDownloader 2 (by Matt Dawson): JDownloader 2.0 Download Lists, JDownloader 2.0 General Settings, JDownloader 2.0 Link Collector, JDownloader 2.0 Link Grabber Settings, JDownloader 2.0 Proxy Settings"
+    type: bool
+  - name: JavaWebCache
+    description: "Java WebStart Cache - (IDX Files) (by piesecurity): Java WebStart Cache System level, Java WebStart Cache System level, Java WebStart Cache System level (SysWow64), Java WebStart Cache System level (SysWow64), Java WebStart Cache System level (SysWow64) - IE Protected Mode, Java WebStart Cache System level (SysWow64) - IE Protected Mode, Java WebStart Cache System level - IE Protected Mode, Java WebStart Cache System level - IE Protected Mode, Java WebStart Cache User Level - Default, Java WebStart Cache User Level - IE Protected Mode, Java WebStart Cache User Level - XP"
+    type: bool
+  - name: Kali
+    description: "Kali on Windows Subsystem for Linux (by Matt Dawson): Kali WSL .bash_history, Kali WSL .bashrc, Kali WSL .profile, Kali WSL /etc/bash.bashrc, Kali WSL /etc/crontab, Kali WSL /etc/debian_version, Kali WSL /etc/fstab, Kali WSL /etc/group, Kali WSL /etc/hostname, Kali WSL /etc/hosts, Kali WSL /etc/os-release, Kali WSL /etc/passwd, Kali WSL /etc/profile, Kali WSL /etc/shadow, Kali WSL /etc/timezone, Kali WSL Apt Logs, Kali WSL User Crontabs"
+    type: bool
+  - name: KapeTriage
+    description: "Kape Triage collections that will collect most of the files needed for a DFIR Investigation.  This module pulls evidence from File System files, Registry Hives, Event Logs, Scheduled Tasks, Evidence of Execution, SRUM data, SUM data, Web Browser data (IE/Edge, Chrome, Mozilla history), LNK Files, Jump Lists, 3rd party remote access software logs, 3rd party antivirus software logs, Windows 10 Timeline database, and $I Recycle Bin data files. (by Scott Downie): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, ActivitiesCache.db, Addons, Addons XP, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, Bookmarks, Bookmarks, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, ComboFix, Cookies, Cookies, Cookies XP, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, Desktop LNK Files, Desktop LNK Files XP, Downloads, Downloads XP, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Emsisoft Scan Logs, Event logs Win7+, Event logs Win7+, Event logs XP, Extensions, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, Favicons, Favicons XP, Form history, Form history XP, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, PowerShell Console Log, Preferences, Prefetch, Prefetch, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RECYCLER - WinXP, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, Restore point LNK Files XP, Roaming Internet Explorer folder, RogueKiller Reports, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SUM Database (.mdb files), SUPERAntiSpyware Logs, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Search, Search XP, SecureAge Antvirus Logs, SentinelOne EDR Log, Sessionstore, Sessionstore Folder, Sessionstore XP, Signons, Signons XP, Sophos Logs, Sophos Logs (XP), Storage Sync, Supremo Connection Logs, Supremo File Transfer Inbox, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, UsrClass.dat registry hive, UsrClass.dat registry transaction files, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Webappstore, Webappstore XP, Webroot Program Data, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Protect Folder, Windows Protect Folder, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, ccSubSDK Database, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings, registrationInfo.xml"
+    type: bool
+  - name: Kaseya
+    description: "Kaseya Data (by Drew Ervin and Andrew Rathbun): Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log"
+    type: bool
+  - name: LNKFilesAndJumpLists
+    description: "LNK Files and jump lists (by Eric Zimmerman and Andrew Rathbun): Desktop LNK Files, Desktop LNK Files XP, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Restore point LNK Files XP"
+    type: bool
+  - name: LinuxOnWindowsProfileFiles
+    description: "Linux on Windows Profile Files (by Troy Larson): .bash_history, .bash_logout, .bashrc, .profile"
+    type: bool
+  - name: LiveUserFiles
+    description: "Live User Files (by Mark Hallman): User Files - Desktop, User Files - Documents, User Files - Downloads, User Files - Dropbox"
+    type: bool
+  - name: LogFiles
+    description: "LogFiles (includes SUM) (by Fabian Murer): LogFiles, LogFiles"
+    type: bool
+  - name: LogMeIn
+    description: "LogMeIn Data (by Drew Ervin): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, LogMeIn Application Logs, LogMeIn ProgramData Logs"
+    type: bool
+  - name: MOF
+    description: "MOF files (WMI) (by Eric Zimmerman): MOF files"
+    type: bool
+  - name: MSSQLErrorLog
+    description: "MS SQL ErrorLogs (by Troy Larson): MS SQL Errorlog, MS SQL Errorlogs"
+    type: bool
+  - name: MacriumReflect
+    description: "Macrium Reflect (by Andrew Rathbun): Macrium Reflect, Macrium Reflect, Macrium Reflect"
+    type: bool
+  - name: Malwarebytes
+    description: "Malwarebytes Data (by Drew Ervin & Kirtan Shah): MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs"
+    type: bool
+  - name: ManageEngineLogs
+    description: "ManageEngine Desktop Central Log Files (by Whitney Champion): ManageEngine Desktop Central Log Files"
+    type: bool
+  - name: Mattermost
+    description: "Mattermost (by Andrew Rathbun): Mattermost - Chat Logs"
+    type: bool
+  - name: McAfee
+    description: "McAfee Log Files (by Sam Smoker): McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs"
+    type: bool
+  - name: McAfee_ePO
+    description: "McAfee ePO Log Files (by Doug Metz): McAfee ePO Logs"
+    type: bool
+  - name: MediaMonkey
+    description: "MediaMonkey (by Andrew Rathbun): MediaMonkey - Media SQLite Database, MediaMonkey - MediaMonkey.ini"
+    type: bool
+  - name: MemoryFiles
+    description: "Memory Files (by Ahmed Elshaer, Teo Kia Meng): Small Memory Dump directory, Small Memory Dump directory, hiberfil.sys, pagefile.sys, swapfile.sys"
+    type: bool
+  - name: MessagingClients
+    description: "Messaging and communication apps (by Gregor Wegberg): Cisco Jabber Database, Discord Cache Files, Discord Local Storage LevelDB Files, HexChat Chat Logs, IceChat Chat Logs, Mattermost - Chat Logs, Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11), Signal Attachments cache, Signal Database, Signal Logs, Signal config.json, Skype for Destkop v8+ Chromium Cache, Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage, Telegram app folder, Telegram downloaded files, Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache, WhatsApp Cache, WhatsApp Local Storage, leveldb (Skype for Desktop +v8), mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
+    type: bool
+  - name: MicrosoftOneNote
+    description: "Microsoft OneNote (by Andrew Rathbun): Microsoft OneNote - AccessibilityCheckerIndex, Microsoft OneNote - FullTextSearchIndex, Microsoft OneNote - RecentNotebooks_SeenURLs, Microsoft OneNote - RecentSearches, Microsoft OneNote - User NoteTags"
+    type: bool
+  - name: MicrosoftStickyNotes
+    description: "Microsoft Sticky Notes (by Andrew Rathbun): Microsoft Sticky Notes - 1607 and later, Microsoft Sticky Notes - Windows 7, 8, and 10 version 1511 and earlier"
+    type: bool
+  - name: MicrosoftTeams
+    description: "Microsoft Teams (by Matt Dawson and Andrew Rathbun): Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11)"
+    type: bool
+  - name: MicrosoftToDo
+    description: "Microsoft To Do (by Andrew Rathbun): Microsoft To Do - SQLite Database of To Do tasks, Microsoft To Do - User Avatar"
+    type: bool
+  - name: MidnightCommander
+    description: "Midnight Commander (by Andrew Rathbun): Midnight Commander -- All Configuation Files"
+    type: bool
+  - name: MiniTimelineCollection
+    description: "MFT, Registry and Event Logs to generate a mini timeline (by Mari DeGrazia): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, Event logs Win7+, Event logs Win7+, Event logs XP, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, RegBack registry transaction files, RegBack registry transaction files, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), UsrClass.dat registry hive, UsrClass.dat registry transaction files"
+    type: bool
+  - name: MultiCommander
+    description: "Multi Commander (by Andrew Rathbun): Multi Commander - Application Folder, Multi Commander - Config Folder, Multi Commander - Log File, Multi Commander - Log Folder, Multi Commander - UserData Folder"
+    type: bool
+  - name: NGINXLogs
+    description: "NGINX Log Files (by Eric Capuano): NGINX Log Files"
+    type: bool
+  - name: NZBGet
+    description: "NZBGet (by Andrew Rathbun): Usenet Clients - NZBGet Log File, Usenet Clients - NZBGet NZBs"
+    type: bool
+  - name: Nessus
+    description: "Nessus (by Andrew Rathbun): Nessus Logs, Nessus Logs"
+    type: bool
+  - name: NewsbinPro
+    description: "Newsbin Pro (by Andrew Rathbun): Usenet Clients - Newsbin Pro"
+    type: bool
+  - name: Newsleecher
+    description: "Newsleecher (by Andrew Rathbun): Usenet Clients - Newsleecher"
+    type: bool
+  - name: Nicotine__
+    description: "Nicotine++ (by Andrew Rathbun): Nicotine++ Buddyfileindex.db, Nicotine++ Buddyfiles.db, Nicotine++ Buddymtimes.db, Nicotine++ Buddystreams.db, Nicotine++ Buddywordindex.db, Nicotine++ Config Files, Nicotine++ Downloads.json, Nicotine++ Incomplete Downloads, Nicotine++ Logs, Nicotine++ Uploads.json, Nicotine++ User Shares"
+    type: bool
+  - name: Notepad__
+    description: "Notepad++ Backups, recently searched/replaced terms and recently opened documents (by Banaanhangwagen and Matt Dawson): Notepad++ Config, Notepad++ Unsaved Edits"
+    type: bool
+  - name: OfficeAutosave
+    description: "Office Autosave (by Russ Taylor): Excel Autosave Location, Powerpoint Autosave Location, Publisher Autosave Location, Word Autosave Location"
+    type: bool
+  - name: OfficeDocumentCache
+    description: "Office Document Cache (by Banaanhangwagen): Office Document Cache"
+    type: bool
+  - name: OneCommander
+    description: "One Commander (by Andrew Rathbun): One Commander - All Configuration Files, One Commander - Other Configuration Files"
+    type: bool
+  - name: OneDrive_Metadata
+    description: "Microsoft OneDrive Storage Metadata (by Chad Tilbury): OneDrive Metadata Logs, OneDrive Metadata Settings"
+    type: bool
+  - name: OneDrive_UserFiles
+    description: "Microsoft OneDrive Storage Files (by Chad Tilbury): OneDrive User Files"
+    type: bool
+  - name: OpenSSHClient
+    description: "OpenSSH Client config, known hosts and keys (by Matt Dawson): OpenSSH Config File, OpenSSH Default Private Key, OpenSSH Known Hosts, OpenSSH Public Keys"
+    type: bool
+  - name: OpenSSHServer
+    description: "OpenSSH Server Config and Logs (by Matt Dawson): OpenSSH Authorized Administrator Keys, OpenSSH Host DSA Key, OpenSSH Host ECDSA Key, OpenSSH Host ED25519 Key, OpenSSH Host RSA Key, OpenSSH Server Config File, OpenSSH Server Logs, OpenSSH User Authorized Keys, OpenSSH User Authorized Keys 2"
+    type: bool
+  - name: OpenVPNClient
+    description: "OpenVPN Client Config and Log (by Mathias Frank): OpenVPN Client Config, OpenVPN Client Config, OpenVPN Client Config"
+    type: bool
+  - name: Opera
+    description: "Opera (by Andrew Rathbun): Opera - Local Folder, Opera - Roaming Folder"
+    type: bool
+  - name: OutlookPSTOST
+    description: "Outlook PST and OST files (by Eric Zimmerman and Chad Tilbury): NST, OST, OST (2013 or 2016), OST XP, Outlook Attachment Temporary Storage, PST, PST (2013 or 2016), PST XP"
+    type: bool
+  - name: P2PClients
+    description: "P2P Clients (by Andrew Rathbun): DC++ Chat Logs, FrostWire AppData, FrostWire AppData, FrostWire Downloads, Gigatribe Files Windows Vista/7/8/10, Gigatribe Files Windows XP, Gigatribe Files Windows XP, Shareaza Logs, Soulseek Chat Logs, Soulseek Search History/Shared Folders/Settings"
+    type: bool
+  - name: PeaZip
+    description: "PeaZip (by Andrew Rathbun): PeaZip Configuration Files"
+    type: bool
+  - name: PowerShellConsole
+    description: "PowerShell Console Log File (by Mike Cary): PowerShell Console Log"
+    type: bool
+  - name: Prefetch
+    description: "Prefetch files (by Eric Zimmerman): Prefetch, Prefetch"
+    type: bool
+  - name: ProtonVPN
+    description: "ProtonVPN (by Andrew Rathbun): ProtonVPN - Connection Logs"
+    type: bool
+  - name: PuffinSecureBrowser
+    description: "Puffin Secure Browser (by Andrew Rathbun): Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db"
+    type: bool
+  - name: Q_Dir
+    description: "Q-Dir (by Andrew Rathbun): Q-Dir - .ini File, Q-Dir - .qdr file"
+    type: bool
+  - name: QFinderPro__QNAP_
+    description: "QFinderPro (QNAP) (by Andrew Rathbun): QFinderPro"
+    type: bool
+  - name: RDPCache
+    description: "RDP Cache Files (by Hadar Yudovich): RDP Cache Files, RDP Cache Files"
+    type: bool
+  - name: RDPLogs
+    description: "RDP Logs (by Drew Ervin): LocalSessionManager Event Logs, LocalSessionManager Event Logs, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs"
+    type: bool
+  - name: Radmin
+    description: "Radmin Server/Viewer Logs and Chats (by Mathias Frank): Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats"
+    type: bool
+  - name: RecentFileCache
+    description: "RecentFileCache (by Eric Zimmerman): RecentFileCache, RecentFileCache"
+    type: bool
+  - name: RecycleBin
+    description: "Recycle Bin DataAndInfo (by Mark Hallman / Joshua Hickman): RECYCLER - WinXP, RECYCLER - WinXP, Recycle Bin - Windows Vista+, Recycle Bin - Windows Vista+"
+    type: bool
+  - name: RecycleBin_DataFiles
+    description: "Recycle Bin Data Files (by Joshua Hickman, Andreas Hunkeler (@Karneades)): RECYCLER - WinXP, Recycle Bin - Windows Vista+"
+    type: bool
+  - name: RecycleBin_InfoFiles
+    description: "Recycle Bin Info Files (by Joshua Hickman, Andreas Hunkeler (@Karneades)): RECYCLER - WinXP, Recycle Bin - Windows Vista+"
+    type: bool
+  - name: RegistryHives
+    description: "System and user related Registry hives (by Eric Zimmerman): Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, RegBack registry transaction files, RegBack registry transaction files, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), UsrClass.dat registry hive, UsrClass.dat registry transaction files"
+    type: bool
+  - name: RegistryHivesOther
+    description: "Other Registry Hives (by Andrew Rathbun): BBI registry hive, BBI registry hive, BBI registry transaction files, BBI registry transaction files, BCD-Template registry hive, BCD-Template registry hive, BCD-Template registry transaction files, BCD-Template registry transaction files, COMPONENTS registry hive, COMPONENTS registry hive, COMPONENTS registry transaction files, COMPONENTS registry transaction files, DRIVERS registry hive, DRIVERS registry hive, DRIVERS registry transaction files, DRIVERS registry transaction files, ELAM registry hive, ELAM registry hive, ELAM registry transaction files, ELAM registry transaction files, VSMIDK registry hive, VSMIDK registry hive, VSMIDK registry transaction files, VSMIDK registry transaction files, userdiff registry hive, userdiff registry hive, userdiff registry transaction files, userdiff registry transaction files"
+    type: bool
+  - name: RegistryHivesSystem
+    description: "System level/related Registry hives (by Eric Zimmerman / Mark Hallman): Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, RegBack registry transaction files, RegBack registry transaction files, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP)"
+    type: bool
+  - name: RegistryHivesUser
+    description: "User Related Registry hives (by Eric Zimmerman / Mark Hallman): NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, UsrClass.dat registry hive, UsrClass.dat registry transaction files"
+    type: bool
+  - name: RemoteAdmin
+    description: "Composite target for files related to remote administration tools (by Drew Ervin, Mathias Frank, Andrew Rathbun): Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Supremo Connection Logs, Supremo File Transfer Inbox, TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings"
+    type: bool
+  - name: RogueKiller
+    description: "RogueKiller Anti-Malware (by Adlice Software) (by Drew Ervin): RogueKiller Reports"
+    type: bool
+  - name: SABnbzd
+    description: "SABnbzd (by Andrew Rathbun): Usenet Clients - SABnzbd Download Logs, Usenet Clients - SABnzbd History.db"
+    type: bool
+  - name: SDB
+    description: "Shim SDB FIles (by Troy Larson): SDB Files, SDB Files, SDB Files x64, SDB Files x64"
+    type: bool
+  - name: SOFELK
+    description: "SOF-ELK related files of interest (by Tony Knutson and Andrew Rathbun): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Desktop LNK Files, Desktop LNK Files XP, Event logs Win7+, Event logs Win7+, Event logs XP, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Prefetch, Prefetch, RecentFileCache, RecentFileCache, Restore point LNK Files XP, Syscache, Syscache transaction files"
+    type: bool
+  - name: SQLiteDatabases
+    description: "SQLDatabases Target for use with SQLECmd Module (by Andrew Rathbun): 4K Video Downloader, ActivitiesCache.db, Addons, Bitdefender SQLite DB Files, Bookmarks, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Cookies, Cookies, Downloads, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, EventTranscript.db, EventTranscript.db, Favicons, FileZilla SQLite3 Log Files, Form history, Google File Stream Metadata, Google File Stream Metadata, Google File Stream Metadata, Google File Stream Metadata, Microsoft OneNote - AccessibilityCheckerIndex, Microsoft OneNote - FullTextSearchIndex, Microsoft OneNote - RecentNotebooks_SeenURLs, Microsoft OneNote - RecentSearches, Microsoft OneNote - User NoteTags, Microsoft Sticky Notes - 1607 and later, Microsoft To Do - SQLite Database of To Do tasks, Permissions, Places, Protections, Search, Signons, Storage Sync, TeraCopy - History Databases, TeraCopy - Main Database, Update Store.db, Webappstore, Windows 10 Notification DB, Windows 10 Notification DB"
+    type: bool
+  - name: SRUM
+    description: "System Resource Usage Monitor (SRUM) Data (by Mark Hallman): SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM"
+    type: bool
+  - name: SUM
+    description: "SUM Database (by Andrew Rathbun): SUM Database (.mdb files)"
+    type: bool
+  - name: SUPERAntiSpyware
+    description: "SUPERAntiSpyware Data (by Drew Ervin): SUPERAntiSpyware Logs"
+    type: bool
+  - name: SUSELinuxEnterpriseServer
+    description: "SUSE Linux Enterprise Server on Windows Subsystem for Linux (by Matt Dawson): SUSE Linux Enterprise Server WSL .bash_history, SUSE Linux Enterprise Server WSL .bashrc, SUSE Linux Enterprise Server WSL .profile, SUSE Linux Enterprise Server WSL /etc/bash.bashrc, SUSE Linux Enterprise Server WSL /etc/fstab, SUSE Linux Enterprise Server WSL /etc/group, SUSE Linux Enterprise Server WSL /etc/hostname, SUSE Linux Enterprise Server WSL /etc/hosts, SUSE Linux Enterprise Server WSL /etc/os-release, SUSE Linux Enterprise Server WSL /etc/passwd, SUSE Linux Enterprise Server WSL /etc/profile, SUSE Linux Enterprise Server WSL /etc/shadow, SUSE Linux Enterprise Server WSL /etc/timezone"
+    type: bool
+  - name: ScheduledTasks
+    description: "Scheduled tasks (*.job and XML) (by Eric Zimmerman): XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt"
+    type: bool
+  - name: ScreenConnect
+    description: "ScreenConnect Data (now known as ConnectWise Control) (by Drew Ervin): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config"
+    type: bool
+  - name: SecureAge
+    description: "SecureAge Antivirus Logs (by Andrew Rathbun): SecureAge Antvirus Logs"
+    type: bool
+  - name: SentinelOne
+    description: "Sentinel One Logs (by Kirtan Shah): SentinelOne EDR Log"
+    type: bool
+  - name: ServerTriage
+    description: "A compound target for gathering artifacts common to servers. (by Eric Capuano): Apache Access Log, Confluence Wiki Log Files, Confluence Wiki Log Files, Exchange TransportRoles log files, Exchange client access log files, FileZilla Log Files, FileZilla Server XML Log Files, IIS log files, IIS log files, IIS log files, IIS log files, IIS log files, MS SQL Errorlog, MS SQL Errorlogs, ManageEngine Desktop Central Log Files, NGINX Log Files, OpenSSH Authorized Administrator Keys, OpenSSH Host DSA Key, OpenSSH Host ECDSA Key, OpenSSH Host ED25519 Key, OpenSSH Host RSA Key, OpenSSH Server Config File, OpenSSH Server Logs, OpenSSH User Authorized Keys, OpenSSH User Authorized Keys 2"
+    type: bool
+  - name: ShareX
+    description: "ShareX (by Andrew Rathbun): ShareX"
+    type: bool
+  - name: Shareaza
+    description: "Shareaza (by Andrew Rathbun): Shareaza Logs"
+    type: bool
+  - name: Signal
+    description: "Signal (Please view this tkape file for documentation on decryption!) (by Matt Dawson): Signal Attachments cache, Signal Database, Signal Logs, Signal config.json"
+    type: bool
+  - name: SignatureCatalog
+    description: "Obtain detached signature catalog files (by Mike Pilkington): SignatureCatalog, SignatureCatalog"
+    type: bool
+  - name: Skype
+    description: "Skype (by Eric Zimmerman, Matt Dawson): Skype for Destkop v8+ Chromium Cache, leveldb (Skype for Desktop +v8), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
+    type: bool
+  - name: Slack
+    description: "Slack (by Andrew Rathbun and Chad Tilbury): Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage"
+    type: bool
+  - name: Snagit
+    description: "Snagit (by Andrew Rathbun): Snagit - Captures"
+    type: bool
+  - name: Sophos
+    description: "Sophos Data (by Drew Ervin): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Sophos Logs, Sophos Logs (XP)"
+    type: bool
+  - name: Soulseek
+    description: "Soulseek (by Andrew Rathbun): Soulseek Chat Logs, Soulseek Search History/Shared Folders/Settings"
+    type: bool
+  - name: SpeedCommander
+    description: "SpeedCommander (by Andrew Rathbun): SpeedCommander - .ini File"
+    type: bool
+  - name: StartupInfo
+    description: "StartupInfo XML Files (by Hadar Yudovich): StartupInfo XML Files, StartupInfo XML Files"
+    type: bool
+  - name: SublimeText
+    description: "Sublime Text 2/3 Auto Save Session (by Mathias Frank): SublimeText 2/3 Auto Save Session"
+    type: bool
+  - name: SugarSync
+    description: "SugarSync (by Andrew Rathbun): SugarSync - My SugarSync (Default Location), SugarSync - Shared Folders (Default Location), SugarSync Log File"
+    type: bool
+  - name: SumatraPDF
+    description: "SumatraPDF (by Andrew Rathbun): SumatraPDF Cache, SumatraPDF Settings - SessionData"
+    type: bool
+  - name: SupremoRemoteDesktop
+    description: "Supremo Remote Desktop Control Logs (by Sandro Heckendorn): Supremo Connection Logs, Supremo File Transfer Inbox"
+    type: bool
+  - name: Symantec_AV_Logs
+    description: "Symantec AV Logs (by Brian Maloney): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, ccSubSDK Database, registrationInfo.xml"
+    type: bool
+  - name: Syscache
+    description: "syscache.hve (by Phill Moore): Syscache, Syscache transaction files"
+    type: bool
+  - name: TablacusExplorer
+    description: "Tablacus Explorer (by Andrew Rathbun): Tablacus Explorer - remember.xml, Tablacus Explorer - window.xml, Tablacus Explorer - window1.xml"
+    type: bool
+  - name: TeamViewerLogs
+    description: "TeamViewer Logs (by Hadar Yudovich): TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs"
+    type: bool
+  - name: Telegram
+    description: "Telegram Desktop (by Simone Marinari): Telegram app folder, Telegram downloaded files"
+    type: bool
+  - name: TeraCopy
+    description: "TeraCopy log history (by Kevin Pagano): TeraCopy"
+    type: bool
+  - name: ThumbCache
+    description: "Thumbcache DB (by Eric Zimmerman): Thumbcache DB"
+    type: bool
+  - name: Thunderbird
+    description: "Mozilla Thunderbird Email Client (by Matt Dawson): Mozilla Thunderbird Address Book, Mozilla Thunderbird Attachments, Mozilla Thunderbird Calendar Data, Mozilla Thunderbird Global Messages Database, Mozilla Thunderbird ImapMail INBOX, Mozilla Thunderbird Install Date, Mozilla Thunderbird Mail INBOX, Mozilla Thunderbird Profiles.ini, Mozilla Thunderbird logins.json, Mozilla Thunderbird places.sqlite, Mozilla Thunderbird prefs.js"
+    type: bool
+  - name: TorrentClients
+    description: "Torrent Clients (by Andrew Rathbun): TorrentClients - BitTorrent, TorrentClients - qBittorrent, TorrentClients - qBittorrent, TorrentClients - uTorrent"
+    type: bool
+  - name: Torrents
+    description: "Torrent Files (by Tony Knutson): Torrents"
+    type: bool
+  - name: TotalAV
+    description: "TotalAV Antivirus Data (by Kirtan Shah): TotalAV Logs, TotalAV Logs"
+    type: bool
+  - name: TotalCommander
+    description: "Total Commander (by Andrew Rathbun and Jessica Venturo): Total Commander - .ini File, Total Commander - FTP .ini File, Total Commander - FTP Logs, Total Commander - File Tree, Total Commander - Log File, Total Commander - Temp Files Created During Folder Traversal"
+    type: bool
+  - name: TreeSize
+    description: "TreeSize - Scan History (by Andrew Rathbun): TreeSize - ScanHistory.XML"
+    type: bool
+  - name: TrendMicro
+    description: "Trend Micro Data (by Drew Ervin): Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs"
+    type: bool
+  - name: USBDetective
+    description: "Collects files that can be input into USB Detective for parsing (by Kevin Pagano): Amcache, Amcache, Amcache transaction files, Amcache transaction files, Desktop LNK Files, Desktop LNK Files XP, Event logs Win7+, Event logs Win7+, Event logs XP, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, RegBack registry transaction files, RegBack registry transaction files, Restore point LNK Files XP, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), UsrClass.dat registry hive, UsrClass.dat registry transaction files"
+    type: bool
+  - name: USBDevicesLogs
+    description: "USB devices log files (by Eric Zimmerman): Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP"
+    type: bool
+  - name: Ubuntu
+    description: "Ubuntu on Windows Subsystem for Linux (by Matt Dawson): Ubuntu WSL .bash_history, Ubuntu WSL .bashrc, Ubuntu WSL .profile, Ubuntu WSL /etc/bash.bashrc, Ubuntu WSL /etc/crontab, Ubuntu WSL /etc/fstab, Ubuntu WSL /etc/group, Ubuntu WSL /etc/hostname, Ubuntu WSL /etc/hosts, Ubuntu WSL /etc/os-release, Ubuntu WSL /etc/passwd, Ubuntu WSL /etc/profile, Ubuntu WSL /etc/shadow, Ubuntu WSL /etc/timezone, Ubuntu WSL Apt Logs, Ubuntu WSL User Crontabs"
+    type: bool
+  - name: Usenet
+    description: "Usenet (NZB) Files (by Andrew Rathbun): Usenet (NZB) Files"
+    type: bool
+  - name: UsenetClients
+    description: "Usenet Clients (by Andrew Rathbun): Usenet Clients - NZBGet Log File, Usenet Clients - NZBGet NZBs, Usenet Clients - Newsbin Pro, Usenet Clients - Newsleecher, Usenet Clients - SABnzbd Download Logs, Usenet Clients - SABnzbd History.db"
+    type: bool
+  - name: VIPRE
+    description: "VIPRE Data (by Drew Ervin): VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+)"
+    type: bool
+  - name: VLC_Media_Player
+    description: "VLC Media Player (by Matt Dawson): VLC Recently Opened Files, VLC Recorded Files"
+    type: bool
+  - name: VMware
+    description: "Runs all VMware modules to collect VMware VM config files, logs and Virtual Hard Disks (by Matt Dawson): VDI, VHD, VHDX, VMDK, VMware (Fusion/Workstation/Server/Player), VMware (Fusion/Workstation/Server/Player), VMware (Fusion/Workstation/Server/Player), VMware - Virtual Machine Inventory"
+    type: bool
+  - name: VMwareInventory
+    description: "VMware - Virtual Machine Inventory (by Andrew Rathbun): VMware - Virtual Machine Inventory"
+    type: bool
+  - name: VMwareMemory
+    description: "VMware - Virtual Machine Memory (by Andrew Rathbun): VMware (Fusion/Workstation/Server/Player), VMware (Fusion/Workstation/Server/Player), VMware (Fusion/Workstation/Server/Player)"
+    type: bool
+  - name: VNCLogs
+    description: "VNC Logs (by Phill Moore): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, RealVNC Log"
+    type: bool
+  - name: Viber
+    description: "ViberPC Messaging App (by Matt Dawson): Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache"
+    type: bool
+  - name: VirtualBox
+    description: "Runs all VirtualBox modules to collect Virtualbox VM config files, logs and Virtual Hard Disks (by Matt Dawson): VDI, VHD, VHDX, VMDK, VirtualBox, VirtualBox Backup Logs, VirtualBox Hardening Logs, VirtualBox Logs, VirtualBox VM backup configs, VirtualBox VM configs"
+    type: bool
+  - name: VirtualBoxConfig
+    description: "Collects VirtualBox configuration files (by Matt Dawson): VirtualBox VM backup configs, VirtualBox VM configs"
+    type: bool
+  - name: VirtualBoxLogs
+    description: "Collects VirtualBox log files (by Matt Dawson): VirtualBox Backup Logs, VirtualBox Hardening Logs, VirtualBox Logs"
+    type: bool
+  - name: VirtualBoxMemory
+    description: "VirtualBox - Memory (by Andrew Rathbun): VirtualBox"
+    type: bool
+  - name: VirtualDisks
+    description: "Virtual Disks (by Phill Moore): VDI, VHD, VHDX, VMDK"
+    type: bool
+  - name: WBEM
+    description: "Web-Based Enterprise Management (WBEM) (by Mark Hallman): WBEM, WBEM"
+    type: bool
+  - name: WER
+    description: "Windows Error Reporting (by Troy Larson): Crash Dumps, Crash Dumps, Crash Dumps, WER Files"
+    type: bool
+  - name: WSL
+    description: "All Windows Subsystem for Linux targets (by Matt Dawson): Debian WSL .bash_history, Debian WSL .bashrc, Debian WSL .profile, Debian WSL /etc/bash.bashrc, Debian WSL /etc/crontab, Debian WSL /etc/debian_version, Debian WSL /etc/fstab, Debian WSL /etc/group, Debian WSL /etc/hostname, Debian WSL /etc/hosts, Debian WSL /etc/os-release, Debian WSL /etc/passwd, Debian WSL /etc/profile, Debian WSL /etc/shadow, Debian WSL /etc/timezone, Debian WSL Apt Logs, Debian WSL User Crontabs, Kali WSL .bash_history, Kali WSL .bashrc, Kali WSL .profile, Kali WSL /etc/bash.bashrc, Kali WSL /etc/crontab, Kali WSL /etc/debian_version, Kali WSL /etc/fstab, Kali WSL /etc/group, Kali WSL /etc/hostname, Kali WSL /etc/hosts, Kali WSL /etc/os-release, Kali WSL /etc/passwd, Kali WSL /etc/profile, Kali WSL /etc/shadow, Kali WSL /etc/timezone, Kali WSL Apt Logs, Kali WSL User Crontabs, SUSE Linux Enterprise Server WSL .bash_history, SUSE Linux Enterprise Server WSL .bashrc, SUSE Linux Enterprise Server WSL .profile, SUSE Linux Enterprise Server WSL /etc/bash.bashrc, SUSE Linux Enterprise Server WSL /etc/fstab, SUSE Linux Enterprise Server WSL /etc/group, SUSE Linux Enterprise Server WSL /etc/hostname, SUSE Linux Enterprise Server WSL /etc/hosts, SUSE Linux Enterprise Server WSL /etc/os-release, SUSE Linux Enterprise Server WSL /etc/passwd, SUSE Linux Enterprise Server WSL /etc/profile, SUSE Linux Enterprise Server WSL /etc/shadow, SUSE Linux Enterprise Server WSL /etc/timezone, Ubuntu WSL .bash_history, Ubuntu WSL .bashrc, Ubuntu WSL .profile, Ubuntu WSL /etc/bash.bashrc, Ubuntu WSL /etc/crontab, Ubuntu WSL /etc/fstab, Ubuntu WSL /etc/group, Ubuntu WSL /etc/hostname, Ubuntu WSL /etc/hosts, Ubuntu WSL /etc/os-release, Ubuntu WSL /etc/passwd, Ubuntu WSL /etc/profile, Ubuntu WSL /etc/shadow, Ubuntu WSL /etc/timezone, Ubuntu WSL Apt Logs, Ubuntu WSL User Crontabs, openSUSE WSL .bash_history, openSUSE WSL .bashrc, openSUSE WSL .profile, openSUSE WSL /etc/bash.bashrc, openSUSE WSL /etc/fstab, openSUSE WSL /etc/group, openSUSE WSL /etc/hostname, openSUSE WSL /etc/hosts, openSUSE WSL /etc/os-release, openSUSE WSL /etc/passwd, openSUSE WSL /etc/profile, openSUSE WSL /etc/shadow, openSUSE WSL /etc/timezone"
+    type: bool
+  - name: WebBrowsers
+    description: "Web browser history, bookmarks, etc. (by Eric Zimmerman): Addons, Addons XP, Bookmarks, Bookmarks, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Cookies, Cookies, Cookies XP, Downloads, Downloads XP, Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Extensions, Favicons, Favicons XP, Form history, Form history XP, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Local Internet Explorer folder, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, Preferences, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, Roaming Internet Explorer folder, Search, Search XP, Sessionstore, Sessionstore Folder, Sessionstore XP, Signons, Signons XP, Storage Sync, Webappstore, Webappstore XP, Windows Protect Folder, Windows Protect Folder"
+    type: bool
+  - name: WebServers
+    description: "Logs from all known web server applications and supporting services (by Eric Capuano): Apache Access Log, IIS log files, IIS log files, IIS log files, IIS log files, IIS log files, MS SQL Errorlog, MS SQL Errorlogs, NGINX Log Files"
+    type: bool
+  - name: Webroot
+    description: "Webroot Antivirus (by Drew Ervin): Webroot Program Data"
+    type: bool
+  - name: WhatsApp
+    description: "WhatsApp Local Files (by Matt Dawson): WhatsApp Cache, WhatsApp Local Storage"
+    type: bool
+  - name: WinSCP
+    description: "WinSCP (by Andrew Rathbun): WinSCP (.ini file)"
+    type: bool
+  - name: WindowsDefender
+    description: "Windows Defender Data (by Drew Ervin): Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs"
+    type: bool
+  - name: WindowsFirewall
+    description: "Windows Firewall Logs (by Mike Cary): Windows Firewall Logs, Windows Firewall Logs"
+    type: bool
+  - name: WindowsIndexSearch
+    description: "Windows Index Search (by Mark Hallman): WindowsIndexSearch"
+    type: bool
+  - name: WindowsNotificationsDB
+    description: "Windows 10 Notification DB (by Hadar Yudovich): Windows 10 Notification DB, Windows 10 Notification DB"
+    type: bool
+  - name: WindowsOSUpgradeArtifacts
+    description: "Windows OS Upgrade Artifacts (by Andrew Rathbun): FolderMoveLog.txt, HumanReadable.xml, MigLog.xml, Setupact.log, Update Store.db"
+    type: bool
+  - name: WindowsPowerDiagnostics
+    description: "Windows Power Diagnostics (by Andrew Rathbun): Windows Power Diagnostics"
+    type: bool
+  - name: WindowsSubsystemforAndroid
+    description: "Windows Subsystem for Android (WSA) (by Andrew Rathbun): App download artifacts (ICO), App download artifacts (PNG), Appcompatdb.json, Diagnostic Logs for WSA, userdata.vhdx"
+    type: bool
+  - name: WindowsTelemetryDiagnosticsLegacy
+    description: "Legacy Windows Telemetry and Diagnostics files (*.rbs) (by Andrew Rathbun and Josh Mitchell): Legacy .rbs files relating to Windows Telemetry and Diagnostics, Legacy .rbs files relating to Windows Telemetry and Diagnostics"
+    type: bool
+  - name: WindowsTimeline
+    description: "ActivitiesCache.db collector (by Lee Whitfield): ActivitiesCache.db"
+    type: bool
+  - name: WindowsYourPhone
+    description: "Windows Your Phone (by Andrew Rathbun): Windows Your Phone - All Databases"
+    type: bool
+  - name: XPRestorePoints
+    description: "XP Restore Points - System Volume Information directory (by Phill Moore): System Volume Information"
+    type: bool
+  - name: XYplorer
+    description: "XYplorer (by Andrew Rathbun): XYplorer - .dat files, XYplorer - .ini file, XYplorer - .ini file for each respective pane, XYplorer - AutoBackup folder"
+    type: bool
+  - name: iTunesBackup
+    description: "iTunes Backups (by Tony Knutson): iTunes Backup Folder, iTunes Backup Folder, iTunes Backup Folder - iOS13"
+    type: bool
+  - name: mIRC
+    description: "mIRC (by Andrew Rathbun): mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+)"
+    type: bool
+  - name: mRemoteNG
+    description: "mRemoteNG (by Markus Einarsson (@einarssonm)): mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings"
+    type: bool
+  - name: openSUSE
+    description: "openSUSE on Windows Subsystem for Linux (by Matt Dawson): openSUSE WSL .bash_history, openSUSE WSL .bashrc, openSUSE WSL .profile, openSUSE WSL /etc/bash.bashrc, openSUSE WSL /etc/fstab, openSUSE WSL /etc/group, openSUSE WSL /etc/hostname, openSUSE WSL /etc/hosts, openSUSE WSL /etc/os-release, openSUSE WSL /etc/passwd, openSUSE WSL /etc/profile, openSUSE WSL /etc/shadow, openSUSE WSL /etc/timezone"
+    type: bool
+  - name: pCloudDatabase
+    description: "pCloud Database (by Josh Hickman): pCloud Database, pCloud Database Shared Memory File, pCloud Database WAL File"
+    type: bool
+  - name: qBittorrent
+    description: "qBittorrent (by Banaanhangwagen): TorrentClients - qBittorrent, TorrentClients - qBittorrent"
+    type: bool
+  - name: uTorrent
+    description: "uTorrent (by Banaanhangwagen): TorrentClients - uTorrent"
+    type: bool
+
+  - name: KapeRules
+    type: hidden
+    description: A CSV file controlling the different Kape Target Rules
+    default: |
+      Id,Name,Category,Glob,Accessor,Comment
+      1,Chrome Cache Folder,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Cache/**10,lazy_ntfs,
+      2,Firefox Cache Folder,Communications,Users/*/AppData/Local/Mozilla/Firefox/Profiles/*/**10,lazy_ntfs,
+      3,IE 9/10 Cache,Communications,Users/*/AppData/Local/Microsoft/Windows/Temporary Internet Files/**10,lazy_ntfs,
+      4,IE Index.dat temp internet files,Communications,Documents and Settings/*/Local Settings/Temporary Internet Files/Content.IE5/index.dat,lazy_ntfs,
+      5,IE 11 Cache,Communications,Users/*/AppData/Local/Microsoft/Windows/INetCache/**10,lazy_ntfs,
+      6,Edge WebcacheV01.dat,Communications,Users/*/AppData/Local/Microsoft/Windows/WebCache/*,lazy_ntfs,
+      7,Chrome bookmarks XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Bookmarks*,lazy_ntfs,
+      8,Chrome Cookies XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Cookies*,lazy_ntfs,
+      9,Chrome Current Session XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Current Session,lazy_ntfs,
+      10,Chrome Current Tabs XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Current Tabs,lazy_ntfs,
+      11,Chrome Favicons XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Favicons*,lazy_ntfs,
+      12,Chrome History XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/History*,lazy_ntfs,
+      13,Chrome Last Session XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Last Session,lazy_ntfs,
+      14,Chrome Last Tabs XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Last Tabs,lazy_ntfs,
+      15,Chrome Login Data XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Login Data,lazy_ntfs,
+      16,Chrome Preferences XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Preferences,lazy_ntfs,
+      17,Chrome Shortcuts XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Shortcuts*,lazy_ntfs,
+      18,Chrome Top Sites XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Top Sites*,lazy_ntfs,
+      19,Chrome Visited Links XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Visited Links,lazy_ntfs,
+      20,Chrome Web Data XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Web Data*,lazy_ntfs,
+      21,Chrome bookmarks,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Bookmarks*,lazy_ntfs,
+      22,Chrome Cookies,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Cookies*,lazy_ntfs,
+      23,Chrome Current Session,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Current Session,lazy_ntfs,
+      24,Chrome Current Tabs,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Current Tabs,lazy_ntfs,
+      25,Chrome Download Metadata,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Download Metadata,lazy_ntfs,
+      26,Chrome Extension Cookies,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Extension Cookies,lazy_ntfs,
+      27,Chrome Favicons,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Favicons*,lazy_ntfs,
+      28,Chrome History,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/History*,lazy_ntfs,
+      29,Chrome Last Session,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Last Session,lazy_ntfs,
+      30,Chrome Last Tabs,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Last Tabs,lazy_ntfs,
+      31,Chrome Sessions Folder,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Sessions/*,lazy_ntfs,
+      32,Chrome Login Data,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data,lazy_ntfs,
+      33,Chrome Media History,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Media History*,lazy_ntfs,
+      34,Chrome Network Action Predictor,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Network Action Predictor,lazy_ntfs,
+      35,Chrome Network Persistent State,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Network Persistent State,lazy_ntfs,
+      36,Chrome Preferences,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Preferences,lazy_ntfs,
+      37,Chrome Quota Manager,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/QuotaManager,lazy_ntfs,
+      38,Chrome Reporting and NEL,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Reporting and NEL,lazy_ntfs,
+      39,Chrome Shortcuts,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Shortcuts*,lazy_ntfs,
+      40,Chrome Top Sites,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Top Sites*,lazy_ntfs,
+      41,Chrome Trust Tokens,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Trust Tokens*,lazy_ntfs,
+      42,Chrome SyncData Database,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Sync Data/SyncData.sqlite3,lazy_ntfs,
+      43,Chrome Visited Links,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Visited Links,lazy_ntfs,
+      44,Chrome Web Data,Communications,Users/*/AppData/Local/Google/Chrome/User Data/*/Web Data*,lazy_ntfs,
+      45,Windows Protect Folder,FileSystem,Users/*/AppData/Roaming/Microsoft/Protect/*/**10,lazy_ntfs,Required for offline decryption
+      46,Chrome Extension Files,Communication,Users/*/AppData/Local/Google/Chrome/User Data/*/Extensions/**10,lazy_ntfs,
+      47,Chrome Extension Files XP,Communications,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Extensions/**10,lazy_ntfs,
+      48,Chrome HTML5 File System Folder,Communication,Users/*/AppData/Local/Google/Chrome/User Data/*/File System/**10,lazy_ntfs,
+      49,Edge folder,Communications,Users/*/AppData/Local/Packages/Microsoft.MicrosoftEdge_8wekyb3d8bbwe/**10,lazy_ntfs,
+      50,Edge bookmarks,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Bookmarks*,lazy_ntfs,
+      51,Edge Collections,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Collections/collectionsSQLite,lazy_ntfs,
+      52,Edge Cookies,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Cookies*,lazy_ntfs,
+      53,Edge Current Session,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Current Session,lazy_ntfs,
+      54,Edge Current Tabs,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Current Tabs,lazy_ntfs,
+      55,Edge Favicons,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Favicons*,lazy_ntfs,
+      56,Edge History,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/History*,lazy_ntfs,
+      57,Edge Last Session,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Last Session,lazy_ntfs,
+      58,Edge Last Tabs,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Last Tabs,lazy_ntfs,
+      59,Edge Sessions Folder,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Sessions/*,lazy_ntfs,
+      60,Edge Login Data,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data,lazy_ntfs,
+      61,Edge Media History,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Media History*,lazy_ntfs,
+      62,Edge Network Action Predictor,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Network Action Predictor,lazy_ntfs,
+      63,Edge Preferences,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Preferences,lazy_ntfs,
+      64,Edge Shortcuts,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Shortcuts*,lazy_ntfs,
+      65,Edge Top Sites,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Top Sites*,lazy_ntfs,
+      66,Edge SyncData Database,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Sync Data/SyncData.sqlite3,lazy_ntfs,
+      67,Edge Bookmarks,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Bookmarks*,lazy_ntfs,
+      68,Edge Visited Links,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Visited Links,lazy_ntfs,
+      69,Edge Web Data,Communications,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Web Data*,lazy_ntfs,
+      70,Windows Protect Folder,FileSystem,Users/*/AppData/Roaming/Microsoft/Protect/*/**10,lazy_ntfs,Required for offline DPAPI decryption
+      71,Addons,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/addons.sqlite*,lazy_ntfs,
+      72,Bookmarks,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/weave/bookmarks.sqlite*,lazy_ntfs,
+      73,Bookmarks,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/bookmarkbackups/**10,lazy_ntfs,
+      74,Cookies,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/cookies.sqlite*,lazy_ntfs,
+      75,Cookies,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/firefox_cookies.sqlite*,lazy_ntfs,
+      76,Downloads,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/downloads.sqlite*,lazy_ntfs,
+      77,Extensions,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/extensions.json,lazy_ntfs,
+      78,Favicons,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/favicons.sqlite*,lazy_ntfs,
+      79,Form history,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/formhistory.sqlite*,lazy_ntfs,
+      80,Permissions,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/permissions.sqlite*,lazy_ntfs,
+      81,Places,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/places.sqlite*,lazy_ntfs,
+      82,Protections,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/protections.sqlite*,lazy_ntfs,
+      83,Search,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/search.sqlite*,lazy_ntfs,
+      84,Signons,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/signons.sqlite*,lazy_ntfs,
+      85,Storage Sync,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/storage-sync.sqlite*,lazy_ntfs,
+      86,Webappstore,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/webappstore.sqlite*,lazy_ntfs,
+      87,Password,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/key*.db,lazy_ntfs,
+      88,Password,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/signon*.*,lazy_ntfs,
+      89,Password,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/logins.json,lazy_ntfs,
+      90,Preferences,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/prefs.js,lazy_ntfs,
+      91,Sessionstore,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/sessionstore*,lazy_ntfs,
+      92,Sessionstore Folder,Communications,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/sessionstore-backups/**10,lazy_ntfs,
+      93,Places XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/places.sqlite*,lazy_ntfs,
+      94,Downloads XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/downloads.sqlite*,lazy_ntfs,
+      95,Form history XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/formhistory.sqlite*,lazy_ntfs,
+      96,Cookies XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/cookies.sqlite*,lazy_ntfs,
+      97,Signons XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/signons.sqlite*,lazy_ntfs,
+      98,Webappstore XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/webappstore.sqlite*,lazy_ntfs,
+      99,Favicons XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/favicons.sqlite*,lazy_ntfs,
+      100,Addons XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/addons.sqlite*,lazy_ntfs,
+      101,Search XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/search.sqlite*,lazy_ntfs,
+      102,Password XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/key*.db,lazy_ntfs,
+      103,Password XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/signon*.*,lazy_ntfs,
+      104,Password XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/logins.json,lazy_ntfs,
+      105,Sessionstore XP,Communications,Documents and Settings/*/Application Data/Mozilla/Firefox/Profiles/*/sessionstore*,lazy_ntfs,
+      106,Index.dat History,Communications,Documents and Settings/*/Local Settings/History/History.IE5/index.dat,lazy_ntfs,
+      107,Index.dat History subdirectory,Communications,Documents and Settings/*/Local Settings/History/History.IE5/*/index.dat,lazy_ntfs,
+      108,Index.dat cookies,Communications,Documents and Settings/*/Cookies/index.dat,lazy_ntfs,
+      109,Index.dat UserData,Communications,Documents and Settings/*/Application Data/Microsoft/Internet Explorer/UserData/index.dat,lazy_ntfs,
+      110,Index.dat Office XP,Communications,Documents and Settings/*/Application Data/Microsoft/Office/Recent/index.dat,lazy_ntfs,
+      111,Index.dat Office,Communications,Users/*/AppData/Roaming/Microsoft/Office/Recent/index.dat,lazy_ntfs,
+      112,Local Internet Explorer folder,Communications,Users/*/AppData/Local/Microsoft/Internet Explorer/**10,lazy_ntfs,
+      113,Roaming Internet Explorer folder,Communications,Users/*/AppData/Roaming/Microsoft/Internet Explorer/**10,lazy_ntfs,
+      114,IE 9/10 History,Communications,Users/*/AppData/Local/Microsoft/Windows/History/**10,lazy_ntfs,
+      115,IE 9/10 Cookies,Communications,Users/*/AppData/Local/Microsoft/Windows/Cookies/**10,lazy_ntfs,
+      116,IE 9/10 Download History,Communications,Users/*/AppData/Local/Microsoft/Windows/IEDownloadHistory/**10,lazy_ntfs,
+      117,IE 11 Metadata,Communications,Users/*/AppData/Local/Microsoft/Windows/WebCache/*,lazy_ntfs,
+      118,IE 11 Cookies,Communications,Users/*/AppData/Local/Microsoft/Windows/INetCookies/**10,lazy_ntfs,
+      119,Opera - Local Folder,Communications,Users/*/AppData/Local/Opera Software/Opera Stable/**10,lazy_ntfs,Grabs entire contents of the Opera AppData
+      ocal folder
+      120,Opera - Roaming Folder,Communications,Users/*/AppData/Roaming/Opera Software/Opera Stable/**10,lazy_ntfs,“Grabs entire contents of the Opera AppData\Roaming folder”
+      121,Puffin - data.db,Communications,Users/*/AppData/Local/PuffinSecureBrowser/data.db,lazy_ntfs,Grabs an important database file that contains browser history
+      122,Puffin - Autocomplete Data,Communications,Users/*/AppData/Local/PuffinSecureBrowser/autocompletes.dat,lazy_ntfs,Grabs a file that stores autocomplete data
+      123,Puffin - Password Forms Data,Communications,Users/*/AppData/Local/PuffinSecureBrowser/passwordForms.dat,lazy_ntfs,Grabs a file that stores some saved password data
+      124,Puffin - Password (Encrypted),Communications,Users/*/AppData/Local/PuffinSecureBrowser/credential.dat,lazy_ntfs,Grabs a file that stores passwords in an encrypted format
+      125,Puffin - Subscription Data,Communications,Users/*/AppData/Local/PuffinSecureBrowser/subscription,lazy_ntfs,Grabs a file that stores the user's email address that's associated with their Puffin subscription
+      126,Puffin - Cookies,Communications,Users/*/AppData/Local/PuffinSecureBrowser/cookies.dat,lazy_ntfs,Grabs a file that stores information related to cookies
+      127,Puffin - Image Cache,Communications,Users/*/AppData/Local/PuffinSecureBrowser/image_cache/**10,lazy_ntfs,Grabs a directory that caches images from websites visited
+      128,Apache Access Log,Webservers,**10/access.log,lazy_ntfs,
+      129,IIS log files,Logs,Windows/System32/LogFiles/W3SVC*/*.log,lazy_ntfs,
+      130,IIS log files,Logs,Windows.old/Windows/System32/LogFiles/W3SVC*/*.log,lazy_ntfs,
+      131,IIS log files,Logs,inetpub/logs/LogFiles/*.log,lazy_ntfs,
+      132,IIS log files,Logs,inetpub/logs/LogFiles/W3SVC*/*.log,lazy_ntfs,
+      133,IIS log files,Logs,Resources/Directory/*/LogFiles/Web/W3SVC*/*.log,lazy_ntfs,
+      134,MS SQL Errorlog,SQL Exploitation,Program Files/Microsoft SQL Server/*/MSSQL/LOG/ERRORLOG,lazy_ntfs,
+      135,MS SQL Errorlogs,SQL Exploitation,Program Files/Microsoft SQL Server/*/MSSQL/LOG/ERRORLOG.*,lazy_ntfs,
+      136,ManageEngine Desktop Central Log Files,Logs,ManageEngine/DesktopCentral_Server/logs/**10,lazy_ntfs,
+      137,NGINX Log Files,Logs,nginx/logs/*.log,lazy_ntfs,
+      138,PowerShell Console Log,PowerShellConsleLog,Users/*/AppData/Roaming/Microsoft/Windows/PowerShell/PSReadline/ConsoleHost_history.txt,lazy_ntfs,
+      139,AVG AV Logs (XP),Antivirus,Documents and Settings/All Users/Application Data/AVG/Antivirus/log/**10,lazy_ntfs,
+      140,AVG AV Report Logs (XP),Antivirus,Documents and Settings/All Users/Application Data/AVG/Antivirus/report/**10,lazy_ntfs,
+      141,AVG AV Logs,Antivirus,ProgramData/AVG/Antivirus/log/**10,lazy_ntfs,
+      142,AVG Report Logs,Antivirus,ProgramData/AVG/Antivirus/report/**10,lazy_ntfs,
+      143,Avast AV Logs (XP),Antivirus,Documents And Settings/All Users/Application Data/Avast Software/Avast/Log/**10,lazy_ntfs,
+      144,Avast AV Logs,Antivirus,ProgramData/Avast Software/Avast/Log/**10,lazy_ntfs,
+      145,Avast AV User Logs,Antivirus,Users/*/Avast Software/Avast/Log/**10,lazy_ntfs,
+      146,Avast AV Index,Antivirus,ProgramData/Avast Software/Avast/Chest/index.xml,lazy_ntfs,
+      147,Avira Activity Logs,AntiVirus,ProgramData/Avira/Antivirus/LOGFILES/**10,lazy_ntfs,Collects the scan logs of Avira AntiVirus
+      148,Bitdefender Endpoint Security Logs,Antivirus,ProgramData/Bitdefender/Endpoint Security/Logs/**10,lazy_ntfs,
+      149,Bitdefender Internet Security Logs,Antivirus,ProgramData/Bitdefender/Desktop/Profiles/Logs/**10,lazy_ntfs,
+      150,Bitdefender SQLite DB Files,Antivirus,Program Files*/Bitdefender*/**10/regex:*.+/.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
+      151,ComboFix,Antivirus,ComboFix.txt,lazy_ntfs,
+      152,Cybereason Anti-Ransomware Logs,AntiVirus,ProgramData/crs1/Logs/**10,lazy_ntfs,
+      153,Cybereason Sensor Communications and Anti-Malware Logs,AntiVirus,ProgramData/apv2/Logs/**10,lazy_ntfs,
+      154,Cybereason Application Control and NGAV Logs,AntiVirus,ProgramData/crb1/Logs/**10,lazy_ntfs,
+      155,ESET NOD32 AV Logs (XP),Antivirus,Documents and Settings/All Users/Application Data/ESET/ESET NOD32 Antivirus/Logs/**10,lazy_ntfs,
+      156,ESET NOD32 AV Logs,Antivirus,ProgramData/ESET/ESET NOD32 Antivirus/Logs/**10,lazy_ntfs,Parser available at https://github.com/laciKE/EsetLogParser
+      157,Emsisoft Scan Logs,ApplicationLogs,ProgramData/Emsisoft/Reports/scan*.txt,lazy_ntfs,Can contain file detection and quarantine info
+      158,F-Secure Logs,Antivirus,ProgramData/F-Secure/Log/**10,lazy_ntfs,
+      159,F-Secure User Logs,Antivirus,Users/*/AppData/Local/F-Secure/Log/**10,lazy_ntfs,
+      160,F-Secure Scheduled Scan Reports,Antivirus,ProgramData/F-Secure/Antivirus/ScheduledScanReports/**10,lazy_ntfs,
+      161,HitmanPro Logs,Antivirus,ProgramData/HitmanPro/Logs/**10,lazy_ntfs,
+      162,HitmanPro Alert Logs,Antivirus,ProgramData/HitmanPro.Alert/Logs/**10,lazy_ntfs,
+      163,HitmanPro Database,Antivirus,ProgramData/HitmanPro.Alert/excalibur.db,lazy_ntfs,SQLite DB
+      164,MalwareBytes Anti-Malware Logs,Antivirus,ProgramData/Malwarebytes/Malwarebytes Anti-Malware/Logs/mbam-log-*.xml,lazy_ntfs,
+      165,MalwareBytes Anti-Malware Service Logs,Antivirus,ProgramData/Malwarebytes/MBAMService/logs/mbamservice.log*,lazy_ntfs,
+      166,MalwareBytes Anti-Malware Scan Logs,Antivirus,Users/*/AppData/Roaming/Malwarebytes/Malwarebytes Anti-Malware/Logs/**10,lazy_ntfs,
+      167,MalwareBytes Anti-Malware Scan Results Logs,Antivirus,ProgramData/Malwarebytes/MBAMService/ScanResults/**10,lazy_ntfs,
+      168,McAfee Desktop Protection Logs XP,AntiVirus,Users/All Users/Application Data/McAfee/DesktopProtection/**10,lazy_ntfs,
+      169,McAfee Desktop Protection Logs,AntiVirus,ProgramData/McAfee/DesktopProtection/**10,lazy_ntfs,
+      170,McAfee Endpoint Security Logs,AntiVirus,ProgramData/McAfee/Endpoint Security/Logs/**10,lazy_ntfs,
+      171,McAfee Endpoint Security Logs,AntiVirus,ProgramData/McAfee/Endpoint Security/Logs_Old/**10,lazy_ntfs,
+      172,McAfee VirusScan Logs,AntiVirus,ProgramData/Mcafee/VirusScan/**10,lazy_ntfs,
+      173,McAfee ePO Logs,AntiVirus,ProgramData/McAfee/Endpoint Security/Logs/**10,lazy_ntfs,
+      174,RogueKiller Reports,Antivirus,ProgramData/RogueKiller/logs/AdliceReport_*.json,lazy_ntfs,
+      175,SUPERAntiSpyware Logs,Antivirus,Users/*/AppData/Roaming/SUPERAntiSpyware/Logs/**10,lazy_ntfs,
+      176,SecureAge Antvirus Logs,Antivirus,ProgramData/SecureAge Technology/SecureAge/log/**10,lazy_ntfs,
+      177,SentinelOne EDR Log,Antivirus,programdata/sentinel/logs/**10,lazy_ntfs,Logs are in Binary Format (.binlog)
+      178,Sophos Logs (XP),Antivirus,Documents and Settings/All Users/Application Data/Sophos/Sophos */Logs/**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+      179,Sophos Logs,Antivirus,ProgramData/Sophos/Sophos */Logs/**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+      180,Symantec Endpoint Protection Logs (XP),AntiVirus,Documents and Settings/All Users/Application Data/Symantec/Symantec Endpoint Protection/Logs/AV/**10,lazy_ntfs,
+      181,Symantec Endpoint Protection Logs,AntiVirus,ProgramData/Symantec/Symantec Endpoint Protection/*/Data/Logs/**10,lazy_ntfs,
+      182,Symantec Endpoint Protection User Logs,AntiVirus,Users/*/AppData/Local/Symantec/Symantec Endpoint Protection/Logs/**10,lazy_ntfs,
+      183,Symantec Event Log Win7+,EventLogs,Windows/System32/winevt/logs/Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
+      184,Symantec Event Log Win7+,EventLogs,Windows.old/Windows/System32/winevt/logs/Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
+      185,Symantec Endpoint Protection Quarantine (XP),AntiVirus,Documents and Settings/All Users/Application Data/Symantec/Symantec Endpoint Protection/Quarantine/**10,lazy_ntfs,
+      186,Symantec Endpoint Protection Quarantine,AntiVirus,ProgramData/Symantec/Symantec Endpoint Protection/*/Data/Quarantine/**10,lazy_ntfs,
+      187,ccSubSDK Database,AntiVirus,ProgramData/Symantec/Symantec Endpoint Protection/*/Data/CmnClnt/ccSubSDK/**10,lazy_ntfs,
+      188,registrationInfo.xml,AntiVirus,ProgramData/Symantec/Symantec Endpoint Protection/*/Data/registrationInfo.xml,lazy_ntfs,
+      189,TotalAV Logs,Antivirus,Program Files*/TotalAV/logs/**10,lazy_ntfs,
+      190,TotalAV Logs,Antivirus,ProgramData/TotalAV/logs/**10,lazy_ntfs,
+      191,Trend Micro Logs,Antivirus,ProgramData/Trend Micro/**10,lazy_ntfs,
+      192,Trend Micro Security Agent Report Logs,Antivirus,Program Files*/Trend Micro/Security Agent/Report/*.log,lazy_ntfs,
+      193,Trend Micro Security Agent Connection Logs,Antivirus,Program Files*/Trend Micro/Security Agent/ConnLog/*.log,lazy_ntfs,
+      194,VIPRE Business Agent Logs,Antivirus,ProgramData/VIPRE Business Agent/Logs/**10,lazy_ntfs,
+      195,VIPRE Business User Logs (v7+),Antivirus,Users/*/AppData/Roaming/VIPRE Business/**10,lazy_ntfs,
+      196,VIPRE Business User Logs (v5-v6),Antivirus,Users/*/AppData/Roaming/GFI Software/AntiMalware/Logs/**10,lazy_ntfs,
+      197,VIPRE Business User Logs (up to v4),Antivirus,Users/*/AppData/Roaming/Sunbelt Software/AntiMalware/Logs/**10,lazy_ntfs,
+      198,Webroot Program Data,Antivirus,ProgramData/WRData/WRLog.log,lazy_ntfs,
+      199,Windows Defender Logs,Antivirus,ProgramData/Microsoft/Microsoft AntiMalware/Support/**10,lazy_ntfs,
+      200,Windows Defender Event Logs,EventLogs,Windows/System32/winevt/Logs/Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
+      201,Windows Defender Event Logs,EventLogs,Windows.old/Windows/System32/winevt/Logs/Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
+      202,Windows Defender Logs,Antivirus,ProgramData/Microsoft/Windows Defender/Support/**10,lazy_ntfs,
+      203,Windows Defender Logs,Antivirus,Windows/Temp/MpCmdRun.log,lazy_ntfs,
+      204,Windows Defender Logs,Antivirus,Windows.old/Windows/Temp/MpCmdRun.log,lazy_ntfs,
+      205,AppData,UserData,Users/*/AppData/**10,lazy_ntfs,
+      206,Audio files,Multimedia,**10/regex:*.+/.(3gp|aa|aac|act|aiff|alac|amr|ape|au|awb|dss|dvf|flac|gsm|iklax|ivs|m4a|m4b|m4p|mmf|mp3|mpc|msv|nmf|ogg|oga|mogg|opus|ra|rm|raw|rf64|sln|tta|voc|vox|wav|wma|wv|webm),ntfs,Covers most (if not all) audio file formats
+      207,Excel and Excel-like Documents,Documents,**10/regex:*.+/.(xls|xlsx|csv|tsv|xlt|xlm|xlsm|xltx|xltm|xlsb|xla|xlam|xll|xlw|ods|fodp|qpw),ntfs,"Covers all document file formats for Excel, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
+      208,PDF and PDF-like Documents,Documents,**10/regex:*.+/.(pdf|xps|oxps),ntfs,Covers all PDF and PDF-like document formats
+      209,Picture files,Multimedia,**10/regex:*.+/.(ai|bmp|bpg|cdr|cpc|eps|exr|flif|gif|heif|ilbm|ima|jp2|j2k|jpf|jpm|jpg2|j2c|jpc|jpx|mj2jpeg|jpg|jxl|kra|ora|pcx|pgf|pgm|png|pnm|ppm|psb|psd|psp|svg|tga|tiff|webp|xaml|xcf),ntfs,Covers most (if not all) picture file formats
+      210,SQLite Files (.db* and .sqlite*),Databases,**10/regex:*.+/.(db*|sqlite*|),ntfs,Covers all common file extensions for SQLite databases
+      211,Video files,Multimedia,**10/regex:*.+/.(3g2|3gp|amv|asf|avi|drc|flv|f4v|f4p|f4a|f4b|gif|gifv|m4v|mkv|mov|qt|mp4|m4p|mpg|mpeg|m2v|mp2|mpe|mpv|mts|m2ts|ts|mxf|nsv|ogv|ogg|rm|rmvb|roq|svi|viv|vob|webm|wmv|yuv),ntfs,Covers most (if not all) video file formats
+      212,Zips,Archives,**10/*.zip,lazy_ntfs,This is an example of how to walk a drive for a file mask. Probably do not want to use this one as is
+      213,Word and Word-like Documents,Documents,**10/regex:*.+/.(doc|docx|docm|dotx|dotm|docb|dot|wbk|odt|fodt|rtf|wp*|tmd),ntfs,"Covers all document file formats for Word, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
+      214,User Files - Desktop,LiveUserFiles,Users/*/Desktop/**10,lazy_ntfs,
+      215,User Files - Documents,LiveUserFiles,Users/*/Documents/**10,lazy_ntfs,
+      216,User Files - Downloads,LiveUserFiles,Users/*/Downloads/**10,lazy_ntfs,
+      217,User Files - Dropbox,LiveUserFiles,Users/*/Dropbox*/**10,lazy_ntfs,
+      218,1Password Database,Apps,Users/*/AppData/Local/1password/data/1Password10.sqlite,lazy_ntfs,"Database which holds information about 1Password installation, such as accounts, categories, settings and more"
+      219,1Password Backup Databases,Apps,Users/*/AppData/Local/1password/backups/1Password10.sqlite,lazy_ntfs,Backups of 1Password Database
+      220,1Password Logs,Apps,Users/*/AppData/Local/1password/logs/*.log,lazy_ntfs,Log of usage of 1Password - can be useful for identifying periods of user activity
+      221,4K Video Downloader,Apps,Users/*/AppData/Local/4kdownload.com/4K Video Downloader/4K Video Downloader/*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
+      222,AceText - Clipboard History,Apps,Users/*/Documents/*.atc,lazy_ntfs,Locates the Clipboard history for AceText
+      223,Acronis True Image - Logs,Apps,ProgramData/Acronis/TrueImageHome/Logs/ti_demon/*,lazy_ntfs,Copies out all log files
+      224,Acronis True Image - Database Files,Apps,ProgramData/Acronis/TrueImageHome/Database/archives.db*,lazy_ntfs,Copies out the Database folder which appears to have important information
+      225,Acronis True Image - Scripts Folder,Apps,ProgramData/Acronis/TrueImageHome/Scripts/*,lazy_ntfs,Copies out all scripts files
+      226,Ammyy Program Data,ApplicationLogs,ProgramData/Ammyy/**10,lazy_ntfs,"May not contain traditional log files, but presence of this folder may indicate historical usage"
+      227,AnyDesk Logs - User Profile - *.trace,Communications,Users/*/AppData/Roaming/AnyDesk/*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from user profile
+      228,AnyDesk Logs - ProgramData - *.trace,Communications,ProgramData/AnyDesk/*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from programdata
+      229,AnyDesk Videos,Communications,Users/*/Videos/AnyDesk/*.anydesk,lazy_ntfs,Collects any session recordings made by the user while using AnyDesk
+      230,AnyDesk Logs - User Profile - connection_trace.txt,Communications,Users/*/AppData/Roaming/AnyDesk/connection_trace.txt,lazy_ntfs,Collects the connection trace log from user profile
+      231,AnyDesk Logs - ProgramData - connection_trace.txt,Communications,ProgramData/AnyDesk/connection_trace.txt,lazy_ntfs,Collects the connection trace log from ProgramData
+      232,AnyDesk Logs - System User Account,Communications,Windows/SysWOW64/config/systemprofile/AppData/Roaming/AnyDesk/*,lazy_ntfs,Collects the logs associated with the System user account
+      233,Aspera Client Logs,FileDownload,Users/*/AppData/Local/Aspera/Aspera Connect/var/log/**10/*.log,lazy_ntfs,
+      234,Aspera Server Logs,FileDownload,Users/*/.aspera/connect/var/log/**10/*.log,lazy_ntfs,
+      235,Box Drive Application Metadata,Apps,Users/*/AppData/Local/Box/Box/**10,lazy_ntfs,
+      236,Box Sync Application Metadata,Apps,Users/*/AppData/Local/Box Sync/**10,lazy_ntfs,
+      237,Box Drive User Files,Apps,Users/*/Box/**10,lazy_ntfs,Caution! This target will collect Box Drive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use or isolate system from network
+      238,Box Sync User Files,Apps,Users/*/Box Sync/**10,lazy_ntfs,
+      239,Cisco Jabber Database,Communications,Users/*/AppData/Local/Cisco/Unified Communications/Jabber/CSF/History/*.db,lazy_ntfs,The Cisco Jabber process needs to be killed before database can be copied.
+      240,ClipboardMaster - Clipboard History - Text,Apps,Users/*/AppData/Roaming/Jumping Bytes/ClipboardMaster/Clipboard.clm4,lazy_ntfs,Locates the user’s clipboard history (text) for ClipboardMaster
+      241,ClipboardMaster - Clipboard History - Images,Apps,Users/*/AppData/Roaming/Jumping Bytes/ClipboardMaster/pics/**10,lazy_ntfs,Locates the user’s clipboard history (images) for ClipboardMaster
+      242,ClipboardMaster - Clipboard History - Backups,Apps,Users/*/AppData/Roaming/Jumping Bytes/ClipboardMaster/Clipboard.clm4.ba*,lazy_ntfs,Locates the user’s clipboard history (backups) for ClipboardMaster
+      243,Confluence Wiki Log Files,Logs,Atlassian/Application Data/Confluence/logs/*.log*,lazy_ntfs,
+      244,Confluence Wiki Log Files,Logs,Program Files/Atlassian/Confluence/logs/*.log,lazy_ntfs,
+      245,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/MRU/rename_folders.osd,lazy_ntfs,Locates .osd file which contains names of folders that have been renamed manually by the user.
+      246,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/MRU/rename_files.osd,lazy_ntfs,Locates .osd file which contains names of files that have been renamed manually by the user.
+      247,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/MRU/find_contains.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with contents related to the search query.
+      248,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/MRU/find_name.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with a filename related to the search query.
+      249,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/MRU/find_path.osd,lazy_ntfs,Locates .osd file which contains file paths related to user activity - not exactly sure how these are generated at this time.
+      250,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/recent.osd,lazy_ntfs,Locates .osd file which contains file paths related to recent user activity. Effectively the DOpus Shellbags-equivalent. Appears to be for last 10 folder visited within the Lister.
+      251,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/State Data/backupconfig.osd,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
+      252,Directory Opus,Apps,Users/*/AppData/Local/GPSoftware/Directory Opus/Thumbnail Cache/*,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
+      253,Directory Opus,Apps,Users/*/AppData/Roaming/GPSoftware/Directory Opus/Logs/*,lazy_ntfs,Locates .txt files that will be named with the IP address of the FTP server Directory Opus was used to connect to. All-activity.txt will simply be a combination of all other .txt files present in this directory.
+      254,Discord Cache Files,Communications,Users/*/AppData/Roaming/discord/cache/**10,lazy_ntfs,Gets cached data from Discord app
+      255,Discord Local Storage LevelDB Files,Communications,Users/*/AppData/Roaming/discord/local storage/leveldb/**10,lazy_ntfs,Gets LevelDB database from Discord app
+      256,Double Commander - history.xml,Apps,Users/*/AppData/Roaming/doublecmd/history.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from bottom to top.
+      257,Double Commander - doublecmd.xml,Apps,Users/*/AppData/Roaming/doublecmd/doublecmd.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom.
+      258,Double Commander - FTP Log,Apps,Users/*/AppData/Roaming/doublecmd/doublecmd*.log,lazy_ntfs,Locates log files that'll be named with the following naming convention: doublecmd_2021-04-03.log.
+      259,Dropbox Metadata,Apps,Users/*/AppData/Local/Dropbox/info.json,lazy_ntfs,Getting individual files because folder may contain very large extraneous files. Info.json contains user's Dropbox folder location
+      260,Dropbox Metadata,Apps,Users/*/AppData/Local/Dropbox/host.db,lazy_ntfs,SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64.
+      261,Dropbox Metadata,Apps,Users/*/AppData/Local/Dropbox/host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      262,Windows Protect Folder,FileSystem,Users/*/AppData/Roaming/Microsoft/Protect/*/**10,lazy_ntfs,Required for offline decryption of Dropbox databases
+      263,Dropbox Metadata,Apps,Users/*/AppData/Local/Dropbox/instance*/**10,lazy_ntfs,instance folder holds multiple SQLite databases related to Dropbox activity and contents
+      264,Dropbox User Files,Apps,Users/*/Dropbox*/**10,lazy_ntfs,"Default storage location for Dropbox Personal and Business (when using wildcard), but can be user-defined. Check info.json file in user Dropbox metadata files to identify default folder."
+      265,EF Commander - .ini File,Apps,Users/*/AppData/Roaming/EFSoftware/*,lazy_ntfs,Locates folder where all configuration files reside
+      266,Evernote Accounts,App,Users/*/AppData/Local/Evernote/Evernote/Databases/**10/.accounts,lazy_ntfs,Holds username and email of accounts
+      267,Evernote Notebooks,App,Users/*/AppData/Local/Evernote/Evernote/Databases/**10/*.exb,lazy_ntfs,SQLite Database of the notes
+      268,Evernote Notebook Snippets,App,Users/*/AppData/Local/Evernote/Evernote/Databases/**10/*.exb.snippets,lazy_ntfs,Note 'Snippets'
+      269,Everything (VoidTools),FileSystem,Users/*/AppData/Local/Everything/Everything.db,lazy_ntfs,Copies out Everything.db
+      270,Everything (VoidTools) - Run History,FileSystem,Users/*/AppData/Roaming/Everything/Run History.csv,lazy_ntfs,Copies out a CSV containing the history of items ran from Everything's search results window
+      271,Everything (VoidTools) - Search History,FileSystem,Users/*/AppData/Roaming/Everything/Search History.csv,lazy_ntfs,Copies out a CSV containing the history of items searched for within Everything with timestamps
+      272,Exchange client access log files,Logs,Program Files/Microsoft/Exchange Server/*/Logging/**10/*.log,lazy_ntfs,Highly dependent on Exchange configuration
+      273,Exchange Server Modified Compiled Files,Apps,Windows/Microsoft.NET/Framework*/v*/Temporary ASP.NET Files/**10/Regex:*./b[a-zA-Z0-9_-]{8}/b.compiled,ntfs,Highly dependent on Exchange configuration
+      274,Exchange Server Modified Compiled Files,Apps,inetpub/wwwroot/aspnet_client/**10/Regex:*./b[a-zA-Z0-9_-]{8}/b.compiled,ntfs,Highly dependent on Exchange configuration
+      275,Exchange Server Modified Compiled Files,Apps,inetpub/wwwroot/aspnet_client/system_web/**10/Regex:*./b[a-zA-Z0-9_-]{8}/b.compiled,ntfs,Highly dependent on Exchange configuration
+      276,Exchange Server Modified Compiled Files,Apps,Program Files/Microsoft/Exchange Server/V15/FrontEnd/HttpProxy/owa/auth/**10/Regex:*./b[a-zA-Z0-9_-]{8}/b.compiled,ntfs,Highly dependent on Exchange configuration
+      277,Exchange TransportRoles log files,Logs,Program Files/Microsoft/Exchange Server/*/TransportRoles/Logs/**10/*.log,lazy_ntfs,Highly dependent on Exchange configuration
+      278,Fences - Desktop Screenshots,Apps,Users/*/AppData/Roaming/Stardock/Fences/Backups,lazy_ntfs,Locates all screenshots taken automatically by the Fences application
+      279,FileZilla XML Log Files,Logs,Users/*/AppData/Roaming/FileZilla/*.xml*,lazy_ntfs,
+      280,FileZilla SQLite3 Log Files,Logs,Users/*/AppData/Roaming/FileZilla/*.sqlite3*,lazy_ntfs,
+      281,FileZilla Server XML Log Files,Logs,Users/*/AppData/Roaming/FileZilla Server/*.xml*,lazy_ntfs,
+      282,FileZilla Log Files,Logs,Program Files (x86)/FileZilla Server/Logs/*.log*,lazy_ntfs,
+      283,Free Commander - FreeCommander.ini,Apps,Users/*/AppData/Local/FreeCommanderXE/Settings/FreeCommander.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts.
+      284,Free Commander - FreeCommander.ftp.ini,Apps,Users/*/AppData/Local/FreeCommanderXE/Settings/FreeCommander.ftp.ini,lazy_ntfs,Locates an .ini file that contains the file path to the FTP log for Free Commander.
+      285,Free Commander - FreeCommander.hist.ini,Apps,Users/*/AppData/Local/FreeCommanderXE/Settings/FreeCommander.hist.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom for both left and right directory browsers.
+      286,Free Commander - FreeCommander.fav.xml,Apps,Users/*/AppData/Local/FreeCommanderXE/Settings/FreeCommander.fav.xml,lazy_ntfs,Locates an .xml file that contains favorited files/folder by the user.
+      287,Free Commander - Backup Settings,Apps,Users/*/AppData/Local/FreeCommanderXE/Settings/Bkp_Settings*/**10,lazy_ntfs,"Locates an exact copy of the above files which will have a timestamped folder name, i.e. Bkp_Settings-YYYY-MM-DD HH-MM-SS."
+      288,Free Commander - FTP Log,Apps,Users/*/AppData/Local/Temp/fc*.log,lazy_ntfs,Locates log file(s) that have a default naming convention of fc_ftplog_20210403 but can be modified by the user.
+      289,Free Commander - FTP Related Information,Apps,Users/*/AppData/Local/Temp/FreeCommander*/**10,lazy_ntfs,Locates a folder that may be named randomly that contains more FTP related information as well as .tmp files that are created while the user is traversing folders during an active FTP session. These files are deleted upon program exit.
+      290,FDM Database,App,Users/*/AppData/Local/Free Download Manager/**10/fdm.sqlite,lazy_ntfs,"fdm.sqlite shows Torrents, downloads, folder history, auth credentials and more. Will also pull fdm.sqlite in db_backup/"
+      291,FDM Backup Info,App,Users/*/AppData/Local/Free Download Manager/backup/backup.info,lazy_ntfs,"Backup info file - can change backup name from userdata.zip, so could give indication of file name"
+      292,FDM Database (userdata.zip),App,Users/*/AppData/Local/Free Download Manager/backup/userdata.zip,lazy_ntfs,fdm.sqlite can also appear in the backup folder in a compressed userdata.zip file
+      293,FreeFileSync,Apps,Users/*/AppData/Roaming/FreeFileSync/Logs,lazy_ntfs,Copies out all log files
+      294,Google Drive Backup and Sync User Files,Apps,Users/*/Google Drive*/**10,lazy_ntfs,Older Google Drive Backup and Sync application only
+      295,Google Drive Backup and Sync Metadata,Apps,Users/*/AppData/Local/Google/Drive/**10,lazy_ntfs,Older version of Google Drive
+      296,Google Drive for Desktop Metadata,Apps,Users/*/AppData/Local/Google/DriveFS/**10,lazy_ntfs,Metadata folder the same for both newer Google Drive for Desktop and older Google File Stream application
+      297,HeidiSQL Backup files (*.sql),Apps,Users/*/AppData/Roaming/HeidiSQL/Backups/*,lazy_ntfs,
+      298,HeidiSQL (tabs.ini),Apps,Users/*/AppData/Roaming/HeidiSQL/tabs.ini,lazy_ntfs,
+      299,HexChat Chat Logs,Communications,Users/*/AppData/Roaming/HexChat/logs/**10,lazy_ntfs,
+      300,IceChat Chat Logs,Communications,Users/*/AppData/Local/IceChat Networks/IceChat/Logs/**10,lazy_ntfs,
+      301,IrfanView Configuration File,FileKnowledge,Users/*/AppData/Roaming/IrfanView/i_view32.ini,lazy_ntfs,
+      302,JDownloader 2.0 Download Lists,App,Users/*/AppData/Local/JDownloader 2.0/cfg/**10/downloadList*.zip,lazy_ntfs,"Zip folder which contains several files (00,00_00 and extraInfo) which list the download folder, the time it was created, the name of the download, origin URL, referral URL and more"
+      303,JDownloader 2.0 Link Collector,App,Users/*/AppData/Local/JDownloader 2.0/cfg/**10/linkcollector*.zip,lazy_ntfs,"Zip folder which contains several files (0X,0X_00 and extraInfo) which list the websites crawled for links, the referral URLs, timestamps and more"
+      304,JDownloader 2.0 General Settings,App,Users/*/AppData/Local/JDownloader 2.0/cfg/**10/org.jdownloader.settings.GeneralSettings.json,lazy_ntfs,General user config for JDownloader 2.0. Holds default download folder.
+      305,JDownloader 2.0 Link Grabber Settings,App,Users/*/AppData/Local/JDownloader 2.0/cfg/**10/org.jdownloader.gui.views.linkgrabber.addlinksdialog.LinkgrabberSettings.json,lazy_ntfs,Linkgrabber Settings for JDownloader 2.0. Holds latest download destination folder.
+      306,JDownloader 2.0 Proxy Settings,App,Users/*/AppData/Local/JDownloader 2.0/cfg/**10/org.jdownloader.settings.InternetConnectionSettings.customproxylist.json,lazy_ntfs,Proxy configuration for JDownloader 2.0
+      307,Java WebStart Cache User Level - Default,Communication,Users/*/AppData/Local/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      308,Java WebStart Cache User Level - IE Protected Mode,Communication,Users/*/AppData/LocalLow/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      309,Java WebStart Cache System level,Communication,Windows/System32/config/systemprofile/AppData/Local/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      310,Java WebStart Cache System level,Communication,Windows.old/Windows/System32/config/systemprofile/AppData/Local/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      311,Java WebStart Cache System level - IE Protected Mode,Communication,Windows/System32/config/systemprofile/AppData/LocalLow/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      312,Java WebStart Cache System level - IE Protected Mode,Communication,Windows.old/Windows/System32/config/systemprofile/AppData/LocalLow/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      313,Java WebStart Cache System level (SysWow64),Communication,Windows/SysWOW64/config/systemprofile/AppData/Local/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      314,Java WebStart Cache System level (SysWow64),Communication,Windows.old/Windows/SysWOW64/config/systemprofile/AppData/Local/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      315,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows/SysWOW64/config/systemprofile/AppData/LocalLow/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      316,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows.old/Windows/SysWOW64/config/systemprofile/AppData/LocalLow/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      317,Java WebStart Cache User Level - XP,Communications,Documents and Settings/*/Application Data/Sun/Java/Deployment/cache/*/*/*.idx,lazy_ntfs,
+      318,Kaseya Live Connect Logs (XP),ApplicationLogs,Documents and Settings/*/Application Data/Kaseya/Log/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      319,Kaseya Live Connect Logs,ApplicationLogs,Users/*/AppData/Local/Kaseya/Log/KaseyaLiveConnect/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      320,Kaseya Agent Endpoint Service Logs (XP),ApplicationLogs,Documents and Settings/All Users/Application Data/Kaseya/Log/Endpoint/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      321,Kaseya Agent Endpoint Service Logs,ApplicationLogs,ProgramData/Kaseya/Log/Endpoint/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      322,Kaseya Agent Service Log,ApplicationLogs,Program Files*/Kaseya/*/agentmon.log*,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      323,Kaseya Setup Log,ApplicationLogs,Users/*/AppData/Local/Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      324,Kaseya Setup Log,ApplicationLogs,Windows/Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      325,Kaseya Setup Log,ApplicationLogs,Windows.old/Windows/Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      326,Kaseya Agent Edge Service Logs,ApplicationLogs,ProgramData/Kaseya/Log/KaseyaEdgeServices/**10,lazy_ntfs,https://www.huntress.com/blog/rapid-response-kaseya-vsa-mass-msp-ransomware-incident
+      327,LogMeIn ProgramData Logs,ApplicationLogs,ProgramData/LogMeIn/Logs/**10,lazy_ntfs,
+      328,LogMeIn Application Logs,ApplicationLogs,Users/*/AppData/Local/temp/LogMeInLogs/**10,lazy_ntfs,"Contains RemoteAssist (formerly GoToAssist), GoToMeeting, and other GoTo* logs"
+      329,Macrium Reflect,Apps,ProgramData/Macrium/Macrium Service/*,lazy_ntfs,Copies out all log files
+      330,Macrium Reflect,Apps,ProgramData/Macrium/Reflect/*,lazy_ntfs,Copies out the Reflect folder which contains many important logs
+      331,Macrium Reflect,Apps,ProgramData/Macrium/Reflect Launcher,lazy_ntfs,Copies out the Reflect folder which contains many important logs
+      332,Mattermost - Chat Logs,Apps,Users/*/AppData/Roaming/Mattermost/IndexedDB/**10,lazy_ntfs,Locates Mattermost logs and copies them
+      333,MediaMonkey - Media SQLite Database,Apps,Users/*/AppData/Roaming/MediaMonkey/MM.DB,lazy_ntfs,Locates SQLite DB that contains a complete enumeration of the user's media collection within MediaMonkey
+      334,MediaMonkey - MediaMonkey.ini,Apps,Users/*/AppData/Roaming/MediaMonkey/MediaMonkey.ini,lazy_ntfs,Locates .ini file which contains information about the user's MediaMonkey application instance
+      335,Microsoft OneNote - FullTextSearchIndex,Apps,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/*/FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
+      336,Microsoft OneNote - RecentNotebooks_SeenURLs,Apps,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/Notifications/RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
+      337,Microsoft OneNote - AccessibilityCheckerIndex,Apps,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
+      338,Microsoft OneNote - User NoteTags,Apps,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/NoteTags/*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
+      339,Microsoft OneNote - RecentSearches,Apps,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/RecentSearches/RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
+      340,"Microsoft Sticky Notes - Windows 7, 8, and 10 version 1511 and earlier",Apps,Users/*/AppData/Roaming/Microsoft/StickyNotes/StickyNotes.snt,lazy_ntfs,
+      341,Microsoft Sticky Notes - 1607 and later,Apps,Users/*/AppData/Local/Packages/Microsoft.MicrosoftStickyNotes*/LocalState/plum.sqlite*,lazy_ntfs,
+      342,Microsoft Teams IndexedDB Cache,Apps,Users/*/AppData/Roaming/Microsoft/Teams/IndexedDB/https_teams.microsoft.com_0.indexeddb.leveldb/**10,lazy_ntfs,"LevelDB database which can contain inbound/outbound chat messages, call history and more"
+      343,Microsoft Teams Local Storage Cache,Apps,Users/*/AppData/Roaming/Microsoft/Teams/Local Storage/leveldb/**10,lazy_ntfs,"LevelDB database which can contain meeting history, file transfer logs and more"
+      344,Microsoft Teams Cache,Apps,Users/*/AppData/Roaming/Microsoft/Teams/Cache/**10,lazy_ntfs,Chromium cache which can be viewed with Nirsoft's ChromeCacheView
+      345,Microsoft Teams Config,Apps,Users/*/AppData/Roaming/Microsoft/Teams/desktop-config.json,lazy_ntfs,JSON config file for Teams
+      346,Microsoft Teams Logs (Windows 11),Apps,Users/%User%/AppData/Local/Packages/MicrosoftTeams_8wekyb3d8bbwe/LocalCache/Microsoft/MSTeams/Logs,lazy_ntfs,Lots of log files for MS Teams
+      347,Microsoft To Do - SQLite Database of To Do tasks,Apps,Users/*/AppData/Local/Packages/Microsoft.Todos_8wekyb3d8bbwe/LocalState/AccountsRoot/*/todosqlite.db*,lazy_ntfs,
+      348,Microsoft To Do - User Avatar,Apps,Users/*/AppData/Local/Packages/Microsoft.Todos_8wekyb3d8bbwe/LocalState/AccountsRoot/4c444a17ebb042fb92df97d00d1c802a/avatars/UserAvatar.jpg,lazy_ntfs,
+      349,Midnight Commander -- All Configuation Files,Apps,Users/*/Midnight Commander/*,lazy_ntfs,Locates folder where all configuration files reside
+      350,Multi Commander - Application Folder,Apps,Users/*/AppData/Local/MultiCommander*/**10,lazy_ntfs,Locates the contents of the Application folder.
+      351,Multi Commander - Config Folder,Apps,Users/*/AppData/Roaming/MultiCommander*/Config/**10,lazy_ntfs,Locates the contents of the Config folder.
+      352,Multi Commander - Log Folder,Apps,Users/*/AppData/Roaming/MultiCommander*/Logs/**10,lazy_ntfs,Locates log file(s) related to user activity within Multi Commander.
+      353,Multi Commander - UserData Folder,Apps,Users/*/AppData/Roaming/MultiCommander*/UserData/**10,lazy_ntfs,Locates the contents of the UserData folder.
+      354,Multi Commander - Log File,Apps,Users/*/AppData/Roaming/MultiCommander*/**10/*MultiCommander.log,lazy_ntfs,Locates log file(s) associated with Milti Commander. Commonly in YYYY-MM-DD (numbers)-MultiCommander.log naming convention.
+      355,Nessus Logs,Nessus,ProgramData/Tenable/Nessus/conf/**10,lazy_ntfs,
+      356,Nessus Logs,Nessus Logs,ProgramData/Tenable/Nessus/nessus/logs/**10,lazy_ntfs,
+      357,Notepad++ Unsaved Edits,Text Editor,Users/*/AppData/Roaming/Notepad++/backup/**10,lazy_ntfs,Locates non-saved Notepad++ files and copies them.
+      358,Notepad++ Config,Text Editor,Users/*/AppData/Roaming/Notepad++/config.xml,lazy_ntfs,"Retrieves config.xml which contains recently searched terms, replaced terms and recently opened documents"
+      359,One Commander - All Configuration Files,Apps,Users/*/OneCommander/*,lazy_ntfs,Locates folder where all configuration files reside
+      360,One Commander - Other Configuration Files,Apps,Users/*/AppData/Local/Apps/2.0/*/*/onec*/**10,lazy_ntfs,Locates folder where all configuration files reside
+      361,OneDrive Metadata Logs,Apps,Users/*/AppData/Local/Microsoft/OneDrive/logs/**10,lazy_ntfs,
+      362,OneDrive Metadata Settings,Apps,Users/*/AppData/Local/Microsoft/OneDrive/settings/**10,lazy_ntfs,
+      363,OneDrive User Files,Apps,Users/*/OneDrive*/**10,lazy_ntfs,Caution -- This target will collect OneDrive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use or isolate system from network.
+      364,OpenSSH Config File,Apps,Users/*/.ssh/config,lazy_ntfs,"Config file can hold usernames, IP addresses and ports, key locations and configured shortcuts for servers e.g. ssh web-server"
+      365,OpenSSH Known Hosts,Apps,Users/*/.ssh/known_hosts,lazy_ntfs,"Known hosts file can hold a list of connected FQDNs/IP Addresses and ports if they are non-default, as well as public key fingerprints"
+      366,OpenSSH Public Keys,Apps,Users/*/.ssh/*.pub,lazy_ntfs,"Gets all public keys (*.pub). It is more difficult to find private keys as they typically do not have a file extension. However, the .pub files should be able to help find the private keys as they are typically named the same."
+      367,OpenSSH Default Private Key,Apps,Users/*/.ssh/id_rsa,lazy_ntfs,Default name for an auto-generated SSH private key
+      368,OpenSSH Server Config File,Apps,ProgramData/ssh/sshd_config,lazy_ntfs,Config file can hold information on allowed/denied users
+      369,OpenSSH Server Logs,Apps,ProgramData/ssh/logs/*,lazy_ntfs,OpenSSH server logs
+      370,OpenSSH Host ECDSA Key,Apps,ProgramData/ssh/ssh_host_ecdsa_key,lazy_ntfs,Retrieves the host ECDSA key
+      371,OpenSSH Host ED25519 Key,Apps,ProgramData/ssh/ssh_host_ed25519_key,lazy_ntfs,Retrieves the host ED25519 key
+      372,OpenSSH Host DSA Key,Apps,ProgramData/ssh/ssh_host_dsa_key,lazy_ntfs,Retrieves the host DSA key
+      373,OpenSSH Host RSA Key,Apps,ProgramData/ssh/ssh_host_rsa_key,lazy_ntfs,Retrieves the host RSA key
+      374,OpenSSH User Authorized Keys,Apps,Users/*/.ssh/authorized_keys,lazy_ntfs,Retrieves the user's authorised public keys
+      375,OpenSSH User Authorized Keys 2,Apps,Users/*/.ssh/authorized_keys2,lazy_ntfs,Retrieves the user's authorised public keys from the second file
+      376,OpenSSH Authorized Administrator Keys,Apps,ProgramData/ssh/administrators_authorized_keys,lazy_ntfs,Retrieves the administrator group's authorised public keys
+      377,OpenVPN Client Config,ApplicationLogs,Users/*/OpenVPN/config/**10,lazy_ntfs,Contains OpenVPN Configs (Profiles)
+      378,OpenVPN Client Config,ApplicationLogs,Program Files*/OpenVPN/config/**10,lazy_ntfs,Contains OpenVPN Configs(Profiles)
+      379,OpenVPN Client Config,ApplicationLogs,Users/*/OpenVPN/log/*.log,lazy_ntfs,Contains OpenVPN Logs for each Config(Profile)
+      380,PST XP,Communications,Documents and Settings/*/Local Settings/Application Data/Microsoft/Outlook/*.pst,lazy_ntfs,
+      381,OST XP,Communications,Documents and Settings/*/Local Settings/Application Data/Microsoft/Outlook/*.ost,lazy_ntfs,
+      382,PST (2013 or 2016),Communications,Users/*/Documents/Outlook Files/*.pst,lazy_ntfs,
+      383,OST (2013 or 2016),Communications,Users/*/Documents/Outlook Files/*.ost,lazy_ntfs,
+      384,PST,Communications,Users/*/AppData/Local/Microsoft/Outlook/*.pst,lazy_ntfs,"Outlook Data File: POP accounts, archives, older installations"
+      385,OST,Communications,Users/*/AppData/Local/Microsoft/Outlook/*.ost,lazy_ntfs,"Offline Outlook Data File: M365, Exchange, IMAP"
+      386,NST,Communications,Users/*/AppData/Local/Microsoft/Outlook/*.nst,lazy_ntfs,Outlook Group Storage File: Group conversations and calendar
+      387,Outlook Attachment Temporary Storage,Communications,Users/*/AppData/Local/Microsoft/Windows/INetCache/Content.Outlook/**10,lazy_ntfs,Outlook temporary storage folder for user attachments
+      388,PeaZip Configuration Files,FileKnowledge,Users/*/AppData/Roaming/PeaZip/**10,lazy_ntfs,
+      389,ProtonVPN - Connection Logs,ApplicationLogs,Users/*/AppData/Local/ProtonVPN/Logs,lazy_ntfs,Locates ProtonVPN connection logs.
+      390,Q-Dir - .ini File,Apps,Users/*/AppData/Roaming/Q-Dir/Q-Dir.ini,lazy_ntfs,Locates .ini file associated with Q-Dir which stores useful user activity information.
+      391,Q-Dir - .qdr file,Apps,Users/*/AppData/Roaming/Q-Dir/start.qdr,lazy_ntfs,"Locates .qdr file associated with Q-Dir which stores useful user activity information, including the last 4 folders opened (encoded, unfortunately)."
+      392,QFinderPro,Apps,Users/*/AppData/Local/QNAP/QfinderPro,lazy_ntfs,Locates a JSON file that provides network location information for any QNAP connected devices.
+      393,Radmin Server 32bit Log,ApplicationLogs,Windows/SysWOW64/rserver30/Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
+      394,Radmin Server 64bit Log,ApplicationLogs,Windows/System32/rserver30/Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
+      395,Radmin Server 32bit Chats,ApplicationLogs,Windows/SysWOW64/rserver30/CHATLOGS/*/*.htm,lazy_ntfs,Previous chat logs
+      396,Radmin Server 64bit Chats,ApplicationLogs,Windows/System32/rserver30/CHATLOGS/*/*.htm,lazy_ntfs,Previous chat logs
+      397,Radmin Viewer Chats,ApplicationLogs,Users/*/Documents/ChatLogs/*/*.htm,lazy_ntfs,Previous chat logs
+      398,ScreenConnect Session Database,ApplicationLogs,Program Files*/ScreenConnect/App_Data/Session.db,lazy_ntfs,SQLite database with session information
+      399,ScreenConnect Session Database,ApplicationLogs,Program Files*/ScreenConnect/App_Data/User.xml,lazy_ntfs,Contains each user's last authenticated time
+      400,ScreenConnect User Config,ApplicationLogs,ProgramData/ScreenConnect Client*/user.config,lazy_ntfs,Contains server domain and IP info
+      401,ShareX,Apps,Users/*/Documents/ShareX/**10,lazy_ntfs,Locates and captures all files within the default ShareX folder path
+      402,Signal Attachments cache,Communications,Users/*/AppData/Roaming/Signal/attachments.noindex/**10,lazy_ntfs,Profile pictures (and possibly attachments) for users who this individual has as contacts or has communicated with
+      403,Signal Logs,Communications,Users/*/AppData/Roaming/Signal/logs/**10,lazy_ntfs,"Logs for Signal. Most recent has the extension .log while old ones will have extension .log.0, .log.1 etc."
+      404,Signal config.json,Communications,Users/*/AppData/Roaming/Signal/config.json,lazy_ntfs,config.json holds the db.sqlite SQLCipher raw key
+      405,Signal Database,Communications,Users/*/AppData/Roaming/Signal/sql/db.sqlite,lazy_ntfs,"Stores attachment details, conversations, messages, and more"
+      406,main.db (App <v12),Communications,Users/*/AppData/Local/Packages/Microsoft.SkypeApp_*/LocalState/*/main.db,lazy_ntfs,
+      407,skype.db (App +v12),Communications,Users/*/AppData/Local/Packages/Microsoft.SkypeApp_*/LocalState/*/skype.db,lazy_ntfs,
+      408,main.db XP,Communications,Documents and Settings/*/Application Data/Skype/*/main.db,lazy_ntfs,
+      409,main.db Win7+,Communications,Users/*/AppData/Roaming/Skype/*/main.db,lazy_ntfs,
+      410,s4l-[username].db (App +v8),Communications,Users/*/AppData/Local/Packages/Microsoft.SkypeApp_*/LocalState/s4l-*.db,lazy_ntfs,
+      411,leveldb (Skype for Desktop +v8),Communications,Users/*/AppData/Roaming/Microsoft/Skype for Desktop/IndexedDB/*.leveldb/**10,lazy_ntfs,
+      412,Skype for Destkop v8+ Chromium Cache,Communications,Users/*/AppData/Roaming/Microsoft/Skype for Desktop/Cache/**10,lazy_ntfs,Can be viewed with Nirsoft's ChromeCacheView
+      413,Slack - Chat Logs,Apps,Users/*/AppData/Roaming/Slack/IndexedDB/**10,lazy_ntfs,Locates Slack logs and copies them
+      414,Slack LevelDB Files,Apps,Users/*/AppData/Roaming/Slack/Local Storage/leveldb/**10,lazy_ntfs,
+      415,Slack Electron Logs,Apps,Users/*/AppData/Roaming/Slack/logs/**10,lazy_ntfs,Current Slack application is based on Electron and additional logging can be found here.
+      416,Slack Cache,Apps,Users/*/AppData/Roaming/Slack/Cache/**10,lazy_ntfs,Collects Slack cache files. This folder can be parsed like a Chrome Browser cache using a tool like Nirsoft ChromeCacheView
+      417,Slack Storage,Apps,Users/*/AppData/Roaming/Slack/storage/**10,lazy_ntfs,User activity logs can be present including slack-downloads log
+      418,Snagit - Captures,Apps,Users/*/AppData/Local/TechSmith/Snagit/DataStore,lazy_ntfs,Locates all Snagit captures
+      419,SpeedCommander - .ini File,Apps,Users/*/AppData/Roaming/SpeedProject/SpeedCommander 19/*,lazy_ntfs,Locates folder where all configuration files reside
+      420,SublimeText 2/3 Auto Save Session,Text Editor,Users/*/AppData/Roaming/Sublime Text*/Settings/Session.sublime_session,lazy_ntfs,Sublime Text 2/3 stores unsaved (temporary) files and its content in its Session.sublime_session file
+      421,SugarSync Log File,Apps,Users/*/AppData/Local/SugarSync/sc1.log,lazy_ntfs,Locates a log file the gives a play-by-play of what the user synced when.
+      422,SugarSync - Shared Folders (Default Location),Apps,Users/*/Documents/SugarSync Shared Folders/**10,lazy_ntfs,
+      423,SugarSync - My SugarSync (Default Location),Apps,Users/*/Documents/My SugarSync/**10,lazy_ntfs,
+      424,SumatraPDF Settings - SessionData,FileKnowledge,Users/*/AppData/Local/SumatraPDF/SumatraPDF-settings.txt,lazy_ntfs,Settings file which contains information about previous user session
+      425,SumatraPDF Cache,FileKnowledge,Users/*/AppData/Local/SumatraPDF/sumatrapdfcache,lazy_ntfs,Folder contains a PNG snapshot of each PDF file the user had open at the time of last application close
+      426,Supremo Connection Logs,Communications,ProgramData/SupremoRemoteDesktop/Log/*.log,lazy_ntfs,Includes Supremo.00.Client.log and Supremo.00.Incoming.log
+      427,Supremo File Transfer Inbox,Communications,ProgramData/SupremoRemoteDesktop/Inbox,lazy_ntfs,Includes all files transferred to the inbox folder during a remote session
+      428,Tablacus Explorer - remember.xml,Logs,Users/*/AppData/Local/Temp/*/config/**10/remember.xml,lazy_ntfs,
+      429,Tablacus Explorer - window.xml,Logs,Users/*/AppData/Local/Temp/*/config/**10/window.xml,lazy_ntfs,
+      430,Tablacus Explorer - window1.xml,Logs,Users/*/AppData/Local/Temp/*/config/**10/window1.xml,lazy_ntfs,
+      431,TeamViewer Connection Logs,Communications,Program Files*/TeamViewer/connections*.txt,lazy_ntfs,Includes connections_incoming.txt and connections.txt
+      432,TeamViewer Application Logs,ApplicationLogs,Program Files*/TeamViewer/TeamViewer*_Logfile*,lazy_ntfs,Includes TeamViewer<version>_Logfile.log and TeamViewer<version>_Logfile_OLD.log
+      433,TeamViewer Configuration Files,ApplicationLogs,Users/*/AppData/Roaming/TeamViewer/MRU/RemoteSupport/**10,lazy_ntfs,Includes miscellaneous config files
+      434,Telegram app folder,Apps,Users/*/AppData/Roaming/Telegram Desktop/**10,lazy_ntfs,Telegram app folder structure
+      435,Telegram downloaded files,Apps,Users/*/Downloads/Telegram Desktop/**10,lazy_ntfs,Chat Attachments
+      436,TeraCopy,TeraCopy,Users/*/AppData/Roaming/TeraCopy/**10,lazy_ntfs,
+      437,Mozilla Thunderbird Install Date,Apps,Users/*/AppData/Roaming/Thunderbird/Crash Reports/InstallTime*,lazy_ntfs,Holds install time in Unix Seconds timestamp
+      438,Mozilla Thunderbird Profiles.ini,Apps,Users/*/AppData/Roaming/Thunderbird/profiles.ini,lazy_ntfs,Profiles list - can hold references to other profiles held elsewhere on the device
+      439,Mozilla Thunderbird prefs.js,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/prefs.js,lazy_ntfs,User Preferences for that profile
+      440,Mozilla Thunderbird Global Messages Database,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/global-messages-db.sqlite,lazy_ntfs,"Holds list of contacts, emails, and other potentially useful artifacts"
+      441,Mozilla Thunderbird logins.json,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/logins.json,lazy_ntfs,"Holds last time online login used, last time password changed, hostname, HTTP(s) URL and more"
+      442,Mozilla Thunderbird places.sqlite,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/places.sqlite,lazy_ntfs,"Holds history for Thunderbird - as it contains portions of Firefox embedded, it can be used to visit websites too"
+      443,Mozilla Thunderbird ImapMail INBOX,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/ImapMail/**10/INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
+      444,Mozilla Thunderbird Mail INBOX,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/Mail/**10/INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
+      445,Mozilla Thunderbird Calendar Data,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/calendar-data/local.sqlite,lazy_ntfs,Holds local calendar data
+      446,Mozilla Thunderbird Attachments,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/Attachments/*,lazy_ntfs,Holds attachments
+      447,Mozilla Thunderbird Address Book,Apps,Users/*/AppData/Roaming/Thunderbird/Profiles/*/abook.sqlite,lazy_ntfs,Holds local address book
+      448,Total Commander - .ini File,Apps,Users/*/AppData/Roaming/GHISLER/wincmd.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
+      449,Total Commander - Log File,Apps,**10/totalcmd.log,lazy_ntfs,Locates log file associated with Total Commander. NOTE: this log file is NOT enabled by default and the filename can be modified.
+      450,Total Commander - Temp Files Created During Folder Traversal,Apps,Users/*/AppData/Local/Temp/FTP*.tmp,lazy_ntfs,Locates .tmp files which are created during the user's folder traversal and provide insight into contents of each folder traversed.
+      451,Total Commander - FTP .ini File,Apps,Users/*/AppData/Roaming/GHISLER/wcx_ftp.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful FTP information.
+      452,Total Commander - File Tree,Apps,Users/*/AppData/Local/GHISLER/treeinfo*.wc,lazy_ntfs,Locates a file that contains an exhaustive file tree of a user's file system.
+      453,Total Commander - FTP Logs,Apps,Users/*/AppData/Local/Temp/tcftp.log,lazy_ntfs,Locates a file that contains the Total Commander FTP logs.
+      454,TreeSize - ScanHistory.XML,Apps,Users/*/AppData/Roaming/JAM Software/TreeSize/scanhistory.xml,lazy_ntfs,Locates XML file that provides a list of previously scanned directories by the user.
+      455,VLC Recently Opened Files,Apps,Users/*/AppData/Roaming/vlc/vlc-qt-interface.ini,lazy_ntfs,Configuration file for VLC. Holds [RecentsMRL] key which lists recently opened files as well as sometimes retaining timestamps for file opening
+      456,VLC Recorded Files,Apps,Users/*/Videos/vlc-*.avi,lazy_ntfs,"Recorded files in VLC. Sometimes the Record button may be pressed instead of Play by suspects, which can record them watching content with VLC"
+      457,VMware - Virtual Machine Inventory,Apps,Users/*/AppData/Roaming/VMware,lazy_ntfs,Locates an inventory of all Virtual Machines on disk.
+      458,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmem,lazy_ntfs,Captures all raw memory from VMware virtual machines.
+      459,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmss,lazy_ntfs,Captures all memory images from VMware virtual machines.
+      460,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmsn,lazy_ntfs,Captures all memory images from VMware virtual machines.
+      461,RealVNC Log,ApplicationLogs,Users/*/AppData/Local/RealVNC/vncserver.log,lazy_ntfs,https://www.realvnc.com/en/connect/docs/logging.html#logging
+      462,Viber Config Database,Apps,Users/*/AppData/Roaming/ViberPC/config.db,lazy_ntfs,Configuration file for Viber
+      463,Viber Users Data Database,Apps,Users/*/AppData/Roaming/ViberPC/*/viber.db,lazy_ntfs,"Viber data for that user, containing Calls, Chat Messages, Contacts and more"
+      464,Viber Users Avatars Cache,Apps,Users/*/AppData/Roaming/ViberPC/*/Avatars,lazy_ntfs,Cache of the Avatars for other Viber users
+      465,Viber Users Backgrounds Cache,Apps,Users/*/AppData/Roaming/ViberPC/*/Backgrounds,lazy_ntfs,Store of the backgrounds
+      466,Viber Users Thumbnails Cache,Apps,Users/*/AppData/Roaming/ViberPC/*/Thumbnails,lazy_ntfs,Cache of the thumbnails for uploaded/downloaded images
+      467,VirtualBox VM configs,Apps,**10/*.vbox,lazy_ntfs,Locates all .vbox VM configuration files on disk
+      468,VirtualBox VM backup configs,Apps,**10/*.vbox-prev,lazy_ntfs,Locates all backup .vbox VM configuration files on disk
+      469,VirtualBox Logs,Apps,**10/VBox.log,lazy_ntfs,Locates all VBox.log files on disk
+      470,VirtualBox Backup Logs,Apps,**10/VBox.log.*,lazy_ntfs,Locates all backup VBox.log files on disk - these can show historic VM usage
+      471,VirtualBox Hardening Logs,Apps,**10/VBoxHardening.log,lazy_ntfs,Locates all VBoxHardening.log files on disk
+      472,VirtualBox,Memory,**10/*.sav,lazy_ntfs,Captures all partial memory images from VirtualBox.
+      473,WhatsApp Cache,Apps,Users/*/AppData/Roaming/WhatsApp/Cache,lazy_ntfs,"Copies the cache of WhatsApp. Can be opened with Chrome Cache Viewer for viewing embedded thumbnails and other image artefacts, as well as extracting .enc message files or other files"
+      474,WhatsApp Local Storage,Apps,Users/*/AppData/Roaming/WhatsApp/Local Storage/leveldb,lazy_ntfs,"Copies the Local Storage leveldb of WhatsApp. Contains phone model and name of user, plus encrypted base64 strings which can be viewed with LevelDBDumper"
+      475,WinSCP (.ini file),Logs,**10/WinSCP.ini,lazy_ntfs,
+      476,Windows Your Phone - All Databases,Apps,Users/*/AppData/Local/Packages/Microsoft.YourPhone_8wekyb3d8bbwe/LocalCache/Indexed/**10,lazy_ntfs,Locates all Your Phone database files
+      477,XYplorer - .ini file,Apps,Users/*/AppData/Roaming/XYplorer/XYplorer.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
+      478,XYplorer - .ini file for each respective pane,Apps,Users/*/AppData/Roaming/XYplorer/Panes/*/**10/pane.ini,lazy_ntfs,Locates the .ini file for the left and right pane.
+      479,XYplorer - AutoBackup folder,Apps,Users/*/AppData/Roaming/XYplorer/AutoBackup/**10,lazy_ntfs,Locates the AutoBackup folder and copies its contents.
+      480,XYplorer - .dat files,Apps,Users/*/AppData/Roaming/XYplorer/**10/*.dat,lazy_ntfs,"Locates the .dat files in the XYplorer's AppData folder, all of which are updated upon program's exit."
+      481,iTunes Backup Folder,Communications,Users/*/AppData/Roaming/Apple/Mobilesync/Backup/**10,lazy_ntfs,
+      482,iTunes Backup Folder,Communications,Users/*/AppData/Roaming/Apple Computer/Mobilesync/Backup/**10,lazy_ntfs,
+      483,iTunes Backup Folder - iOS13,Communications,Users/*/Apple/Mobilesync/Backup/*,lazy_ntfs,
+      484,mIRC Chat Logs (Vista+),Communications,Users/*/AppData/Roaming/mIRC/logs/**10,lazy_ntfs,
+      485,mIRC Chat Logs (2000/XP),Communications,Documents and Settings/*/Application Data/mIRC/logs/**10,lazy_ntfs,
+      486,mRemoteNG Logs,Communications,Users/*/AppData/Roaming/mRemoteNG/mRemoteNG.log,lazy_ntfs,Contains log entries for remote connections
+      487,mRemoteNG Connection Configuration and Backups,Communications,Users/*/AppData/Roaming/mRemoteNG/confCons.xml*,lazy_ntfs,"Contains connection config, often with obfuscated credentials"
+      488,mRemoteNG Program Settings,Communications,Users/*/AppData/*/mRemoteNG/**10/user.config,lazy_ntfs,Contains user-specific program settings
+      489,pCloud Database,Apps,Users/*/AppData/Local/pCloud/*.db,lazy_ntfs,Database contains all files sync'd with pCloud account.
+      490,pCloud Database WAL File,Apps,Users/*/AppData/Local/pCloud/*.db-wal,lazy_ntfs,Write-Ahead Log for pCloud database file.
+      491,pCloud Database Shared Memory File,Apps,Users/*/AppData/Local/pCloud/*.db-shm,lazy_ntfs,Shared Memory for the pCloud database file.
+      492,4K Video Downloader,SQLDatabases,Users/*/AppData/Local/4kdownload.com/4K Video Downloader/4K Video Downloader/*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
+      493,Microsoft OneNote - FullTextSearchIndex,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/*/FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
+      494,Microsoft OneNote - RecentNotebooks_SeenURLs,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/Notifications/RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
+      495,Microsoft OneNote - AccessibilityCheckerIndex,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
+      496,Microsoft OneNote - User NoteTags,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/NoteTags/*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
+      497,Microsoft OneNote - RecentSearches,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Office.OneNote_8wekyb3d8bbwe/LocalState/AppData/Local/OneNote/16.0/RecentSearches/RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
+      498,Microsoft Sticky Notes - 1607 and later,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.MicrosoftStickyNotes*/LocalState/plum.sqlite*,lazy_ntfs,
+      499,Microsoft To Do - SQLite Database of To Do tasks,SQLDatabases,Users/*/AppData/Local/Packages/Microsoft.Todos_8wekyb3d8bbwe/LocalState/AccountsRoot/*/todosqlite.db*,lazy_ntfs,
+      500,TeraCopy - History Databases,SQLDatabases,Users/*/AppData/Roaming/TeraCopy/History/*.db,lazy_ntfs,
+      501,TeraCopy - Main Database,SQLDatabases,Users/*/AppData/Roaming/TeraCopy/main.db,lazy_ntfs,
+      502,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/filecache.db*,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
+      503,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/config.dbx,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
+      504,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/home.db,lazy_ntfs,SQlite database which appears to keep track of the user's recent Dropbox activity
+      505,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/icon.db,lazy_ntfs,SQLite database which appears to keep track of icons in the user's Drobox sync history which can give an indication as to which files and folders are present
+      506,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/sync_history.db,lazy_ntfs,SQLite database which appears to keep track of the user's Drobox sync history
+      507,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/sync/nucleus.sqlite3*,lazy_ntfs,SQLite database which appears to contain a table for deleted files
+      508,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/host.db,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      509,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      510,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/sync/aggregation.dbx,lazy_ntfs,SQLite database which appears to contain snapshot table of the user's Dropbox contents in JSON with timestamps in UNIX Epoch
+      511,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
+      512,Dropbox Metadata,SQLDatabases,Users/*/AppData/Local/Dropbox/*/avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
+      513,Google File Stream Metadata,SQLDatabases,Users/*/AppData/Local/Google/Drive/*/cloud_graph/cloud_graph.db,lazy_ntfs,Windows_GoogleDrive_CloudGraphDB.smap
+      514,Google File Stream Metadata,SQLDatabases,Users/*/AppData/Local/Google/Drive/*/TempData/*/change_buffer/**10,lazy_ntfs,DB(s) with seemingly randomized filename(s) that track file system changes within Google Drive
+      515,Google File Stream Metadata,SQLDatabases,Users/*/AppData/Local/Google/Drive/*/snapshot.db,lazy_ntfs,Windows_GoogleDrive_SnapshotDB.smap
+      516,Google File Stream Metadata,SQLDatabases,Users/*/AppData/Local/Google/Drive/*/sync_config.db,lazy_ntfs,Windows_GoogleDrive_SyncConfigDB.smap
+      517,FileZilla SQLite3 Log Files,SQLDatabases,Users/*/AppData/Roaming/FileZilla/*.sqlite3*,lazy_ntfs,
+      518,Chrome bookmarks XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Bookmarks*,lazy_ntfs,
+      519,Chrome Cookies XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Cookies*,lazy_ntfs,
+      520,Chrome Current Session XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Current Session,lazy_ntfs,
+      521,Chrome Current Tabs XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Current Tabs,lazy_ntfs,
+      522,Chrome Favicons XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Favicons*,lazy_ntfs,
+      523,Chrome History XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/History*,lazy_ntfs,
+      524,Chrome Last Session XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Last Session,lazy_ntfs,
+      525,Chrome Last Tabs XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Last Tabs,lazy_ntfs,
+      526,Chrome Login Data XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Login Data,lazy_ntfs,
+      527,Chrome Preferences XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Preferences,lazy_ntfs,
+      528,Chrome Shortcuts XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Shortcuts*,lazy_ntfs,
+      529,Chrome Top Sites XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Top Sites*,lazy_ntfs,
+      530,Chrome Visited Links XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Visited Links,lazy_ntfs,
+      531,Chrome Web Data XP,SQLDatabases,Documents and Settings/*/Local Settings/Application Data/Google/Chrome/User Data/*/Web Data*,lazy_ntfs,
+      532,Chrome bookmarks,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Bookmarks*,lazy_ntfs,
+      533,Chrome Cookies,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Cookies*,lazy_ntfs,
+      534,Chrome Current Session,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Current Session,lazy_ntfs,
+      535,Chrome Current Tabs,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Current Tabs,lazy_ntfs,
+      536,Chrome Download Metadata,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Download Metadata,lazy_ntfs,
+      537,Chrome Extension Cookies,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Extension Cookies,lazy_ntfs,
+      538,Chrome Favicons,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Favicons*,lazy_ntfs,
+      539,Chrome History,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/History*,lazy_ntfs,
+      540,Chrome Last Session,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Last Session,lazy_ntfs,
+      541,Chrome Last Tabs,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Last Tabs,lazy_ntfs,
+      542,Chrome Login Data,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data,lazy_ntfs,
+      543,Chrome Media History,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Media History*,lazy_ntfs,
+      544,Chrome Network Action Predictor,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Network Action Predictor,lazy_ntfs,
+      545,Chrome Network Persistent State,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Network Persistent State,lazy_ntfs,
+      546,Chrome Preferences,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Preferences,lazy_ntfs,
+      547,Chrome Quota Manager,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/QuotaManager,lazy_ntfs,
+      548,Chrome Reporting and NEL,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Reporting and NEL,lazy_ntfs,
+      549,Chrome Shortcuts,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Shortcuts*,lazy_ntfs,
+      550,Chrome Top Sites,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Top Sites*,lazy_ntfs,
+      551,Chrome Trust Tokens,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Trust Tokens*,lazy_ntfs,
+      552,Chrome SyncData Database,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Sync Data/SyncData.sqlite3,lazy_ntfs,
+      553,Chrome Visited Links,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Visited Links,lazy_ntfs,
+      554,Chrome Web Data,SQLDatabases,Users/*/AppData/Local/Google/Chrome/User Data/*/Web Data*,lazy_ntfs,
+      555,Edge bookmarks,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Bookmarks*,lazy_ntfs,
+      556,Edge Collections,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Collections/collectionsSQLite,lazy_ntfs,
+      557,Edge Cookies,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Cookies*,lazy_ntfs,
+      558,Edge Current Session,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Current Session,lazy_ntfs,
+      559,Edge Current Tabs,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Current Tabs,lazy_ntfs,
+      560,Edge Favicons,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Favicons*,lazy_ntfs,
+      561,Edge History,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/History*,lazy_ntfs,
+      562,Edge Last Session,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Last Session,lazy_ntfs,
+      563,Edge Last Tabs,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Last Tabs,lazy_ntfs,
+      564,Edge Login Data,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data,lazy_ntfs,
+      565,Edge Media History,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Media History*,lazy_ntfs,
+      566,Edge Network Action Predictor,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Network Action Predictor,lazy_ntfs,
+      567,Edge Preferences,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Preferences,lazy_ntfs,
+      568,Edge Shortcuts,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Shortcuts*,lazy_ntfs,
+      569,Edge Top Sites,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Top Sites*,lazy_ntfs,
+      570,Edge SyncData Database,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Sync Data/SyncData.sqlite3,lazy_ntfs,
+      571,Edge Bookmarks,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Bookmarks*,lazy_ntfs,
+      572,Edge Visited Links,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Visited Links,lazy_ntfs,
+      573,Edge Web Data,SQLDatabases,Users/*/AppData/Local/Microsoft/Edge/User Data/*/Web Data*,lazy_ntfs,
+      574,Addons,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/addons.sqlite*,lazy_ntfs,
+      575,Bookmarks,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/weave/bookmarks.sqlite*,lazy_ntfs,
+      576,Cookies,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/cookies.sqlite*,lazy_ntfs,
+      577,Cookies,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/firefox_cookies.sqlite*,lazy_ntfs,
+      578,Downloads,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/downloads.sqlite*,lazy_ntfs,
+      579,Favicons,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/favicons.sqlite*,lazy_ntfs,
+      580,Form history,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/formhistory.sqlite*,lazy_ntfs,
+      581,Permissions,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/permissions.sqlite*,lazy_ntfs,
+      582,Places,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/places.sqlite*,lazy_ntfs,
+      583,Protections,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/protections.sqlite*,lazy_ntfs,
+      584,Search,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/search.sqlite*,lazy_ntfs,
+      585,Signons,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/signons.sqlite*,lazy_ntfs,
+      586,Storage Sync,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/storage-sync.sqlite*,lazy_ntfs,
+      587,Webappstore,SQLDatabases,Users/*/AppData/Roaming/Mozilla/Firefox/Profiles/*/webappstore.sqlite*,lazy_ntfs,
+      588,Windows 10 Notification DB,SQLDatabases,Users/*/AppData/Local/Microsoft/Windows/Notifications/wpndatabase.db,lazy_ntfs,
+      589,Windows 10 Notification DB,SQLDatabases,Users/*/AppData/Local/Microsoft/Windows/Notifications/appdb.dat,lazy_ntfs,
+      590,ActivitiesCache.db,SQLDatabases,Users/*/AppData/Local/ConnectedDevicesPlatform/*/ActivitiesCache.db*,lazy_ntfs,
+      591,Update Store.db,OS Upgrade,ProgramData/USOPrivate/UpdateStore/store.db,lazy_ntfs,
+      592,Bitdefender SQLite DB Files,Antivirus,Program Files*/Bitdefender*/**10/regex:*.+/.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
+      593,EventTranscript.db,SystemEvents,ProgramData/Microsoft/Diagnosis/EventTranscript/EventTranscript.db*,lazy_ntfs,
+      594,EventTranscript.db,SystemEvents,Windows.old/ProgramData/Microsoft/Diagnosis/EventTranscript/EventTranscript.db*,lazy_ntfs,
+      595,Debian WSL /etc/debian_version,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/debian_version,lazy_ntfs,
+      596,Debian WSL /etc/fstab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/fstab,lazy_ntfs,
+      597,Debian WSL /etc/os-release,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/os-release,lazy_ntfs,
+      598,Debian WSL /etc/passwd,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/passwd,lazy_ntfs,
+      599,Debian WSL /etc/group,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/group,lazy_ntfs,
+      600,Debian WSL /etc/shadow,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/shadow,lazy_ntfs,
+      601,Debian WSL /etc/timezone,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/timezone,lazy_ntfs,
+      602,Debian WSL /etc/hostname,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/hostname,lazy_ntfs,
+      603,Debian WSL /etc/hosts,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/hosts,lazy_ntfs,
+      604,Debian WSL /etc/crontab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/crontab,lazy_ntfs,
+      605,Debian WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/bash.bashrc,lazy_ntfs,
+      606,Debian WSL /etc/profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/etc/profile,lazy_ntfs,
+      607,Debian WSL .bash_history,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/**10/.bash_history,lazy_ntfs,
+      608,Debian WSL .bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/**10/.bashrc,lazy_ntfs,
+      609,Debian WSL .profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/**10/.profile,lazy_ntfs,
+      610,Debian WSL User Crontabs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/var/spool/cron/crontabs/**10,lazy_ntfs,
+      611,Debian WSL Apt Logs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/TheDebianProject.DebianGNULinux_*/LocalState/rootfs/var/log/apt/**10/*.log,lazy_ntfs,
+      612,Kali WSL /etc/debian_version,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/debian_version,lazy_ntfs,
+      613,Kali WSL /etc/fstab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/fstab,lazy_ntfs,
+      614,Kali WSL /etc/os-release,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/os-release,lazy_ntfs,
+      615,Kali WSL /etc/passwd,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/passwd,lazy_ntfs,
+      616,Kali WSL /etc/group,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/group,lazy_ntfs,
+      617,Kali WSL /etc/shadow,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/shadow,lazy_ntfs,
+      618,Kali WSL /etc/timezone,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/timezone,lazy_ntfs,
+      619,Kali WSL /etc/hostname,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/hostname,lazy_ntfs,
+      620,Kali WSL /etc/hosts,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/hosts,lazy_ntfs,
+      621,Kali WSL /etc/crontab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/crontab,lazy_ntfs,
+      622,Kali WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/bash.bashrc,lazy_ntfs,
+      623,Kali WSL /etc/profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/etc/profile,lazy_ntfs,
+      624,Kali WSL .bash_history,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/**10/.bash_history,lazy_ntfs,
+      625,Kali WSL .bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/**10/.bashrc,lazy_ntfs,
+      626,Kali WSL .profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/**10/.profile,lazy_ntfs,
+      627,Kali WSL User Crontabs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/var/spool/cron/crontabs/**10,lazy_ntfs,
+      628,Kali WSL Apt Logs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/KaliLinux.54290C8133FEE_*/LocalState/rootfs/var/log/apt/**10/*.log,lazy_ntfs,
+      629,SUSE Linux Enterprise Server WSL /etc/os-release,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/os-release,lazy_ntfs,
+      630,SUSE Linux Enterprise Server WSL /etc/fstab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/fstab,lazy_ntfs,
+      631,SUSE Linux Enterprise Server WSL /etc/passwd,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/passwd,lazy_ntfs,
+      632,SUSE Linux Enterprise Server WSL /etc/group,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/group,lazy_ntfs,
+      633,SUSE Linux Enterprise Server WSL /etc/shadow,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/shadow,lazy_ntfs,
+      634,SUSE Linux Enterprise Server WSL /etc/timezone,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/timezone,lazy_ntfs,
+      635,SUSE Linux Enterprise Server WSL /etc/hostname,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/hostname,lazy_ntfs,
+      636,SUSE Linux Enterprise Server WSL /etc/hosts,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/hosts,lazy_ntfs,
+      637,SUSE Linux Enterprise Server WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/bash.bashrc,lazy_ntfs,
+      638,SUSE Linux Enterprise Server WSL /etc/profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/etc/profile,lazy_ntfs,
+      639,SUSE Linux Enterprise Server WSL .bash_history,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/**10/.bash_history,lazy_ntfs,
+      640,SUSE Linux Enterprise Server WSL .bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/**10/.bashrc,lazy_ntfs,
+      641,SUSE Linux Enterprise Server WSL .profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.SUSELinuxEnterpriseServer*/LocalState/rootfs/**10/.profile,lazy_ntfs,
+      642,Ubuntu WSL /etc/os-release,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/os-release,lazy_ntfs,
+      643,Ubuntu WSL /etc/fstab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/fstab,lazy_ntfs,
+      644,Ubuntu WSL /etc/passwd,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/passwd,lazy_ntfs,
+      645,Ubuntu WSL /etc/group,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/group,lazy_ntfs,
+      646,Ubuntu WSL /etc/shadow,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/shadow,lazy_ntfs,
+      647,Ubuntu WSL /etc/timezone,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/timezone,lazy_ntfs,
+      648,Ubuntu WSL /etc/hostname,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/hostname,lazy_ntfs,
+      649,Ubuntu WSL /etc/hosts,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/hosts,lazy_ntfs,
+      650,Ubuntu WSL /etc/crontab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/crontab,lazy_ntfs,
+      651,Ubuntu WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/bash.bashrc,lazy_ntfs,
+      652,Ubuntu WSL /etc/profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/etc/profile,lazy_ntfs,
+      653,Ubuntu WSL .bash_history,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/**10/.bash_history,lazy_ntfs,
+      654,Ubuntu WSL .bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/**10/.bashrc,lazy_ntfs,
+      655,Ubuntu WSL .profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/**10/.profile,lazy_ntfs,
+      656,Ubuntu WSL User Crontabs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/var/spool/cron/crontabs/**10,lazy_ntfs,
+      657,Ubuntu WSL Apt Logs,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*/LocalState/rootfs/var/log/apt/**10/*.log,lazy_ntfs,
+      658,openSUSE WSL /etc/os-release,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/os-release,lazy_ntfs,
+      659,openSUSE WSL /etc/fstab,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/fstab,lazy_ntfs,
+      660,openSUSE WSL /etc/passwd,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/passwd,lazy_ntfs,
+      661,openSUSE WSL /etc/group,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/group,lazy_ntfs,
+      662,openSUSE WSL /etc/shadow,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/shadow,lazy_ntfs,
+      663,openSUSE WSL /etc/timezone,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/timezone,lazy_ntfs,
+      664,openSUSE WSL /etc/hostname,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/hostname,lazy_ntfs,
+      665,openSUSE WSL /etc/hosts,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/hosts,lazy_ntfs,
+      666,openSUSE WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/bash.bashrc,lazy_ntfs,
+      667,openSUSE WSL /etc/profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/etc/profile,lazy_ntfs,
+      668,openSUSE WSL .bash_history,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/**10/.bash_history,lazy_ntfs,
+      669,openSUSE WSL .bashrc,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/**10/.bashrc,lazy_ntfs,
+      670,openSUSE WSL .profile,Windows Subsystem for Linux,Users/*/AppData/Local/Packages/46932SUSE.openSUSE*Leap*/LocalState/rootfs/**10/.profile,lazy_ntfs,
+      671,Diagnostic Logs for WSA,Windows Subsystem for Android,Users/*/AppData/Local/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/LocalState/diagnostics/logcat/*.log,lazy_ntfs,Filenames should be %timestamp%.log
+      672,App download artifacts (PNG),Windows Subsystem for Android,Users/*/AppData/Local/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/LocalCache/*.png,lazy_ntfs,Will provide examiners with indicators of which apps were downloaded
+      673,App download artifacts (ICO),Windows Subsystem for Android,Users/*/AppData/Local/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/LocalCache/*.ico,lazy_ntfs,Will provide examiners with indicators of which apps were downloaded WHEN since .ico files appear immediately when download of an application completes
+      674,Appcompatdb.json,Windows Subsystem for Android,Users/*/AppData/Local/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/LocalState/appcompatdb.json,lazy_ntfs,"Grabs the appcompatdb.json, unknown exactly what this is but further relevance could be uncovered after more research is conducted"
+      675,userdata.vhdx,Windows Subsystem for Android,Users/*/AppData/Local/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/LocalCache/userdata.vhdx,lazy_ntfs,Grabs the user's data which appears to be stored in a VHDX
+      676,$Boot,FileSystem,$Boot,ntfs,
+      677,$J,FileSystem,$Extend/$UsnJrnl:$J,ntfs,
+      678,$Max,FileSystem,$Extend/$UsnJrnl:$Max,ntfs,
+      679,$J,FileSystem,$Extend/$J,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      680,$Max,FileSystem,$Extend/$Max,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      681,$LogFile,FileSystem,$LogFile,ntfs,
+      682,$MFT,FileSystem,$MFT,ntfs,
+      683,$MFTMirr,FileSystem,$MFTMirr,ntfs,$MFTMirr is a redundant copy of the first four (4) records of the MFT.
+      684,$T,FileSystem,$Extend/$RmMetadata/$TxfLog/$Tops:$T,ntfs,
+      685,$T,FileSystem,$Extend/$RmMetadata/$TxfLog/$T,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Target is looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      686,Amcache,ApplicationCompatibility,Windows/AppCompat/Programs/Amcache.hve,lazy_ntfs,
+      687,Amcache,ApplicationCompatibility,Windows.old/Windows/AppCompat/Programs/Amcache.hve,lazy_ntfs,
+      688,Amcache transaction files,ApplicationCompatibility,Windows/AppCompat/Programs/Amcache.hve.LOG*,lazy_ntfs,
+      689,Amcache transaction files,ApplicationCompatibility,Windows.old/Windows/AppCompat/Programs/Amcache.hve.LOG*,lazy_ntfs,
+      690,Application Event Log XP,EventLogs,Windows/System32/config/AppEvent.evt,lazy_ntfs,
+      691,Application Event Log XP,EventLogs,Windows.old/Windows/System32/config/AppEvent.evt,lazy_ntfs,
+      692,Application Event Log Win7+,EventLogs,Windows/System32/winevt/logs/application.evtx,lazy_ntfs,
+      693,Application Event Log Win7+,EventLogs,Windows.old/Windows/System32/winevt/logs/application.evtx,lazy_ntfs,
+      694,BCD,Registry,Boot/BCD,lazy_ntfs,
+      695,BCD Logs,Registry,Boot/BCD.LOG*,lazy_ntfs,
+      696,BITS files,Persistence,ProgramData/Microsoft/Network/Downloader/**10,lazy_ntfs,
+      697,System CryptnetUrlCache,FileKnowledge,Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/**10,lazy_ntfs,
+      698,User CryptnetUrlCache,FileKnowledge,Users/*/AppData/LocalLow/Microsoft/CryptnetUrlCache/**10,lazy_ntfs,
+      699,INetCache,FileKnowledge,Users/*/AppData/Local/Microsoft/Windows/INetCache/IE/**10,lazy_ntfs,
+      700,EncapsulationLogging,Executables,Windows/Appcompat/Programs/EncapsulationLogging.hve,lazy_ntfs,
+      701,EncapsulationLogging,Executables,Windows.old/Windows/Appcompat/Programs/EncapsulationLogging.hve,lazy_ntfs,
+      702,EncapsulationLogging Logs,Executables,Windows/Appcompat/Programs/EncapsulationLogging.hve.log*,lazy_ntfs,
+      703,EncapsulationLogging Logs,Executables,Windows.old/Windows/Appcompat/Programs/EncapsulationLogging.hve.log*,lazy_ntfs,
+      704,Event logs Win7+,EventLogs,Windows/System32/winevt/logs/System.evtx,lazy_ntfs,
+      705,Event logs Win7+,EventLogs,Windows.old/Windows/System32/winevt/logs/System.evtx,lazy_ntfs,
+      706,Event logs Win7+,EventLogs,Windows/System32/winevt/logs/Security.evtx,lazy_ntfs,
+      707,Event logs Win7+,EventLogs,Windows.old/Windows/System32/winevt/logs/Security.evtx,lazy_ntfs,
+      708,Event logs Win7+,EventLogs,Windows/System32/winevt/Logs/Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx/Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx,lazy_ntfs,
+      709,Event logs Win7+,EventLogs,Windows/System32/winevt/Logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx,lazy_ntfs,
+      710,Event logs XP,EventLogs,Windows/System32/config/*.evt,lazy_ntfs,
+      711,Event logs Win7+,EventLogs,Windows/System32/winevt/logs/*.evtx,lazy_ntfs,
+      712,Event logs Win7+,EventLogs,Windows.old/Windows/System32/winevt/logs/*.evtx,lazy_ntfs,
+      713,WDI Trace Logs 1,Event Trace Logs,Windows/System32/WDI/LogFiles/*.etl*,lazy_ntfs,
+      714,WDI Trace Logs 1,Event Trace Logs,Windows.old/Windows/System32/WDI/LogFiles/*.etl*,lazy_ntfs,
+      715,WDI Trace Logs 2,Event Trace Logs,Windows/System32/WDI/{*/**10,lazy_ntfs,
+      716,WDI Trace Logs 2,Event Trace Logs,Windows.old/Windows/System32/WDI/{*/**10,lazy_ntfs,
+      717,WMI Trace Logs,Event Trace Logs,Windows/System32/LogFiles/WMI/**10,lazy_ntfs,
+      718,WMI Trace Logs,Event Trace Logs,Windows.old/Windows/System32/LogFiles/WMI/**10,lazy_ntfs,
+      719,SleepStudy Trace Logs,Event Trace Logs,Windows/System32/SleepStudy/**10,lazy_ntfs,
+      720,SleepStudy Trace Logs,Event Trace Logs,Windows.old/Windows/System32/SleepStudy/**10,lazy_ntfs,
+      721,Energy-NTKL Trace Logs,Event Trace Logs,ProgramData/Microsoft/Windows/PowerEfficiency Diagnostics/energy-ntkl.etl,lazy_ntfs,
+      722,Delivery Optimization Trace Logs,Event Trace Logs,Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/*.etl*,lazy_ntfs,
+      723,EventTranscript.db,SystemEvents,ProgramData/Microsoft/Diagnosis/EventTranscript/EventTranscript.db*,lazy_ntfs,
+      724,EventTranscript.db,SystemEvents,Windows.old/ProgramData/Microsoft/Diagnosis/EventTranscript/EventTranscript.db*,lazy_ntfs,
+      725,Microsoft Office Diagnostic Logs,SystemEvents,Users/%User%/AppData/Local/Temp/Diagnostics/**10,lazy_ntfs,
+      726,Local Group Policy INI Files,Communication,Windows/System32/grouppolicy/*.ini,lazy_ntfs,
+      727,Local Group Policy INI Files,Communication,Windows.old/Windows/System32/grouppolicy/*.ini,lazy_ntfs,
+      728,Local Group Policy Files - Registry Policy Files,Communication,Windows/System32/grouppolicy/*.pol,lazy_ntfs,
+      729,Local Group Policy Files - Registry Policy Files,Communication,Windows.old/Windows/System32/grouppolicy/*.pol,lazy_ntfs,
+      730,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows/System32/grouppolicy/*/Scripts/**10,lazy_ntfs,
+      731,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows.old/Windows/System32/grouppolicy/*/Scripts/**10,lazy_ntfs,
+      732,LNK Files from Recent,LNKFiles,Users/*/AppData/Roaming/Microsoft/Windows/Recent/**10,lazy_ntfs,Also includes automatic and custom jumplist directories
+      733,LNK Files from Microsoft Office Recent,LNKFiles,Users/*/AppData/Roaming/Microsoft/Office/Recent/**10,lazy_ntfs,
+      734,LNK Files from Recent (XP),LNKFiles,Documents and Settings/*/Recent/**10,lazy_ntfs,
+      735,Desktop LNK Files XP,LNKFiles,Documents and Settings/*/Desktop/*.LNK,lazy_ntfs,
+      736,Desktop LNK Files,LNKFiles,Users/*/Desktop/*.LNK,lazy_ntfs,
+      737,Restore point LNK Files XP,LNKFiles,System Volume Information/_restore*/RP*/*.LNK,lazy_ntfs,
+      738,LNK Files from C:\ProgramData,LNKFiles,ProgramData/Microsoft/Windows/Start Menu/Programs/*.LNK,lazy_ntfs,
+      739,.bash_history,Windows Linux Profile,Users/*/AppData/Local/Packages/*/LocalState/rootfs/home/*/.bash_history,lazy_ntfs,
+      740,.bash_logout,Windows Linux Profile,Users/*/AppData/Local/Packages/*/LocalState/rootfs/home/*/.bash_logout,lazy_ntfs,
+      741,.bashrc,Windows Linux Profile,Users/*/AppData/Local/Packages/*/LocalState/rootfs/home/*/.bashrc,lazy_ntfs,
+      742,.profile,Windows Linux Profile,Users/*/AppData/Local/Packages/*/LocalState/rootfs/home/*/.profile,lazy_ntfs,
+      743,LogFiles,Logs,Windows/System32/LogFiles/**10,lazy_ntfs,
+      744,LogFiles,Logs,Windows.old/Windows/System32/LogFiles/**10,lazy_ntfs,
+      745,MOF files,WMI,**10/*.MOF,lazy_ntfs,
+      746,hiberfil.sys,Memory,hiberfil.sys,lazy_ntfs,
+      747,pagefile.sys,Memory,pagefile.sys,lazy_ntfs,
+      748,swapfile.sys,Memory,swapfile.sys,lazy_ntfs,
+      749,Small Memory Dump directory,Memory,Windows/Minidump/*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
+      750,Small Memory Dump directory,Memory,Windows.old/Windows/Minidump/*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
+      751,Word Autosave Location,FileKnowledge,Users/*/AppData/Roaming/Microsoft/Word/**10,lazy_ntfs,
+      752,Excel Autosave Location,ApplicationCompatibility,Users/*/AppData/Roaming/Microsoft/Excel/**10,lazy_ntfs,
+      753,Powerpoint Autosave Location,FileKnowledge,Users/*/AppData/Roaming/Microsoft/Powerpoint/**10,lazy_ntfs,
+      754,Publisher Autosave Location,FileKnowledge,Users/*/AppData/Roaming/Microsoft/Publisher/**10,lazy_ntfs,
+      755,Office Document Cache,FileKnowledge,Users/*/AppData/Local/Microsoft/Office/*/OfficeFileCache/**10,lazy_ntfs,
+      756,Prefetch,Prefetch,Windows/prefetch/*.pf,lazy_ntfs,
+      757,Prefetch,Prefetch,Windows.old/Windows/prefetch/*.pf,lazy_ntfs,
+      758,RDP Cache Files,FileSystem,Users/*/AppData/Local/Microsoft/Terminal Server Client/Cache/*,lazy_ntfs,
+      759,RDP Cache Files,FileSystem,Documents and Settings/*/Local Settings/Application Data/Microsoft/Terminal Server Client/Cache/*,lazy_ntfs,
+      760,RemoteConnectionManager Event Logs,EventLogs,Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
+      761,RemoteConnectionManager Event Logs,EventLogs,Windows.old/Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
+      762,LocalSessionManager Event Logs,EventLogs,Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
+      763,LocalSessionManager Event Logs,EventLogs,Windows.old/Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
+      764,RDPClient Event Logs,EventLogs,Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
+      765,RDPClient Event Logs,EventLogs,Windows.old/Windows/System32/winevt/logs/Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
+      766,RDPCoreTS Event Logs,EventLogs,Windows/System32/winevt/logs/Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
+      767,RDPCoreTS Event Logs,EventLogs,Windows.old/Windows/System32/winevt/logs/Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
+      768,RecentFileCache,ApplicationCompatability,Windows/AppCompat/Programs/RecentFileCache.bcf,lazy_ntfs,
+      769,RecentFileCache,ApplicationCompatability,Windows.old/Windows/AppCompat/Programs/RecentFileCache.bcf,lazy_ntfs,
+      770,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$R*,lazy_ntfs,
+      771,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/D*,lazy_ntfs,
+      772,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$I*,lazy_ntfs,
+      773,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/INFO2,lazy_ntfs,
+      774,BBI registry hive,Registry,Windows/System32/config/BBI,lazy_ntfs,
+      775,BBI registry hive,Registry,Windows.old/Windows/System32/config/BBI,lazy_ntfs,
+      776,BBI registry transaction files,Registry,Windows/System32/config/BBI.LOG*,lazy_ntfs,
+      777,BBI registry transaction files,Registry,Windows.old/System32/config/BBI.LOG*,lazy_ntfs,
+      778,BCD-Template registry hive,Registry,Windows/System32/config/BCD-Template,lazy_ntfs,
+      779,BCD-Template registry hive,Registry,Windows.old/Windows/System32/config/BCD-Template,lazy_ntfs,
+      780,BCD-Template registry transaction files,Registry,Windows/System32/config/BCD-Template.LOG*,lazy_ntfs,
+      781,BCD-Template registry transaction files,Registry,Windows.old/System32/config/BCD-Template.LOG*,lazy_ntfs,
+      782,COMPONENTS registry hive,Registry,Windows/System32/config/COMPONENTS,lazy_ntfs,
+      783,COMPONENTS registry hive,Registry,Windows.old/Windows/System32/config/COMPONENTS,lazy_ntfs,
+      784,COMPONENTS registry transaction files,Registry,Windows/System32/config/COMPONENTS.LOG*,lazy_ntfs,
+      785,COMPONENTS registry transaction files,Registry,Windows.old/System32/config/COMPONENTS.LOG*,lazy_ntfs,
+      786,DRIVERS registry hive,Registry,Windows/System32/config/DRIVERS,lazy_ntfs,
+      787,DRIVERS registry hive,Registry,Windows.old/Windows/System32/config/DRIVERS,lazy_ntfs,
+      788,DRIVERS registry transaction files,Registry,Windows/System32/config/DRIVERS.LOG*,lazy_ntfs,
+      789,DRIVERS registry transaction files,Registry,Windows.old/System32/config/DRIVERS.LOG*,lazy_ntfs,
+      790,ELAM registry hive,Registry,Windows/System32/config/ELAM,lazy_ntfs,
+      791,ELAM registry hive,Registry,Windows.old/Windows/System32/config/ELAM,lazy_ntfs,
+      792,ELAM registry transaction files,Registry,Windows/System32/config/ELAM.LOG*,lazy_ntfs,
+      793,ELAM registry transaction files,Registry,Windows.old/System32/config/ELAM.LOG*,lazy_ntfs,
+      794,userdiff registry hive,Registry,Windows/System32/config/userdiff,lazy_ntfs,
+      795,userdiff registry hive,Registry,Windows.old/Windows/System32/config/userdiff,lazy_ntfs,
+      796,userdiff registry transaction files,Registry,Windows/System32/config/userdiff.LOG*,lazy_ntfs,
+      797,userdiff registry transaction files,Registry,Windows.old/System32/config/userdiff.LOG*,lazy_ntfs,
+      798,VSMIDK registry hive,Registry,Windows/System32/config/VSMIDK,lazy_ntfs,
+      799,VSMIDK registry hive,Registry,Windows.old/Windows/System32/config/VSMIDK,lazy_ntfs,
+      800,VSMIDK registry transaction files,Registry,Windows/System32/config/VSMIDK.LOG*,lazy_ntfs,
+      801,VSMIDK registry transaction files,Registry,Windows.old/System32/config/VSMIDK.LOG*,lazy_ntfs,
+      802,SAM registry transaction files,Registry,Windows/System32/config/SAM.LOG*,lazy_ntfs,
+      803,SAM registry transaction files,Registry,Windows.old/Windows/System32/config/SAM.LOG*,lazy_ntfs,
+      804,SECURITY registry transaction files,Registry,Windows/System32/config/SECURITY.LOG*,lazy_ntfs,
+      805,SECURITY registry transaction files,Registry,Windows.old/Windows/System32/config/SECURITY.LOG*,lazy_ntfs,
+      806,SOFTWARE registry transaction files,Registry,Windows/System32/config/SOFTWARE.LOG*,lazy_ntfs,
+      807,SOFTWARE registry transaction files,Registry,Windows.old/Windows/System32/config/SOFTWARE.LOG*,lazy_ntfs,
+      808,SYSTEM registry transaction files,Registry,Windows/System32/config/SYSTEM.LOG*,lazy_ntfs,
+      809,SYSTEM registry transaction files,Registry,Windows.old/Windows/System32/config/SYSTEM.LOG*,lazy_ntfs,
+      810,SAM registry hive,Registry,Windows/System32/config/SAM,lazy_ntfs,
+      811,SAM registry hive,Registry,Windows.old/Windows/System32/config/SAM,lazy_ntfs,
+      812,SECURITY registry hive,Registry,Windows/System32/config/SECURITY,lazy_ntfs,
+      813,SECURITY registry hive,Registry,Windows.old/Windows/System32/config/SECURITY,lazy_ntfs,
+      814,SOFTWARE registry hive,Registry,Windows/System32/config/SOFTWARE,lazy_ntfs,
+      815,SOFTWARE registry hive,Registry,Windows.old/Windows/System32/config/SOFTWARE,lazy_ntfs,
+      816,SYSTEM registry hive,Registry,Windows/System32/config/SYSTEM,lazy_ntfs,
+      817,SYSTEM registry hive,Registry,Windows.old/Windows/System32/config/SYSTEM,lazy_ntfs,
+      818,RegBack registry transaction files,Registry,Windows/System32/config/RegBack/*.LOG*,lazy_ntfs,
+      819,RegBack registry transaction files,Registry,Windows.old/Windows/System32/config/RegBack/*.LOG*,lazy_ntfs,
+      820,SAM registry hive (RegBack),Registry,Windows/System32/config/RegBack/SAM,lazy_ntfs,
+      821,SAM registry hive (RegBack),Registry,Windows.old/Windows/System32/config/RegBack/SAM,lazy_ntfs,
+      822,SECURITY registry hive (RegBack),Registry,Windows/System32/config/RegBack/SECURITY,lazy_ntfs,
+      823,SECURITY registry hive (RegBack),Registry,Windows.old/Windows/System32/config/RegBack/SECURITY,lazy_ntfs,
+      824,SOFTWARE registry hive (RegBack),Registry,Windows/System32/config/RegBack/SOFTWARE,lazy_ntfs,
+      825,SOFTWARE registry hive (RegBack),Registry,Windows.old/Windows/System32/config/RegBack/SOFTWARE,lazy_ntfs,
+      826,SYSTEM registry hive (RegBack),Registry,Windows/System32/config/RegBack/SYSTEM,lazy_ntfs,
+      827,SYSTEM registry hive (RegBack),Registry,Windows.old/Windows/System32/config/RegBack/SYSTEM,lazy_ntfs,
+      828,SYSTEM registry hive (RegBack),Registry,Windows/System32/config/RegBack/SYSTEM1,lazy_ntfs,
+      829,SYSTEM registry hive (RegBack),Registry,Windows.old/Windows/System32/config/RegBack/SYSTEM1,lazy_ntfs,
+      830,System Profile registry hive,Registry,Windows/System32/config/systemprofile/NTUSER.DAT,lazy_ntfs,
+      831,System Profile registry hive,Registry,Windows.old/Windows/System32/config/systemprofile/NTUSER.DAT,lazy_ntfs,
+      832,System Profile registry transaction files,Registry,Windows/System32/config/systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
+      833,System Profile registry transaction files,Registry,Windows.old/Windows/System32/config/systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
+      834,Local Service registry hive,Registry,Windows/ServiceProfiles/LocalService/NTUSER.DAT,lazy_ntfs,
+      835,Local Service registry hive,Registry,Windows.old/Windows/ServiceProfiles/LocalService/NTUSER.DAT,lazy_ntfs,
+      836,Local Service registry transaction files,Registry,Windows/ServiceProfiles/LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
+      837,Local Service registry transaction files,Registry,Windows.old/Windows/ServiceProfiles/LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
+      838,Network Service registry hive,Registry,Windows/ServiceProfiles/NetworkService/NTUSER.DAT,lazy_ntfs,
+      839,Network Service registry hive,Registry,Windows.old/Windows/ServiceProfiles/NetworkService/NTUSER.DAT,lazy_ntfs,
+      840,Network Service registry transaction files,Registry,Windows/ServiceProfiles/NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
+      841,Network Service registry transaction files,Registry,Windows.old/Windows/ServiceProfiles/NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
+      842,System Restore Points Registry Hives (XP),Registry,System Volume Information/_restore*/RP*/snapshot/_REGISTRY_*,lazy_ntfs,
+      843,NTUSER.DAT registry hive XP,Registry,Documents and Settings/*/NTUSER.DAT,lazy_ntfs,
+      844,NTUSER.DAT registry hive,Registry,Users/*/NTUSER.DAT,lazy_ntfs,
+      845,NTUSER.DAT registry transaction files,Registry,Users/*/NTUSER.DAT.LOG*,lazy_ntfs,
+      846,NTUSER.DAT DEFAULT registry hive,Registry,Windows/System32/config/DEFAULT,lazy_ntfs,
+      847,NTUSER.DAT DEFAULT registry hive,Registry,Windows.old/Windows/System32/config/DEFAULT,lazy_ntfs,
+      848,NTUSER.DAT DEFAULT transaction files,Registry,Windows/System32/config/DEFAULT.LOG*,lazy_ntfs,
+      849,NTUSER.DAT DEFAULT transaction files,Registry,Windows.old/Windows/System32/config/DEFAULT.LOG*,lazy_ntfs,
+      850,UsrClass.dat registry hive,Registry,Users/*/AppData/Local/Microsoft/Windows/UsrClass.dat,lazy_ntfs,
+      851,UsrClass.dat registry transaction files,Registry,Users/*/AppData/Local/Microsoft/Windows/UsrClass.dat.LOG*,lazy_ntfs,
+      852,SDB Files,Executables,Windows/apppatch/Custom/*.sdb,lazy_ntfs,
+      853,SDB Files,Executables,Windows.old/Windows/apppatch/Custom/*.sdb,lazy_ntfs,
+      854,SDB Files x64,Executables,Windows/apppatch/Custom/Custom64/*.sdb,lazy_ntfs,
+      855,SDB Files x64,Executables,Windows.old/Windows/apppatch/Custom/Custom64/*.sdb,lazy_ntfs,
+      856,SRUM,Execution,Windows/System32/SRU/**10,lazy_ntfs,
+      857,SRUM,Execution,Windows.old/Windows/System32/SRU/**10,lazy_ntfs,
+      858,SOFTWARE registry hive,Registry,Windows/System32/config/SOFTWARE,lazy_ntfs,
+      859,SOFTWARE registry hive,Registry,Windows.old/Windows/System32/config/SOFTWARE,lazy_ntfs,
+      860,SOFTWARE registry transaction files,Registry,Windows/System32/config/SOFTWARE.LOG*,lazy_ntfs,
+      861,SOFTWARE registry transaction files,Registry,Windows.old/Windows/System32/config/SOFTWARE.LOG*,lazy_ntfs,
+      862,SUM Database (.mdb files),Logs,Windows/System32/LogFiles/SUM/*.mdb,lazy_ntfs,"Grabs Current.mdb, SystemIdentity.mdb, and [GUID].mdb"
+      863,at .job,Persistence,Windows/Tasks/*.job,lazy_ntfs,
+      864,at .job,Persistence,Windows.old/Windows/Tasks/*.job,lazy_ntfs,
+      865,at SchedLgU.txt,Persistence,Windows/SchedLgU.txt,lazy_ntfs,
+      866,at SchedLgU.txt,Persistence,Windows.old/Windows/SchedLgU.txt,lazy_ntfs,
+      867,XML,Persistence,Windows/System32/Tasks/**10,lazy_ntfs,
+      868,XML,Persistence,Windows.old/Windows/System32/Tasks/**10,lazy_ntfs,
+      869,SignatureCatalog,FileMetadata,Windows/System32/CatRoot/**10,lazy_ntfs,
+      870,SignatureCatalog,FileMetadata,Windows.old/Windows/System32/CatRoot/**10,lazy_ntfs,
+      871,StartupInfo XML Files,Persistence,Windows/System32/WDI/LogFiles/StartupInfo/*.xml,lazy_ntfs,
+      872,StartupInfo XML Files,Persistence,Windows.old/Windows/System32/WDI/LogFiles/StartupInfo/*.xml,lazy_ntfs,
+      873,Syscache,Program Execution,System Volume Information/Syscache.hve,lazy_ntfs,
+      874,Syscache transaction files,Program Execution,System Volume Information/Syscache.hve.LOG*,lazy_ntfs,
+      875,Thumbcache DB,FileKnowledge,Users/*/AppData/Local/Microsoft/Windows/Explorer/thumbcache_*.db,lazy_ntfs,
+      876,Setupapi.log XP,USBDevices,Windows/setupapi.log,lazy_ntfs,
+      877,Setupapi.log Win7+,USBDevices,Windows/inf/setupapi.dev.log,lazy_ntfs,
+      878,Setupapi.log Win7+,USBDevices,Windows.old/Windows/inf/setupapi.dev.log,lazy_ntfs,
+      879,VHD,Disk Images,**10/*.VHD,lazy_ntfs,
+      880,VHDX,Disk Images,**10/*.VHDX,lazy_ntfs,
+      881,VDI,Disk Images,**10/*.VDI,lazy_ntfs,
+      882,VMDK,Disk Images,**10/*.VMDK,lazy_ntfs,
+      883,WBEM,WBEM,Windows/System32/wbem/Repository/**10,lazy_ntfs,
+      884,WBEM,WBEM,Windows.old/Windows/System32/wbem/Repository/**10,lazy_ntfs,
+      885,WER Files,Executables,ProgramData/Microsoft/Windows/WER/**10,lazy_ntfs,
+      886,Crash Dumps,SQL Exploitation,Users/*/AppData/Local/CrashDumps/*.dmp,lazy_ntfs,
+      887,Crash Dumps,SQL Exploitation,Windows/*.dmp,lazy_ntfs,
+      888,Crash Dumps,SQL Exploitation,Windows.old/Windows/*.dmp,lazy_ntfs,
+      889,Windows Firewall Logs,WindowsFirewallLogs,Windows/System32/LogFiles/Firewall/pfirewall.*,lazy_ntfs,
+      890,Windows Firewall Logs,WindowsFirewallLogs,Windows.old/Windows/System32/LogFiles/Firewall/pfirewall.*,lazy_ntfs,
+      891,WindowsIndexSearch,FileKnowledge,programdata/microsoft/search/data/applications/windows/Windows.edb,lazy_ntfs,
+      892,Windows 10 Notification DB,Notifications,Users/*/AppData/Local/Microsoft/Windows/Notifications/wpndatabase.db,lazy_ntfs,
+      893,Windows 10 Notification DB,Notifications,Users/*/AppData/Local/Microsoft/Windows/Notifications/appdb.dat,lazy_ntfs,
+      894,MigLog.xml,OS Upgrade,Windows/Panther/MigLog.xml,lazy_ntfs,
+      895,Setupact.log,OS Upgrade,Windows/Panther/Setupact.log,lazy_ntfs,
+      896,HumanReadable.xml,OS Upgrade,Windows/Panther/*HumanReadable.xml,lazy_ntfs,
+      897,FolderMoveLog.txt,OS Upgrade,Windows/Panther/Rollback/FolderMoveLog.txt,lazy_ntfs,
+      898,Update Store.db,OS Upgrade,ProgramData/USOPrivate/UpdateStore/store.db,lazy_ntfs,
+      899,Windows Power Diagnostics,Diagnostics,ProgramData/Microsoft/Windows/Power Efficiency Diagnostics/**10,lazy_ntfs,
+      900,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,ProgramData/Microsoft/Diagnosis/events*.rbs,lazy_ntfs,
+      901,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,Windows.old/ProgramData/Microsoft/Diagnosis/events*.rbs,lazy_ntfs,
+      902,ActivitiesCache.db,FileFolderAccess,Users/*/AppData/Local/ConnectedDevicesPlatform/*/ActivitiesCache.db*,lazy_ntfs,
+      903,System Volume Information,Folder capture,System Volume Information/**10,lazy_ntfs,
+      904,TorrentClients - BitTorrent,FileDownload,Users/*/AppData/Roaming/BitTorrent/*.dat,lazy_ntfs,
+      905,DC++ Chat Logs,FileDownload,Users/*/AppData/Local/DC++/Logs/**10,lazy_ntfs,Locates DC++ hub/chat logs and copies them. Current as of version 0.868.
+      906,Freenet,File Downloads,Users/*/AppData/Local/Freenet/node*,lazy_ntfs,
+      907,Freenet,File Downloads,Users/*/AppData/Local/Freenet/*completed.list.downloads,lazy_ntfs,
+      908,Freenet,File Downloads,Users/*/AppData/Local/Freenet/*completed.list.uploads,lazy_ntfs,
+      909,Freenet,File Downloads,Users/*/AppData/Local/Freenet/*.bak,lazy_ntfs,
+      910,Freenet,File Downloads,Users/*/AppData/Local/Freenet/downloads/**10,lazy_ntfs,
+      911,FrostWire Downloads,FileDownload,Users/*/Documents/FrostWire/Torrent Data/**10,lazy_ntfs,Locates files downloaded that land in the default location as specified by FrostWire
+      912,FrostWire AppData,FileDownload,Users/*/.frostwire5/frostwire.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
+      913,FrostWire AppData,FileDownload,Users/*/.frostwire5/itunes.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
+      914,Gigatribe Files Windows Vista/7/8/10,FileDownload,Users/*/AppData/Local/Shalsoft/**10,lazy_ntfs,Locates Gigatribe files and copies them
+      915,Gigatribe Files Windows XP,FileDownload,Documents and Settings/*/*/Application Data/Gigatribe/**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Gigatribe
+      916,Gigatribe Files Windows XP,FileDownload,Documents and Settings/*/*/Application Data/Shalsoft/**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Shalsoft
+      917,Usenet Clients - NZBGet Log File,FileDownload,ProgramData/NZBGet/nzbget.log,lazy_ntfs,Locates NZBGet download log file
+      918,Usenet Clients - NZBGet NZBs,FileDownload,ProgramData/NZBGet/nzb/*,lazy_ntfs,Locates NZBGet NZB files that were used by the user
+      919,Usenet Clients - Newsbin Pro,FileDownload,Users/*/AppData/Local/Newsbin/Downloaded.db3,lazy_ntfs,Locates Newsbin Pro download log database
+      920,Usenet Clients - Newsleecher,FileDownload,Users/*/AppData/Roaming/NewsLeecher/downloaded.dat,lazy_ntfs,Locates Newsleecher download .dat file
+      921,Nicotine++ Logs,FileDownload,Users/%User%/AppData/Roaming/nicotine/logs/**10,lazy_ntfs,"Locates Nicotine++ chat logs, room logs, transfer logs, and debug logs (if enabled)"
+      922,Nicotine++ Incomplete Downloads,FileDownload,Users/%User%/AppData/Roaming/nicotine/incomplete/**10,lazy_ntfs,Locates files that did not finish downloading
+      923,Nicotine++ Buddyfiles.db,FileDownload,Users/%User%/AppData/Roaming/nicotine/buddyfiles.db/**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
+      924,Nicotine++ Buddystreams.db,FileDownload,Users/%User%/AppData/Roaming/nicotine/buddystreams.db/**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
+      925,Nicotine++ Buddymtimes.db,FileDownload,Users/%User%/AppData/Roaming/nicotine/buddymtimes.db/**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a folder level"
+      926,Nicotine++ Buddyfileindex.db,FileDownload,Users/%User%/AppData/Roaming/nicotine/buddyfileindex.db/**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a file level"
+      927,Nicotine++ Buddywordindex.db,FileDownload,Users/%User%/AppData/Roaming/nicotine/buddywordindex.db/**10,lazy_ntfs,Unknown what this is for at this time
+      928,Nicotine++ Config Files,FileDownload,Users/%User%/AppData/Roaming/nicotine/config/**10,lazy_ntfs,Locates config files
+      929,Nicotine++ User Shares,FileDownload,Users/%User%/AppData/Roaming/nicotine/usershares/**10,lazy_ntfs,Locates a DB that appears to store a list of files per user that they are sharing within Nicotine++. Note: this requires the user to right-click -> browse files shared by that user
+      930,Nicotine++ Downloads.json,FileDownload,Users/%User%/AppData/Roaming/nicotine/downloads.json*,lazy_ntfs,Locates downloads.json
+      931,Nicotine++ Uploads.json,FileDownload,Users/%User%/AppData/Roaming/nicotine/uploads.json*,lazy_ntfs,Locates uploads.json
+      932,Usenet Clients - SABnzbd Download Logs,FileDownload,Users/*/AppData/Local/sabnzbd/logs/sabnzbd.log,lazy_ntfs,Locates SABnzbd download log
+      933,Usenet Clients - SABnzbd History.db,FileDownload,Users/*/AppData/Local/sabnzbd/admin/history1.db,lazy_ntfs,Locates SABnzbd history log
+      934,Shareaza Logs,FileDownload,Users/*/AppData/Roaming/Shareaza/**10,lazy_ntfs,Locates Shareaza logs and copies them.
+      935,Soulseek Chat Logs,FileDownload,Users/*/AppData/Local/SoulseekQt/Soulseek Chat Logs/**10,lazy_ntfs,Locates Soulseek chat logs and copies them. Chat logs are in plaintext. Current as of version 2019.7.22.
+      936,Soulseek Search History/Shared Folders/Settings,FileDownload,Users/*/AppData/Local/SoulseekQt/1/*.dat,lazy_ntfs,"Locates .dat file(s) containing: search history, active searches (search_record), current shared folders (shared_file_folder), and wish list items (wish_list_item)."
+      937,Torrents,FileDownload,**10/*.torrent,lazy_ntfs,
+      938,Usenet (NZB) Files,FileDownload,**10/*.nzb,lazy_ntfs,
+      939,TorrentClients - qBittorrent,FileDownload,Users/*/AppData/Roaming/qBittorrent/*.ini,lazy_ntfs,
+      940,TorrentClients - qBittorrent,FileDownload,Users/*/AppData/Local/qBittorrent/logs/*,lazy_ntfs,
+      941,TorrentClients - uTorrent,FileDownload,Users/*/AppData/Roaming/uTorrent/*.dat,lazy_ntfs,
+  - name: KapeTargets
+    type: hidden
+    description: Each parameter above represents a group of rules to be triggered. This table specifies which rule IDs will be included when the parameter is checked.
+    default: |
+      Group,RuleIds
+      _BasicCollection,"[138, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 863, 864, 865, 866, 867, 868, 873, 874, 875, 876, 877, 878, 891]"
+      _SANS_Triage,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 226, 227, 228, 229, 230, 231, 232, 235, 236, 239, 254, 255, 259, 260, 261, 262, 263, 295, 296, 299, 300, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 332, 342, 343, 344, 345, 346, 361, 362, 393, 394, 395, 396, 397, 398, 399, 400, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 426, 427, 431, 432, 433, 434, 435, 461, 462, 463, 464, 465, 466, 473, 474, 484, 485, 486, 487, 488, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 873, 874, 875, 883, 884, 891, 902]"
+      _Boot,[676]
+      _J,"[677, 678, 679, 680]"
+      _LogFile,[681]
+      _MFT,[682]
+      _MFTMirr,[683]
+      _T,"[684, 685]"
+      1Password,"[218, 219, 220]"
+      4KVideoDownloader,[221]
+      AVG,"[139, 140, 141, 142]"
+      AceText,[222]
+      AcronisTrueImage,"[223, 224, 225]"
+      Amcache,"[686, 687, 688, 689]"
+      Ammyy,[226]
+      Antivirus,"[139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 690, 691, 692, 693]"
+      AnyDesk,"[227, 228, 229, 230, 231, 232]"
+      ApacheAccessLog,[128]
+      AppData,[205]
+      ApplicationEvents,"[690, 691, 692, 693]"
+      AsperaConnect,"[233, 234]"
+      Avast,"[143, 144, 145, 146]"
+      AviraAVLogs,[147]
+      BCD,"[694, 695]"
+      BITS,[696]
+      BitTorrent,[904]
+      Bitdefender,"[148, 149, 150]"
+      BoxDrive_Metadata,"[235, 236]"
+      BoxDrive_UserFiles,"[237, 238]"
+      BrowserCache,"[1, 2, 3, 4, 5, 6]"
+      CertUtil,"[697, 698, 699]"
+      Chrome,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]"
+      ChromeExtensions,"[46, 47]"
+      ChromeFileSystem,[48]
+      CiscoJabber,[239]
+      ClipboardMaster,"[240, 241, 242]"
+      CloudStorage_All,"[235, 236, 237, 238, 259, 260, 261, 262, 263, 264, 294, 295, 296, 361, 362, 363, 421, 422, 423, 489, 490, 491]"
+      CloudStorage_Metadata,"[235, 236, 259, 260, 261, 262, 263, 295, 296, 361, 362]"
+      CombinedLogs,"[138, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 876, 877, 878, 889, 890]"
+      ComboFix,[151]
+      ConfluenceLogs,"[243, 244]"
+      Cybereason,"[152, 153, 154]"
+      DC__,[905]
+      Debian,"[595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611]"
+      DirectoryOpus,"[245, 246, 247, 248, 249, 250, 251, 252, 253]"
+      DirectoryTraversal_AudioFiles,[206]
+      DirectoryTraversal_ExcelDocuments,[207]
+      DirectoryTraversal_PDFDocuments,[208]
+      DirectoryTraversal_PictureFiles,[209]
+      DirectoryTraversal_SQLiteDatabases,[210]
+      DirectoryTraversal_VideoFiles,[211]
+      DirectoryTraversal_WildCardExample,[212]
+      DirectoryTraversal_WordDocuments,[213]
+      Discord,"[254, 255]"
+      DoubleCommander,"[256, 257, 258]"
+      Dropbox_Metadata,"[259, 260, 261, 262, 263]"
+      Dropbox_UserFiles,[264]
+      EFCommander,[265]
+      ESET,"[155, 156]"
+      Edge,[49]
+      EdgeChromium,"[50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]"
+      Emsisoft,[157]
+      EncapsulationLogging,"[700, 701, 702, 703]"
+      EventLogs_RDP,"[704, 705, 706, 707, 708, 709]"
+      EventLogs,"[710, 711, 712]"
+      EventTraceLogs,"[713, 714, 715, 716, 717, 718, 719, 720, 721, 722]"
+      EventTranscriptDB,"[723, 724, 725]"
+      Evernote,"[266, 267, 268]"
+      Everything__VoidTools_,"[269, 270, 271]"
+      EvidenceOfExecution,"[686, 687, 688, 689, 756, 757, 768, 769, 873, 874]"
+      Exchange,"[272, 277]"
+      ExchangeClientAccess,[272]
+      ExchangeCve_2021_26855,"[273, 274, 275, 276]"
+      ExchangeTransport,[277]
+      FSecure,"[158, 159, 160]"
+      FTPClients,"[279, 280, 281, 282, 475]"
+      Fences,[278]
+      FileExplorerReplacements,"[245, 246, 247, 248, 249, 250, 251, 252, 253, 256, 257, 258, 265, 283, 284, 285, 286, 287, 288, 289, 349, 350, 351, 352, 353, 354, 359, 360, 390, 391, 419, 428, 429, 430, 448, 449, 450, 451, 452, 453, 477, 478, 479, 480]"
+      FileSystem,"[676, 677, 678, 679, 680, 681, 682, 684, 685]"
+      FileZillaClient,"[279, 280]"
+      FileZillaServer,"[281, 282]"
+      Firefox,"[71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105]"
+      FreeCommander,"[283, 284, 285, 286, 287, 288, 289]"
+      FreeDownloadManager,"[290, 291, 292]"
+      FreeFileSync,[293]
+      Freenet,"[906, 907, 908, 909, 910]"
+      FrostWire,"[911, 912, 913]"
+      Gigatribe,"[914, 915, 916]"
+      GoogleDriveBackupSync_UserFiles,[294]
+      GoogleDrive_Metadata,"[295, 296]"
+      GroupPolicy,"[726, 727, 728, 729, 730, 731]"
+      HeidiSQL,"[297, 298]"
+      HexChat,[299]
+      HitmanPro,"[161, 162, 163]"
+      IISLogFiles,"[129, 130, 131, 132, 133]"
+      IRCClients,"[299, 300, 484, 485]"
+      IceChat,[300]
+      InternetExplorer,"[106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118]"
+      IrfanView,[301]
+      JDownloader2,"[302, 303, 304, 305, 306]"
+      JavaWebCache,"[307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317]"
+      Kali,"[612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628]"
+      KapeTriage,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 226, 227, 228, 229, 230, 231, 232, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 393, 394, 395, 396, 397, 398, 399, 400, 426, 427, 431, 432, 433, 461, 486, 487, 488, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 873, 874, 902]"
+      Kaseya,"[318, 319, 320, 321, 322, 323, 324, 325, 326]"
+      LNKFilesAndJumpLists,"[732, 733, 734, 735, 736, 737, 738]"
+      LinuxOnWindowsProfileFiles,"[739, 740, 741, 742]"
+      LiveUserFiles,"[214, 215, 216, 217]"
+      LogFiles,"[743, 744]"
+      LogMeIn,"[327, 328, 690, 691, 692, 693]"
+      MOF,[745]
+      MSSQLErrorLog,"[134, 135]"
+      MacriumReflect,"[329, 330, 331]"
+      Malwarebytes,"[164, 165, 166, 167]"
+      ManageEngineLogs,[136]
+      Mattermost,[332]
+      McAfee,"[168, 169, 170, 171, 172]"
+      McAfee_ePO,[173]
+      MediaMonkey,"[333, 334]"
+      MemoryFiles,"[746, 747, 748, 749, 750]"
+      MessagingClients,"[239, 254, 255, 299, 300, 332, 342, 343, 344, 345, 346, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 434, 435, 462, 463, 464, 465, 466, 473, 474, 484, 485]"
+      MicrosoftOneNote,"[335, 336, 337, 338, 339]"
+      MicrosoftStickyNotes,"[340, 341]"
+      MicrosoftTeams,"[342, 343, 344, 345, 346]"
+      MicrosoftToDo,"[347, 348]"
+      MidnightCommander,[349]
+      MiniTimelineCollection,"[676, 677, 678, 679, 680, 681, 682, 684, 685, 710, 711, 712, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      MultiCommander,"[350, 351, 352, 353, 354]"
+      NGINXLogs,[137]
+      NZBGet,"[917, 918]"
+      Nessus,"[355, 356]"
+      NewsbinPro,[919]
+      Newsleecher,[920]
+      Nicotine__,"[921, 922, 923, 924, 925, 926, 927, 928, 929, 930, 931]"
+      Notepad__,"[357, 358]"
+      OfficeAutosave,"[751, 752, 753, 754]"
+      OfficeDocumentCache,[755]
+      OneCommander,"[359, 360]"
+      OneDrive_Metadata,"[361, 362]"
+      OneDrive_UserFiles,[363]
+      OpenSSHClient,"[364, 365, 366, 367]"
+      OpenSSHServer,"[368, 369, 370, 371, 372, 373, 374, 375, 376]"
+      OpenVPNClient,"[377, 378, 379]"
+      Opera,"[119, 120]"
+      OutlookPSTOST,"[380, 381, 382, 383, 384, 385, 386, 387]"
+      P2PClients,"[905, 911, 912, 913, 914, 915, 916, 934, 935, 936]"
+      PeaZip,[388]
+      PowerShellConsole,[138]
+      Prefetch,"[756, 757]"
+      ProtonVPN,[389]
+      PuffinSecureBrowser,"[121, 122, 123, 124, 125, 126, 127]"
+      Q_Dir,"[390, 391]"
+      QFinderPro__QNAP_,[392]
+      RDPCache,"[758, 759]"
+      RDPLogs,"[760, 761, 762, 763, 764, 765, 766, 767]"
+      Radmin,"[393, 394, 395, 396, 397]"
+      RecentFileCache,"[768, 769]"
+      RecycleBin,"[770, 771, 772, 773]"
+      RecycleBin_DataFiles,"[770, 771]"
+      RecycleBin_InfoFiles,"[772, 773]"
+      RegistryHives,"[802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      RegistryHivesOther,"[774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801]"
+      RegistryHivesSystem,"[802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842]"
+      RegistryHivesUser,"[843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      RemoteAdmin,"[226, 227, 228, 229, 230, 231, 232, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 393, 394, 395, 396, 397, 398, 399, 400, 426, 427, 431, 432, 433, 461, 486, 487, 488, 690, 691, 692, 693, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767]"
+      RogueKiller,[174]
+      SABnbzd,"[932, 933]"
+      SDB,"[852, 853, 854, 855]"
+      SOFELK,"[676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 768, 769, 873, 874]"
+      SQLiteDatabases,"[492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594]"
+      SRUM,"[856, 857, 858, 859, 860, 861]"
+      SUM,[862]
+      SUPERAntiSpyware,[175]
+      SUSELinuxEnterpriseServer,"[629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641]"
+      ScheduledTasks,"[863, 864, 865, 866, 867, 868]"
+      ScreenConnect,"[398, 399, 400, 690, 691, 692, 693]"
+      SecureAge,[176]
+      SentinelOne,[177]
+      ServerTriage,"[128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 243, 244, 272, 277, 281, 282, 368, 369, 370, 371, 372, 373, 374, 375, 376]"
+      ShareX,[401]
+      Shareaza,[934]
+      Signal,"[402, 403, 404, 405]"
+      SignatureCatalog,"[869, 870]"
+      Skype,"[406, 407, 408, 409, 410, 411, 412]"
+      Slack,"[413, 414, 415, 416, 417]"
+      Snagit,[418]
+      Sophos,"[178, 179, 690, 691, 692, 693]"
+      Soulseek,"[935, 936]"
+      SpeedCommander,[419]
+      StartupInfo,"[871, 872]"
+      SublimeText,[420]
+      SugarSync,"[421, 422, 423]"
+      SumatraPDF,"[424, 425]"
+      SupremoRemoteDesktop,"[426, 427]"
+      Symantec_AV_Logs,"[180, 181, 182, 183, 184, 185, 186, 187, 188, 690, 691, 692, 693]"
+      Syscache,"[873, 874]"
+      TablacusExplorer,"[428, 429, 430]"
+      TeamViewerLogs,"[431, 432, 433]"
+      Telegram,"[434, 435]"
+      TeraCopy,[436]
+      ThumbCache,[875]
+      Thunderbird,"[437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447]"
+      TorrentClients,"[904, 939, 940, 941]"
+      Torrents,[937]
+      TotalAV,"[189, 190]"
+      TotalCommander,"[448, 449, 450, 451, 452, 453]"
+      TreeSize,[454]
+      TrendMicro,"[191, 192, 193]"
+      USBDetective,"[686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 876, 877, 878]"
+      USBDevicesLogs,"[876, 877, 878]"
+      Ubuntu,"[642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657]"
+      Usenet,[938]
+      UsenetClients,"[917, 918, 919, 920, 932, 933]"
+      VIPRE,"[194, 195, 196, 197]"
+      VLC_Media_Player,"[455, 456]"
+      VMware,"[457, 458, 459, 460, 879, 880, 881, 882]"
+      VMwareInventory,[457]
+      VMwareMemory,"[458, 459, 460]"
+      VNCLogs,"[461, 690, 691, 692, 693]"
+      Viber,"[462, 463, 464, 465, 466]"
+      VirtualBox,"[467, 468, 469, 470, 471, 472, 879, 880, 881, 882]"
+      VirtualBoxConfig,"[467, 468]"
+      VirtualBoxLogs,"[469, 470, 471]"
+      VirtualBoxMemory,[472]
+      VirtualDisks,"[879, 880, 881, 882]"
+      WBEM,"[883, 884]"
+      WER,"[885, 886, 887, 888]"
+      WSL,"[595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670]"
+      WebBrowsers,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]"
+      WebServers,"[128, 129, 130, 131, 132, 133, 134, 135, 137]"
+      Webroot,[198]
+      WhatsApp,"[473, 474]"
+      WinSCP,[475]
+      WindowsDefender,"[199, 200, 201, 202, 203, 204]"
+      WindowsFirewall,"[889, 890]"
+      WindowsIndexSearch,[891]
+      WindowsNotificationsDB,"[892, 893]"
+      WindowsOSUpgradeArtifacts,"[894, 895, 896, 897, 898]"
+      WindowsPowerDiagnostics,[899]
+      WindowsSubsystemforAndroid,"[671, 672, 673, 674, 675]"
+      WindowsTelemetryDiagnosticsLegacy,"[900, 901]"
+      WindowsTimeline,[902]
+      WindowsYourPhone,[476]
+      XPRestorePoints,[903]
+      XYplorer,"[477, 478, 479, 480]"
+      iTunesBackup,"[481, 482, 483]"
+      mIRC,"[484, 485]"
+      mRemoteNG,"[486, 487, 488]"
+      openSUSE,"[658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670]"
+      pCloudDatabase,"[489, 490, 491]"
+      qBittorrent,"[939, 940]"
+      uTorrent,[941]
+
+sources:
+  - name: All File Metadata
+    query: |
+      -- Select all the rule Ids to be included depending on the group
+      -- selection.
+      LET targets <= SELECT * FROM parse_csv(
+           filename=KapeTargets, accessor="data")
+      WHERE get(member=Group) AND log(message="Selecting " + Group)
+
+      -- Filter only the rules in the rule table that have an Id we
+      -- want. Targets with $ in their name probably refer to ntfs
+      -- special files and so they are designated as ntfs
+      -- accessor. Other targets may need ntfs parsing but not
+      -- necessary - they are designated with the lazy_ntfs accessor.
+      LET rule_specs <= SELECT Id, Glob
+        FROM parse_csv(filename=KapeRules, accessor="data")
+        WHERE Id in array(array=targets.RuleIds)
+        AND log(message="file: Selecting glob " + Glob)
+
+      -- Call the generic VSS file collector with the globs we want in
+      -- a new CSV file.
+      LET all_results <= SELECT * FROM Artifact.Generic.Collectors.File(
+        Root=Device, Separator="/", Accessor="file", collectionSpec=rule_specs)
+
+      SELECT * FROM all_results WHERE _Source =~ "Metadata"
+
+  - name: Uploads
+    query: |
+      SELECT * FROM all_results WHERE _Source =~ "Uploads"
+
+reports:
+  - type: CLIENT
+    template: |
+      {{ import "Reporting.Default" "Templates" }}
+
+      <!-- Default report in case the artifact does not have one -->
+      ## {{ .Name }}
+
+      {{ $name := .Name }}
+
+      {{ template "hidden_paragraph_start" dict "description" "View Artifact Description" }}
+
+      {{ Markdown .Description }}
+
+      ### References</h3>
+
+      {{ range .Reference }}
+      * [{{ . }}]({{.}})
+      {{- end }}
+
+      {{ template "hidden_paragraph_end" }}
+
+      {{ $query := print "SELECT SourceFile, Size, Modified, LastAccessed, Created \
+          FROM source(source='All File Metadata')" }}
+
+      <!-- There could be a huge number of rows just to get the count, so we cap at 10000 -->
+      {{ $count := Get ( Query (print "LET X = " $query " LIMIT 10000 " \
+         " SELECT 1 AS ALL, count() AS Count FROM X Group BY ALL") | Expand ) \
+         "0.Count" 0 }}
+
+      <!-- If this is a flow show the parameters. -->
+      {{ $flow := Query "LET X = SELECT Request.Parameters.env AS \
+         Env FROM flows(client_id=ClientId, flow_id=FlowId)" \
+         "SELECT * FROM foreach(row=X[0].Env, query={ \
+             SELECT Key, Value FROM scope()})" | Expand }}
+
+      {{ if $flow }}
+
+      ### Selected Targets
+
+      {{- range $flow -}}{{- if eq (Get . "Value") "Y" }}
+      * {{ Get . "Key" }}
+      {{- end -}}{{- end }}
+      {{ end }}
+
+      ## Files collected
+
+      {{ if gt $count 9999 }}
+      Collected more than {{ $count }} files.
+      {{ else }}
+      Collected a total of {{ $count }} files.
+      {{ end }}
+
+      {{ Query $query | Table }}
+
+

--- a/artifacts/definitions/Windows/KapeFiles/Targets.yaml
+++ b/artifacts/definitions/Windows/KapeFiles/Targets.yaml
@@ -39,7 +39,7 @@ parameters:
     description: "Basic Collection (by Phill Moore): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Desktop LNK Files, Desktop LNK Files XP, Event logs Win7+, Event logs Win7+, Event logs XP, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, PowerShell Console Log, Prefetch, Prefetch, RECYCLER - WinXP, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, Restore point LNK Files XP, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), Thumbcache DB, UsrClass.dat registry hive, UsrClass.dat registry transaction files, WindowsIndexSearch, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt"
     type: bool
   - name: _SANS_Triage
-    description: "SANS Triage Collection. (by Mark Hallman): $Boot, $J, $LogFile, $MFT, $Max, $SDS, $T, ActivitiesCache.db, ActivitiesCache.db-shm, ActivitiesCache.db-wal, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Extension Files, Chrome Extension Files XP, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Preferences, Chrome Preferences XP, Chrome Shortcuts, Chrome Shortcuts XP, Chrome Top Sites, Chrome Top Sites XP, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Desktop LNK files, Desktop LNK files XP, Edge folder, Event logs Win7+, Event logs Win7+, Event logs XP, Firefox Addons, Firefox Addons (XP), Firefox Cookies, Firefox Cookies (XP), Firefox Downloads, Firefox Downloads (XP), Firefox Favicons, Firefox Favicons (XP), Firefox Form history, Firefox Form history (XP), Firefox Places, Firefox Places (XP), Firefox Search, Firefox Search  (XP), Firefox Signons, Firefox Webappstore, Firefox Webappstore (XP), Forefox Signons (XP), IE 11 Cache, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cache, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData (XP), Index.dat cookies (XP), Index.dat temp internet files, LNK files from Microsoft Office Recent, LNK files from Recent, LNK files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, OST, OST XP, PST, PST XP, PowerShell Console Log, Prefetch, Prefetch, RECYCLER - WinXP, RECYCLER - WinXP, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, Restore point LNK files XP, Roaming Internet Explorer folder, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), Thumbcache DB, UsrClass.dat registry hive, UsrClass.dat registry transaction files, WBEM, WBEM, WebcacheV01.dat, WindowsIndexSearch, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, leveldb (Skype for Desktop +v8), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
+    description: "SANS Triage Collection (by Mark Hallman): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, ActivitiesCache.db, Addons, Addons XP, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, Bookmarks, Bookmarks, Box Drive Application Metadata, Box Sync Application Metadata, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, Cisco Jabber Database, ComboFix, Cookies, Cookies, Cookies XP, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, Desktop LNK Files, Desktop LNK Files XP, Discord Cache Files, Discord Local Storage LevelDB Files, Downloads, Downloads XP, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Emsisoft Scan Logs, Event logs Win7+, Event logs Win7+, Event logs XP, Extensions, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, Favicons, Favicons XP, Form history, Form history XP, Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata, HexChat Chat Logs, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, IceChat Chat Logs, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, Mattermost - Chat Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11), NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, OneDrive Metadata Logs, OneDrive Metadata Settings, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, Preferences, Prefetch, Prefetch, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RECYCLER - WinXP, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, Restore point LNK Files XP, Roaming Internet Explorer folder, RogueKiller Reports, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SUM Database (.mdb files), SUPERAntiSpyware Logs, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Search, Search XP, SecureAge Antvirus Logs, SentinelOne EDR Log, Sessionstore, Sessionstore Folder, Sessionstore XP, Signal Attachments cache, Signal Database, Signal Logs, Signal config.json, Signons, Signons XP, Skype for Destkop v8+ Chromium Cache, Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage, Sophos Logs, Sophos Logs (XP), Storage Sync, Supremo Connection Logs, Supremo File Transfer Inbox, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, Telegram app folder, Telegram downloaded files, Thumbcache DB, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, UsrClass.dat registry hive, UsrClass.dat registry transaction files, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache, WBEM, WBEM, Webappstore, Webappstore XP, Webroot Program Data, WhatsApp Cache, WhatsApp Local Storage, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Protect Folder, Windows Protect Folder, Windows Protect Folder, WindowsIndexSearch, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, ccSubSDK Database, leveldb (Skype for Desktop +v8), mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+), mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings, main.db (App <v12), main.db Win7+, main.db XP, registrationInfo.xml, s4l-[username].db (App +v8), skype.db (App +v12)"
     type: bool
   - name: _Boot
     description: "$Boot (by Eric Zimmerman): $Boot"
@@ -116,8 +116,11 @@ parameters:
   - name: Bitdefender
     description: "Bitdefender Antivirus Data (by Drew Ervin, Ahmed Elshaer): Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files"
     type: bool
-  - name: BoxDrive
-    description: "Box Cloud Storage Files and Metadata (by Chad Tilbury): Box Drive Application Metadata, Box Sync Application Metadata, Box Sync User Files, Box User Files"
+  - name: BoxDrive_Metadata
+    description: "Box Cloud Storage Metadata (by Chad Tilbury): Box Drive Application Metadata, Box Sync Application Metadata"
+    type: bool
+  - name: BoxDrive_UserFiles
+    description: "Box Cloud Storage Files (by Chad Tilbury): Box Drive User Files, Box Sync User Files"
     type: bool
   - name: BrowserCache
     description: "Browser Caches (by Bjorn Vanhaeren): Chrome Cache Folder, Edge WebcacheV01.dat, Firefox Cache Folder, IE 11 Cache, IE 9/10 Cache, IE Index.dat temp internet files"
@@ -140,11 +143,14 @@ parameters:
   - name: ClipboardMaster
     description: "ClipboardMaster (by Andrew Rathbun): ClipboardMaster - Clipboard History - Backups, ClipboardMaster - Clipboard History - Images, ClipboardMaster - Clipboard History - Text"
     type: bool
-  - name: CloudStorage
-    description: "Cloud Storage Contents and Metadata (by Chad Tilbury and Andrew Rathbun): Box Drive Application Metadata, Box Sync Application Metadata, Box Sync User Files, Box User Files, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox User Files, Google Drive Metadata, Google Drive User Files, Google File Stream Metadata, OneDrive Metadata Logs, OneDrive Metadata Settings, OneDrive User Files, SugarSync - My SugarSync (Default Location), SugarSync - Shared Folders (Default Location), SugarSync Log File, Windows Protect Folder, pCloud Database, pCloud Database Shared Memory File, pCloud Database WAL File"
+  - name: CloudStorage_All
+    description: "Cloud Storage Contents and Metadata (by Chad Tilbury and Andrew Rathbun): Box Drive Application Metadata, Box Drive User Files, Box Sync Application Metadata, Box Sync User Files, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox User Files, Google Drive Backup and Sync Metadata, Google Drive Backup and Sync User Files, Google Drive for Desktop Metadata, OneDrive Metadata Logs, OneDrive Metadata Settings, OneDrive User Files, SugarSync - My SugarSync (Default Location), SugarSync - Shared Folders (Default Location), SugarSync Log File, Windows Protect Folder, pCloud Database, pCloud Database Shared Memory File, pCloud Database WAL File"
+    type: bool
+  - name: CloudStorage_Metadata
+    description: "Cloud Storage Metadata (by Chad Tilbury and Andrew Rathbun): Box Drive Application Metadata, Box Sync Application Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata, OneDrive Metadata Logs, OneDrive Metadata Settings, Windows Protect Folder"
     type: bool
   - name: CombinedLogs
-    description: "Collect Event logs, Trace logs, Windows Firewall and PowerShell console (by Mike Cary): Delivery Optimization Trace Logs, Energy-NTKL Trace Logs, Event logs Win7+, Event logs Win7+, Event logs XP, PowerShell Console Log, SleepStudy Trace Logs, SleepStudy Trace Logs, WDI Trace Logs 1, WDI Trace Logs 1, WDI Trace Logs 2, WDI Trace Logs 2, WMI Trace Logs, WMI Trace Logs, Windows Firewall Logs, Windows Firewall Logs"
+    description: "Collect Event logs, Trace logs, Windows Firewall and PowerShell console (by Mike Cary, Mark Hallman added the USBDevicelogs target): Delivery Optimization Trace Logs, Energy-NTKL Trace Logs, Event logs Win7+, Event logs Win7+, Event logs XP, PowerShell Console Log, Setupapi.log Win7+, Setupapi.log Win7+, Setupapi.log XP, SleepStudy Trace Logs, SleepStudy Trace Logs, WDI Trace Logs 1, WDI Trace Logs 1, WDI Trace Logs 2, WDI Trace Logs 2, WMI Trace Logs, WMI Trace Logs, Windows Firewall Logs, Windows Firewall Logs"
     type: bool
   - name: ComboFix
     description: "ComboFix Antivirus Data (by Drew Ervin): ComboFix"
@@ -164,9 +170,6 @@ parameters:
   - name: DirectoryOpus
     description: "Directory Opus (by Andrew Rathbun): Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus, Directory Opus"
     type: bool
-  - name: DirectoryTraversalWildCardExample
-    description: "Find zip archives (by Eric Zimmerman): Zips"
-    type: bool
   - name: DirectoryTraversal_AudioFiles
     description: "Find audio files covering a multitude of formats (by Andrew Rathbun): Audio files"
     type: bool
@@ -185,6 +188,9 @@ parameters:
   - name: DirectoryTraversal_VideoFiles
     description: "Find video files covering a multitude of formats (by Andrew Rathbun): Video files"
     type: bool
+  - name: DirectoryTraversal_WildCardExample
+    description: "Find zip archives (by Eric Zimmerman): Zips"
+    type: bool
   - name: DirectoryTraversal_WordDocuments
     description: "Find Word and Word alternative documents (by Andrew Rathbun): Word and Word-like Documents"
     type: bool
@@ -194,8 +200,11 @@ parameters:
   - name: DoubleCommander
     description: "Double Commander (by Andrew Rathbun): Double Commander - FTP Log, Double Commander - doublecmd.xml, Double Commander - history.xml"
     type: bool
-  - name: Dropbox
-    description: "Dropbox Cloud Storage Files and Metadata (by Chad Tilbury and Andrew Rathbun): Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox User Files, Windows Protect Folder"
+  - name: Dropbox_Metadata
+    description: "Dropbox Cloud Storage Metadata (by Chad Tilbury and Andrew Rathbun): Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Dropbox Metadata, Windows Protect Folder"
+    type: bool
+  - name: Dropbox_UserFiles
+    description: "Dropbox Cloud Storage Files (by Chad Tilbury): Dropbox User Files"
     type: bool
   - name: EFCommander
     description: "EF Commander (by Andrew Rathbun): EF Commander - .ini File"
@@ -290,8 +299,11 @@ parameters:
   - name: Gigatribe
     description: "Gigatribe Files (by Linus Nissi): Gigatribe Files Windows Vista/7/8/10, Gigatribe Files Windows XP, Gigatribe Files Windows XP"
     type: bool
-  - name: GoogleDrive
-    description: "Google Drive Storage Files and Metadata (by Chad Tilbury): Google Drive Metadata, Google Drive User Files, Google File Stream Metadata"
+  - name: GoogleDriveBackupSync_UserFiles
+    description: "Google Backup and Sync Storage Files (by Chad Tilbury): Google Drive Backup and Sync User Files"
+    type: bool
+  - name: GoogleDrive_Metadata
+    description: "Google Drive Metadata (by Chad Tilbury): Google Drive Backup and Sync Metadata, Google Drive for Desktop Metadata"
     type: bool
   - name: GroupPolicy
     description: "Current Group Policy Enforcement (by piesecurity): Local Group Policy Files - Registry Policy Files, Local Group Policy Files - Registry Policy Files, Local Group Policy Files - Startup/Shutdown Scripts, Local Group Policy Files - Startup/Shutdown Scripts, Local Group Policy INI Files, Local Group Policy INI Files"
@@ -330,7 +342,7 @@ parameters:
     description: "Kali on Windows Subsystem for Linux (by Matt Dawson): Kali WSL .bash_history, Kali WSL .bashrc, Kali WSL .profile, Kali WSL /etc/bash.bashrc, Kali WSL /etc/crontab, Kali WSL /etc/debian_version, Kali WSL /etc/fstab, Kali WSL /etc/group, Kali WSL /etc/hostname, Kali WSL /etc/hosts, Kali WSL /etc/os-release, Kali WSL /etc/passwd, Kali WSL /etc/profile, Kali WSL /etc/shadow, Kali WSL /etc/timezone, Kali WSL Apt Logs, Kali WSL User Crontabs"
     type: bool
   - name: KapeTriage
-    description: "Kape Triage collections that will collect most of the files needed for a DFIR Investigation.  This module pulls evidence from File System files, Registry Hives, Event Logs, Scheduled Tasks, Evidence of Execution, SRUM data, SUM data, Web Browser data (IE/Edge, Chrome, Mozilla history), LNK Files, Jump Lists, 3rd party remote access software logs, 3rd party antivirus software logs, Windows 10 Timeline database, and $I Recycle Bin data files. (by Scott Downie): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, ActivitiesCache.db, Addons, Addons XP, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, Bookmarks, Bookmarks, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, ComboFix, Cookies, Cookies, Cookies XP, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, Desktop LNK Files, Desktop LNK Files XP, Downloads, Downloads XP, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Emsisoft Scan Logs, Event logs Win7+, Event logs Win7+, Event logs XP, Extensions, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, Favicons, Favicons XP, Form history, Form history XP, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, PowerShell Console Log, Preferences, Prefetch, Prefetch, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RECYCLER - WinXP, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, Restore point LNK Files XP, Roaming Internet Explorer folder, RogueKiller Reports, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SUM Database (.mdb files), SUPERAntiSpyware Logs, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Search, Search XP, SecureAge Antvirus Logs, SentinelOne EDR Log, Sessionstore, Sessionstore Folder, Sessionstore XP, Signons, Signons XP, Sophos Logs, Sophos Logs (XP), Storage Sync, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, UsrClass.dat registry hive, UsrClass.dat registry transaction files, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Webappstore, Webappstore XP, Webroot Program Data, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Protect Folder, Windows Protect Folder, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, ccSubSDK Database, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings, registrationInfo.xml"
+    description: "Kape Triage collections that will collect most of the files needed for a DFIR Investigation.  This module pulls evidence from File System files, Registry Hives, Event Logs, Scheduled Tasks, Evidence of Execution, SRUM data, SUM data, Web Browser data (IE/Edge, Chrome, Mozilla history), LNK Files, Jump Lists, 3rd party remote access software logs, 3rd party antivirus software logs, Windows 10 Timeline database, and $I Recycle Bin data files. (by Scott Downie): $Boot, $J, $J, $LogFile, $MFT, $Max, $Max, $T, $T, AVG AV Logs, AVG AV Logs (XP), AVG AV Report Logs (XP), AVG Report Logs, ActivitiesCache.db, Addons, Addons XP, Amcache, Amcache, Amcache transaction files, Amcache transaction files, Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Avast AV Index, Avast AV Logs, Avast AV Logs (XP), Avast AV User Logs, Avira Activity Logs, Bitdefender Endpoint Security Logs, Bitdefender Internet Security Logs, Bitdefender SQLite DB Files, Bookmarks, Bookmarks, Chrome Cookies, Chrome Cookies XP, Chrome Current Session, Chrome Current Session XP, Chrome Current Tabs, Chrome Current Tabs XP, Chrome Download Metadata, Chrome Extension Cookies, Chrome Favicons, Chrome Favicons XP, Chrome History, Chrome History XP, Chrome Last Session, Chrome Last Session XP, Chrome Last Tabs, Chrome Last Tabs XP, Chrome Login Data, Chrome Login Data XP, Chrome Media History, Chrome Network Action Predictor, Chrome Network Persistent State, Chrome Preferences, Chrome Preferences XP, Chrome Quota Manager, Chrome Reporting and NEL, Chrome Sessions Folder, Chrome Shortcuts, Chrome Shortcuts XP, Chrome SyncData Database, Chrome Top Sites, Chrome Top Sites XP, Chrome Trust Tokens, Chrome Visited Links, Chrome Visited Links XP, Chrome Web Data, Chrome Web Data XP, Chrome bookmarks, Chrome bookmarks XP, ComboFix, Cookies, Cookies, Cookies XP, Cybereason Anti-Ransomware Logs, Cybereason Application Control and NGAV Logs, Cybereason Sensor Communications and Anti-Malware Logs, Desktop LNK Files, Desktop LNK Files XP, Downloads, Downloads XP, ESET NOD32 AV Logs, ESET NOD32 AV Logs (XP), Edge Bookmarks, Edge Collections, Edge Cookies, Edge Current Session, Edge Current Tabs, Edge Favicons, Edge History, Edge Last Session, Edge Last Tabs, Edge Login Data, Edge Media History, Edge Network Action Predictor, Edge Preferences, Edge Sessions Folder, Edge Shortcuts, Edge SyncData Database, Edge Top Sites, Edge Visited Links, Edge Web Data, Edge bookmarks, Edge folder, Emsisoft Scan Logs, Event logs Win7+, Event logs Win7+, Event logs XP, Extensions, F-Secure Logs, F-Secure Scheduled Scan Reports, F-Secure User Logs, Favicons, Favicons XP, Form history, Form history XP, HitmanPro Alert Logs, HitmanPro Database, HitmanPro Logs, IE 11 Cookies, IE 11 Metadata, IE 9/10 Cookies, IE 9/10 Download History, IE 9/10 History, Index.dat History, Index.dat History subdirectory, Index.dat Office, Index.dat Office XP, Index.dat UserData, Index.dat cookies, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LNK Files from C:\ProgramData, LNK Files from Microsoft Office Recent, LNK Files from Recent, LNK Files from Recent (XP), Local Internet Explorer folder, Local Service registry hive, Local Service registry hive, Local Service registry transaction files, Local Service registry transaction files, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, MalwareBytes Anti-Malware Logs, MalwareBytes Anti-Malware Scan Logs, MalwareBytes Anti-Malware Scan Results Logs, MalwareBytes Anti-Malware Service Logs, McAfee Desktop Protection Logs, McAfee Desktop Protection Logs XP, McAfee Endpoint Security Logs, McAfee Endpoint Security Logs, McAfee VirusScan Logs, McAfee ePO Logs, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, Network Service registry hive, Network Service registry hive, Network Service registry transaction files, Network Service registry transaction files, Opera - Local Folder, Opera - Roaming Folder, Password, Password, Password, Password XP, Password XP, Password XP, Permissions, Places, Places XP, PowerShell Console Log, Preferences, Prefetch, Prefetch, Protections, Puffin - Autocomplete Data, Puffin - Cookies, Puffin - Image Cache, Puffin - Password (Encrypted), Puffin - Password Forms Data, Puffin - Subscription Data, Puffin - data.db, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, RECYCLER - WinXP, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RecentFileCache, RecentFileCache, Recycle Bin - Windows Vista+, RegBack registry transaction files, RegBack registry transaction files, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, Restore point LNK Files XP, Roaming Internet Explorer folder, RogueKiller Reports, SAM registry hive, SAM registry hive, SAM registry hive (RegBack), SAM registry hive (RegBack), SAM registry transaction files, SAM registry transaction files, SECURITY registry hive, SECURITY registry hive, SECURITY registry hive (RegBack), SECURITY registry hive (RegBack), SECURITY registry transaction files, SECURITY registry transaction files, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive, SOFTWARE registry hive (RegBack), SOFTWARE registry hive (RegBack), SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SOFTWARE registry transaction files, SRUM, SRUM, SUM Database (.mdb files), SUPERAntiSpyware Logs, SYSTEM registry hive, SYSTEM registry hive, SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry hive (RegBack), SYSTEM registry transaction files, SYSTEM registry transaction files, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Search, Search XP, SecureAge Antvirus Logs, SentinelOne EDR Log, Sessionstore, Sessionstore Folder, Sessionstore XP, Signons, Signons XP, Sophos Logs, Sophos Logs (XP), Storage Sync, Supremo Connection Logs, Supremo File Transfer Inbox, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, Syscache, Syscache transaction files, System Profile registry hive, System Profile registry hive, System Profile registry transaction files, System Profile registry transaction files, System Restore Points Registry Hives (XP), TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, TotalAV Logs, TotalAV Logs, Trend Micro Logs, Trend Micro Security Agent Connection Logs, Trend Micro Security Agent Report Logs, UsrClass.dat registry hive, UsrClass.dat registry transaction files, VIPRE Business Agent Logs, VIPRE Business User Logs (up to v4), VIPRE Business User Logs (v5-v6), VIPRE Business User Logs (v7+), Webappstore, Webappstore XP, Webroot Program Data, Windows Defender Event Logs, Windows Defender Event Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Defender Logs, Windows Protect Folder, Windows Protect Folder, XML, XML, at .job, at .job, at SchedLgU.txt, at SchedLgU.txt, ccSubSDK Database, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings, registrationInfo.xml"
     type: bool
   - name: Kaseya
     description: "Kaseya Data (by Drew Ervin and Andrew Rathbun): Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log"
@@ -381,7 +393,7 @@ parameters:
     description: "Memory Files (by Ahmed Elshaer, Teo Kia Meng): Small Memory Dump directory, Small Memory Dump directory, hiberfil.sys, pagefile.sys, swapfile.sys"
     type: bool
   - name: MessagingClients
-    description: "Messaging and communication apps (by Gregor Wegberg): Cisco Jabber Database, Discord Cache Files, Discord Local Storage LevelDB Files, HexChat Chat Logs, IceChat Chat Logs, Mattermost - Chat Logs, Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11), Signal Attachments cache, Signal Database, Signal Logs, Signal config.json, Skype for Destkop v8+ Chromium Cache, Slack - Chat Logs, Telegram app folder, Telegram downloaded files, Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache, WhatsApp Cache, WhatsApp Local Storage, leveldb (Skype for Desktop +v8), mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
+    description: "Messaging and communication apps (by Gregor Wegberg): Cisco Jabber Database, Discord Cache Files, Discord Local Storage LevelDB Files, HexChat Chat Logs, IceChat Chat Logs, Mattermost - Chat Logs, Microsoft Teams Cache, Microsoft Teams Config, Microsoft Teams IndexedDB Cache, Microsoft Teams Local Storage Cache, Microsoft Teams Logs (Windows 11), Signal Attachments cache, Signal Database, Signal Logs, Signal config.json, Skype for Destkop v8+ Chromium Cache, Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage, Telegram app folder, Telegram downloaded files, Viber Config Database, Viber Users Avatars Cache, Viber Users Backgrounds Cache, Viber Users Data Database, Viber Users Thumbnails Cache, WhatsApp Cache, WhatsApp Local Storage, leveldb (Skype for Desktop +v8), mIRC Chat Logs (2000/XP), mIRC Chat Logs (Vista+), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
     type: bool
   - name: MicrosoftOneNote
     description: "Microsoft OneNote (by Andrew Rathbun): Microsoft OneNote - AccessibilityCheckerIndex, Microsoft OneNote - FullTextSearchIndex, Microsoft OneNote - RecentNotebooks_SeenURLs, Microsoft OneNote - RecentSearches, Microsoft OneNote - User NoteTags"
@@ -410,6 +422,9 @@ parameters:
   - name: NZBGet
     description: "NZBGet (by Andrew Rathbun): Usenet Clients - NZBGet Log File, Usenet Clients - NZBGet NZBs"
     type: bool
+  - name: Nessus
+    description: "Nessus (by Andrew Rathbun): Nessus Logs, Nessus Logs"
+    type: bool
   - name: NewsbinPro
     description: "Newsbin Pro (by Andrew Rathbun): Usenet Clients - Newsbin Pro"
     type: bool
@@ -431,8 +446,11 @@ parameters:
   - name: OneCommander
     description: "One Commander (by Andrew Rathbun): One Commander - All Configuration Files, One Commander - Other Configuration Files"
     type: bool
-  - name: OneDrive
-    description: "Microsoft OneDrive Storage Files and Metadata (by Chad Tilbury): OneDrive Metadata Logs, OneDrive Metadata Settings, OneDrive User Files"
+  - name: OneDrive_Metadata
+    description: "Microsoft OneDrive Storage Metadata (by Chad Tilbury): OneDrive Metadata Logs, OneDrive Metadata Settings"
+    type: bool
+  - name: OneDrive_UserFiles
+    description: "Microsoft OneDrive Storage Files (by Chad Tilbury): OneDrive User Files"
     type: bool
   - name: OpenSSHClient
     description: "OpenSSH Client config, known hosts and keys (by Matt Dawson): OpenSSH Config File, OpenSSH Default Private Key, OpenSSH Known Hosts, OpenSSH Public Keys"
@@ -447,7 +465,7 @@ parameters:
     description: "Opera (by Andrew Rathbun): Opera - Local Folder, Opera - Roaming Folder"
     type: bool
   - name: OutlookPSTOST
-    description: "Outlook PST and OST files (by Eric Zimmerman): OST, OST (2013 or 2016), OST XP, PST, PST (2013 or 2016), PST XP"
+    description: "Outlook PST and OST files (by Eric Zimmerman and Chad Tilbury): NST, OST, OST (2013 or 2016), OST XP, Outlook Attachment Temporary Storage, PST, PST (2013 or 2016), PST XP"
     type: bool
   - name: P2PClients
     description: "P2P Clients (by Andrew Rathbun): DC++ Chat Logs, FrostWire AppData, FrostWire AppData, FrostWire Downloads, Gigatribe Files Windows Vista/7/8/10, Gigatribe Files Windows XP, Gigatribe Files Windows XP, Shareaza Logs, Soulseek Chat Logs, Soulseek Search History/Shared Folders/Settings"
@@ -507,7 +525,7 @@ parameters:
     description: "User Related Registry hives (by Eric Zimmerman / Mark Hallman): NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT registry hive, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT DEFAULT transaction files, NTUSER.DAT registry hive, NTUSER.DAT registry hive XP, NTUSER.DAT registry transaction files, UsrClass.dat registry hive, UsrClass.dat registry transaction files"
     type: bool
   - name: RemoteAdmin
-    description: "Composite target for files related to remote administration tools (by Drew Ervin, Mathias Frank, Andrew Rathbun): Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings"
+    description: "Composite target for files related to remote administration tools (by Drew Ervin, Mathias Frank, Andrew Rathbun): Ammyy Program Data, AnyDesk Logs - ProgramData - *.trace, AnyDesk Logs - ProgramData - connection_trace.txt, AnyDesk Logs - System User Account, AnyDesk Logs - User Profile - *.trace, AnyDesk Logs - User Profile - connection_trace.txt, AnyDesk Videos, Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Kaseya Agent Edge Service Logs, Kaseya Agent Endpoint Service Logs, Kaseya Agent Endpoint Service Logs (XP), Kaseya Agent Service Log, Kaseya Live Connect Logs, Kaseya Live Connect Logs (XP), Kaseya Setup Log, Kaseya Setup Log, Kaseya Setup Log, LocalSessionManager Event Logs, LocalSessionManager Event Logs, LogMeIn Application Logs, LogMeIn ProgramData Logs, RDP Cache Files, RDP Cache Files, RDPClient Event Logs, RDPClient Event Logs, RDPCoreTS Event Logs, RDPCoreTS Event Logs, Radmin Server 32bit Chats, Radmin Server 32bit Log, Radmin Server 64bit Chats, Radmin Server 64bit Log, Radmin Viewer Chats, RealVNC Log, RemoteConnectionManager Event Logs, RemoteConnectionManager Event Logs, ScreenConnect Session Database, ScreenConnect Session Database, ScreenConnect User Config, Supremo Connection Logs, Supremo File Transfer Inbox, TeamViewer Application Logs, TeamViewer Configuration Files, TeamViewer Connection Logs, mRemoteNG Connection Configuration and Backups, mRemoteNG Logs, mRemoteNG Program Settings"
     type: bool
   - name: RogueKiller
     description: "RogueKiller Anti-Malware (by Adlice Software) (by Drew Ervin): RogueKiller Reports"
@@ -567,7 +585,7 @@ parameters:
     description: "Skype (by Eric Zimmerman, Matt Dawson): Skype for Destkop v8+ Chromium Cache, leveldb (Skype for Desktop +v8), main.db (App <v12), main.db Win7+, main.db XP, s4l-[username].db (App +v8), skype.db (App +v12)"
     type: bool
   - name: Slack
-    description: "Slack (by Andrew Rathbun): Slack - Chat Logs"
+    description: "Slack (by Andrew Rathbun and Chad Tilbury): Slack - Chat Logs, Slack Cache, Slack Electron Logs, Slack LevelDB Files, Slack Storage"
     type: bool
   - name: Snagit
     description: "Snagit (by Andrew Rathbun): Snagit - Captures"
@@ -592,6 +610,9 @@ parameters:
     type: bool
   - name: SumatraPDF
     description: "SumatraPDF (by Andrew Rathbun): SumatraPDF Cache, SumatraPDF Settings - SessionData"
+    type: bool
+  - name: SupremoRemoteDesktop
+    description: "Supremo Remote Desktop Control Logs (by Sandro Heckendorn): Supremo Connection Logs, Supremo File Transfer Inbox"
     type: bool
   - name: Symantec_AV_Logs
     description: "Symantec AV Logs (by Brian Maloney): Application Event Log Win7+, Application Event Log Win7+, Application Event Log XP, Application Event Log XP, Symantec Endpoint Protection Logs, Symantec Endpoint Protection Logs (XP), Symantec Endpoint Protection Quarantine, Symantec Endpoint Protection Quarantine (XP), Symantec Endpoint Protection User Logs, Symantec Event Log Win7+, Symantec Event Log Win7+, ccSubSDK Database, registrationInfo.xml"
@@ -725,6 +746,12 @@ parameters:
   - name: WindowsOSUpgradeArtifacts
     description: "Windows OS Upgrade Artifacts (by Andrew Rathbun): FolderMoveLog.txt, HumanReadable.xml, MigLog.xml, Setupact.log, Update Store.db"
     type: bool
+  - name: WindowsPowerDiagnostics
+    description: "Windows Power Diagnostics (by Andrew Rathbun): Windows Power Diagnostics"
+    type: bool
+  - name: WindowsSubsystemforAndroid
+    description: "Windows Subsystem for Android (WSA) (by Andrew Rathbun): App download artifacts (ICO), App download artifacts (PNG), Appcompatdb.json, Diagnostic Logs for WSA, userdata.vhdx"
+    type: bool
   - name: WindowsTelemetryDiagnosticsLegacy
     description: "Legacy Windows Telemetry and Diagnostics files (*.rbs) (by Andrew Rathbun and Josh Mitchell): Legacy .rbs files relating to Windows Telemetry and Diagnostics, Legacy .rbs files relating to Windows Telemetry and Diagnostics"
     type: bool
@@ -767,1359 +794,1204 @@ parameters:
     description: A CSV file controlling the different Kape Target Rules
     default: |
       Id,Name,Category,Glob,Accessor,Comment
-      1,AVG AV Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\AVG\Antivirus\log/**10,lazy_ntfs,
-      2,AVG AV Report Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\AVG\Antivirus\report/**10,lazy_ntfs,
-      3,AVG AV Logs,Antivirus,ProgramData\AVG\Antivirus\log/**10,lazy_ntfs,
-      4,AVG Report Logs,Antivirus,ProgramData\AVG\Antivirus\report/**10,lazy_ntfs,
-      5,Avast AV Logs (XP),Antivirus,Documents And Settings\All Users\Application Data\Avast Software\Avast\Log/**10,lazy_ntfs,
-      6,Avast AV Logs,Antivirus,ProgramData\Avast Software\Avast\Log/**10,lazy_ntfs,
-      7,Avast AV User Logs,Antivirus,Users\*\Avast Software\Avast\Log/**10,lazy_ntfs,
-      8,Avast AV Index,Antivirus,ProgramData\Avast Software\Avast\Chest/index.xml,lazy_ntfs,
-      9,Avira Activity Logs,AntiVirus,ProgramData\Avira\Antivirus\LOGFILES/**10,lazy_ntfs,Collects the scan logs of Avira AntiVirus
-      10,Bitdefender Endpoint Security Logs,Antivirus,ProgramData\Bitdefender\Endpoint Security\Logs/**10,lazy_ntfs,
-      11,Bitdefender Internet Security Logs,Antivirus,ProgramData\Bitdefender\Desktop\Profiles\Logs/**10,lazy_ntfs,
-      12,Bitdefender SQLite DB Files,Antivirus,Program Files*\Bitdefender*/**10/regex:*.+\.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
-      13,ComboFix,Antivirus,ComboFix.txt,lazy_ntfs,
-      14,Cybereason Anti-Ransomware Logs,AntiVirus,ProgramData\crs1\Logs/**10,lazy_ntfs,
-      15,Cybereason Sensor Communications and Anti-Malware Logs,AntiVirus,ProgramData\apv2\Logs/**10,lazy_ntfs,
-      16,Cybereason Application Control and NGAV Logs,AntiVirus,ProgramData\crb1\Logs/**10,lazy_ntfs,
-      17,ESET NOD32 AV Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\ESET\ESET NOD32 Antivirus\Logs/**10,lazy_ntfs,
-      18,ESET NOD32 AV Logs,Antivirus,ProgramData\ESET\ESET NOD32 Antivirus\Logs/**10,lazy_ntfs,Parser available at https://github.com/laciKE/EsetLogParser
-      19,Emsisoft Scan Logs,ApplicationLogs,ProgramData\Emsisoft\Reports/scan*.txt,lazy_ntfs,Can contain file detection and quarantine info
-      20,F-Secure Logs,Antivirus,ProgramData\F-Secure\Log/**10,lazy_ntfs,
-      21,F-Secure User Logs,Antivirus,Users\*\AppData\Local\F-Secure\Log/**10,lazy_ntfs,
-      22,F-Secure Scheduled Scan Reports,Antivirus,ProgramData\F-Secure\Antivirus\ScheduledScanReports/**10,lazy_ntfs,
-      23,HitmanPro Logs,Antivirus,ProgramData\HitmanPro\Logs/**10,lazy_ntfs,
-      24,HitmanPro Alert Logs,Antivirus,ProgramData\HitmanPro.Alert\Logs/**10,lazy_ntfs,
-      25,HitmanPro Database,Antivirus,ProgramData\HitmanPro.Alert/excalibur.db,lazy_ntfs,SQLite DB
-      26,MalwareBytes Anti-Malware Logs,Antivirus,ProgramData\Malwarebytes\Malwarebytes Anti-Malware\Logs/mbam-log-*.xml,lazy_ntfs,
-      27,MalwareBytes Anti-Malware Service Logs,Antivirus,ProgramData\Malwarebytes\MBAMService\logs/mbamservice.log*,lazy_ntfs,
-      28,MalwareBytes Anti-Malware Scan Logs,Antivirus,Users\*\AppData\Roaming\Malwarebytes\Malwarebytes Anti-Malware\Logs/**10,lazy_ntfs,
-      29,MalwareBytes Anti-Malware Scan Results Logs,Antivirus,ProgramData\Malwarebytes\MBAMService\ScanResults/**10,lazy_ntfs,
-      30,McAfee Desktop Protection Logs XP,AntiVirus,Users\All Users\Application Data\McAfee\DesktopProtection/**10,lazy_ntfs,
-      31,McAfee Desktop Protection Logs,AntiVirus,ProgramData\McAfee\DesktopProtection/**10,lazy_ntfs,
-      32,McAfee Endpoint Security Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs/**10,lazy_ntfs,
-      33,McAfee Endpoint Security Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs_Old/**10,lazy_ntfs,
-      34,McAfee VirusScan Logs,AntiVirus,ProgramData\Mcafee\VirusScan/**10,lazy_ntfs,
-      35,McAfee ePO Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs/**10,lazy_ntfs,
-      36,RogueKiller Reports,Antivirus,ProgramData\RogueKiller\logs/AdliceReport_*.json,lazy_ntfs,
-      37,SUPERAntiSpyware Logs,Antivirus,Users\*\AppData\Roaming\SUPERAntiSpyware\Logs/**10,lazy_ntfs,
-      38,SecureAge Antvirus Logs,Antivirus,ProgramData\SecureAge Technology\SecureAge\log/**10,lazy_ntfs,
-      39,SentinelOne EDR Log,Antivirus,programdata\sentinel\logs/**10,lazy_ntfs,Logs are in Binary Format (.binlog)
-      40,Sophos Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\Sophos\Sophos *\Logs/**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
-      41,Sophos Logs,Antivirus,ProgramData\Sophos\Sophos *\Logs/**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
-      42,Symantec Endpoint Protection Logs (XP),AntiVirus,Documents and Settings\All Users\Application Data\Symantec\Symantec Endpoint Protection\Logs\AV/**10,lazy_ntfs,
-      43,Symantec Endpoint Protection Logs,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\Logs/**10,lazy_ntfs,
-      44,Symantec Endpoint Protection User Logs,AntiVirus,Users\*\AppData\Local\Symantec\Symantec Endpoint Protection\Logs/**10,lazy_ntfs,
-      45,Symantec Event Log Win7+,EventLogs,Windows\System32\winevt\logs/Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
-      46,Symantec Event Log Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
-      47,Symantec Endpoint Protection Quarantine (XP),AntiVirus,Documents and Settings\All Users\Application Data\Symantec\Symantec Endpoint Protection\Quarantine/**10,lazy_ntfs,
-      48,Symantec Endpoint Protection Quarantine,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\Quarantine/**10,lazy_ntfs,
-      49,ccSubSDK Database,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\CmnClnt\ccSubSDK/**10,lazy_ntfs,
-      50,registrationInfo.xml,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data/registrationInfo.xml,lazy_ntfs,
-      51,TotalAV Logs,Antivirus,Program Files*\TotalAV\logs/**10,lazy_ntfs,
-      52,TotalAV Logs,Antivirus,ProgramData\TotalAV\logs/**10,lazy_ntfs,
-      53,Trend Micro Logs,Antivirus,ProgramData\Trend Micro/**10,lazy_ntfs,
-      54,Trend Micro Security Agent Report Logs,Antivirus,Program Files*\Trend Micro\Security Agent\Report/*.log,lazy_ntfs,
-      55,Trend Micro Security Agent Connection Logs,Antivirus,Program Files*\Trend Micro\Security Agent\ConnLog/*.log,lazy_ntfs,
-      56,VIPRE Business Agent Logs,Antivirus,ProgramData\VIPRE Business Agent\Logs/**10,lazy_ntfs,
-      57,VIPRE Business User Logs (v7+),Antivirus,Users\*\AppData\Roaming\VIPRE Business/**10,lazy_ntfs,
-      58,VIPRE Business User Logs (v5-v6),Antivirus,Users\*\AppData\Roaming\GFI Software\AntiMalware\Logs/**10,lazy_ntfs,
-      59,VIPRE Business User Logs (up to v4),Antivirus,Users\*\AppData\Roaming\Sunbelt Software\AntiMalware\Logs/**10,lazy_ntfs,
-      60,Webroot Program Data,Antivirus,ProgramData\WRData/WRLog.log,lazy_ntfs,
-      61,Windows Defender Logs,Antivirus,ProgramData\Microsoft\Microsoft AntiMalware\Support/**10,lazy_ntfs,
-      62,Windows Defender Event Logs,EventLogs,Windows\System32\winevt\Logs/Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
-      63,Windows Defender Event Logs,EventLogs,Windows.old\Windows\System32\winevt\Logs/Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
-      64,Windows Defender Logs,Antivirus,ProgramData\Microsoft\Windows Defender\Support/**10,lazy_ntfs,
-      65,Windows Defender Logs,Antivirus,Windows\Temp/MpCmdRun.log,lazy_ntfs,
-      66,Windows Defender Logs,Antivirus,Windows.old\Windows\Temp/MpCmdRun.log,lazy_ntfs,
-      67,Debian WSL /etc/debian_version,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/debian_version,lazy_ntfs,
-      68,Debian WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/fstab,lazy_ntfs,
-      69,Debian WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/os-release,lazy_ntfs,
-      70,Debian WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/passwd,lazy_ntfs,
-      71,Debian WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/group,lazy_ntfs,
-      72,Debian WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/shadow,lazy_ntfs,
-      73,Debian WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/timezone,lazy_ntfs,
-      74,Debian WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/hostname,lazy_ntfs,
-      75,Debian WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/hosts,lazy_ntfs,
-      76,Debian WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/crontab,lazy_ntfs,
-      77,Debian WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/bash.bashrc,lazy_ntfs,
-      78,Debian WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc/profile,lazy_ntfs,
-      79,Debian WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs/**10/.bash_history,lazy_ntfs,
-      80,Debian WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs/**10/.bashrc,lazy_ntfs,
-      81,Debian WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs/**10/.profile,lazy_ntfs,
-      82,Debian WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs/**10,lazy_ntfs,
-      83,Debian WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\log\apt/**10/*.log,lazy_ntfs,
-      84,Kali WSL /etc/debian_version,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/debian_version,lazy_ntfs,
-      85,Kali WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/fstab,lazy_ntfs,
-      86,Kali WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/os-release,lazy_ntfs,
-      87,Kali WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/passwd,lazy_ntfs,
-      88,Kali WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/group,lazy_ntfs,
-      89,Kali WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/shadow,lazy_ntfs,
-      90,Kali WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/timezone,lazy_ntfs,
-      91,Kali WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/hostname,lazy_ntfs,
-      92,Kali WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/hosts,lazy_ntfs,
-      93,Kali WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/crontab,lazy_ntfs,
-      94,Kali WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/bash.bashrc,lazy_ntfs,
-      95,Kali WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc/profile,lazy_ntfs,
-      96,Kali WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs/**10/.bash_history,lazy_ntfs,
-      97,Kali WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs/**10/.bashrc,lazy_ntfs,
-      98,Kali WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs/**10/.profile,lazy_ntfs,
-      99,Kali WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\var\spool\cron\crontabs/**10,lazy_ntfs,
-      100,Kali WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\var\log\apt/**10/*.log,lazy_ntfs,
-      101,SUSE Linux Enterprise Server WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/os-release,lazy_ntfs,
-      102,SUSE Linux Enterprise Server WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/fstab,lazy_ntfs,
-      103,SUSE Linux Enterprise Server WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/passwd,lazy_ntfs,
-      104,SUSE Linux Enterprise Server WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/group,lazy_ntfs,
-      105,SUSE Linux Enterprise Server WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/shadow,lazy_ntfs,
-      106,SUSE Linux Enterprise Server WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/timezone,lazy_ntfs,
-      107,SUSE Linux Enterprise Server WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/hostname,lazy_ntfs,
-      108,SUSE Linux Enterprise Server WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/hosts,lazy_ntfs,
-      109,SUSE Linux Enterprise Server WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/bash.bashrc,lazy_ntfs,
-      110,SUSE Linux Enterprise Server WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc/profile,lazy_ntfs,
-      111,SUSE Linux Enterprise Server WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs/**10/.bash_history,lazy_ntfs,
-      112,SUSE Linux Enterprise Server WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs/**10/.bashrc,lazy_ntfs,
-      113,SUSE Linux Enterprise Server WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs/**10/.profile,lazy_ntfs,
-      114,Ubuntu WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/os-release,lazy_ntfs,
-      115,Ubuntu WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/fstab,lazy_ntfs,
-      116,Ubuntu WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/passwd,lazy_ntfs,
-      117,Ubuntu WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/group,lazy_ntfs,
-      118,Ubuntu WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/shadow,lazy_ntfs,
-      119,Ubuntu WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/timezone,lazy_ntfs,
-      120,Ubuntu WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/hostname,lazy_ntfs,
-      121,Ubuntu WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/hosts,lazy_ntfs,
-      122,Ubuntu WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/crontab,lazy_ntfs,
-      123,Ubuntu WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/bash.bashrc,lazy_ntfs,
-      124,Ubuntu WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc/profile,lazy_ntfs,
-      125,Ubuntu WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs/**10/.bash_history,lazy_ntfs,
-      126,Ubuntu WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs/**10/.bashrc,lazy_ntfs,
-      127,Ubuntu WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs/**10/.profile,lazy_ntfs,
-      128,Ubuntu WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\spool\cron\crontabs/**10,lazy_ntfs,
-      129,Ubuntu WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\log\apt/**10/*.log,lazy_ntfs,
-      130,openSUSE WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/os-release,lazy_ntfs,
-      131,openSUSE WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/fstab,lazy_ntfs,
-      132,openSUSE WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/passwd,lazy_ntfs,
-      133,openSUSE WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/group,lazy_ntfs,
-      134,openSUSE WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/shadow,lazy_ntfs,
-      135,openSUSE WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/timezone,lazy_ntfs,
-      136,openSUSE WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/hostname,lazy_ntfs,
-      137,openSUSE WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/hosts,lazy_ntfs,
-      138,openSUSE WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/bash.bashrc,lazy_ntfs,
-      139,openSUSE WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc/profile,lazy_ntfs,
-      140,openSUSE WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs/**10/.bash_history,lazy_ntfs,
-      141,openSUSE WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs/**10/.bashrc,lazy_ntfs,
-      142,openSUSE WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs/**10/.profile,lazy_ntfs,
-      143,Apache Access Log,Webservers,**10/access.log,lazy_ntfs,
-      144,IIS log files,Logs,Windows\System32\LogFiles\W3SVC*/*.log,lazy_ntfs,
-      145,IIS log files,Logs,Windows.old\Windows\System32\LogFiles\W3SVC*/*.log,lazy_ntfs,
-      146,IIS log files,Logs,inetpub\logs\LogFiles/*.log,lazy_ntfs,
-      147,IIS log files,Logs,inetpub\logs\LogFiles\W3SVC*/*.log,lazy_ntfs,
-      148,IIS log files,Logs,Resources\Directory\*\LogFiles\Web\W3SVC*/*.log,lazy_ntfs,
-      149,MS SQL Errorlog,SQL Exploitation,Program Files\Microsoft SQL Server\*\MSSQL\LOG/ERRORLOG,lazy_ntfs,
-      150,MS SQL Errorlogs,SQL Exploitation,Program Files\Microsoft SQL Server\*\MSSQL\LOG/ERRORLOG.*,lazy_ntfs,
-      151,ManageEngine Desktop Central Log Files,Logs,ManageEngine\DesktopCentral_Server\logs/**10,lazy_ntfs,
-      152,NGINX Log Files,Logs,nginx\logs/*.log,lazy_ntfs,
-      153,PowerShell Console Log,PowerShellConsleLog,Users\*\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadline/ConsoleHost_history.txt,lazy_ntfs,
-      154,Event logs XP,EventLogs,Windows\System32\config/*.evt,lazy_ntfs,
-      155,Event logs Win7+,EventLogs,Windows\System32\winevt\logs/*.evtx,lazy_ntfs,
-      156,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/*.evtx,lazy_ntfs,
-      157,Prefetch,Prefetch,Windows\prefetch/*.pf,lazy_ntfs,
-      158,Prefetch,Prefetch,Windows.old\Windows\prefetch/*.pf,lazy_ntfs,
-      159,RecentFileCache,ApplicationCompatability,Windows\AppCompat\Programs/RecentFileCache.bcf,lazy_ntfs,
-      160,RecentFileCache,ApplicationCompatability,Windows.old\Windows\AppCompat\Programs/RecentFileCache.bcf,lazy_ntfs,
-      161,Amcache,ApplicationCompatibility,Windows\AppCompat\Programs/Amcache.hve,lazy_ntfs,
-      162,Amcache,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs/Amcache.hve,lazy_ntfs,
-      163,Amcache transaction files,ApplicationCompatibility,Windows\AppCompat\Programs/Amcache.hve.LOG*,lazy_ntfs,
-      164,Amcache transaction files,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs/Amcache.hve.LOG*,lazy_ntfs,
-      165,Syscache,Program Execution,System Volume Information/Syscache.hve,lazy_ntfs,
-      166,Syscache transaction files,Program Execution,System Volume Information/Syscache.hve.LOG*,lazy_ntfs,
-      167,PowerShell Console Log,PowerShellConsleLog,Users\*\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadline/ConsoleHost_history.txt,lazy_ntfs,
-      168,$MFT,FileSystem,$MFT,ntfs,
-      169,$LogFile,FileSystem,$LogFile,ntfs,
-      170,$J,FileSystem,$Extend/$UsnJrnl:$J,ntfs,
-      171,$Max,FileSystem,$Extend/$UsnJrnl:$Max,ntfs,
-      172,$SDS,FileSystem,$Secure:$SDS,ntfs,
-      173,$Boot,FileSystem,$Boot,ntfs,
-      174,$T,FileSystem,$Extend\$RmMetadata\$TxfLog/$Tops:$T,ntfs,
-      175,LNK files from Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Windows\Recent/**10,lazy_ntfs,Also includes automatic and custom jumplist directories
-      176,LNK files from Microsoft Office Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Office\Recent/**10,lazy_ntfs,
-      177,LNK files from Recent (XP),LNKFiles,Documents and Settings\*\Recent/**10,lazy_ntfs,
-      178,Desktop LNK files XP,LNKFiles,Documents and Settings\*\Desktop/*.LNK,lazy_ntfs,
-      179,Desktop LNK files,LNKFiles,Users\*\Desktop/*.LNK,lazy_ntfs,
-      180,Restore point LNK files XP,LNKFiles,System Volume Information\_restore*\RP*/*.LNK,lazy_ntfs,
-      181,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$R*.*,lazy_ntfs,
-      182,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/D*.*,lazy_ntfs,
-      183,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$I*.*,lazy_ntfs,
-      184,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/INFO2,lazy_ntfs,
-      185,SAM registry transaction files,Registry,Windows\System32\config/SAM.LOG*,lazy_ntfs,
-      186,SAM registry transaction files,Registry,Windows.old\Windows\System32\config/SAM.LOG*,lazy_ntfs,
-      187,SECURITY registry transaction files,Registry,Windows\System32\config/SECURITY.LOG*,lazy_ntfs,
-      188,SECURITY registry transaction files,Registry,Windows.old\Windows\System32\config/SECURITY.LOG*,lazy_ntfs,
-      189,SOFTWARE registry transaction files,Registry,Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      190,SOFTWARE registry transaction files,Registry,Windows.old\Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      191,SYSTEM registry transaction files,Registry,Windows\System32\config/SYSTEM.LOG*,lazy_ntfs,
-      192,SYSTEM registry transaction files,Registry,Windows.old\Windows\System32\config/SYSTEM.LOG*,lazy_ntfs,
-      193,SAM registry hive,Registry,Windows\System32\config/SAM,lazy_ntfs,
-      194,SAM registry hive,Registry,Windows.old\Windows\System32\config/SAM,lazy_ntfs,
-      195,SECURITY registry hive,Registry,Windows\System32\config/SECURITY,lazy_ntfs,
-      196,SECURITY registry hive,Registry,Windows.old\Windows\System32\config/SECURITY,lazy_ntfs,
-      197,SOFTWARE registry hive,Registry,Windows\System32\config/SOFTWARE,lazy_ntfs,
-      198,SOFTWARE registry hive,Registry,Windows.old\Windows\System32\config/SOFTWARE,lazy_ntfs,
-      199,SYSTEM registry hive,Registry,Windows\System32\config/SYSTEM,lazy_ntfs,
-      200,SYSTEM registry hive,Registry,Windows.old\Windows\System32\config/SYSTEM,lazy_ntfs,
-      201,RegBack registry transaction files,Registry,Windows\System32\config\RegBack/*.LOG*,lazy_ntfs,
-      202,RegBack registry transaction files,Registry,Windows.old\Windows\System32\config\RegBack/*.LOG*,lazy_ntfs,
-      203,SAM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SAM,lazy_ntfs,
-      204,SAM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SAM,lazy_ntfs,
-      205,SECURITY registry hive (RegBack),Registry,Windows\System32\config\RegBack/SECURITY,lazy_ntfs,
-      206,SECURITY registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SECURITY,lazy_ntfs,
-      207,SOFTWARE registry hive (RegBack),Registry,Windows\System32\config\RegBack/SOFTWARE,lazy_ntfs,
-      208,SOFTWARE registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SOFTWARE,lazy_ntfs,
-      209,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SYSTEM,lazy_ntfs,
-      210,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SYSTEM,lazy_ntfs,
-      211,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SYSTEM1,lazy_ntfs,
-      212,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SYSTEM1,lazy_ntfs,
-      213,System Profile registry hive,Registry,Windows\System32\config\systemprofile/NTUSER.DAT,lazy_ntfs,
-      214,System Profile registry hive,Registry,Windows.old\Windows\System32\config\systemprofile/NTUSER.DAT,lazy_ntfs,
-      215,System Profile registry transaction files,Registry,Windows\System32\config\systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
-      216,System Profile registry transaction files,Registry,Windows.old\Windows\System32\config\systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
-      217,Local Service registry hive,Registry,Windows\ServiceProfiles\LocalService/NTUSER.DAT,lazy_ntfs,
-      218,Local Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\LocalService/NTUSER.DAT,lazy_ntfs,
-      219,Local Service registry transaction files,Registry,Windows\ServiceProfiles\LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
-      220,Local Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
-      221,Network Service registry hive,Registry,Windows\ServiceProfiles\NetworkService/NTUSER.DAT,lazy_ntfs,
-      222,Network Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\NetworkService/NTUSER.DAT,lazy_ntfs,
-      223,Network Service registry transaction files,Registry,Windows\ServiceProfiles\NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
-      224,Network Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
-      225,System Restore Points Registry Hives (XP),Registry,System Volume Information\_restore*\RP*\snapshot/_REGISTRY_*,lazy_ntfs,
-      226,NTUSER.DAT registry hive XP,Registry,Documents and Settings\*/NTUSER.DAT,lazy_ntfs,
-      227,NTUSER.DAT registry hive,Registry,Users\*/NTUSER.DAT,lazy_ntfs,
-      228,NTUSER.DAT registry transaction files,Registry,Users\*/NTUSER.DAT.LOG*,lazy_ntfs,
-      229,NTUSER.DAT DEFAULT registry hive,Registry,Windows\System32\config/DEFAULT,lazy_ntfs,
-      230,NTUSER.DAT DEFAULT registry hive,Registry,Windows.old\Windows\System32\config/DEFAULT,lazy_ntfs,
-      231,NTUSER.DAT DEFAULT transaction files,Registry,Windows\System32\config/DEFAULT.LOG*,lazy_ntfs,
-      232,NTUSER.DAT DEFAULT transaction files,Registry,Windows.old\Windows\System32\config/DEFAULT.LOG*,lazy_ntfs,
-      233,UsrClass.dat registry hive,Registry,Users\*\AppData\Local\Microsoft\Windows/UsrClass.dat,lazy_ntfs,
-      234,UsrClass.dat registry transaction files,Registry,Users\*\AppData\Local\Microsoft\Windows/UsrClass.dat.LOG*,lazy_ntfs,
-      235,at .job,Persistence,Windows\Tasks/*.job,lazy_ntfs,
-      236,at .job,Persistence,Windows.old\Windows\Tasks/*.job,lazy_ntfs,
-      237,at SchedLgU.txt,Persistence,Windows/SchedLgU.txt,lazy_ntfs,
-      238,at SchedLgU.txt,Persistence,Windows.old\Windows/SchedLgU.txt,lazy_ntfs,
-      239,XML,Persistence,Windows\System32\Tasks/**10,lazy_ntfs,
-      240,XML,Persistence,Windows.old\Windows\System32\Tasks/**10,lazy_ntfs,
-      241,SRUM,Execution,Windows\System32\SRU/**10,lazy_ntfs,
-      242,SRUM,Execution,Windows.old\Windows\System32\SRU/**10,lazy_ntfs,
-      243,Thumbcache DB,FileKnowledge,Users\*\AppData\Local\Microsoft\Windows\Explorer/thumbcache_*.db,lazy_ntfs,
-      244,Setupapi.log XP,USBDevices,Windows/setupapi.log,lazy_ntfs,
-      245,Setupapi.log Win7+,USBDevices,Windows\inf/setupapi.dev.log,lazy_ntfs,
-      246,Setupapi.log Win7+,USBDevices,Windows.old\Windows\inf/setupapi.dev.log,lazy_ntfs,
-      247,WindowsIndexSearch,FileKnowledge,programdata\microsoft\search\data\applications\windows/Windows.edb,lazy_ntfs,
-      248,WBEM,WBEM,Windows\System32\wbem\Repository/**10,lazy_ntfs,
-      249,WBEM,WBEM,Windows.old\Windows\System32\wbem\Repository/**10,lazy_ntfs,
-      250,PST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook/*.pst,lazy_ntfs,
-      251,OST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook/*.ost,lazy_ntfs,
-      252,PST,Communications,Users\*\AppData\Local\Microsoft\Outlook/*.pst,lazy_ntfs,
-      253,OST,Communications,Users\*\AppData\Local\Microsoft\Outlook/*.ost,lazy_ntfs,
-      254,main.db (App <v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*/main.db,lazy_ntfs,
-      255,skype.db (App +v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*/skype.db,lazy_ntfs,
-      256,main.db XP,Communications,Documents and Settings\*\Application Data\Skype\*/main.db,lazy_ntfs,
-      257,main.db Win7+,Communications,Users\*\AppData\Roaming\Skype\*/main.db,lazy_ntfs,
-      258,s4l-[username].db (App +v8),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState/s4l-*.db,lazy_ntfs,
-      259,leveldb (Skype for Desktop +v8),Communications,Users\*\AppData\Roaming\Microsoft\Skype for Desktop\IndexedDB\*.leveldb/*.log,lazy_ntfs,
-      260,Chrome bookmarks XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      261,Chrome Cookies XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      262,Chrome Current Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      263,Chrome Current Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      264,Chrome Favicons XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      265,Chrome History XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      266,Chrome Last Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      267,Chrome Last Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      268,Chrome Preferences XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      269,Chrome Shortcuts XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      270,Chrome Top Sites XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      271,Chrome Visited Links XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      272,Chrome Web Data XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      273,Chrome bookmarks,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      274,Chrome Cookies,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      275,Chrome Current Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      276,Chrome Current Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      277,Chrome Favicons,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      278,Chrome History,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      279,Chrome Last Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      280,Chrome Last Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      281,Chrome Preferences,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      282,Chrome Shortcuts,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      283,Chrome Top Sites,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      284,Chrome Visited Links,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      285,Chrome Web Data,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      286,Chrome Extension Files,Communication,Users\*\AppData\Local\Google\Chrome\User Data\*\Extensions/**10,lazy_ntfs,
-      287,Chrome Extension Files XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Extensions/**10,lazy_ntfs,
-      288,Edge folder,Communications,Users\*\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe/**10,lazy_ntfs,
-      289,WebcacheV01.dat,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
-      290,Firefox Places,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/places.sqlite*,lazy_ntfs,
-      291,Firefox Downloads,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/downloads.sqlite*,lazy_ntfs,
-      292,Firefox Form history,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/formhistory.sqlite*,lazy_ntfs,
-      293,Firefox Cookies,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/cookies.sqlite*,lazy_ntfs,
-      294,Firefox Signons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/signons.sqlite*,lazy_ntfs,
-      295,Firefox Webappstore,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/webappstore.sqlite*,lazy_ntfs,
-      296,Firefox Favicons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/favicons.sqlite*,lazy_ntfs,
-      297,Firefox Addons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/addons.sqlite*,lazy_ntfs,
-      298,Firefox Search,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/search.sqlite*,lazy_ntfs,
-      299,Firefox Places (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/places.sqlite*,lazy_ntfs,
-      300,Firefox Downloads (XP),Communications (XP),Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/downloads.sqlite*,lazy_ntfs,
-      301,Firefox Form history (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/formhistory.sqlite*,lazy_ntfs,
-      302,Firefox Cookies (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/cookies.sqlite*,lazy_ntfs,
-      303,Forefox Signons (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/signons.sqlite*,lazy_ntfs,
-      304,Firefox Webappstore (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/webappstore.sqlite*,lazy_ntfs,
-      305,Firefox Favicons (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/favicons.sqlite*,lazy_ntfs,
-      306,Firefox Addons (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/addons.sqlite*,lazy_ntfs,
-      307,Firefox Search  (XP),Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/search.sqlite*,lazy_ntfs,
-      308,Index.dat History,Communications,Documents and Settings\*\Local Settings\History\History.IE5/index.dat,lazy_ntfs,
-      309,Index.dat History subdirectory,Communications,Documents and Settings\*\Local Settings\History\History.IE5\*/index.dat,lazy_ntfs,
-      310,Index.dat temp internet files,Communications,Documents and Settings\*\Local Settings\Temporary Internet Files\Content.IE5/index.dat,lazy_ntfs,
-      311,Index.dat cookies (XP),Communications,Documents and Settings\*\Cookies/index.dat,lazy_ntfs,
-      312,Index.dat UserData (XP),Communications,Documents and Settings\*\Application Data\Microsoft\Internet Explorer\UserData/index.dat,lazy_ntfs,
-      313,Index.dat Office XP,Communications,Documents and Settings\*\Application Data\Microsoft\Office\Recent/index.dat,lazy_ntfs,
-      314,Index.dat Office,Communications,Users\*\AppData\Roaming\Microsoft\Office\Recent/index.dat,lazy_ntfs,
-      315,Local Internet Explorer folder,Communications,Users\*\AppData\Local\Microsoft\Internet Explorer/**10,lazy_ntfs,
-      316,Roaming Internet Explorer folder,Communications,Users\*\AppData\Roaming\Microsoft\Internet Explorer/**10,lazy_ntfs,
-      317,IE 9/10 History,Communications,Users\*\AppData\Local\Microsoft\Windows\History/**10,lazy_ntfs,
-      318,IE 9/10 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\Temporary Internet Files/**10,lazy_ntfs,
-      319,IE 9/10 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\Cookies/**10,lazy_ntfs,
-      320,IE 9/10 Download History,Communications,Users\*\AppData\Local\Microsoft\Windows\IEDownloadHistory/**10,lazy_ntfs,
-      321,IE 11 Metadata,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
-      322,IE 11 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCache/**10,lazy_ntfs,
-      323,IE 11 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCookies/**10,lazy_ntfs,
-      324,ActivitiesCache.db,FileFolderAccess,Users\*\AppData\Local\ConnectedDevicesPlatform\*/ActivitiesCache.db,lazy_ntfs,
-      325,ActivitiesCache.db-shm,FileFolderAccess,Users\*\AppData\Local\ConnectedDevicesPlatform\*/ActivitiesCache.db-shm,lazy_ntfs,
-      326,ActivitiesCache.db-wal,FileFolderAccess,Users\*\AppData\Local\ConnectedDevicesPlatform\*/ActivitiesCache.db-wal,lazy_ntfs,
-      327,4K Video Downloader,SQLDatabases,Users\*\AppData\Local\4kdownload.com\4K Video Downloader\4K Video Downloader/*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
-      328,Microsoft OneNote - FullTextSearchIndex,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\*\FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
-      329,Microsoft OneNote - RecentNotebooks_SeenURLs,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\Notifications/RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
-      330,Microsoft OneNote - AccessibilityCheckerIndex,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
-      331,Microsoft OneNote - User NoteTags,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\NoteTags/*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
-      332,Microsoft OneNote - RecentSearches,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\RecentSearches/RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
-      333,Microsoft Sticky Notes - 1607 and later,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.MicrosoftStickyNotes*\LocalState/plum.sqlite*,lazy_ntfs,
-      334,Microsoft To Do - SQLite Database of To Do tasks,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\*/todosqlite.db*,lazy_ntfs,
-      335,TeraCopy - History Databases,SQLDatabases,Users\*\AppData\Roaming\TeraCopy\History/*.db,lazy_ntfs,
-      336,TeraCopy - Main Database,SQLDatabases,Users\*\AppData\Roaming\TeraCopy/main.db,lazy_ntfs,
-      337,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/filecache.db*,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
-      338,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/config.dbx,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
-      339,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/home.db,lazy_ntfs,SQlite database which appears to keep track of the user's recent Dropbox activity
-      340,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/icon.db,lazy_ntfs,SQLite database which appears to keep track of icons in the user's Drobox sync history which can give an indication as to which files and folders are present
-      341,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/sync_history.db,lazy_ntfs,SQLite database which appears to keep track of the user's Drobox sync history
-      342,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\sync/nucleus.sqlite3*,lazy_ntfs,SQLite database which appears to contain a table for deleted files
-      343,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox/host.db,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
-      344,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox/host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
-      345,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\sync/aggregation.dbx,lazy_ntfs,SQLite database which appears to contain snapshot table of the user's Dropbox contents in JSON with timestamps in UNIX Epoch
-      346,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
-      347,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*/avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
-      348,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\cloud_graph/cloud_graph.db,lazy_ntfs,Windows_GoogleDrive_CloudGraphDB.smap
-      349,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\TempData\*\change_buffer/**10,lazy_ntfs,DB(s) with seemingly randomized filename(s) that track file system changes within Google Drive
-      350,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*/snapshot.db,lazy_ntfs,Windows_GoogleDrive_SnapshotDB.smap
-      351,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*/sync_config.db,lazy_ntfs,Windows_GoogleDrive_SyncConfigDB.smap
-      352,FileZilla SQLite3 Log Files,SQLDatabases,Users\*\AppData\Roaming\FileZilla/*.sqlite3*,lazy_ntfs,
-      353,Chrome bookmarks XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      354,Chrome Cookies XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      355,Chrome Current Session XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      356,Chrome Current Tabs XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      357,Chrome Favicons XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      358,Chrome History XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      359,Chrome Last Session XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      360,Chrome Last Tabs XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      361,Chrome Login Data XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Login Data,lazy_ntfs,
-      362,Chrome Preferences XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      363,Chrome Shortcuts XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      364,Chrome Top Sites XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      365,Chrome Visited Links XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      366,Chrome Web Data XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      367,Chrome bookmarks,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      368,Chrome Cookies,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      369,Chrome Current Session,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      370,Chrome Current Tabs,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      371,Chrome Download Metadata,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Download Metadata,lazy_ntfs,
-      372,Chrome Extension Cookies,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Extension Cookies,lazy_ntfs,
-      373,Chrome Favicons,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      374,Chrome History,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      375,Chrome Last Session,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      376,Chrome Last Tabs,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      377,Chrome Login Data,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Login Data,lazy_ntfs,
-      378,Chrome Media History,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Media History*,lazy_ntfs,
-      379,Chrome Network Action Predictor,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Network Action Predictor,lazy_ntfs,
-      380,Chrome Network Persistent State,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Network Persistent State,lazy_ntfs,
-      381,Chrome Preferences,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      382,Chrome Quota Manager,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/QuotaManager,lazy_ntfs,
-      383,Chrome Reporting and NEL,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Reporting and NEL,lazy_ntfs,
-      384,Chrome Shortcuts,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      385,Chrome Top Sites,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      386,Chrome Trust Tokens,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Trust Tokens*,lazy_ntfs,
-      387,Chrome SyncData Database,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Sync Data/SyncData.sqlite3,lazy_ntfs,
-      388,Chrome Visited Links,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      389,Chrome Web Data,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      390,Edge bookmarks,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Bookmarks*,lazy_ntfs,
-      391,Edge Collections,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Collections/collectionsSQLite,lazy_ntfs,
-      392,Edge Cookies,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Cookies*,lazy_ntfs,
-      393,Edge Current Session,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Current Session,lazy_ntfs,
-      394,Edge Current Tabs,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Current Tabs,lazy_ntfs,
-      395,Edge Favicons,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Favicons*,lazy_ntfs,
-      396,Edge History,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/History*,lazy_ntfs,
-      397,Edge Last Session,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Last Session,lazy_ntfs,
-      398,Edge Last Tabs,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Last Tabs,lazy_ntfs,
-      399,Edge Login Data,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Login Data,lazy_ntfs,
-      400,Edge Media History,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Media History*,lazy_ntfs,
-      401,Edge Network Action Predictor,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Network Action Predictor,lazy_ntfs,
-      402,Edge Preferences,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Preferences,lazy_ntfs,
-      403,Edge Shortcuts,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Shortcuts*,lazy_ntfs,
-      404,Edge Top Sites,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Top Sites*,lazy_ntfs,
-      405,Edge SyncData Database,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sync Data/SyncData.sqlite3,lazy_ntfs,
-      406,Edge Bookmarks,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Bookmarks*,lazy_ntfs,
-      407,Edge Visited Links,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Visited Links,lazy_ntfs,
-      408,Edge Web Data,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Web Data*,lazy_ntfs,
-      409,Addons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/addons.sqlite*,lazy_ntfs,
-      410,Bookmarks,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\weave/bookmarks.sqlite*,lazy_ntfs,
-      411,Cookies,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/cookies.sqlite*,lazy_ntfs,
-      412,Cookies,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/firefox_cookies.sqlite*,lazy_ntfs,
-      413,Downloads,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/downloads.sqlite*,lazy_ntfs,
-      414,Favicons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/favicons.sqlite*,lazy_ntfs,
-      415,Form history,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/formhistory.sqlite*,lazy_ntfs,
-      416,Permissions,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/permissions.sqlite*,lazy_ntfs,
-      417,Places,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/places.sqlite*,lazy_ntfs,
-      418,Protections,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/protections.sqlite*,lazy_ntfs,
-      419,Search,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/search.sqlite*,lazy_ntfs,
-      420,Signons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/signons.sqlite*,lazy_ntfs,
-      421,Storage Sync,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/storage-sync.sqlite*,lazy_ntfs,
-      422,Webappstore,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/webappstore.sqlite*,lazy_ntfs,
-      423,Windows 10 Notification DB,SQLDatabases,Users\*\AppData\Local\Microsoft\Windows\Notifications/wpndatabase.db,lazy_ntfs,
-      424,Windows 10 Notification DB,SQLDatabases,Users\*\AppData\Local\Microsoft\Windows\Notifications/appdb.dat,lazy_ntfs,
-      425,ActivitiesCache.db,SQLDatabases,Users\*\AppData\Local\ConnectedDevicesPlatform\*/ActivitiesCache.db*,lazy_ntfs,
-      426,Update Store.db,OS Upgrade,ProgramData\USOPrivate\UpdateStore/store.db,lazy_ntfs,
-      427,Bitdefender SQLite DB Files,Antivirus,Program Files*\Bitdefender*/**10/regex:*.+\.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
-      428,EventTranscript.db,SystemEvents,ProgramData\Microsoft\Diagnosis\EventTranscript/EventTranscript.db*,lazy_ntfs,
-      429,EventTranscript.db,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis\EventTranscript/EventTranscript.db*,lazy_ntfs,
-      430,Chrome Cache Folder,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Cache/**10,lazy_ntfs,
-      431,Firefox Cache Folder,Communications,Users\*\AppData\Local\Mozilla\Firefox\Profiles\*/**10,lazy_ntfs,
-      432,IE 9/10 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\Temporary Internet Files/**10,lazy_ntfs,
-      433,IE Index.dat temp internet files,Communications,Documents and Settings\*\Local Settings\Temporary Internet Files\Content.IE5/index.dat,lazy_ntfs,
-      434,IE 11 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCache/**10,lazy_ntfs,
-      435,Edge WebcacheV01.dat,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
-      436,Chrome bookmarks XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      437,Chrome Cookies XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      438,Chrome Current Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      439,Chrome Current Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      440,Chrome Favicons XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      441,Chrome History XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      442,Chrome Last Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      443,Chrome Last Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      444,Chrome Login Data XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Login Data,lazy_ntfs,
-      445,Chrome Preferences XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      446,Chrome Shortcuts XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      447,Chrome Top Sites XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      448,Chrome Visited Links XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      449,Chrome Web Data XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      450,Chrome bookmarks,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Bookmarks*,lazy_ntfs,
-      451,Chrome Cookies,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Cookies*,lazy_ntfs,
-      452,Chrome Current Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Session,lazy_ntfs,
-      453,Chrome Current Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Current Tabs,lazy_ntfs,
-      454,Chrome Download Metadata,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Download Metadata,lazy_ntfs,
-      455,Chrome Extension Cookies,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Extension Cookies,lazy_ntfs,
-      456,Chrome Favicons,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Favicons*,lazy_ntfs,
-      457,Chrome History,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/History*,lazy_ntfs,
-      458,Chrome Last Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Session,lazy_ntfs,
-      459,Chrome Last Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Last Tabs,lazy_ntfs,
-      460,Chrome Sessions Folder,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Sessions\*,lazy_ntfs,
-      461,Chrome Login Data,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Login Data,lazy_ntfs,
-      462,Chrome Media History,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Media History*,lazy_ntfs,
-      463,Chrome Network Action Predictor,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Network Action Predictor,lazy_ntfs,
-      464,Chrome Network Persistent State,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Network Persistent State,lazy_ntfs,
-      465,Chrome Preferences,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Preferences,lazy_ntfs,
-      466,Chrome Quota Manager,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/QuotaManager,lazy_ntfs,
-      467,Chrome Reporting and NEL,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Reporting and NEL,lazy_ntfs,
-      468,Chrome Shortcuts,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Shortcuts*,lazy_ntfs,
-      469,Chrome Top Sites,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Top Sites*,lazy_ntfs,
-      470,Chrome Trust Tokens,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Trust Tokens*,lazy_ntfs,
-      471,Chrome SyncData Database,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Sync Data/SyncData.sqlite3,lazy_ntfs,
-      472,Chrome Visited Links,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Visited Links,lazy_ntfs,
-      473,Chrome Web Data,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*/Web Data*,lazy_ntfs,
-      474,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*/**10,lazy_ntfs,Required for offline decryption
-      475,Chrome Extension Files,Communication,Users\*\AppData\Local\Google\Chrome\User Data\*\Extensions/**10,lazy_ntfs,
-      476,Chrome Extension Files XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Extensions/**10,lazy_ntfs,
-      477,Chrome HTML5 File System Folder,Communication,Users\*\AppData\Local\Google\Chrome\User Data\*\File System/**10,lazy_ntfs,
-      478,Edge folder,Communications,Users\*\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe/**10,lazy_ntfs,
-      479,Edge bookmarks,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Bookmarks*,lazy_ntfs,
-      480,Edge Collections,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Collections/collectionsSQLite,lazy_ntfs,
-      481,Edge Cookies,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Cookies*,lazy_ntfs,
-      482,Edge Current Session,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Current Session,lazy_ntfs,
-      483,Edge Current Tabs,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Current Tabs,lazy_ntfs,
-      484,Edge Favicons,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Favicons*,lazy_ntfs,
-      485,Edge History,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/History*,lazy_ntfs,
-      486,Edge Last Session,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Last Session,lazy_ntfs,
-      487,Edge Last Tabs,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Last Tabs,lazy_ntfs,
-      488,Edge Sessions Folder,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sessions\*,lazy_ntfs,
-      489,Edge Login Data,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Login Data,lazy_ntfs,
-      490,Edge Media History,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Media History*,lazy_ntfs,
-      491,Edge Network Action Predictor,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Network Action Predictor,lazy_ntfs,
-      492,Edge Preferences,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Preferences,lazy_ntfs,
-      493,Edge Shortcuts,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Shortcuts*,lazy_ntfs,
-      494,Edge Top Sites,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Top Sites*,lazy_ntfs,
-      495,Edge SyncData Database,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sync Data/SyncData.sqlite3,lazy_ntfs,
-      496,Edge Bookmarks,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Bookmarks*,lazy_ntfs,
-      497,Edge Visited Links,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Visited Links,lazy_ntfs,
-      498,Edge Web Data,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*/Web Data*,lazy_ntfs,
-      499,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*/**10,lazy_ntfs,Required for offline DPAPI decryption
-      500,Addons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/addons.sqlite*,lazy_ntfs,
-      501,Bookmarks,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\weave/bookmarks.sqlite*,lazy_ntfs,
-      502,Bookmarks,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\bookmarkbackups/**10,lazy_ntfs,
-      503,Cookies,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/cookies.sqlite*,lazy_ntfs,
-      504,Cookies,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/firefox_cookies.sqlite*,lazy_ntfs,
-      505,Downloads,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/downloads.sqlite*,lazy_ntfs,
-      506,Extensions,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/extensions.json,lazy_ntfs,
-      507,Favicons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/favicons.sqlite*,lazy_ntfs,
-      508,Form history,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/formhistory.sqlite*,lazy_ntfs,
-      509,Permissions,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/permissions.sqlite*,lazy_ntfs,
-      510,Places,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/places.sqlite*,lazy_ntfs,
-      511,Protections,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/protections.sqlite*,lazy_ntfs,
-      512,Search,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/search.sqlite*,lazy_ntfs,
-      513,Signons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/signons.sqlite*,lazy_ntfs,
-      514,Storage Sync,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/storage-sync.sqlite*,lazy_ntfs,
-      515,Webappstore,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/webappstore.sqlite*,lazy_ntfs,
-      516,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/key*.db,lazy_ntfs,
-      517,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/signon*.*,lazy_ntfs,
-      518,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/logins.json,lazy_ntfs,
-      519,Preferences,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/prefs.js,lazy_ntfs,
-      520,Sessionstore,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*/sessionstore*,lazy_ntfs,
-      521,Sessionstore Folder,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\sessionstore-backups/**10,lazy_ntfs,
-      522,Places XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/places.sqlite*,lazy_ntfs,
-      523,Downloads XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/downloads.sqlite*,lazy_ntfs,
-      524,Form history XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/formhistory.sqlite*,lazy_ntfs,
-      525,Cookies XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/cookies.sqlite*,lazy_ntfs,
-      526,Signons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/signons.sqlite*,lazy_ntfs,
-      527,Webappstore XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/webappstore.sqlite*,lazy_ntfs,
-      528,Favicons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/favicons.sqlite*,lazy_ntfs,
-      529,Addons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/addons.sqlite*,lazy_ntfs,
-      530,Search XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/search.sqlite*,lazy_ntfs,
-      531,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/key*.db,lazy_ntfs,
-      532,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/signon*.*,lazy_ntfs,
-      533,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/logins.json,lazy_ntfs,
-      534,Sessionstore XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*/sessionstore*,lazy_ntfs,
-      535,Index.dat History,Communications,Documents and Settings\*\Local Settings\History\History.IE5/index.dat,lazy_ntfs,
-      536,Index.dat History subdirectory,Communications,Documents and Settings\*\Local Settings\History\History.IE5\*/index.dat,lazy_ntfs,
-      537,Index.dat cookies,Communications,Documents and Settings\*\Cookies/index.dat,lazy_ntfs,
-      538,Index.dat UserData,Communications,Documents and Settings\*\Application Data\Microsoft\Internet Explorer\UserData/index.dat,lazy_ntfs,
-      539,Index.dat Office XP,Communications,Documents and Settings\*\Application Data\Microsoft\Office\Recent/index.dat,lazy_ntfs,
-      540,Index.dat Office,Communications,Users\*\AppData\Roaming\Microsoft\Office\Recent/index.dat,lazy_ntfs,
-      541,Local Internet Explorer folder,Communications,Users\*\AppData\Local\Microsoft\Internet Explorer/**10,lazy_ntfs,
-      542,Roaming Internet Explorer folder,Communications,Users\*\AppData\Roaming\Microsoft\Internet Explorer/**10,lazy_ntfs,
-      543,IE 9/10 History,Communications,Users\*\AppData\Local\Microsoft\Windows\History/**10,lazy_ntfs,
-      544,IE 9/10 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\Cookies/**10,lazy_ntfs,
-      545,IE 9/10 Download History,Communications,Users\*\AppData\Local\Microsoft\Windows\IEDownloadHistory/**10,lazy_ntfs,
-      546,IE 11 Metadata,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
-      547,IE 11 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCookies/**10,lazy_ntfs,
-      548,Opera - Local Folder,Communications,Users\*\AppData\Local\Opera Software\Opera Stable/**10,lazy_ntfs,Grabs entire contents of the Opera AppData
+      1,Chrome Cache Folder,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Cache\**10,lazy_ntfs,
+      2,Firefox Cache Folder,Communications,Users\*\AppData\Local\Mozilla\Firefox\Profiles\*\**10,lazy_ntfs,
+      3,IE 9/10 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\Temporary Internet Files\**10,lazy_ntfs,
+      4,IE Index.dat temp internet files,Communications,Documents and Settings\*\Local Settings\Temporary Internet Files\Content.IE5\index.dat,lazy_ntfs,
+      5,IE 11 Cache,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCache\**10,lazy_ntfs,
+      6,Edge WebcacheV01.dat,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
+      7,Chrome bookmarks XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Bookmarks*,lazy_ntfs,
+      8,Chrome Cookies XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Cookies*,lazy_ntfs,
+      9,Chrome Current Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Current Session,lazy_ntfs,
+      10,Chrome Current Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Current Tabs,lazy_ntfs,
+      11,Chrome Favicons XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Favicons*,lazy_ntfs,
+      12,Chrome History XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\History*,lazy_ntfs,
+      13,Chrome Last Session XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Last Session,lazy_ntfs,
+      14,Chrome Last Tabs XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Last Tabs,lazy_ntfs,
+      15,Chrome Login Data XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Login Data,lazy_ntfs,
+      16,Chrome Preferences XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Preferences,lazy_ntfs,
+      17,Chrome Shortcuts XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Shortcuts*,lazy_ntfs,
+      18,Chrome Top Sites XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Top Sites*,lazy_ntfs,
+      19,Chrome Visited Links XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Visited Links,lazy_ntfs,
+      20,Chrome Web Data XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Web Data*,lazy_ntfs,
+      21,Chrome bookmarks,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Bookmarks*,lazy_ntfs,
+      22,Chrome Cookies,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Cookies*,lazy_ntfs,
+      23,Chrome Current Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Current Session,lazy_ntfs,
+      24,Chrome Current Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Current Tabs,lazy_ntfs,
+      25,Chrome Download Metadata,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Download Metadata,lazy_ntfs,
+      26,Chrome Extension Cookies,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Extension Cookies,lazy_ntfs,
+      27,Chrome Favicons,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Favicons*,lazy_ntfs,
+      28,Chrome History,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\History*,lazy_ntfs,
+      29,Chrome Last Session,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Last Session,lazy_ntfs,
+      30,Chrome Last Tabs,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Last Tabs,lazy_ntfs,
+      31,Chrome Sessions Folder,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Sessions\*,lazy_ntfs,
+      32,Chrome Login Data,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Login Data,lazy_ntfs,
+      33,Chrome Media History,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Media History*,lazy_ntfs,
+      34,Chrome Network Action Predictor,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Network Action Predictor,lazy_ntfs,
+      35,Chrome Network Persistent State,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Network Persistent State,lazy_ntfs,
+      36,Chrome Preferences,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Preferences,lazy_ntfs,
+      37,Chrome Quota Manager,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\QuotaManager,lazy_ntfs,
+      38,Chrome Reporting and NEL,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Reporting and NEL,lazy_ntfs,
+      39,Chrome Shortcuts,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Shortcuts*,lazy_ntfs,
+      40,Chrome Top Sites,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Top Sites*,lazy_ntfs,
+      41,Chrome Trust Tokens,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Trust Tokens*,lazy_ntfs,
+      42,Chrome SyncData Database,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Sync Data\SyncData.sqlite3,lazy_ntfs,
+      43,Chrome Visited Links,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Visited Links,lazy_ntfs,
+      44,Chrome Web Data,Communications,Users\*\AppData\Local\Google\Chrome\User Data\*\Web Data*,lazy_ntfs,
+      45,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*\**10,lazy_ntfs,Required for offline decryption
+      46,Chrome Extension Files,Communication,Users\*\AppData\Local\Google\Chrome\User Data\*\Extensions\**10,lazy_ntfs,
+      47,Chrome Extension Files XP,Communications,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Extensions\**10,lazy_ntfs,
+      48,Chrome HTML5 File System Folder,Communication,Users\*\AppData\Local\Google\Chrome\User Data\*\File System\**10,lazy_ntfs,
+      49,Edge folder,Communications,Users\*\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\**10,lazy_ntfs,
+      50,Edge bookmarks,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Bookmarks*,lazy_ntfs,
+      51,Edge Collections,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Collections\collectionsSQLite,lazy_ntfs,
+      52,Edge Cookies,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Cookies*,lazy_ntfs,
+      53,Edge Current Session,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Current Session,lazy_ntfs,
+      54,Edge Current Tabs,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Current Tabs,lazy_ntfs,
+      55,Edge Favicons,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Favicons*,lazy_ntfs,
+      56,Edge History,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\History*,lazy_ntfs,
+      57,Edge Last Session,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Last Session,lazy_ntfs,
+      58,Edge Last Tabs,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Last Tabs,lazy_ntfs,
+      59,Edge Sessions Folder,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sessions\*,lazy_ntfs,
+      60,Edge Login Data,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Login Data,lazy_ntfs,
+      61,Edge Media History,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Media History*,lazy_ntfs,
+      62,Edge Network Action Predictor,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Network Action Predictor,lazy_ntfs,
+      63,Edge Preferences,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Preferences,lazy_ntfs,
+      64,Edge Shortcuts,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Shortcuts*,lazy_ntfs,
+      65,Edge Top Sites,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Top Sites*,lazy_ntfs,
+      66,Edge SyncData Database,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sync Data\SyncData.sqlite3,lazy_ntfs,
+      67,Edge Bookmarks,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Bookmarks*,lazy_ntfs,
+      68,Edge Visited Links,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Visited Links,lazy_ntfs,
+      69,Edge Web Data,Communications,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Web Data*,lazy_ntfs,
+      70,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*\**10,lazy_ntfs,Required for offline DPAPI decryption
+      71,Addons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\addons.sqlite*,lazy_ntfs,
+      72,Bookmarks,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\weave\bookmarks.sqlite*,lazy_ntfs,
+      73,Bookmarks,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\bookmarkbackups\**10,lazy_ntfs,
+      74,Cookies,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\cookies.sqlite*,lazy_ntfs,
+      75,Cookies,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\firefox_cookies.sqlite*,lazy_ntfs,
+      76,Downloads,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\downloads.sqlite*,lazy_ntfs,
+      77,Extensions,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\extensions.json,lazy_ntfs,
+      78,Favicons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\favicons.sqlite*,lazy_ntfs,
+      79,Form history,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\formhistory.sqlite*,lazy_ntfs,
+      80,Permissions,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\permissions.sqlite*,lazy_ntfs,
+      81,Places,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\places.sqlite*,lazy_ntfs,
+      82,Protections,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\protections.sqlite*,lazy_ntfs,
+      83,Search,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\search.sqlite*,lazy_ntfs,
+      84,Signons,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\signons.sqlite*,lazy_ntfs,
+      85,Storage Sync,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\storage-sync.sqlite*,lazy_ntfs,
+      86,Webappstore,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\webappstore.sqlite*,lazy_ntfs,
+      87,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\key*.db,lazy_ntfs,
+      88,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\signon*.*,lazy_ntfs,
+      89,Password,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\logins.json,lazy_ntfs,
+      90,Preferences,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\prefs.js,lazy_ntfs,
+      91,Sessionstore,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\sessionstore*,lazy_ntfs,
+      92,Sessionstore Folder,Communications,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\sessionstore-backups\**10,lazy_ntfs,
+      93,Places XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\places.sqlite*,lazy_ntfs,
+      94,Downloads XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\downloads.sqlite*,lazy_ntfs,
+      95,Form history XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\formhistory.sqlite*,lazy_ntfs,
+      96,Cookies XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\cookies.sqlite*,lazy_ntfs,
+      97,Signons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\signons.sqlite*,lazy_ntfs,
+      98,Webappstore XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\webappstore.sqlite*,lazy_ntfs,
+      99,Favicons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\favicons.sqlite*,lazy_ntfs,
+      100,Addons XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\addons.sqlite*,lazy_ntfs,
+      101,Search XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\search.sqlite*,lazy_ntfs,
+      102,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\key*.db,lazy_ntfs,
+      103,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\signon*.*,lazy_ntfs,
+      104,Password XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\logins.json,lazy_ntfs,
+      105,Sessionstore XP,Communications,Documents and Settings\*\Application Data\Mozilla\Firefox\Profiles\*\sessionstore*,lazy_ntfs,
+      106,Index.dat History,Communications,Documents and Settings\*\Local Settings\History\History.IE5\index.dat,lazy_ntfs,
+      107,Index.dat History subdirectory,Communications,Documents and Settings\*\Local Settings\History\History.IE5\*\index.dat,lazy_ntfs,
+      108,Index.dat cookies,Communications,Documents and Settings\*\Cookies\index.dat,lazy_ntfs,
+      109,Index.dat UserData,Communications,Documents and Settings\*\Application Data\Microsoft\Internet Explorer\UserData\index.dat,lazy_ntfs,
+      110,Index.dat Office XP,Communications,Documents and Settings\*\Application Data\Microsoft\Office\Recent\index.dat,lazy_ntfs,
+      111,Index.dat Office,Communications,Users\*\AppData\Roaming\Microsoft\Office\Recent\index.dat,lazy_ntfs,
+      112,Local Internet Explorer folder,Communications,Users\*\AppData\Local\Microsoft\Internet Explorer\**10,lazy_ntfs,
+      113,Roaming Internet Explorer folder,Communications,Users\*\AppData\Roaming\Microsoft\Internet Explorer\**10,lazy_ntfs,
+      114,IE 9/10 History,Communications,Users\*\AppData\Local\Microsoft\Windows\History\**10,lazy_ntfs,
+      115,IE 9/10 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\Cookies\**10,lazy_ntfs,
+      116,IE 9/10 Download History,Communications,Users\*\AppData\Local\Microsoft\Windows\IEDownloadHistory\**10,lazy_ntfs,
+      117,IE 11 Metadata,Communications,Users\*\AppData\Local\Microsoft\Windows\WebCache\*,lazy_ntfs,
+      118,IE 11 Cookies,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCookies\**10,lazy_ntfs,
+      119,Opera - Local Folder,Communications,Users\*\AppData\Local\Opera Software\Opera Stable\**10,lazy_ntfs,Grabs entire contents of the Opera AppData
       ocal folder
-      549,Opera - Roaming Folder,Communications,Users\*\AppData\Roaming\Opera Software\Opera Stable/**10,lazy_ntfs,“Grabs entire contents of the Opera AppData\Roaming folder”
-      550,Puffin - data.db,Communications,Users\*\AppData\Local\PuffinSecureBrowser/data.db,lazy_ntfs,Grabs an important database file that contains browser history
-      551,Puffin - Autocomplete Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser/autocompletes.dat,lazy_ntfs,Grabs a file that stores autocomplete data
-      552,Puffin - Password Forms Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser/passwordForms.dat,lazy_ntfs,Grabs a file that stores some saved password data
-      553,Puffin - Password (Encrypted),Communications,Users\*\AppData\Local\PuffinSecureBrowser/credential.dat,lazy_ntfs,Grabs a file that stores passwords in an encrypted format
-      554,Puffin - Subscription Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser/subscription,lazy_ntfs,Grabs a file that stores the user's email address that's associated with their Puffin subscription
-      555,Puffin - Cookies,Communications,Users\*\AppData\Local\PuffinSecureBrowser/cookies.dat,lazy_ntfs,Grabs a file that stores information related to cookies
-      556,Puffin - Image Cache,Communications,Users\*\AppData\Local\PuffinSecureBrowser\image_cache/**10,lazy_ntfs,Grabs a directory that caches images from websites visited
-      557,AppData,UserData,Users\*\AppData/**10,lazy_ntfs,
-      558,Zips,Archives,**10/*.zip,lazy_ntfs,This is an example of how to walk a drive for a file mask. Probably do not want to use this one as is
-      559,Audio files,Multimedia,**10/regex:*.+\.(3gp|aa|aac|act|aiff|alac|amr|ape|au|awb|dss|dvf|flac|gsm|iklax|ivs|m4a|m4b|m4p|mmf|mp3|mpc|msv|nmf|ogg|oga|mogg|opus|ra|rm|raw|rf64|sln|tta|voc|vox|wav|wma|wv|webm),ntfs,Covers most (if not all) audio file formats
-      560,Excel and Excel-like Documents,Documents,**10/regex:*.+\.(xls|xlsx|csv|tsv|xlt|xlm|xlsm|xltx|xltm|xlsb|xla|xlam|xll|xlw|ods|fodp|qpw),ntfs,"Covers all document file formats for Excel, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
-      561,PDF and PDF-like Documents,Documents,**10/regex:*.+\.(pdf|xps|oxps),ntfs,Covers all PDF and PDF-like document formats
-      562,Picture files,Multimedia,**10/regex:*.+\.(ai|bmp|bpg|cdr|cpc|eps|exr|flif|gif|heif|ilbm|ima|jp2|j2k|jpf|jpm|jpg2|j2c|jpc|jpx|mj2jpeg|jpg|jxl|kra|ora|pcx|pgf|pgm|png|pnm|ppm|psb|psd|psp|svg|tga|tiff|webp|xaml|xcf),ntfs,Covers most (if not all) picture file formats
-      563,SQLite Files (.db* and .sqlite*),Databases,**10/regex:*.+\.(db*|sqlite*|),ntfs,Covers all common file extensions for SQLite databases
-      564,Video files,Multimedia,**10/regex:*.+\.(3g2|3gp|amv|asf|avi|drc|flv|f4v|f4p|f4a|f4b|gif|gifv|m4v|mkv|mov|qt|mp4|m4p|mpg|mpeg|m2v|mp2|mpe|mpv|mts|m2ts|ts|mxf|nsv|ogv|ogg|rm|rmvb|roq|svi|viv|vob|webm|wmv|yuv),ntfs,Covers most (if not all) video file formats
-      565,Word and Word-like Documents,Documents,**10/regex:*.+\.(doc|docx|docm|dotx|dotm|docb|dot|wbk|odt|fodt|rtf|wp*|tmd),ntfs,"Covers all document file formats for Word, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
-      566,User Files - Desktop,LiveUserFiles,Users\*\Desktop/**10,lazy_ntfs,
-      567,User Files - Documents,LiveUserFiles,Users\*\Documents/**10,lazy_ntfs,
-      568,User Files - Downloads,LiveUserFiles,Users\*\Downloads/**10,lazy_ntfs,
-      569,User Files - Dropbox,LiveUserFiles,Users\*\Dropbox*/**10,lazy_ntfs,
-      570,TorrentClients - BitTorrent,FileDownload,Users\*\AppData\Roaming\BitTorrent/*.dat,lazy_ntfs,
-      571,DC++ Chat Logs,FileDownload,Users\*\AppData\Local\DC++\Logs/**10,lazy_ntfs,Locates DC++ hub/chat logs and copies them. Current as of version 0.868.
-      572,Freenet,File Downloads,Users\*\AppData\Local\Freenet/node*,lazy_ntfs,
-      573,Freenet,File Downloads,Users\*\AppData\Local\Freenet/*completed.list.downloads,lazy_ntfs,
-      574,Freenet,File Downloads,Users\*\AppData\Local\Freenet/*completed.list.uploads,lazy_ntfs,
-      575,Freenet,File Downloads,Users\*\AppData\Local\Freenet/*.bak,lazy_ntfs,
-      576,Freenet,File Downloads,Users\*\AppData\Local\Freenet\downloads/**10,lazy_ntfs,
-      577,FrostWire Downloads,FileDownload,Users\*\Documents\FrostWire\Torrent Data/**10,lazy_ntfs,Locates files downloaded that land in the default location as specified by FrostWire
-      578,FrostWire AppData,FileDownload,Users\*\.frostwire5/frostwire.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
-      579,FrostWire AppData,FileDownload,Users\*\.frostwire5/itunes.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
-      580,Gigatribe Files Windows Vista/7/8/10,FileDownload,Users\*\AppData\Local\Shalsoft/**10,lazy_ntfs,Locates Gigatribe files and copies them
-      581,Gigatribe Files Windows XP,FileDownload,Documents and Settings\*\*\Application Data\Gigatribe/**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Gigatribe
-      582,Gigatribe Files Windows XP,FileDownload,Documents and Settings\*\*\Application Data\Shalsoft/**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Shalsoft
-      583,Usenet Clients - NZBGet Log File,FileDownload,ProgramData\NZBGet/nzbget.log,lazy_ntfs,Locates NZBGet download log file
-      584,Usenet Clients - NZBGet NZBs,FileDownload,ProgramData\NZBGet\nzb\*,lazy_ntfs,Locates NZBGet NZB files that were used by the user
-      585,Usenet Clients - Newsbin Pro,FileDownload,Users\*\AppData\Local\Newsbin/Downloaded.db3,lazy_ntfs,Locates Newsbin Pro download log database
-      586,Usenet Clients - Newsleecher,FileDownload,Users\*\AppData\Roaming\NewsLeecher/downloaded.dat,lazy_ntfs,Locates Newsleecher download .dat file
-      587,Nicotine++ Logs,FileDownload,Users\%User%\AppData\Roaming\nicotine\logs/**10,lazy_ntfs,"Locates Nicotine++ chat logs, room logs, transfer logs, and debug logs (if enabled)"
-      588,Nicotine++ Incomplete Downloads,FileDownload,Users\%User%\AppData\Roaming\nicotine\incomplete/**10,lazy_ntfs,Locates files that did not finish downloading
-      589,Nicotine++ Buddyfiles.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddyfiles.db/**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
-      590,Nicotine++ Buddystreams.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddystreams.db/**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
-      591,Nicotine++ Buddymtimes.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddymtimes.db/**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a folder level"
-      592,Nicotine++ Buddyfileindex.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddyfileindex.db/**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a file level"
-      593,Nicotine++ Buddywordindex.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddywordindex.db/**10,lazy_ntfs,Unknown what this is for at this time
-      594,Nicotine++ Config Files,FileDownload,Users\%User%\AppData\Roaming\nicotine\config/**10,lazy_ntfs,Locates config files
-      595,Nicotine++ User Shares,FileDownload,Users\%User%\AppData\Roaming\nicotine\usershares/**10,lazy_ntfs,Locates a DB that appears to store a list of files per user that they are sharing within Nicotine++. Note: this requires the user to right-click -> browse files shared by that user
-      596,Nicotine++ Downloads.json,FileDownload,Users\%User%\AppData\Roaming\nicotine/downloads.json*,lazy_ntfs,Locates downloads.json
-      597,Nicotine++ Uploads.json,FileDownload,Users\%User%\AppData\Roaming\nicotine/uploads.json*,lazy_ntfs,Locates uploads.json
-      598,Usenet Clients - SABnzbd Download Logs,FileDownload,Users\*\AppData\Local\sabnzbd\logs/sabnzbd.log,lazy_ntfs,Locates SABnzbd download log
-      599,Usenet Clients - SABnzbd History.db,FileDownload,Users\*\AppData\Local\sabnzbd\admin/history1.db,lazy_ntfs,Locates SABnzbd history log
-      600,Shareaza Logs,FileDownload,Users\*\AppData\Roaming\Shareaza/**10,lazy_ntfs,Locates Shareaza logs and copies them.
-      601,Soulseek Chat Logs,FileDownload,Users\*\AppData\Local\SoulseekQt\Soulseek Chat Logs/**10,lazy_ntfs,Locates Soulseek chat logs and copies them. Chat logs are in plaintext. Current as of version 2019.7.22.
-      602,Soulseek Search History/Shared Folders/Settings,FileDownload,Users\*\AppData\Local\SoulseekQt\1/*.dat,lazy_ntfs,"Locates .dat file(s) containing: search history, active searches (search_record), current shared folders (shared_file_folder), and wish list items (wish_list_item)."
-      603,Torrents,FileDownload,**10/*.torrent,lazy_ntfs,
-      604,Usenet (NZB) Files,FileDownload,**10/*.nzb,lazy_ntfs,
-      605,TorrentClients - qBittorrent,FileDownload,Users\*\AppData\Roaming\qBittorrent/*.ini,lazy_ntfs,
-      606,TorrentClients - qBittorrent,FileDownload,Users\*\AppData\Local\qBittorrent\logs\*,lazy_ntfs,
-      607,TorrentClients - uTorrent,FileDownload,Users\*\AppData\Roaming\uTorrent/*.dat,lazy_ntfs,
-      608,$Boot,FileSystem,$Boot,ntfs,
-      609,$J,FileSystem,$Extend/$UsnJrnl:$J,ntfs,
-      610,$Max,FileSystem,$Extend/$UsnJrnl:$Max,ntfs,
-      611,$J,FileSystem,$Extend/$J,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
-      612,$Max,FileSystem,$Extend/$Max,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
-      613,$LogFile,FileSystem,$LogFile,ntfs,
-      614,$MFT,FileSystem,$MFT,ntfs,
-      615,$MFTMirr,FileSystem,$MFTMirr,ntfs,$MFTMirr is a redundant copy of the first four (4) records of the MFT.
-      616,$T,FileSystem,$Extend\$RmMetadata\$TxfLog/$Tops:$T,ntfs,
-      617,$T,FileSystem,$Extend\$RmMetadata\$TxfLog/$T,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Target is looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
-      618,Amcache,ApplicationCompatibility,Windows\AppCompat\Programs/Amcache.hve,lazy_ntfs,
-      619,Amcache,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs/Amcache.hve,lazy_ntfs,
-      620,Amcache transaction files,ApplicationCompatibility,Windows\AppCompat\Programs/Amcache.hve.LOG*,lazy_ntfs,
-      621,Amcache transaction files,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs/Amcache.hve.LOG*,lazy_ntfs,
-      622,Application Event Log XP,EventLogs,Windows\System32\config/AppEvent.evt,lazy_ntfs,
-      623,Application Event Log XP,EventLogs,Windows.old\Windows\System32\config/AppEvent.evt,lazy_ntfs,
-      624,Application Event Log Win7+,EventLogs,Windows\System32\winevt\logs/application.evtx,lazy_ntfs,
-      625,Application Event Log Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/application.evtx,lazy_ntfs,
-      626,BCD,Registry,Boot/BCD,lazy_ntfs,
-      627,BCD Logs,Registry,Boot/BCD.LOG*,lazy_ntfs,
-      628,BITS files,Persistence,ProgramData\Microsoft\Network\Downloader/**10,lazy_ntfs,
-      629,System CryptnetUrlCache,FileKnowledge,Windows\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache/**10,lazy_ntfs,
-      630,User CryptnetUrlCache,FileKnowledge,Users\*\AppData\LocalLow\Microsoft\CryptnetUrlCache/**10,lazy_ntfs,
-      631,INetCache,FileKnowledge,Users\*\AppData\Local\Microsoft\Windows\INetCache\IE/**10,lazy_ntfs,
-      632,EncapsulationLogging,Executables,Windows\Appcompat\Programs/EncapsulationLogging.hve,lazy_ntfs,
-      633,EncapsulationLogging,Executables,Windows.old\Windows\Appcompat\Programs/EncapsulationLogging.hve,lazy_ntfs,
-      634,EncapsulationLogging Logs,Executables,Windows\Appcompat\Programs/EncapsulationLogging.hve.log*,lazy_ntfs,
-      635,EncapsulationLogging Logs,Executables,Windows.old\Windows\Appcompat\Programs/EncapsulationLogging.hve.log*,lazy_ntfs,
-      636,Event logs Win7+,EventLogs,Windows\System32\winevt\logs/System.evtx,lazy_ntfs,
-      637,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/System.evtx,lazy_ntfs,
-      638,Event logs Win7+,EventLogs,Windows\System32\winevt\logs/Security.evtx,lazy_ntfs,
-      639,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/Security.evtx,lazy_ntfs,
-      640,Event logs Win7+,EventLogs,Windows\System32\winevt\Logs\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx/Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx,lazy_ntfs,
-      641,Event logs Win7+,EventLogs,Windows\System32\winevt\Logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx,lazy_ntfs,
-      642,Event logs XP,EventLogs,Windows\System32\config/*.evt,lazy_ntfs,
-      643,Event logs Win7+,EventLogs,Windows\System32\winevt\logs/*.evtx,lazy_ntfs,
-      644,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs/*.evtx,lazy_ntfs,
-      645,WDI Trace Logs 1,Event Trace Logs,Windows\System32\WDI\LogFiles/*.etl*,lazy_ntfs,
-      646,WDI Trace Logs 1,Event Trace Logs,Windows.old\Windows\System32\WDI\LogFiles/*.etl*,lazy_ntfs,
-      647,WDI Trace Logs 2,Event Trace Logs,Windows\System32\WDI\{*/**10,lazy_ntfs,
-      648,WDI Trace Logs 2,Event Trace Logs,Windows.old\Windows\System32\WDI\{*/**10,lazy_ntfs,
-      649,WMI Trace Logs,Event Trace Logs,Windows\System32\LogFiles\WMI/**10,lazy_ntfs,
-      650,WMI Trace Logs,Event Trace Logs,Windows.old\Windows\System32\LogFiles\WMI/**10,lazy_ntfs,
-      651,SleepStudy Trace Logs,Event Trace Logs,Windows\System32\SleepStudy/**10,lazy_ntfs,
-      652,SleepStudy Trace Logs,Event Trace Logs,Windows.old\Windows\System32\SleepStudy/**10,lazy_ntfs,
-      653,Energy-NTKL Trace Logs,Event Trace Logs,ProgramData\Microsoft\Windows\PowerEfficiency Diagnostics/energy-ntkl.etl,lazy_ntfs,
-      654,Delivery Optimization Trace Logs,Event Trace Logs,Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs/*.etl*,lazy_ntfs,
-      655,EventTranscript.db,SystemEvents,ProgramData\Microsoft\Diagnosis\EventTranscript/EventTranscript.db*,lazy_ntfs,
-      656,EventTranscript.db,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis\EventTranscript/EventTranscript.db*,lazy_ntfs,
-      657,Microsoft Office Diagnostic Logs,SystemEvents,Users\%User%\AppData\Local\Temp\Diagnostics/**10,lazy_ntfs,
-      658,Local Group Policy INI Files,Communication,Windows\System32\grouppolicy/*.ini,lazy_ntfs,
-      659,Local Group Policy INI Files,Communication,Windows.old\Windows\System32\grouppolicy/*.ini,lazy_ntfs,
-      660,Local Group Policy Files - Registry Policy Files,Communication,Windows\System32\grouppolicy/*.pol,lazy_ntfs,
-      661,Local Group Policy Files - Registry Policy Files,Communication,Windows.old\Windows\System32\grouppolicy/*.pol,lazy_ntfs,
-      662,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows\System32\grouppolicy\*\Scripts/**10,lazy_ntfs,
-      663,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows.old\Windows\System32\grouppolicy\*\Scripts/**10,lazy_ntfs,
-      664,LNK Files from Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Windows\Recent/**10,lazy_ntfs,Also includes automatic and custom jumplist directories
-      665,LNK Files from Microsoft Office Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Office\Recent/**10,lazy_ntfs,
-      666,LNK Files from Recent (XP),LNKFiles,Documents and Settings\*\Recent/**10,lazy_ntfs,
-      667,Desktop LNK Files XP,LNKFiles,Documents and Settings\*\Desktop/*.LNK,lazy_ntfs,
-      668,Desktop LNK Files,LNKFiles,Users\*\Desktop/*.LNK,lazy_ntfs,
-      669,Restore point LNK Files XP,LNKFiles,System Volume Information\_restore*\RP*/*.LNK,lazy_ntfs,
-      670,LNK Files from C:\ProgramData,LNKFiles,ProgramData\Microsoft\Windows\Start Menu\Programs/*.LNK,lazy_ntfs,
-      671,.bash_history,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*/.bash_history,lazy_ntfs,
-      672,.bash_logout,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*/.bash_logout,lazy_ntfs,
-      673,.bashrc,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*/.bashrc,lazy_ntfs,
-      674,.profile,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*/.profile,lazy_ntfs,
-      675,LogFiles,Logs,Windows\System32\LogFiles/**10,lazy_ntfs,
-      676,LogFiles,Logs,Windows.old\Windows\System32\LogFiles/**10,lazy_ntfs,
-      677,MOF files,WMI,**10/*.MOF,lazy_ntfs,
-      678,hiberfil.sys,Memory,hiberfil.sys,lazy_ntfs,
-      679,pagefile.sys,Memory,pagefile.sys,lazy_ntfs,
-      680,swapfile.sys,Memory,swapfile.sys,lazy_ntfs,
-      681,Small Memory Dump directory,Memory,Windows\Minidump/*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
-      682,Small Memory Dump directory,Memory,Windows.old\Windows\Minidump/*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
-      683,Word Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Word/**10,lazy_ntfs,
-      684,Excel Autosave Location,ApplicationCompatibility,Users\*\AppData\Roaming\Microsoft\Excel/**10,lazy_ntfs,
-      685,Powerpoint Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Powerpoint/**10,lazy_ntfs,
-      686,Publisher Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Publisher/**10,lazy_ntfs,
-      687,Office Document Cache,FileKnowledge,Users\*\AppData\Local\Microsoft\Office\*\OfficeFileCache/**10,lazy_ntfs,
-      688,Prefetch,Prefetch,Windows\prefetch/*.pf,lazy_ntfs,
-      689,Prefetch,Prefetch,Windows.old\Windows\prefetch/*.pf,lazy_ntfs,
-      690,RDP Cache Files,FileSystem,Users\*\AppData\Local\Microsoft\Terminal Server Client\Cache\*,lazy_ntfs,
-      691,RDP Cache Files,FileSystem,Documents and Settings\*\Local Settings\Application Data\Microsoft\Terminal Server Client\Cache\*,lazy_ntfs,
-      692,RemoteConnectionManager Event Logs,EventLogs,Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
-      693,RemoteConnectionManager Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
-      694,LocalSessionManager Event Logs,EventLogs,Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
-      695,LocalSessionManager Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
-      696,RDPClient Event Logs,EventLogs,Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
-      697,RDPClient Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs/Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
-      698,RDPCoreTS Event Logs,EventLogs,Windows\System32\winevt\logs/Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
-      699,RDPCoreTS Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs/Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
-      700,RecentFileCache,ApplicationCompatability,Windows\AppCompat\Programs/RecentFileCache.bcf,lazy_ntfs,
-      701,RecentFileCache,ApplicationCompatability,Windows.old\Windows\AppCompat\Programs/RecentFileCache.bcf,lazy_ntfs,
-      702,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$R*,lazy_ntfs,
-      703,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/D*,lazy_ntfs,
-      704,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin/**10/$I*,lazy_ntfs,
-      705,RECYCLER - WinXP,FileDeletion,RECYCLE*/**10/INFO2,lazy_ntfs,
-      706,BBI registry hive,Registry,Windows\System32\config/BBI,lazy_ntfs,
-      707,BBI registry hive,Registry,Windows.old\Windows\System32\config/BBI,lazy_ntfs,
-      708,BBI registry transaction files,Registry,Windows\System32\config/BBI.LOG*,lazy_ntfs,
-      709,BBI registry transaction files,Registry,Windows.old\System32\config/BBI.LOG*,lazy_ntfs,
-      710,BCD-Template registry hive,Registry,Windows\System32\config/BCD-Template,lazy_ntfs,
-      711,BCD-Template registry hive,Registry,Windows.old\Windows\System32\config/BCD-Template,lazy_ntfs,
-      712,BCD-Template registry transaction files,Registry,Windows\System32\config/BCD-Template.LOG*,lazy_ntfs,
-      713,BCD-Template registry transaction files,Registry,Windows.old\System32\config/BCD-Template.LOG*,lazy_ntfs,
-      714,COMPONENTS registry hive,Registry,Windows\System32\config/COMPONENTS,lazy_ntfs,
-      715,COMPONENTS registry hive,Registry,Windows.old\Windows\System32\config/COMPONENTS,lazy_ntfs,
-      716,COMPONENTS registry transaction files,Registry,Windows\System32\config/COMPONENTS.LOG*,lazy_ntfs,
-      717,COMPONENTS registry transaction files,Registry,Windows.old\System32\config/COMPONENTS.LOG*,lazy_ntfs,
-      718,DRIVERS registry hive,Registry,Windows\System32\config/DRIVERS,lazy_ntfs,
-      719,DRIVERS registry hive,Registry,Windows.old\Windows\System32\config/DRIVERS,lazy_ntfs,
-      720,DRIVERS registry transaction files,Registry,Windows\System32\config/DRIVERS.LOG*,lazy_ntfs,
-      721,DRIVERS registry transaction files,Registry,Windows.old\System32\config/DRIVERS.LOG*,lazy_ntfs,
-      722,ELAM registry hive,Registry,Windows\System32\config/ELAM,lazy_ntfs,
-      723,ELAM registry hive,Registry,Windows.old\Windows\System32\config/ELAM,lazy_ntfs,
-      724,ELAM registry transaction files,Registry,Windows\System32\config/ELAM.LOG*,lazy_ntfs,
-      725,ELAM registry transaction files,Registry,Windows.old\System32\config/ELAM.LOG*,lazy_ntfs,
-      726,userdiff registry hive,Registry,Windows\System32\config/userdiff,lazy_ntfs,
-      727,userdiff registry hive,Registry,Windows.old\Windows\System32\config/userdiff,lazy_ntfs,
-      728,userdiff registry transaction files,Registry,Windows\System32\config/userdiff.LOG*,lazy_ntfs,
-      729,userdiff registry transaction files,Registry,Windows.old\System32\config/userdiff.LOG*,lazy_ntfs,
-      730,VSMIDK registry hive,Registry,Windows\System32\config/VSMIDK,lazy_ntfs,
-      731,VSMIDK registry hive,Registry,Windows.old\Windows\System32\config/VSMIDK,lazy_ntfs,
-      732,VSMIDK registry transaction files,Registry,Windows\System32\config/VSMIDK.LOG*,lazy_ntfs,
-      733,VSMIDK registry transaction files,Registry,Windows.old\System32\config/VSMIDK.LOG*,lazy_ntfs,
-      734,SAM registry transaction files,Registry,Windows\System32\config/SAM.LOG*,lazy_ntfs,
-      735,SAM registry transaction files,Registry,Windows.old\Windows\System32\config/SAM.LOG*,lazy_ntfs,
-      736,SECURITY registry transaction files,Registry,Windows\System32\config/SECURITY.LOG*,lazy_ntfs,
-      737,SECURITY registry transaction files,Registry,Windows.old\Windows\System32\config/SECURITY.LOG*,lazy_ntfs,
-      738,SOFTWARE registry transaction files,Registry,Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      739,SOFTWARE registry transaction files,Registry,Windows.old\Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      740,SYSTEM registry transaction files,Registry,Windows\System32\config/SYSTEM.LOG*,lazy_ntfs,
-      741,SYSTEM registry transaction files,Registry,Windows.old\Windows\System32\config/SYSTEM.LOG*,lazy_ntfs,
-      742,SAM registry hive,Registry,Windows\System32\config/SAM,lazy_ntfs,
-      743,SAM registry hive,Registry,Windows.old\Windows\System32\config/SAM,lazy_ntfs,
-      744,SECURITY registry hive,Registry,Windows\System32\config/SECURITY,lazy_ntfs,
-      745,SECURITY registry hive,Registry,Windows.old\Windows\System32\config/SECURITY,lazy_ntfs,
-      746,SOFTWARE registry hive,Registry,Windows\System32\config/SOFTWARE,lazy_ntfs,
-      747,SOFTWARE registry hive,Registry,Windows.old\Windows\System32\config/SOFTWARE,lazy_ntfs,
-      748,SYSTEM registry hive,Registry,Windows\System32\config/SYSTEM,lazy_ntfs,
-      749,SYSTEM registry hive,Registry,Windows.old\Windows\System32\config/SYSTEM,lazy_ntfs,
-      750,RegBack registry transaction files,Registry,Windows\System32\config\RegBack/*.LOG*,lazy_ntfs,
-      751,RegBack registry transaction files,Registry,Windows.old\Windows\System32\config\RegBack/*.LOG*,lazy_ntfs,
-      752,SAM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SAM,lazy_ntfs,
-      753,SAM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SAM,lazy_ntfs,
-      754,SECURITY registry hive (RegBack),Registry,Windows\System32\config\RegBack/SECURITY,lazy_ntfs,
-      755,SECURITY registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SECURITY,lazy_ntfs,
-      756,SOFTWARE registry hive (RegBack),Registry,Windows\System32\config\RegBack/SOFTWARE,lazy_ntfs,
-      757,SOFTWARE registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SOFTWARE,lazy_ntfs,
-      758,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SYSTEM,lazy_ntfs,
-      759,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SYSTEM,lazy_ntfs,
-      760,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack/SYSTEM1,lazy_ntfs,
-      761,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack/SYSTEM1,lazy_ntfs,
-      762,System Profile registry hive,Registry,Windows\System32\config\systemprofile/NTUSER.DAT,lazy_ntfs,
-      763,System Profile registry hive,Registry,Windows.old\Windows\System32\config\systemprofile/NTUSER.DAT,lazy_ntfs,
-      764,System Profile registry transaction files,Registry,Windows\System32\config\systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
-      765,System Profile registry transaction files,Registry,Windows.old\Windows\System32\config\systemprofile/NTUSER.DAT.LOG*,lazy_ntfs,
-      766,Local Service registry hive,Registry,Windows\ServiceProfiles\LocalService/NTUSER.DAT,lazy_ntfs,
-      767,Local Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\LocalService/NTUSER.DAT,lazy_ntfs,
-      768,Local Service registry transaction files,Registry,Windows\ServiceProfiles\LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
-      769,Local Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\LocalService/NTUSER.DAT.LOG*,lazy_ntfs,
-      770,Network Service registry hive,Registry,Windows\ServiceProfiles\NetworkService/NTUSER.DAT,lazy_ntfs,
-      771,Network Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\NetworkService/NTUSER.DAT,lazy_ntfs,
-      772,Network Service registry transaction files,Registry,Windows\ServiceProfiles\NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
-      773,Network Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\NetworkService/NTUSER.DAT.LOG*,lazy_ntfs,
-      774,System Restore Points Registry Hives (XP),Registry,System Volume Information\_restore*\RP*\snapshot/_REGISTRY_*,lazy_ntfs,
-      775,NTUSER.DAT registry hive XP,Registry,Documents and Settings\*/NTUSER.DAT,lazy_ntfs,
-      776,NTUSER.DAT registry hive,Registry,Users\*/NTUSER.DAT,lazy_ntfs,
-      777,NTUSER.DAT registry transaction files,Registry,Users\*/NTUSER.DAT.LOG*,lazy_ntfs,
-      778,NTUSER.DAT DEFAULT registry hive,Registry,Windows\System32\config/DEFAULT,lazy_ntfs,
-      779,NTUSER.DAT DEFAULT registry hive,Registry,Windows.old\Windows\System32\config/DEFAULT,lazy_ntfs,
-      780,NTUSER.DAT DEFAULT transaction files,Registry,Windows\System32\config/DEFAULT.LOG*,lazy_ntfs,
-      781,NTUSER.DAT DEFAULT transaction files,Registry,Windows.old\Windows\System32\config/DEFAULT.LOG*,lazy_ntfs,
-      782,UsrClass.dat registry hive,Registry,Users\*\AppData\Local\Microsoft\Windows/UsrClass.dat,lazy_ntfs,
-      783,UsrClass.dat registry transaction files,Registry,Users\*\AppData\Local\Microsoft\Windows/UsrClass.dat.LOG*,lazy_ntfs,
-      784,SDB Files,Executables,Windows\apppatch\Custom/*.sdb,lazy_ntfs,
-      785,SDB Files,Executables,Windows.old\Windows\apppatch\Custom/*.sdb,lazy_ntfs,
-      786,SDB Files x64,Executables,Windows\apppatch\Custom\Custom64/*.sdb,lazy_ntfs,
-      787,SDB Files x64,Executables,Windows.old\Windows\apppatch\Custom\Custom64/*.sdb,lazy_ntfs,
-      788,SRUM,Execution,Windows\System32\SRU/**10,lazy_ntfs,
-      789,SRUM,Execution,Windows.old\Windows\System32\SRU/**10,lazy_ntfs,
-      790,SOFTWARE registry hive,Registry,Windows\System32\config/SOFTWARE,lazy_ntfs,
-      791,SOFTWARE registry hive,Registry,Windows.old\Windows\System32\config/SOFTWARE,lazy_ntfs,
-      792,SOFTWARE registry transaction files,Registry,Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      793,SOFTWARE registry transaction files,Registry,Windows.old\Windows\System32\config/SOFTWARE.LOG*,lazy_ntfs,
-      794,SUM Database (.mdb files),Logs,Windows\System32\LogFiles\SUM/*.mdb,lazy_ntfs,"Grabs Current.mdb, SystemIdentity.mdb, and [GUID].mdb"
-      795,at .job,Persistence,Windows\Tasks/*.job,lazy_ntfs,
-      796,at .job,Persistence,Windows.old\Windows\Tasks/*.job,lazy_ntfs,
-      797,at SchedLgU.txt,Persistence,Windows/SchedLgU.txt,lazy_ntfs,
-      798,at SchedLgU.txt,Persistence,Windows.old\Windows/SchedLgU.txt,lazy_ntfs,
-      799,XML,Persistence,Windows\System32\Tasks/**10,lazy_ntfs,
-      800,XML,Persistence,Windows.old\Windows\System32\Tasks/**10,lazy_ntfs,
-      801,SignatureCatalog,FileMetadata,Windows\System32\CatRoot/**10,lazy_ntfs,
-      802,SignatureCatalog,FileMetadata,Windows.old\Windows\System32\CatRoot/**10,lazy_ntfs,
-      803,StartupInfo XML Files,Persistence,Windows\System32\WDI\LogFiles\StartupInfo/*.xml,lazy_ntfs,
-      804,StartupInfo XML Files,Persistence,Windows.old\Windows\System32\WDI\LogFiles\StartupInfo/*.xml,lazy_ntfs,
-      805,Syscache,Program Execution,System Volume Information/Syscache.hve,lazy_ntfs,
-      806,Syscache transaction files,Program Execution,System Volume Information/Syscache.hve.LOG*,lazy_ntfs,
-      807,Thumbcache DB,FileKnowledge,Users\*\AppData\Local\Microsoft\Windows\Explorer/thumbcache_*.db,lazy_ntfs,
-      808,Setupapi.log XP,USBDevices,Windows/setupapi.log,lazy_ntfs,
-      809,Setupapi.log Win7+,USBDevices,Windows\inf/setupapi.dev.log,lazy_ntfs,
-      810,Setupapi.log Win7+,USBDevices,Windows.old\Windows\inf/setupapi.dev.log,lazy_ntfs,
-      811,VHD,Disk Images,**10/*.VHD,lazy_ntfs,
-      812,VHDX,Disk Images,**10/*.VHDX,lazy_ntfs,
-      813,VDI,Disk Images,**10/*.VDI,lazy_ntfs,
-      814,VMDK,Disk Images,**10/*.VMDK,lazy_ntfs,
-      815,WBEM,WBEM,Windows\System32\wbem\Repository/**10,lazy_ntfs,
-      816,WBEM,WBEM,Windows.old\Windows\System32\wbem\Repository/**10,lazy_ntfs,
-      817,WER Files,Executables,ProgramData\Microsoft\Windows\WER/**10,lazy_ntfs,
-      818,Crash Dumps,SQL Exploitation,Users\*\AppData\Local\CrashDumps/*.dmp,lazy_ntfs,
-      819,Crash Dumps,SQL Exploitation,Windows/*.dmp,lazy_ntfs,
-      820,Crash Dumps,SQL Exploitation,Windows.old\Windows/*.dmp,lazy_ntfs,
-      821,Windows Firewall Logs,WindowsFirewallLogs,Windows\System32\LogFiles\Firewall/pfirewall.*,lazy_ntfs,
-      822,Windows Firewall Logs,WindowsFirewallLogs,Windows.old\Windows\System32\LogFiles\Firewall/pfirewall.*,lazy_ntfs,
-      823,WindowsIndexSearch,FileKnowledge,programdata\microsoft\search\data\applications\windows/Windows.edb,lazy_ntfs,
-      824,Windows 10 Notification DB,Notifications,Users\*\AppData\Local\Microsoft\Windows\Notifications/wpndatabase.db,lazy_ntfs,
-      825,Windows 10 Notification DB,Notifications,Users\*\AppData\Local\Microsoft\Windows\Notifications/appdb.dat,lazy_ntfs,
-      826,MigLog.xml,OS Upgrade,Windows\Panther/MigLog.xml,lazy_ntfs,
-      827,Setupact.log,OS Upgrade,Windows\Panther/Setupact.log,lazy_ntfs,
-      828,HumanReadable.xml,OS Upgrade,Windows\Panther/*HumanReadable.xml,lazy_ntfs,
-      829,FolderMoveLog.txt,OS Upgrade,Windows\Panther\Rollback/FolderMoveLog.txt,lazy_ntfs,
-      830,Update Store.db,OS Upgrade,ProgramData\USOPrivate\UpdateStore/store.db,lazy_ntfs,
-      831,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,ProgramData\Microsoft\Diagnosis/events*.rbs,lazy_ntfs,
-      832,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis/events*.rbs,lazy_ntfs,
-      833,ActivitiesCache.db,FileFolderAccess,Users\*\AppData\Local\ConnectedDevicesPlatform\*/ActivitiesCache.db*,lazy_ntfs,
-      834,System Volume Information,Folder capture,System Volume Information/**10,lazy_ntfs,
-      835,1Password Database,Apps,Users\*\AppData\Local\1password\data/1Password10.sqlite,lazy_ntfs,"Database which holds information about 1Password installation, such as accounts, categories, settings and more"
-      836,1Password Backup Databases,Apps,Users\*\AppData\Local\1password\backups/1Password10.sqlite,lazy_ntfs,Backups of 1Password Database
-      837,1Password Logs,Apps,Users\*\AppData\Local\1password\logs/*.log,lazy_ntfs,Log of usage of 1Password - can be useful for identifying periods of user activity
-      838,4K Video Downloader,Apps,Users\*\AppData\Local\4kdownload.com\4K Video Downloader\4K Video Downloader/*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
-      839,AceText - Clipboard History,Apps,Users\*\Documents/*.atc,lazy_ntfs,Locates the Clipboard history for AceText
-      840,Acronis True Image - Logs,Apps,ProgramData\Acronis\TrueImageHome\Logs\ti_demon\*,lazy_ntfs,Copies out all log files
-      841,Acronis True Image - Database Files,Apps,ProgramData\Acronis\TrueImageHome\Database/archives.db*,lazy_ntfs,Copies out the Database folder which appears to have important information
-      842,Acronis True Image - Scripts Folder,Apps,ProgramData\Acronis\TrueImageHome\Scripts\*,lazy_ntfs,Copies out all scripts files
-      843,Ammyy Program Data,ApplicationLogs,ProgramData\Ammyy/**10,lazy_ntfs,"May not contain traditional log files, but presence of this folder may indicate historical usage"
-      844,AnyDesk Logs - User Profile - *.trace,Communications,Users\*\AppData\Roaming\AnyDesk/*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from user profile
-      845,AnyDesk Logs - ProgramData - *.trace,Communications,ProgramData\AnyDesk/*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from programdata
-      846,AnyDesk Videos,Communications,Users\*\Videos\AnyDesk/*.anydesk,lazy_ntfs,Collects any session recordings made by the user while using AnyDesk
-      847,AnyDesk Logs - User Profile - connection_trace.txt,Communications,Users\*\AppData\Roaming\AnyDesk/connection_trace.txt,lazy_ntfs,Collects the connection trace log from user profile
-      848,AnyDesk Logs - ProgramData - connection_trace.txt,Communications,ProgramData\AnyDesk/connection_trace.txt,lazy_ntfs,Collects the connection trace log from ProgramData
-      849,AnyDesk Logs - System User Account,Communications,Windows\SysWOW64\config\systemprofile\AppData\Roaming\AnyDesk\*,lazy_ntfs,Collects the logs associated with the System user account
-      850,Aspera Client Logs,FileDownload,Users\*\AppData\Local\Aspera\Aspera Connect\var\log/**10/*.log,lazy_ntfs,
-      851,Aspera Server Logs,FileDownload,Users\*\.aspera\connect\var\log/**10/*.log,lazy_ntfs,
-      852,Box User Files,Apps,Users\*\Box/**10,lazy_ntfs,Caution! This target will collect Box Drive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use
-      853,Box Sync User Files,Apps,Users\*\Box Sync/**10,lazy_ntfs,
-      854,Box Drive Application Metadata,Apps,Users\*\AppData\Local\Box\Box\*/**10,lazy_ntfs,
-      855,Box Sync Application Metadata,Apps,Users\*\AppData\Local\Box Sync\*/**10,lazy_ntfs,
-      856,Cisco Jabber Database,Communications,Users\*\AppData\Local\Cisco\Unified Communications\Jabber\CSF\History/*.db,lazy_ntfs,The Cisco Jabber process needs to be killed before database can be copied.
-      857,ClipboardMaster - Clipboard History - Text,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster/Clipboard.clm4,lazy_ntfs,Locates the user’s clipboard history (text) for ClipboardMaster
-      858,ClipboardMaster - Clipboard History - Images,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster\pics/**10,lazy_ntfs,Locates the user’s clipboard history (images) for ClipboardMaster
-      859,ClipboardMaster - Clipboard History - Backups,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster/Clipboard.clm4.ba*,lazy_ntfs,Locates the user’s clipboard history (backups) for ClipboardMaster
-      860,Confluence Wiki Log Files,Logs,Atlassian\Application Data\Confluence\logs/*.log*,lazy_ntfs,
-      861,Confluence Wiki Log Files,Logs,Program Files\Atlassian\Confluence\logs/*.log,lazy_ntfs,
-      862,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU/rename_folders.osd,lazy_ntfs,Locates .osd file which contains names of folders that have been renamed manually by the user.
-      863,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU/rename_files.osd,lazy_ntfs,Locates .osd file which contains names of files that have been renamed manually by the user.
-      864,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU/find_contains.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with contents related to the search query.
-      865,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU/find_name.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with a filename related to the search query.
-      866,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU/find_path.osd,lazy_ntfs,Locates .osd file which contains file paths related to user activity - not exactly sure how these are generated at this time.
-      867,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data/recent.osd,lazy_ntfs,Locates .osd file which contains file paths related to recent user activity. Effectively the DOpus Shellbags-equivalent. Appears to be for last 10 folder visited within the Lister.
-      868,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data/backupconfig.osd,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
-      869,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\Thumbnail Cache\*,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
-      870,Directory Opus,Apps,Users\*\AppData\Roaming\GPSoftware\Directory Opus\Logs\*,lazy_ntfs,Locates .txt files that will be named with the IP address of the FTP server Directory Opus was used to connect to. All-activity.txt will simply be a combination of all other .txt files present in this directory.
-      871,Discord Cache Files,Communications,Users\*\AppData\Roaming\discord\cache/**10,lazy_ntfs,Gets cached data from Discord app
-      872,Discord Local Storage LevelDB Files,Communications,Users\*\AppData\Roaming\discord\local storage\leveldb/**10,lazy_ntfs,Gets LevelDB database from Discord app
-      873,Double Commander - history.xml,Apps,Users\*\AppData\Roaming\doublecmd/history.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from bottom to top.
-      874,Double Commander - doublecmd.xml,Apps,Users\*\AppData\Roaming\doublecmd/doublecmd.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom.
-      875,Double Commander - FTP Log,Apps,Users\*\AppData\Roaming\doublecmd/doublecmd*.log,lazy_ntfs,Locates log files that'll be named with the following naming convention: doublecmd_2021-04-03.log.
-      876,Dropbox User Files,Apps,Users\*\Dropbox*/**10,lazy_ntfs,
-      877,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox/info.json,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
-      878,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/filecache.db*,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
-      879,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/config.dbx,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
-      880,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*/**10,lazy_ntfs,Required for offline decryption of Dropbox databases
-      881,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/home.db,lazy_ntfs,SQlite database which appears to keep track of the user's recent Dropbox activity
-      882,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/icon.db,lazy_ntfs,SQLite database which appears to keep track of icons in the user's Drobox sync history which can give an indication as to which files and folders are present
-      883,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/sync_history.db,lazy_ntfs,SQLite database which appears to keep track of the user's Drobox sync history
-      884,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*\sync/nucleus.sqlite3*,lazy_ntfs,SQLite database which appears to contain a table for deleted files
-      885,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox/host.db,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
-      886,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox/host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
-      887,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*\sync/aggregation.dbx,lazy_ntfs,SQLite database which appears to contain snapshot table of the user's Dropbox contents in JSON with timestamps in UNIX Epoch
-      888,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\*/avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
-      889,EF Commander - .ini File,Apps,Users\*\AppData\Roaming\EFSoftware\*,lazy_ntfs,Locates folder where all configuration files reside
-      890,Evernote Accounts,App,Users\*\AppData\Local\Evernote\Evernote\Databases/**10/.accounts,lazy_ntfs,Holds username and email of accounts
-      891,Evernote Notebooks,App,Users\*\AppData\Local\Evernote\Evernote\Databases/**10/*.exb,lazy_ntfs,SQLite Database of the notes
-      892,Evernote Notebook Snippets,App,Users\*\AppData\Local\Evernote\Evernote\Databases/**10/*.exb.snippets,lazy_ntfs,Note 'Snippets'
-      893,Everything (VoidTools),FileSystem,Users\*\AppData\Local\Everything/Everything.db,lazy_ntfs,Copies out Everything.db
-      894,Everything (VoidTools) - Run History,FileSystem,Users\*\AppData\Roaming\Everything/Run History.csv,lazy_ntfs,Copies out a CSV containing the history of items ran from Everything's search results window
-      895,Everything (VoidTools) - Search History,FileSystem,Users\*\AppData\Roaming\Everything/Search History.csv,lazy_ntfs,Copies out a CSV containing the history of items searched for within Everything with timestamps
-      896,Exchange client access log files,Logs,Program Files\Microsoft\Exchange Server\*\Logging/**10/*.log,lazy_ntfs,Highly dependent on Exchange configuration
-      897,Exchange Server Modified Compiled Files,Apps,Windows\Microsoft.NET\Framework*\v*\Temporary ASP.NET Files/**10/Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
-      898,Exchange Server Modified Compiled Files,Apps,inetpub\wwwroot\aspnet_client/**10/Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
-      899,Exchange Server Modified Compiled Files,Apps,inetpub\wwwroot\aspnet_client\system_web/**10/Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
-      900,Exchange Server Modified Compiled Files,Apps,Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth/**10/Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
-      901,Exchange TransportRoles log files,Logs,Program Files\Microsoft\Exchange Server\*\TransportRoles\Logs/**10/*.log,lazy_ntfs,Highly dependent on Exchange configuration
-      902,Fences - Desktop Screenshots,Apps,Users\*\AppData\Roaming\Stardock\Fences\Backups,lazy_ntfs,Locates all screenshots taken automatically by the Fences application
-      903,FileZilla XML Log Files,Logs,Users\*\AppData\Roaming\FileZilla/*.xml*,lazy_ntfs,
-      904,FileZilla SQLite3 Log Files,Logs,Users\*\AppData\Roaming\FileZilla/*.sqlite3*,lazy_ntfs,
-      905,FileZilla Server XML Log Files,Logs,Users\*\AppData\Roaming\FileZilla Server/*.xml*,lazy_ntfs,
-      906,FileZilla Log Files,Logs,Program Files (x86)\FileZilla Server\Logs/*.log*,lazy_ntfs,
-      907,Free Commander - FreeCommander.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings/FreeCommander.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts.
-      908,Free Commander - FreeCommander.ftp.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings/FreeCommander.ftp.ini,lazy_ntfs,Locates an .ini file that contains the file path to the FTP log for Free Commander.
-      909,Free Commander - FreeCommander.hist.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings/FreeCommander.hist.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom for both left and right directory browsers.
-      910,Free Commander - FreeCommander.fav.xml,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings/FreeCommander.fav.xml,lazy_ntfs,Locates an .xml file that contains favorited files/folder by the user.
-      911,Free Commander - Backup Settings,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\Bkp_Settings*/**10,lazy_ntfs,"Locates an exact copy of the above files which will have a timestamped folder name, i.e. Bkp_Settings-YYYY-MM-DD HH-MM-SS."
-      912,Free Commander - FTP Log,Apps,Users\*\AppData\Local\Temp/fc*.log,lazy_ntfs,Locates log file(s) that have a default naming convention of fc_ftplog_20210403 but can be modified by the user.
-      913,Free Commander - FTP Related Information,Apps,Users\*\AppData\Local\Temp\FreeCommander*/**10,lazy_ntfs,Locates a folder that may be named randomly that contains more FTP related information as well as .tmp files that are created while the user is traversing folders during an active FTP session. These files are deleted upon program exit.
-      914,FDM Database,App,Users\*\AppData\Local\Free Download Manager/**10/fdm.sqlite,lazy_ntfs,"fdm.sqlite shows Torrents, downloads, folder history, auth credentials and more. Will also pull fdm.sqlite in db_backup/"
-      915,FDM Backup Info,App,Users\*\AppData\Local\Free Download Manager\backup/backup.info,lazy_ntfs,"Backup info file - can change backup name from userdata.zip, so could give indication of file name"
-      916,FDM Database (userdata.zip),App,Users\*\AppData\Local\Free Download Manager\backup/userdata.zip,lazy_ntfs,fdm.sqlite can also appear in the backup folder in a compressed userdata.zip file
-      917,FreeFileSync,Apps,Users\*\AppData\Roaming\FreeFileSync\Logs,lazy_ntfs,Copies out all log files
-      918,Google Drive User Files,Apps,Users\*\Google Drive*/**10,lazy_ntfs,Google Drive Backup and Sync Application
-      919,Google Drive Metadata,Apps,Users\*\AppData\Local\Google\Drive/**10,lazy_ntfs,Google Drive Backup and Sync Application
-      920,Google File Stream Metadata,Apps,Users\*\AppData\Local\Google\DriveFS/**10,lazy_ntfs,Google Drive File Stream Application
-      921,HeidiSQL Backup files (*.sql),Apps,Users\*\AppData\Roaming\HeidiSQL\Backups\*,lazy_ntfs,
-      922,HeidiSQL (tabs.ini),Apps,Users\*\AppData\Roaming\HeidiSQL/tabs.ini,lazy_ntfs,
-      923,HexChat Chat Logs,Communications,Users\*\AppData\Roaming\HexChat\logs/**10,lazy_ntfs,
-      924,IceChat Chat Logs,Communications,Users\*\AppData\Local\IceChat Networks\IceChat\Logs/**10,lazy_ntfs,
-      925,IrfanView Configuration File,FileKnowledge,Users\*\AppData\Roaming\IrfanView/i_view32.ini,lazy_ntfs,
-      926,JDownloader 2.0 Download Lists,App,Users\*\AppData\Local\JDownloader 2.0\cfg/**10/downloadList*.zip,lazy_ntfs,"Zip folder which contains several files (00,00_00 and extraInfo) which list the download folder, the time it was created, the name of the download, origin URL, referral URL and more"
-      927,JDownloader 2.0 Link Collector,App,Users\*\AppData\Local\JDownloader 2.0\cfg/**10/linkcollector*.zip,lazy_ntfs,"Zip folder which contains several files (0X,0X_00 and extraInfo) which list the websites crawled for links, the referral URLs, timestamps and more"
-      928,JDownloader 2.0 General Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg/**10/org.jdownloader.settings.GeneralSettings.json,lazy_ntfs,General user config for JDownloader 2.0. Holds default download folder.
-      929,JDownloader 2.0 Link Grabber Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg/**10/org.jdownloader.gui.views.linkgrabber.addlinksdialog.LinkgrabberSettings.json,lazy_ntfs,Linkgrabber Settings for JDownloader 2.0. Holds latest download destination folder.
-      930,JDownloader 2.0 Proxy Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg/**10/org.jdownloader.settings.InternetConnectionSettings.customproxylist.json,lazy_ntfs,Proxy configuration for JDownloader 2.0
-      931,Java WebStart Cache User Level - Default,Communication,Users\*\AppData\Local\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      932,Java WebStart Cache User Level - IE Protected Mode,Communication,Users\*\AppData\LocalLow\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      933,Java WebStart Cache System level,Communication,Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      934,Java WebStart Cache System level,Communication,Windows.old\Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      935,Java WebStart Cache System level - IE Protected Mode,Communication,Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      936,Java WebStart Cache System level - IE Protected Mode,Communication,Windows.old\Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      937,Java WebStart Cache System level (SysWow64),Communication,Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      938,Java WebStart Cache System level (SysWow64),Communication,Windows.old\Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      939,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      940,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows.old\Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      941,Java WebStart Cache User Level - XP,Communications,Documents and Settings\*\Application Data\Sun\Java\Deployment\cache\*\*/*.idx,lazy_ntfs,
-      942,Kaseya Live Connect Logs (XP),ApplicationLogs,Documents and Settings\*\Application Data\Kaseya\Log/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
-      943,Kaseya Live Connect Logs,ApplicationLogs,Users\*\AppData\Local\Kaseya\Log\KaseyaLiveConnect/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
-      944,Kaseya Agent Endpoint Service Logs (XP),ApplicationLogs,Documents and Settings\All Users\Application Data\Kaseya\Log\Endpoint/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
-      945,Kaseya Agent Endpoint Service Logs,ApplicationLogs,ProgramData\Kaseya\Log\Endpoint/**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
-      946,Kaseya Agent Service Log,ApplicationLogs,Program Files*\Kaseya\*/agentmon.log*,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
-      947,Kaseya Setup Log,ApplicationLogs,Users\*\AppData\Local\Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
-      948,Kaseya Setup Log,ApplicationLogs,Windows\Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
-      949,Kaseya Setup Log,ApplicationLogs,Windows.old\Windows\Temp/KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
-      950,Kaseya Agent Edge Service Logs,ApplicationLogs,ProgramData\Kaseya\Log\KaseyaEdgeServices/**10,lazy_ntfs,https://www.huntress.com/blog/rapid-response-kaseya-vsa-mass-msp-ransomware-incident
-      951,LogMeIn ProgramData Logs,ApplicationLogs,ProgramData\LogMeIn\Logs/**10,lazy_ntfs,
-      952,LogMeIn Application Logs,ApplicationLogs,Users\*\AppData\Local\temp\LogMeInLogs/**10,lazy_ntfs,"Contains RemoteAssist (formerly GoToAssist), GoToMeeting, and other GoTo* logs"
-      953,Macrium Reflect,Apps,ProgramData\Macrium\Macrium Service\*,lazy_ntfs,Copies out all log files
-      954,Macrium Reflect,Apps,ProgramData\Macrium\Reflect\*,lazy_ntfs,Copies out the Reflect folder which contains many important logs
-      955,Macrium Reflect,Apps,ProgramData\Macrium\Reflect Launcher,lazy_ntfs,Copies out the Reflect folder which contains many important logs
-      956,Mattermost - Chat Logs,Apps,Users\*\AppData\Roaming\Mattermost\IndexedDB/**10,lazy_ntfs,Locates Mattermost logs and copies them
-      957,MediaMonkey - Media SQLite Database,Apps,Users\*\AppData\Roaming\MediaMonkey/MM.DB,lazy_ntfs,Locates SQLite DB that contains a complete enumeration of the user's media collection within MediaMonkey
-      958,MediaMonkey - MediaMonkey.ini,Apps,Users\*\AppData\Roaming\MediaMonkey/MediaMonkey.ini,lazy_ntfs,Locates .ini file which contains information about the user's MediaMonkey application instance
-      959,Microsoft OneNote - FullTextSearchIndex,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\*\FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
-      960,Microsoft OneNote - RecentNotebooks_SeenURLs,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\Notifications/RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
-      961,Microsoft OneNote - AccessibilityCheckerIndex,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
-      962,Microsoft OneNote - User NoteTags,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\NoteTags/*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
-      963,Microsoft OneNote - RecentSearches,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\RecentSearches/RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
-      964,"Microsoft Sticky Notes - Windows 7, 8, and 10 version 1511 and earlier",Apps,Users\*\AppData\Roaming\Microsoft\StickyNotes/StickyNotes.snt,lazy_ntfs,
-      965,Microsoft Sticky Notes - 1607 and later,Apps,Users\*\AppData\Local\Packages\Microsoft.MicrosoftStickyNotes*\LocalState/plum.sqlite*,lazy_ntfs,
-      966,Microsoft Teams IndexedDB Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\IndexedDB\https_teams.microsoft.com_0.indexeddb.leveldb/**10,lazy_ntfs,"LevelDB database which can contain inbound/outbound chat messages, call history and more"
-      967,Microsoft Teams Local Storage Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\Local Storage\leveldb/**10,lazy_ntfs,"LevelDB database which can contain meeting history, file transfer logs and more"
-      968,Microsoft Teams Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\Cache/**10,lazy_ntfs,Chromium cache which can be viewed with Nirsoft's ChromeCacheView
-      969,Microsoft Teams Config,Apps,Users\*\AppData\Roaming\Microsoft\Teams/desktop-config.json,lazy_ntfs,JSON config file for Teams
-      970,Microsoft Teams Logs (Windows 11),Apps,Users\%User%\AppData\Local\Packages\MicrosoftTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\Logs,lazy_ntfs,Lots of log files for MS Teams
-      971,Microsoft To Do - SQLite Database of To Do tasks,Apps,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\*/todosqlite.db*,lazy_ntfs,
-      972,Microsoft To Do - User Avatar,Apps,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\4c444a17ebb042fb92df97d00d1c802a\avatars/UserAvatar.jpg,lazy_ntfs,
-      973,Midnight Commander -- All Configuation Files,Apps,Users\*\Midnight Commander\*,lazy_ntfs,Locates folder where all configuration files reside
-      974,Multi Commander - Application Folder,Apps,Users\*\AppData\Local\MultiCommander*/**10,lazy_ntfs,Locates the contents of the Application folder.
-      975,Multi Commander - Config Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\Config/**10,lazy_ntfs,Locates the contents of the Config folder.
-      976,Multi Commander - Log Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\Logs/**10,lazy_ntfs,Locates log file(s) related to user activity within Multi Commander.
-      977,Multi Commander - UserData Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\UserData/**10,lazy_ntfs,Locates the contents of the UserData folder.
-      978,Multi Commander - Log File,Apps,Users\*\AppData\Roaming\MultiCommander*/**10/*MultiCommander.log,lazy_ntfs,Locates log file(s) associated with Milti Commander. Commonly in YYYY-MM-DD (numbers)-MultiCommander.log naming convention.
-      979,Notepad++ Unsaved Edits,Text Editor,Users\*\AppData\Roaming\Notepad++\backup/**10,lazy_ntfs,Locates non-saved Notepad++ files and copies them.
-      980,Notepad++ Config,Text Editor,Users\*\AppData\Roaming\Notepad++/config.xml,lazy_ntfs,"Retrieves config.xml which contains recently searched terms, replaced terms and recently opened documents"
-      981,One Commander - All Configuration Files,Apps,Users\*\OneCommander\*,lazy_ntfs,Locates folder where all configuration files reside
-      982,One Commander - Other Configuration Files,Apps,Users\*\AppData\Local\Apps\2.0\*\*\onec*/**10,lazy_ntfs,Locates folder where all configuration files reside
-      983,OneDrive User Files,Apps,Users\*\OneDrive*/**10,lazy_ntfs,Caution -- This target will collect OneDrive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use
-      984,OneDrive Metadata Logs,Apps,Users\*\AppData\Local\Microsoft\OneDrive\logs/**10,lazy_ntfs,
-      985,OneDrive Metadata Settings,Apps,Users\*\AppData\Local\Microsoft\OneDrive\settings/**10,lazy_ntfs,
-      986,OpenSSH Config File,Apps,Users\*\.ssh/config,lazy_ntfs,"Config file can hold usernames, IP addresses and ports, key locations and configured shortcuts for servers e.g. ssh web-server"
-      987,OpenSSH Known Hosts,Apps,Users\*\.ssh/known_hosts,lazy_ntfs,"Known hosts file can hold a list of connected FQDNs/IP Addresses and ports if they are non-default, as well as public key fingerprints"
-      988,OpenSSH Public Keys,Apps,Users\*\.ssh/*.pub,lazy_ntfs,"Gets all public keys (*.pub). It is more difficult to find private keys as they typically do not have a file extension. However, the .pub files should be able to help find the private keys as they are typically named the same."
-      989,OpenSSH Default Private Key,Apps,Users\*\.ssh/id_rsa,lazy_ntfs,Default name for an auto-generated SSH private key
-      990,OpenSSH Server Config File,Apps,ProgramData\ssh/sshd_config,lazy_ntfs,Config file can hold information on allowed/denied users
-      991,OpenSSH Server Logs,Apps,ProgramData\ssh\logs/*,lazy_ntfs,OpenSSH server logs
-      992,OpenSSH Host ECDSA Key,Apps,ProgramData\ssh/ssh_host_ecdsa_key,lazy_ntfs,Retrieves the host ECDSA key
-      993,OpenSSH Host ED25519 Key,Apps,ProgramData\ssh/ssh_host_ed25519_key,lazy_ntfs,Retrieves the host ED25519 key
-      994,OpenSSH Host DSA Key,Apps,ProgramData\ssh/ssh_host_dsa_key,lazy_ntfs,Retrieves the host DSA key
-      995,OpenSSH Host RSA Key,Apps,ProgramData\ssh/ssh_host_rsa_key,lazy_ntfs,Retrieves the host RSA key
-      996,OpenSSH User Authorized Keys,Apps,Users\*\.ssh/authorized_keys,lazy_ntfs,Retrieves the user's authorised public keys
-      997,OpenSSH User Authorized Keys 2,Apps,Users\*\.ssh/authorized_keys2,lazy_ntfs,Retrieves the user's authorised public keys from the second file
-      998,OpenSSH Authorized Administrator Keys,Apps,ProgramData\ssh/administrators_authorized_keys,lazy_ntfs,Retrieves the administrator group's authorised public keys
-      999,OpenVPN Client Config,ApplicationLogs,Users\*\OpenVPN\config/**10,lazy_ntfs,Contains OpenVPN Configs (Profiles)
-      1000,OpenVPN Client Config,ApplicationLogs,Program Files*\OpenVPN\config/**10,lazy_ntfs,Contains OpenVPN Configs(Profiles)
-      1001,OpenVPN Client Config,ApplicationLogs,Users\*\OpenVPN\log/*.log,lazy_ntfs,Contains OpenVPN Logs for each Config(Profile)
-      1002,PST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook/*.pst,lazy_ntfs,
-      1003,OST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook/*.ost,lazy_ntfs,
-      1004,PST,Communications,Users\*\AppData\Local\Microsoft\Outlook/*.pst,lazy_ntfs,
-      1005,OST,Communications,Users\*\AppData\Local\Microsoft\Outlook/*.ost,lazy_ntfs,
-      1006,PST (2013 or 2016),Communications,Users\*\Documents\Outlook Files/*.pst,lazy_ntfs,
-      1007,OST (2013 or 2016),Communications,Users\*\Documents\Outlook Files/*.ost,lazy_ntfs,
-      1008,PeaZip Configuration Files,FileKnowledge,Users\*\AppData\Roaming\PeaZip/**10,lazy_ntfs,
-      1009,ProtonVPN - Connection Logs,ApplicationLogs,Users\*\AppData\Local\ProtonVPN\Logs,lazy_ntfs,Locates ProtonVPN connection logs.
-      1010,Q-Dir - .ini File,Apps,Users\*\AppData\Roaming\Q-Dir/Q-Dir.ini,lazy_ntfs,Locates .ini file associated with Q-Dir which stores useful user activity information.
-      1011,Q-Dir - .qdr file,Apps,Users\*\AppData\Roaming\Q-Dir/start.qdr,lazy_ntfs,"Locates .qdr file associated with Q-Dir which stores useful user activity information, including the last 4 folders opened (encoded, unfortunately)."
-      1012,QFinderPro,Apps,Users\*\AppData\Local\QNAP\QfinderPro,lazy_ntfs,Locates a JSON file that provides network location information for any QNAP connected devices.
-      1013,Radmin Server 32bit Log,ApplicationLogs,Windows\SysWOW64\rserver30/Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
-      1014,Radmin Server 64bit Log,ApplicationLogs,Windows\System32\rserver30/Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
-      1015,Radmin Server 32bit Chats,ApplicationLogs,Windows\SysWOW64\rserver30\CHATLOGS\*/*.htm,lazy_ntfs,Previous chat logs
-      1016,Radmin Server 64bit Chats,ApplicationLogs,Windows\System32\rserver30\CHATLOGS\*/*.htm,lazy_ntfs,Previous chat logs
-      1017,Radmin Viewer Chats,ApplicationLogs,Users\*\Documents\ChatLogs\*/*.htm,lazy_ntfs,Previous chat logs
-      1018,ScreenConnect Session Database,ApplicationLogs,Program Files*\ScreenConnect\App_Data/Session.db,lazy_ntfs,SQLite database with session information
-      1019,ScreenConnect Session Database,ApplicationLogs,Program Files*\ScreenConnect\App_Data/User.xml,lazy_ntfs,Contains each user's last authenticated time
-      1020,ScreenConnect User Config,ApplicationLogs,ProgramData\ScreenConnect Client*/user.config,lazy_ntfs,Contains server domain and IP info
-      1021,ShareX,Apps,Users\*\Documents\ShareX/**10,lazy_ntfs,Locates and captures all files within the default ShareX folder path
-      1022,Signal Attachments cache,Communications,Users\*\AppData\Roaming\Signal\attachments.noindex/**10,lazy_ntfs,Profile pictures (and possibly attachments) for users who this individual has as contacts or has communicated with
-      1023,Signal Logs,Communications,Users\*\AppData\Roaming\Signal\logs/**10,lazy_ntfs,"Logs for Signal. Most recent has the extension .log while old ones will have extension .log.0, .log.1 etc."
-      1024,Signal config.json,Communications,Users\*\AppData\Roaming\Signal/config.json,lazy_ntfs,config.json holds the db.sqlite SQLCipher raw key
-      1025,Signal Database,Communications,Users\*\AppData\Roaming\Signal\sql/db.sqlite,lazy_ntfs,"Stores attachment details, conversations, messages, and more"
-      1026,main.db (App <v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*/main.db,lazy_ntfs,
-      1027,skype.db (App +v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*/skype.db,lazy_ntfs,
-      1028,main.db XP,Communications,Documents and Settings\*\Application Data\Skype\*/main.db,lazy_ntfs,
-      1029,main.db Win7+,Communications,Users\*\AppData\Roaming\Skype\*/main.db,lazy_ntfs,
-      1030,s4l-[username].db (App +v8),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState/s4l-*.db,lazy_ntfs,
-      1031,leveldb (Skype for Desktop +v8),Communications,Users\*\AppData\Roaming\Microsoft\Skype for Desktop\IndexedDB\*.leveldb/**10,lazy_ntfs,
-      1032,Skype for Destkop v8+ Chromium Cache,Communications,Users\*\AppData\Roaming\Microsoft\Skype for Desktop\Cache/**10,lazy_ntfs,Can be viewed with Nirsoft's ChromeCacheView
-      1033,Slack - Chat Logs,Apps,Users\*\AppData\Roaming\Slack\IndexedDB/**10,lazy_ntfs,Locates Slack logs and copies them
-      1034,Snagit - Captures,Apps,Users\*\AppData\Local\TechSmith\Snagit\DataStore,lazy_ntfs,Locates all Snagit captures
-      1035,SpeedCommander - .ini File,Apps,Users\*\AppData\Roaming\SpeedProject\SpeedCommander 19\*,lazy_ntfs,Locates folder where all configuration files reside
-      1036,SublimeText 2/3 Auto Save Session,Text Editor,Users\*\AppData\Roaming\Sublime Text*\Settings/Session.sublime_session,lazy_ntfs,Sublime Text 2/3 stores unsaved (temporary) files and its content in its Session.sublime_session file
-      1037,SugarSync Log File,Apps,Users\*\AppData\Local\SugarSync/sc1.log,lazy_ntfs,Locates a log file the gives a play-by-play of what the user synced when.
-      1038,SugarSync - Shared Folders (Default Location),Apps,Users\*\Documents\SugarSync Shared Folders/**10,lazy_ntfs,
-      1039,SugarSync - My SugarSync (Default Location),Apps,Users\*\Documents\My SugarSync/**10,lazy_ntfs,
-      1040,SumatraPDF Settings - SessionData,FileKnowledge,Users\*\AppData\Local\SumatraPDF/SumatraPDF-settings.txt,lazy_ntfs,Settings file which contains information about previous user session
-      1041,SumatraPDF Cache,FileKnowledge,Users\*\AppData\Local\SumatraPDF\sumatrapdfcache,lazy_ntfs,Folder contains a PNG snapshot of each PDF file the user had open at the time of last application close
-      1042,Tablacus Explorer - remember.xml,Logs,Users\*\AppData\Local\Temp\*\config/**10/remember.xml,lazy_ntfs,
-      1043,Tablacus Explorer - window.xml,Logs,Users\*\AppData\Local\Temp\*\config/**10/window.xml,lazy_ntfs,
-      1044,Tablacus Explorer - window1.xml,Logs,Users\*\AppData\Local\Temp\*\config/**10/window1.xml,lazy_ntfs,
-      1045,TeamViewer Connection Logs,Communications,Program Files*\TeamViewer/connections*.txt,lazy_ntfs,Includes connections_incoming.txt and connections.txt
-      1046,TeamViewer Application Logs,ApplicationLogs,Program Files*\TeamViewer/TeamViewer*_Logfile*,lazy_ntfs,Includes TeamViewer<version>_Logfile.log and TeamViewer<version>_Logfile_OLD.log
-      1047,TeamViewer Configuration Files,ApplicationLogs,Users\*\AppData\Roaming\TeamViewer\MRU\RemoteSupport/**10,lazy_ntfs,Includes miscellaneous config files
-      1048,Telegram app folder,Apps,Users\*\AppData\Roaming\Telegram Desktop/**10,lazy_ntfs,Telegram app folder structure
-      1049,Telegram downloaded files,Apps,Users\*\Downloads\Telegram Desktop/**10,lazy_ntfs,Chat Attachments
-      1050,TeraCopy,TeraCopy,Users\*\AppData\Roaming\TeraCopy/**10,lazy_ntfs,
-      1051,Mozilla Thunderbird Install Date,Apps,Users\*\AppData\Roaming\Thunderbird\Crash Reports/InstallTime*,lazy_ntfs,Holds install time in Unix Seconds timestamp
-      1052,Mozilla Thunderbird Profiles.ini,Apps,Users\*\AppData\Roaming\Thunderbird/profiles.ini,lazy_ntfs,Profiles list - can hold references to other profiles held elsewhere on the device
-      1053,Mozilla Thunderbird prefs.js,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*/prefs.js,lazy_ntfs,User Preferences for that profile
-      1054,Mozilla Thunderbird Global Messages Database,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*/global-messages-db.sqlite,lazy_ntfs,"Holds list of contacts, emails, and other potentially useful artifacts"
-      1055,Mozilla Thunderbird logins.json,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*/logins.json,lazy_ntfs,"Holds last time online login used, last time password changed, hostname, HTTP(s) URL and more"
-      1056,Mozilla Thunderbird places.sqlite,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*/places.sqlite,lazy_ntfs,"Holds history for Thunderbird - as it contains portions of Firefox embedded, it can be used to visit websites too"
-      1057,Mozilla Thunderbird ImapMail INBOX,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\ImapMail/**10/INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
-      1058,Mozilla Thunderbird Mail INBOX,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\Mail/**10/INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
-      1059,Mozilla Thunderbird Calendar Data,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\calendar-data/local.sqlite,lazy_ntfs,Holds local calendar data
-      1060,Mozilla Thunderbird Attachments,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\Attachments\*,lazy_ntfs,Holds attachments
-      1061,Mozilla Thunderbird Address Book,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*/abook.sqlite,lazy_ntfs,Holds local address book
-      1062,Total Commander - .ini File,Apps,Users\*\AppData\Roaming\GHISLER/wincmd.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
-      1063,Total Commander - Log File,Apps,**10/totalcmd.log,lazy_ntfs,Locates log file associated with Total Commander. NOTE: this log file is NOT enabled by default and the filename can be modified.
-      1064,Total Commander - Temp Files Created During Folder Traversal,Apps,Users\*\AppData\Local\Temp/FTP*.tmp,lazy_ntfs,Locates .tmp files which are created during the user's folder traversal and provide insight into contents of each folder traversed.
-      1065,Total Commander - FTP .ini File,Apps,Users\*\AppData\Roaming\GHISLER/wcx_ftp.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful FTP information.
-      1066,Total Commander - File Tree,Apps,Users\*\AppData\Local\GHISLER/treeinfo*.wc,lazy_ntfs,Locates a file that contains an exhaustive file tree of a user's file system.
-      1067,Total Commander - FTP Logs,Apps,Users\*\AppData\Local\Temp/tcftp.log,lazy_ntfs,Locates a file that contains the Total Commander FTP logs.
-      1068,TreeSize - ScanHistory.XML,Apps,Users\*\AppData\Roaming\JAM Software\TreeSize/scanhistory.xml,lazy_ntfs,Locates XML file that provides a list of previously scanned directories by the user.
-      1069,VLC Recently Opened Files,Apps,Users\*\AppData\Roaming\vlc/vlc-qt-interface.ini,lazy_ntfs,Configuration file for VLC. Holds [RecentsMRL] key which lists recently opened files as well as sometimes retaining timestamps for file opening
-      1070,VLC Recorded Files,Apps,Users\*\Videos/vlc-*.avi,lazy_ntfs,"Recorded files in VLC. Sometimes the Record button may be pressed instead of Play by suspects, which can record them watching content with VLC"
-      1071,VMware - Virtual Machine Inventory,Apps,Users\*\AppData\Roaming\VMware,lazy_ntfs,Locates an inventory of all Virtual Machines on disk.
-      1072,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmem,lazy_ntfs,Captures all raw memory from VMware virtual machines.
-      1073,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmss,lazy_ntfs,Captures all memory images from VMware virtual machines.
-      1074,VMware (Fusion/Workstation/Server/Player),Memory,**10/*.vmsn,lazy_ntfs,Captures all memory images from VMware virtual machines.
-      1075,RealVNC Log,ApplicationLogs,Users\*\AppData\Local\RealVNC/vncserver.log,lazy_ntfs,https://www.realvnc.com/en/connect/docs/logging.html#logging
-      1076,Viber Config Database,Apps,Users\*\AppData\Roaming\ViberPC/config.db,lazy_ntfs,Configuration file for Viber
-      1077,Viber Users Data Database,Apps,Users\*\AppData\Roaming\ViberPC\*/viber.db,lazy_ntfs,"Viber data for that user, containing Calls, Chat Messages, Contacts and more"
-      1078,Viber Users Avatars Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Avatars,lazy_ntfs,Cache of the Avatars for other Viber users
-      1079,Viber Users Backgrounds Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Backgrounds,lazy_ntfs,Store of the backgrounds
-      1080,Viber Users Thumbnails Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Thumbnails,lazy_ntfs,Cache of the thumbnails for uploaded/downloaded images
-      1081,VirtualBox VM configs,Apps,**10/*.vbox,lazy_ntfs,Locates all .vbox VM configuration files on disk
-      1082,VirtualBox VM backup configs,Apps,**10/*.vbox-prev,lazy_ntfs,Locates all backup .vbox VM configuration files on disk
-      1083,VirtualBox Logs,Apps,**10/VBox.log,lazy_ntfs,Locates all VBox.log files on disk
-      1084,VirtualBox Backup Logs,Apps,**10/VBox.log.*,lazy_ntfs,Locates all backup VBox.log files on disk - these can show historic VM usage
-      1085,VirtualBox Hardening Logs,Apps,**10/VBoxHardening.log,lazy_ntfs,Locates all VBoxHardening.log files on disk
-      1086,VirtualBox,Memory,**10/*.sav,lazy_ntfs,Captures all partial memory images from VirtualBox.
-      1087,WhatsApp Cache,Apps,Users\*\AppData\Roaming\WhatsApp\Cache,lazy_ntfs,"Copies the cache of WhatsApp. Can be opened with Chrome Cache Viewer for viewing embedded thumbnails and other image artefacts, as well as extracting .enc message files or other files"
-      1088,WhatsApp Local Storage,Apps,Users\*\AppData\Roaming\WhatsApp\Local Storage\leveldb,lazy_ntfs,"Copies the Local Storage leveldb of WhatsApp. Contains phone model and name of user, plus encrypted base64 strings which can be viewed with LevelDBDumper"
-      1089,WinSCP (.ini file),Logs,**10/WinSCP.ini,lazy_ntfs,
-      1090,Windows Your Phone - All Databases,Apps,Users\*\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed/**10,lazy_ntfs,Locates all Your Phone database files
-      1091,XYplorer - .ini file,Apps,Users\*\AppData\Roaming\XYplorer/XYplorer.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
-      1092,XYplorer - .ini file for each respective pane,Apps,Users\*\AppData\Roaming\XYplorer\Panes\*/**10/pane.ini,lazy_ntfs,Locates the .ini file for the left and right pane.
-      1093,XYplorer - AutoBackup folder,Apps,Users\*\AppData\Roaming\XYplorer\AutoBackup/**10,lazy_ntfs,Locates the AutoBackup folder and copies its contents.
-      1094,XYplorer - .dat files,Apps,Users\*\AppData\Roaming\XYplorer/**10/*.dat,lazy_ntfs,"Locates the .dat files in the XYplorer's AppData folder, all of which are updated upon program's exit."
-      1095,iTunes Backup Folder,Communications,Users\*\AppData\Roaming\Apple\Mobilesync\Backup/**10,lazy_ntfs,
-      1096,iTunes Backup Folder,Communications,Users\*\AppData\Roaming\Apple Computer\Mobilesync\Backup/**10,lazy_ntfs,
-      1097,iTunes Backup Folder - iOS13,Communications,Users\*\Apple\Mobilesync\Backup\*,lazy_ntfs,
-      1098,mIRC Chat Logs (Vista+),Communications,Users\*\AppData\Roaming\mIRC\logs/**10,lazy_ntfs,
-      1099,mIRC Chat Logs (2000/XP),Communications,Documents and Settings\*\Application Data\mIRC\logs/**10,lazy_ntfs,
-      1100,mRemoteNG Logs,Communications,Users\*\AppData\Roaming\mRemoteNG/mRemoteNG.log,lazy_ntfs,Contains log entries for remote connections
-      1101,mRemoteNG Connection Configuration and Backups,Communications,Users\*\AppData\Roaming\mRemoteNG/confCons.xml*,lazy_ntfs,"Contains connection config, often with obfuscated credentials"
-      1102,mRemoteNG Program Settings,Communications,Users\*\AppData\*\mRemoteNG/**10/user.config,lazy_ntfs,Contains user-specific program settings
-      1103,pCloud Database,Apps,Users\*\AppData\Local\pCloud/*.db,lazy_ntfs,Database contains all files sync'd with pCloud account.
-      1104,pCloud Database WAL File,Apps,Users\*\AppData\Local\pCloud/*.db-wal,lazy_ntfs,Write-Ahead Log for pCloud database file.
-      1105,pCloud Database Shared Memory File,Apps,Users\*\AppData\Local\pCloud/*.db-shm,lazy_ntfs,Shared Memory for the pCloud database file.
+      120,Opera - Roaming Folder,Communications,Users\*\AppData\Roaming\Opera Software\Opera Stable\**10,lazy_ntfs,“Grabs entire contents of the Opera AppData\Roaming folder”
+      121,Puffin - data.db,Communications,Users\*\AppData\Local\PuffinSecureBrowser\data.db,lazy_ntfs,Grabs an important database file that contains browser history
+      122,Puffin - Autocomplete Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser\autocompletes.dat,lazy_ntfs,Grabs a file that stores autocomplete data
+      123,Puffin - Password Forms Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser\passwordForms.dat,lazy_ntfs,Grabs a file that stores some saved password data
+      124,Puffin - Password (Encrypted),Communications,Users\*\AppData\Local\PuffinSecureBrowser\credential.dat,lazy_ntfs,Grabs a file that stores passwords in an encrypted format
+      125,Puffin - Subscription Data,Communications,Users\*\AppData\Local\PuffinSecureBrowser\subscription,lazy_ntfs,Grabs a file that stores the user's email address that's associated with their Puffin subscription
+      126,Puffin - Cookies,Communications,Users\*\AppData\Local\PuffinSecureBrowser\cookies.dat,lazy_ntfs,Grabs a file that stores information related to cookies
+      127,Puffin - Image Cache,Communications,Users\*\AppData\Local\PuffinSecureBrowser\image_cache\**10,lazy_ntfs,Grabs a directory that caches images from websites visited
+      128,Apache Access Log,Webservers,**10\access.log,lazy_ntfs,
+      129,IIS log files,Logs,Windows\System32\LogFiles\W3SVC*\*.log,lazy_ntfs,
+      130,IIS log files,Logs,Windows.old\Windows\System32\LogFiles\W3SVC*\*.log,lazy_ntfs,
+      131,IIS log files,Logs,inetpub\logs\LogFiles\*.log,lazy_ntfs,
+      132,IIS log files,Logs,inetpub\logs\LogFiles\W3SVC*\*.log,lazy_ntfs,
+      133,IIS log files,Logs,Resources\Directory\*\LogFiles\Web\W3SVC*\*.log,lazy_ntfs,
+      134,MS SQL Errorlog,SQL Exploitation,Program Files\Microsoft SQL Server\*\MSSQL\LOG\ERRORLOG,lazy_ntfs,
+      135,MS SQL Errorlogs,SQL Exploitation,Program Files\Microsoft SQL Server\*\MSSQL\LOG\ERRORLOG.*,lazy_ntfs,
+      136,ManageEngine Desktop Central Log Files,Logs,ManageEngine\DesktopCentral_Server\logs\**10,lazy_ntfs,
+      137,NGINX Log Files,Logs,nginx\logs\*.log,lazy_ntfs,
+      138,PowerShell Console Log,PowerShellConsleLog,Users\*\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadline\ConsoleHost_history.txt,lazy_ntfs,
+      139,AVG AV Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\AVG\Antivirus\log\**10,lazy_ntfs,
+      140,AVG AV Report Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\AVG\Antivirus\report\**10,lazy_ntfs,
+      141,AVG AV Logs,Antivirus,ProgramData\AVG\Antivirus\log\**10,lazy_ntfs,
+      142,AVG Report Logs,Antivirus,ProgramData\AVG\Antivirus\report\**10,lazy_ntfs,
+      143,Avast AV Logs (XP),Antivirus,Documents And Settings\All Users\Application Data\Avast Software\Avast\Log\**10,lazy_ntfs,
+      144,Avast AV Logs,Antivirus,ProgramData\Avast Software\Avast\Log\**10,lazy_ntfs,
+      145,Avast AV User Logs,Antivirus,Users\*\Avast Software\Avast\Log\**10,lazy_ntfs,
+      146,Avast AV Index,Antivirus,ProgramData\Avast Software\Avast\Chest\index.xml,lazy_ntfs,
+      147,Avira Activity Logs,AntiVirus,ProgramData\Avira\Antivirus\LOGFILES\**10,lazy_ntfs,Collects the scan logs of Avira AntiVirus
+      148,Bitdefender Endpoint Security Logs,Antivirus,ProgramData\Bitdefender\Endpoint Security\Logs\**10,lazy_ntfs,
+      149,Bitdefender Internet Security Logs,Antivirus,ProgramData\Bitdefender\Desktop\Profiles\Logs\**10,lazy_ntfs,
+      150,Bitdefender SQLite DB Files,Antivirus,Program Files*\Bitdefender*\**10\regex:*.+\.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
+      151,ComboFix,Antivirus,ComboFix.txt,lazy_ntfs,
+      152,Cybereason Anti-Ransomware Logs,AntiVirus,ProgramData\crs1\Logs\**10,lazy_ntfs,
+      153,Cybereason Sensor Communications and Anti-Malware Logs,AntiVirus,ProgramData\apv2\Logs\**10,lazy_ntfs,
+      154,Cybereason Application Control and NGAV Logs,AntiVirus,ProgramData\crb1\Logs\**10,lazy_ntfs,
+      155,ESET NOD32 AV Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\ESET\ESET NOD32 Antivirus\Logs\**10,lazy_ntfs,
+      156,ESET NOD32 AV Logs,Antivirus,ProgramData\ESET\ESET NOD32 Antivirus\Logs\**10,lazy_ntfs,Parser available at https://github.com/laciKE/EsetLogParser
+      157,Emsisoft Scan Logs,ApplicationLogs,ProgramData\Emsisoft\Reports\scan*.txt,lazy_ntfs,Can contain file detection and quarantine info
+      158,F-Secure Logs,Antivirus,ProgramData\F-Secure\Log\**10,lazy_ntfs,
+      159,F-Secure User Logs,Antivirus,Users\*\AppData\Local\F-Secure\Log\**10,lazy_ntfs,
+      160,F-Secure Scheduled Scan Reports,Antivirus,ProgramData\F-Secure\Antivirus\ScheduledScanReports\**10,lazy_ntfs,
+      161,HitmanPro Logs,Antivirus,ProgramData\HitmanPro\Logs\**10,lazy_ntfs,
+      162,HitmanPro Alert Logs,Antivirus,ProgramData\HitmanPro.Alert\Logs\**10,lazy_ntfs,
+      163,HitmanPro Database,Antivirus,ProgramData\HitmanPro.Alert\excalibur.db,lazy_ntfs,SQLite DB
+      164,MalwareBytes Anti-Malware Logs,Antivirus,ProgramData\Malwarebytes\Malwarebytes Anti-Malware\Logs\mbam-log-*.xml,lazy_ntfs,
+      165,MalwareBytes Anti-Malware Service Logs,Antivirus,ProgramData\Malwarebytes\MBAMService\logs\mbamservice.log*,lazy_ntfs,
+      166,MalwareBytes Anti-Malware Scan Logs,Antivirus,Users\*\AppData\Roaming\Malwarebytes\Malwarebytes Anti-Malware\Logs\**10,lazy_ntfs,
+      167,MalwareBytes Anti-Malware Scan Results Logs,Antivirus,ProgramData\Malwarebytes\MBAMService\ScanResults\**10,lazy_ntfs,
+      168,McAfee Desktop Protection Logs XP,AntiVirus,Users\All Users\Application Data\McAfee\DesktopProtection\**10,lazy_ntfs,
+      169,McAfee Desktop Protection Logs,AntiVirus,ProgramData\McAfee\DesktopProtection\**10,lazy_ntfs,
+      170,McAfee Endpoint Security Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs\**10,lazy_ntfs,
+      171,McAfee Endpoint Security Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs_Old\**10,lazy_ntfs,
+      172,McAfee VirusScan Logs,AntiVirus,ProgramData\Mcafee\VirusScan\**10,lazy_ntfs,
+      173,McAfee ePO Logs,AntiVirus,ProgramData\McAfee\Endpoint Security\Logs\**10,lazy_ntfs,
+      174,RogueKiller Reports,Antivirus,ProgramData\RogueKiller\logs\AdliceReport_*.json,lazy_ntfs,
+      175,SUPERAntiSpyware Logs,Antivirus,Users\*\AppData\Roaming\SUPERAntiSpyware\Logs\**10,lazy_ntfs,
+      176,SecureAge Antvirus Logs,Antivirus,ProgramData\SecureAge Technology\SecureAge\log\**10,lazy_ntfs,
+      177,SentinelOne EDR Log,Antivirus,programdata\sentinel\logs\**10,lazy_ntfs,Logs are in Binary Format (.binlog)
+      178,Sophos Logs (XP),Antivirus,Documents and Settings\All Users\Application Data\Sophos\Sophos *\Logs\**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+      179,Sophos Logs,Antivirus,ProgramData\Sophos\Sophos *\Logs\**10,lazy_ntfs,"Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+      180,Symantec Endpoint Protection Logs (XP),AntiVirus,Documents and Settings\All Users\Application Data\Symantec\Symantec Endpoint Protection\Logs\AV\**10,lazy_ntfs,
+      181,Symantec Endpoint Protection Logs,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\Logs\**10,lazy_ntfs,
+      182,Symantec Endpoint Protection User Logs,AntiVirus,Users\*\AppData\Local\Symantec\Symantec Endpoint Protection\Logs\**10,lazy_ntfs,
+      183,Symantec Event Log Win7+,EventLogs,Windows\System32\winevt\logs\Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
+      184,Symantec Event Log Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs\Symantec Endpoint Protection Client.evtx,lazy_ntfs,Symantec specific Windows event log
+      185,Symantec Endpoint Protection Quarantine (XP),AntiVirus,Documents and Settings\All Users\Application Data\Symantec\Symantec Endpoint Protection\Quarantine\**10,lazy_ntfs,
+      186,Symantec Endpoint Protection Quarantine,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\Quarantine\**10,lazy_ntfs,
+      187,ccSubSDK Database,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\CmnClnt\ccSubSDK\**10,lazy_ntfs,
+      188,registrationInfo.xml,AntiVirus,ProgramData\Symantec\Symantec Endpoint Protection\*\Data\registrationInfo.xml,lazy_ntfs,
+      189,TotalAV Logs,Antivirus,Program Files*\TotalAV\logs\**10,lazy_ntfs,
+      190,TotalAV Logs,Antivirus,ProgramData\TotalAV\logs\**10,lazy_ntfs,
+      191,Trend Micro Logs,Antivirus,ProgramData\Trend Micro\**10,lazy_ntfs,
+      192,Trend Micro Security Agent Report Logs,Antivirus,Program Files*\Trend Micro\Security Agent\Report\*.log,lazy_ntfs,
+      193,Trend Micro Security Agent Connection Logs,Antivirus,Program Files*\Trend Micro\Security Agent\ConnLog\*.log,lazy_ntfs,
+      194,VIPRE Business Agent Logs,Antivirus,ProgramData\VIPRE Business Agent\Logs\**10,lazy_ntfs,
+      195,VIPRE Business User Logs (v7+),Antivirus,Users\*\AppData\Roaming\VIPRE Business\**10,lazy_ntfs,
+      196,VIPRE Business User Logs (v5-v6),Antivirus,Users\*\AppData\Roaming\GFI Software\AntiMalware\Logs\**10,lazy_ntfs,
+      197,VIPRE Business User Logs (up to v4),Antivirus,Users\*\AppData\Roaming\Sunbelt Software\AntiMalware\Logs\**10,lazy_ntfs,
+      198,Webroot Program Data,Antivirus,ProgramData\WRData\WRLog.log,lazy_ntfs,
+      199,Windows Defender Logs,Antivirus,ProgramData\Microsoft\Microsoft AntiMalware\Support\**10,lazy_ntfs,
+      200,Windows Defender Event Logs,EventLogs,Windows\System32\winevt\Logs\Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
+      201,Windows Defender Event Logs,EventLogs,Windows.old\Windows\System32\winevt\Logs\Microsoft-Windows-Windows Defender*.evtx,lazy_ntfs,
+      202,Windows Defender Logs,Antivirus,ProgramData\Microsoft\Windows Defender\Support\**10,lazy_ntfs,
+      203,Windows Defender Logs,Antivirus,Windows\Temp\MpCmdRun.log,lazy_ntfs,
+      204,Windows Defender Logs,Antivirus,Windows.old\Windows\Temp\MpCmdRun.log,lazy_ntfs,
+      205,AppData,UserData,Users\*\AppData\**10,lazy_ntfs,
+      206,Audio files,Multimedia,**10\regex:*.+\.(3gp|aa|aac|act|aiff|alac|amr|ape|au|awb|dss|dvf|flac|gsm|iklax|ivs|m4a|m4b|m4p|mmf|mp3|mpc|msv|nmf|ogg|oga|mogg|opus|ra|rm|raw|rf64|sln|tta|voc|vox|wav|wma|wv|webm),ntfs,Covers most (if not all) audio file formats
+      207,Excel and Excel-like Documents,Documents,**10\regex:*.+\.(xls|xlsx|csv|tsv|xlt|xlm|xlsm|xltx|xltm|xlsb|xla|xlam|xll|xlw|ods|fodp|qpw),ntfs,"Covers all document file formats for Excel, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
+      208,PDF and PDF-like Documents,Documents,**10\regex:*.+\.(pdf|xps|oxps),ntfs,Covers all PDF and PDF-like document formats
+      209,Picture files,Multimedia,**10\regex:*.+\.(ai|bmp|bpg|cdr|cpc|eps|exr|flif|gif|heif|ilbm|ima|jp2|j2k|jpf|jpm|jpg2|j2c|jpc|jpx|mj2jpeg|jpg|jxl|kra|ora|pcx|pgf|pgm|png|pnm|ppm|psb|psd|psp|svg|tga|tiff|webp|xaml|xcf),ntfs,Covers most (if not all) picture file formats
+      210,SQLite Files (.db* and .sqlite*),Databases,**10\regex:*.+\.(db*|sqlite*|),ntfs,Covers all common file extensions for SQLite databases
+      211,Video files,Multimedia,**10\regex:*.+\.(3g2|3gp|amv|asf|avi|drc|flv|f4v|f4p|f4a|f4b|gif|gifv|m4v|mkv|mov|qt|mp4|m4p|mpg|mpeg|m2v|mp2|mpe|mpv|mts|m2ts|ts|mxf|nsv|ogv|ogg|rm|rmvb|roq|svi|viv|vob|webm|wmv|yuv),ntfs,Covers most (if not all) video file formats
+      212,Zips,Archives,**10\*.zip,lazy_ntfs,This is an example of how to walk a drive for a file mask. Probably do not want to use this one as is
+      213,Word and Word-like Documents,Documents,**10\regex:*.+\.(doc|docx|docm|dotx|dotm|docb|dot|wbk|odt|fodt|rtf|wp*|tmd),ntfs,"Covers all document file formats for Word, OpenOffice, LibreOffice, Apache OpenOffice, WPS Office, SoftMaker Office, and more"
+      214,User Files - Desktop,LiveUserFiles,Users\*\Desktop\**10,lazy_ntfs,
+      215,User Files - Documents,LiveUserFiles,Users\*\Documents\**10,lazy_ntfs,
+      216,User Files - Downloads,LiveUserFiles,Users\*\Downloads\**10,lazy_ntfs,
+      217,User Files - Dropbox,LiveUserFiles,Users\*\Dropbox*\**10,lazy_ntfs,
+      218,1Password Database,Apps,Users\*\AppData\Local\1password\data\1Password10.sqlite,lazy_ntfs,"Database which holds information about 1Password installation, such as accounts, categories, settings and more"
+      219,1Password Backup Databases,Apps,Users\*\AppData\Local\1password\backups\1Password10.sqlite,lazy_ntfs,Backups of 1Password Database
+      220,1Password Logs,Apps,Users\*\AppData\Local\1password\logs\*.log,lazy_ntfs,Log of usage of 1Password - can be useful for identifying periods of user activity
+      221,4K Video Downloader,Apps,Users\*\AppData\Local\4kdownload.com\4K Video Downloader\4K Video Downloader\*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
+      222,AceText - Clipboard History,Apps,Users\*\Documents\*.atc,lazy_ntfs,Locates the Clipboard history for AceText
+      223,Acronis True Image - Logs,Apps,ProgramData\Acronis\TrueImageHome\Logs\ti_demon\*,lazy_ntfs,Copies out all log files
+      224,Acronis True Image - Database Files,Apps,ProgramData\Acronis\TrueImageHome\Database\archives.db*,lazy_ntfs,Copies out the Database folder which appears to have important information
+      225,Acronis True Image - Scripts Folder,Apps,ProgramData\Acronis\TrueImageHome\Scripts\*,lazy_ntfs,Copies out all scripts files
+      226,Ammyy Program Data,ApplicationLogs,ProgramData\Ammyy\**10,lazy_ntfs,"May not contain traditional log files, but presence of this folder may indicate historical usage"
+      227,AnyDesk Logs - User Profile - *.trace,Communications,Users\*\AppData\Roaming\AnyDesk\*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from user profile
+      228,AnyDesk Logs - ProgramData - *.trace,Communications,ProgramData\AnyDesk\*.trace,lazy_ntfs,Collects the trace logs for AnyDesk from programdata
+      229,AnyDesk Videos,Communications,Users\*\Videos\AnyDesk\*.anydesk,lazy_ntfs,Collects any session recordings made by the user while using AnyDesk
+      230,AnyDesk Logs - User Profile - connection_trace.txt,Communications,Users\*\AppData\Roaming\AnyDesk\connection_trace.txt,lazy_ntfs,Collects the connection trace log from user profile
+      231,AnyDesk Logs - ProgramData - connection_trace.txt,Communications,ProgramData\AnyDesk\connection_trace.txt,lazy_ntfs,Collects the connection trace log from ProgramData
+      232,AnyDesk Logs - System User Account,Communications,Windows\SysWOW64\config\systemprofile\AppData\Roaming\AnyDesk\*,lazy_ntfs,Collects the logs associated with the System user account
+      233,Aspera Client Logs,FileDownload,Users\*\AppData\Local\Aspera\Aspera Connect\var\log\**10\*.log,lazy_ntfs,
+      234,Aspera Server Logs,FileDownload,Users\*\.aspera\connect\var\log\**10\*.log,lazy_ntfs,
+      235,Box Drive Application Metadata,Apps,Users\*\AppData\Local\Box\Box\**10,lazy_ntfs,
+      236,Box Sync Application Metadata,Apps,Users\*\AppData\Local\Box Sync\**10,lazy_ntfs,
+      237,Box Drive User Files,Apps,Users\*\Box\**10,lazy_ntfs,Caution! This target will collect Box Drive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use or isolate system from network
+      238,Box Sync User Files,Apps,Users\*\Box Sync\**10,lazy_ntfs,
+      239,Cisco Jabber Database,Communications,Users\*\AppData\Local\Cisco\Unified Communications\Jabber\CSF\History\*.db,lazy_ntfs,The Cisco Jabber process needs to be killed before database can be copied.
+      240,ClipboardMaster - Clipboard History - Text,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster\Clipboard.clm4,lazy_ntfs,Locates the user’s clipboard history (text) for ClipboardMaster
+      241,ClipboardMaster - Clipboard History - Images,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster\pics\**10,lazy_ntfs,Locates the user’s clipboard history (images) for ClipboardMaster
+      242,ClipboardMaster - Clipboard History - Backups,Apps,Users\*\AppData\Roaming\Jumping Bytes\ClipboardMaster\Clipboard.clm4.ba*,lazy_ntfs,Locates the user’s clipboard history (backups) for ClipboardMaster
+      243,Confluence Wiki Log Files,Logs,Atlassian\Application Data\Confluence\logs\*.log*,lazy_ntfs,
+      244,Confluence Wiki Log Files,Logs,Program Files\Atlassian\Confluence\logs\*.log,lazy_ntfs,
+      245,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU\rename_folders.osd,lazy_ntfs,Locates .osd file which contains names of folders that have been renamed manually by the user.
+      246,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU\rename_files.osd,lazy_ntfs,Locates .osd file which contains names of files that have been renamed manually by the user.
+      247,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU\find_contains.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with contents related to the search query.
+      248,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU\find_name.osd,lazy_ntfs,Locates .osd file which contains search queries initiated by the user during a search for files with a filename related to the search query.
+      249,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\MRU\find_path.osd,lazy_ntfs,Locates .osd file which contains file paths related to user activity - not exactly sure how these are generated at this time.
+      250,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\recent.osd,lazy_ntfs,Locates .osd file which contains file paths related to recent user activity. Effectively the DOpus Shellbags-equivalent. Appears to be for last 10 folder visited within the Lister.
+      251,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\State Data\backupconfig.osd,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
+      252,Directory Opus,Apps,Users\*\AppData\Local\GPSoftware\Directory Opus\Thumbnail Cache\*,lazy_ntfs,Locates .osd file which contains file paths related to the location of the backup settings files for Directory Opus.
+      253,Directory Opus,Apps,Users\*\AppData\Roaming\GPSoftware\Directory Opus\Logs\*,lazy_ntfs,Locates .txt files that will be named with the IP address of the FTP server Directory Opus was used to connect to. All-activity.txt will simply be a combination of all other .txt files present in this directory.
+      254,Discord Cache Files,Communications,Users\*\AppData\Roaming\discord\cache\**10,lazy_ntfs,Gets cached data from Discord app
+      255,Discord Local Storage LevelDB Files,Communications,Users\*\AppData\Roaming\discord\local storage\leveldb\**10,lazy_ntfs,Gets LevelDB database from Discord app
+      256,Double Commander - history.xml,Apps,Users\*\AppData\Roaming\doublecmd\history.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from bottom to top.
+      257,Double Commander - doublecmd.xml,Apps,Users\*\AppData\Roaming\doublecmd\doublecmd.xml,lazy_ntfs,Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom.
+      258,Double Commander - FTP Log,Apps,Users\*\AppData\Roaming\doublecmd\doublecmd*.log,lazy_ntfs,Locates log files that'll be named with the following naming convention: doublecmd_2021-04-03.log.
+      259,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\info.json,lazy_ntfs,Getting individual files because folder may contain very large extraneous files. Info.json contains user's Dropbox folder location
+      260,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\host.db,lazy_ntfs,SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64.
+      261,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      262,Windows Protect Folder,FileSystem,Users\*\AppData\Roaming\Microsoft\Protect\*\**10,lazy_ntfs,Required for offline decryption of Dropbox databases
+      263,Dropbox Metadata,Apps,Users\*\AppData\Local\Dropbox\instance*\**10,lazy_ntfs,instance folder holds multiple SQLite databases related to Dropbox activity and contents
+      264,Dropbox User Files,Apps,Users\*\Dropbox*\**10,lazy_ntfs,"Default storage location for Dropbox Personal and Business (when using wildcard), but can be user-defined. Check info.json file in user Dropbox metadata files to identify default folder."
+      265,EF Commander - .ini File,Apps,Users\*\AppData\Roaming\EFSoftware\*,lazy_ntfs,Locates folder where all configuration files reside
+      266,Evernote Accounts,App,Users\*\AppData\Local\Evernote\Evernote\Databases\**10\.accounts,lazy_ntfs,Holds username and email of accounts
+      267,Evernote Notebooks,App,Users\*\AppData\Local\Evernote\Evernote\Databases\**10\*.exb,lazy_ntfs,SQLite Database of the notes
+      268,Evernote Notebook Snippets,App,Users\*\AppData\Local\Evernote\Evernote\Databases\**10\*.exb.snippets,lazy_ntfs,Note 'Snippets'
+      269,Everything (VoidTools),FileSystem,Users\*\AppData\Local\Everything\Everything.db,lazy_ntfs,Copies out Everything.db
+      270,Everything (VoidTools) - Run History,FileSystem,Users\*\AppData\Roaming\Everything\Run History.csv,lazy_ntfs,Copies out a CSV containing the history of items ran from Everything's search results window
+      271,Everything (VoidTools) - Search History,FileSystem,Users\*\AppData\Roaming\Everything\Search History.csv,lazy_ntfs,Copies out a CSV containing the history of items searched for within Everything with timestamps
+      272,Exchange client access log files,Logs,Program Files\Microsoft\Exchange Server\*\Logging\**10\*.log,lazy_ntfs,Highly dependent on Exchange configuration
+      273,Exchange Server Modified Compiled Files,Apps,Windows\Microsoft.NET\Framework*\v*\Temporary ASP.NET Files\**10\Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
+      274,Exchange Server Modified Compiled Files,Apps,inetpub\wwwroot\aspnet_client\**10\Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
+      275,Exchange Server Modified Compiled Files,Apps,inetpub\wwwroot\aspnet_client\system_web\**10\Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
+      276,Exchange Server Modified Compiled Files,Apps,Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\**10\Regex:*.\b[a-zA-Z0-9_-]{8}\b.compiled,ntfs,Highly dependent on Exchange configuration
+      277,Exchange TransportRoles log files,Logs,Program Files\Microsoft\Exchange Server\*\TransportRoles\Logs\**10\*.log,lazy_ntfs,Highly dependent on Exchange configuration
+      278,Fences - Desktop Screenshots,Apps,Users\*\AppData\Roaming\Stardock\Fences\Backups,lazy_ntfs,Locates all screenshots taken automatically by the Fences application
+      279,FileZilla XML Log Files,Logs,Users\*\AppData\Roaming\FileZilla\*.xml*,lazy_ntfs,
+      280,FileZilla SQLite3 Log Files,Logs,Users\*\AppData\Roaming\FileZilla\*.sqlite3*,lazy_ntfs,
+      281,FileZilla Server XML Log Files,Logs,Users\*\AppData\Roaming\FileZilla Server\*.xml*,lazy_ntfs,
+      282,FileZilla Log Files,Logs,Program Files (x86)\FileZilla Server\Logs\*.log*,lazy_ntfs,
+      283,Free Commander - FreeCommander.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\FreeCommander.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts.
+      284,Free Commander - FreeCommander.ftp.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\FreeCommander.ftp.ini,lazy_ntfs,Locates an .ini file that contains the file path to the FTP log for Free Commander.
+      285,Free Commander - FreeCommander.hist.ini,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\FreeCommander.hist.ini,lazy_ntfs,Locates an .ini file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom for both left and right directory browsers.
+      286,Free Commander - FreeCommander.fav.xml,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\FreeCommander.fav.xml,lazy_ntfs,Locates an .xml file that contains favorited files/folder by the user.
+      287,Free Commander - Backup Settings,Apps,Users\*\AppData\Local\FreeCommanderXE\Settings\Bkp_Settings*\**10,lazy_ntfs,"Locates an exact copy of the above files which will have a timestamped folder name, i.e. Bkp_Settings-YYYY-MM-DD HH-MM-SS."
+      288,Free Commander - FTP Log,Apps,Users\*\AppData\Local\Temp\fc*.log,lazy_ntfs,Locates log file(s) that have a default naming convention of fc_ftplog_20210403 but can be modified by the user.
+      289,Free Commander - FTP Related Information,Apps,Users\*\AppData\Local\Temp\FreeCommander*\**10,lazy_ntfs,Locates a folder that may be named randomly that contains more FTP related information as well as .tmp files that are created while the user is traversing folders during an active FTP session. These files are deleted upon program exit.
+      290,FDM Database,App,Users\*\AppData\Local\Free Download Manager\**10\fdm.sqlite,lazy_ntfs,"fdm.sqlite shows Torrents, downloads, folder history, auth credentials and more. Will also pull fdm.sqlite in db_backup/"
+      291,FDM Backup Info,App,Users\*\AppData\Local\Free Download Manager\backup\backup.info,lazy_ntfs,"Backup info file - can change backup name from userdata.zip, so could give indication of file name"
+      292,FDM Database (userdata.zip),App,Users\*\AppData\Local\Free Download Manager\backup\userdata.zip,lazy_ntfs,fdm.sqlite can also appear in the backup folder in a compressed userdata.zip file
+      293,FreeFileSync,Apps,Users\*\AppData\Roaming\FreeFileSync\Logs,lazy_ntfs,Copies out all log files
+      294,Google Drive Backup and Sync User Files,Apps,Users\*\Google Drive*\**10,lazy_ntfs,Older Google Drive Backup and Sync application only
+      295,Google Drive Backup and Sync Metadata,Apps,Users\*\AppData\Local\Google\Drive\**10,lazy_ntfs,Older version of Google Drive
+      296,Google Drive for Desktop Metadata,Apps,Users\*\AppData\Local\Google\DriveFS\**10,lazy_ntfs,Metadata folder the same for both newer Google Drive for Desktop and older Google File Stream application
+      297,HeidiSQL Backup files (*.sql),Apps,Users\*\AppData\Roaming\HeidiSQL\Backups\*,lazy_ntfs,
+      298,HeidiSQL (tabs.ini),Apps,Users\*\AppData\Roaming\HeidiSQL\tabs.ini,lazy_ntfs,
+      299,HexChat Chat Logs,Communications,Users\*\AppData\Roaming\HexChat\logs\**10,lazy_ntfs,
+      300,IceChat Chat Logs,Communications,Users\*\AppData\Local\IceChat Networks\IceChat\Logs\**10,lazy_ntfs,
+      301,IrfanView Configuration File,FileKnowledge,Users\*\AppData\Roaming\IrfanView\i_view32.ini,lazy_ntfs,
+      302,JDownloader 2.0 Download Lists,App,Users\*\AppData\Local\JDownloader 2.0\cfg\**10\downloadList*.zip,lazy_ntfs,"Zip folder which contains several files (00,00_00 and extraInfo) which list the download folder, the time it was created, the name of the download, origin URL, referral URL and more"
+      303,JDownloader 2.0 Link Collector,App,Users\*\AppData\Local\JDownloader 2.0\cfg\**10\linkcollector*.zip,lazy_ntfs,"Zip folder which contains several files (0X,0X_00 and extraInfo) which list the websites crawled for links, the referral URLs, timestamps and more"
+      304,JDownloader 2.0 General Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg\**10\org.jdownloader.settings.GeneralSettings.json,lazy_ntfs,General user config for JDownloader 2.0. Holds default download folder.
+      305,JDownloader 2.0 Link Grabber Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg\**10\org.jdownloader.gui.views.linkgrabber.addlinksdialog.LinkgrabberSettings.json,lazy_ntfs,Linkgrabber Settings for JDownloader 2.0. Holds latest download destination folder.
+      306,JDownloader 2.0 Proxy Settings,App,Users\*\AppData\Local\JDownloader 2.0\cfg\**10\org.jdownloader.settings.InternetConnectionSettings.customproxylist.json,lazy_ntfs,Proxy configuration for JDownloader 2.0
+      307,Java WebStart Cache User Level - Default,Communication,Users\*\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      308,Java WebStart Cache User Level - IE Protected Mode,Communication,Users\*\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      309,Java WebStart Cache System level,Communication,Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      310,Java WebStart Cache System level,Communication,Windows.old\Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      311,Java WebStart Cache System level - IE Protected Mode,Communication,Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      312,Java WebStart Cache System level - IE Protected Mode,Communication,Windows.old\Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      313,Java WebStart Cache System level (SysWow64),Communication,Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      314,Java WebStart Cache System level (SysWow64),Communication,Windows.old\Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      315,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      316,Java WebStart Cache System level (SysWow64) - IE Protected Mode,Communication,Windows.old\Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      317,Java WebStart Cache User Level - XP,Communications,Documents and Settings\*\Application Data\Sun\Java\Deployment\cache\*\*\*.idx,lazy_ntfs,
+      318,Kaseya Live Connect Logs (XP),ApplicationLogs,Documents and Settings\*\Application Data\Kaseya\Log\**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      319,Kaseya Live Connect Logs,ApplicationLogs,Users\*\AppData\Local\Kaseya\Log\KaseyaLiveConnect\**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      320,Kaseya Agent Endpoint Service Logs (XP),ApplicationLogs,Documents and Settings\All Users\Application Data\Kaseya\Log\Endpoint\**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      321,Kaseya Agent Endpoint Service Logs,ApplicationLogs,ProgramData\Kaseya\Log\Endpoint\**10,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      322,Kaseya Agent Service Log,ApplicationLogs,Program Files*\Kaseya\*\agentmon.log*,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229009708-Live-Connect-Log-File-Locations
+      323,Kaseya Setup Log,ApplicationLogs,Users\*\AppData\Local\Temp\KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      324,Kaseya Setup Log,ApplicationLogs,Windows\Temp\KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      325,Kaseya Setup Log,ApplicationLogs,Windows.old\Windows\Temp\KASetup.log,lazy_ntfs,https://helpdesk.kaseya.com/hc/en-gb/articles/229011448
+      326,Kaseya Agent Edge Service Logs,ApplicationLogs,ProgramData\Kaseya\Log\KaseyaEdgeServices\**10,lazy_ntfs,https://www.huntress.com/blog/rapid-response-kaseya-vsa-mass-msp-ransomware-incident
+      327,LogMeIn ProgramData Logs,ApplicationLogs,ProgramData\LogMeIn\Logs\**10,lazy_ntfs,
+      328,LogMeIn Application Logs,ApplicationLogs,Users\*\AppData\Local\temp\LogMeInLogs\**10,lazy_ntfs,"Contains RemoteAssist (formerly GoToAssist), GoToMeeting, and other GoTo* logs"
+      329,Macrium Reflect,Apps,ProgramData\Macrium\Macrium Service\*,lazy_ntfs,Copies out all log files
+      330,Macrium Reflect,Apps,ProgramData\Macrium\Reflect\*,lazy_ntfs,Copies out the Reflect folder which contains many important logs
+      331,Macrium Reflect,Apps,ProgramData\Macrium\Reflect Launcher,lazy_ntfs,Copies out the Reflect folder which contains many important logs
+      332,Mattermost - Chat Logs,Apps,Users\*\AppData\Roaming\Mattermost\IndexedDB\**10,lazy_ntfs,Locates Mattermost logs and copies them
+      333,MediaMonkey - Media SQLite Database,Apps,Users\*\AppData\Roaming\MediaMonkey\MM.DB,lazy_ntfs,Locates SQLite DB that contains a complete enumeration of the user's media collection within MediaMonkey
+      334,MediaMonkey - MediaMonkey.ini,Apps,Users\*\AppData\Roaming\MediaMonkey\MediaMonkey.ini,lazy_ntfs,Locates .ini file which contains information about the user's MediaMonkey application instance
+      335,Microsoft OneNote - FullTextSearchIndex,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\*\FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
+      336,Microsoft OneNote - RecentNotebooks_SeenURLs,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\Notifications\RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
+      337,Microsoft OneNote - AccessibilityCheckerIndex,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
+      338,Microsoft OneNote - User NoteTags,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\NoteTags\*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
+      339,Microsoft OneNote - RecentSearches,Apps,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\RecentSearches\RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
+      340,"Microsoft Sticky Notes - Windows 7, 8, and 10 version 1511 and earlier",Apps,Users\*\AppData\Roaming\Microsoft\StickyNotes\StickyNotes.snt,lazy_ntfs,
+      341,Microsoft Sticky Notes - 1607 and later,Apps,Users\*\AppData\Local\Packages\Microsoft.MicrosoftStickyNotes*\LocalState\plum.sqlite*,lazy_ntfs,
+      342,Microsoft Teams IndexedDB Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\IndexedDB\https_teams.microsoft.com_0.indexeddb.leveldb\**10,lazy_ntfs,"LevelDB database which can contain inbound/outbound chat messages, call history and more"
+      343,Microsoft Teams Local Storage Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\Local Storage\leveldb\**10,lazy_ntfs,"LevelDB database which can contain meeting history, file transfer logs and more"
+      344,Microsoft Teams Cache,Apps,Users\*\AppData\Roaming\Microsoft\Teams\Cache\**10,lazy_ntfs,Chromium cache which can be viewed with Nirsoft's ChromeCacheView
+      345,Microsoft Teams Config,Apps,Users\*\AppData\Roaming\Microsoft\Teams\desktop-config.json,lazy_ntfs,JSON config file for Teams
+      346,Microsoft Teams Logs (Windows 11),Apps,Users\%User%\AppData\Local\Packages\MicrosoftTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\Logs,lazy_ntfs,Lots of log files for MS Teams
+      347,Microsoft To Do - SQLite Database of To Do tasks,Apps,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\*\todosqlite.db*,lazy_ntfs,
+      348,Microsoft To Do - User Avatar,Apps,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\4c444a17ebb042fb92df97d00d1c802a\avatars\UserAvatar.jpg,lazy_ntfs,
+      349,Midnight Commander -- All Configuation Files,Apps,Users\*\Midnight Commander\*,lazy_ntfs,Locates folder where all configuration files reside
+      350,Multi Commander - Application Folder,Apps,Users\*\AppData\Local\MultiCommander*\**10,lazy_ntfs,Locates the contents of the Application folder.
+      351,Multi Commander - Config Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\Config\**10,lazy_ntfs,Locates the contents of the Config folder.
+      352,Multi Commander - Log Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\Logs\**10,lazy_ntfs,Locates log file(s) related to user activity within Multi Commander.
+      353,Multi Commander - UserData Folder,Apps,Users\*\AppData\Roaming\MultiCommander*\UserData\**10,lazy_ntfs,Locates the contents of the UserData folder.
+      354,Multi Commander - Log File,Apps,Users\*\AppData\Roaming\MultiCommander*\**10\*MultiCommander.log,lazy_ntfs,Locates log file(s) associated with Milti Commander. Commonly in YYYY-MM-DD (numbers)-MultiCommander.log naming convention.
+      355,Nessus Logs,Nessus,ProgramData\Tenable\Nessus\conf\**10,lazy_ntfs,
+      356,Nessus Logs,Nessus Logs,ProgramData\Tenable\Nessus\nessus\logs\**10,lazy_ntfs,
+      357,Notepad++ Unsaved Edits,Text Editor,Users\*\AppData\Roaming\Notepad++\backup\**10,lazy_ntfs,Locates non-saved Notepad++ files and copies them.
+      358,Notepad++ Config,Text Editor,Users\*\AppData\Roaming\Notepad++\config.xml,lazy_ntfs,"Retrieves config.xml which contains recently searched terms, replaced terms and recently opened documents"
+      359,One Commander - All Configuration Files,Apps,Users\*\OneCommander\*,lazy_ntfs,Locates folder where all configuration files reside
+      360,One Commander - Other Configuration Files,Apps,Users\*\AppData\Local\Apps\2.0\*\*\onec*\**10,lazy_ntfs,Locates folder where all configuration files reside
+      361,OneDrive Metadata Logs,Apps,Users\*\AppData\Local\Microsoft\OneDrive\logs\**10,lazy_ntfs,
+      362,OneDrive Metadata Settings,Apps,Users\*\AppData\Local\Microsoft\OneDrive\settings\**10,lazy_ntfs,
+      363,OneDrive User Files,Apps,Users\*\OneDrive*\**10,lazy_ntfs,Caution -- This target will collect OneDrive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use or isolate system from network.
+      364,OpenSSH Config File,Apps,Users\*\.ssh\config,lazy_ntfs,"Config file can hold usernames, IP addresses and ports, key locations and configured shortcuts for servers e.g. ssh web-server"
+      365,OpenSSH Known Hosts,Apps,Users\*\.ssh\known_hosts,lazy_ntfs,"Known hosts file can hold a list of connected FQDNs/IP Addresses and ports if they are non-default, as well as public key fingerprints"
+      366,OpenSSH Public Keys,Apps,Users\*\.ssh\*.pub,lazy_ntfs,"Gets all public keys (*.pub). It is more difficult to find private keys as they typically do not have a file extension. However, the .pub files should be able to help find the private keys as they are typically named the same."
+      367,OpenSSH Default Private Key,Apps,Users\*\.ssh\id_rsa,lazy_ntfs,Default name for an auto-generated SSH private key
+      368,OpenSSH Server Config File,Apps,ProgramData\ssh\sshd_config,lazy_ntfs,Config file can hold information on allowed/denied users
+      369,OpenSSH Server Logs,Apps,ProgramData\ssh\logs\*,lazy_ntfs,OpenSSH server logs
+      370,OpenSSH Host ECDSA Key,Apps,ProgramData\ssh\ssh_host_ecdsa_key,lazy_ntfs,Retrieves the host ECDSA key
+      371,OpenSSH Host ED25519 Key,Apps,ProgramData\ssh\ssh_host_ed25519_key,lazy_ntfs,Retrieves the host ED25519 key
+      372,OpenSSH Host DSA Key,Apps,ProgramData\ssh\ssh_host_dsa_key,lazy_ntfs,Retrieves the host DSA key
+      373,OpenSSH Host RSA Key,Apps,ProgramData\ssh\ssh_host_rsa_key,lazy_ntfs,Retrieves the host RSA key
+      374,OpenSSH User Authorized Keys,Apps,Users\*\.ssh\authorized_keys,lazy_ntfs,Retrieves the user's authorised public keys
+      375,OpenSSH User Authorized Keys 2,Apps,Users\*\.ssh\authorized_keys2,lazy_ntfs,Retrieves the user's authorised public keys from the second file
+      376,OpenSSH Authorized Administrator Keys,Apps,ProgramData\ssh\administrators_authorized_keys,lazy_ntfs,Retrieves the administrator group's authorised public keys
+      377,OpenVPN Client Config,ApplicationLogs,Users\*\OpenVPN\config\**10,lazy_ntfs,Contains OpenVPN Configs (Profiles)
+      378,OpenVPN Client Config,ApplicationLogs,Program Files*\OpenVPN\config\**10,lazy_ntfs,Contains OpenVPN Configs(Profiles)
+      379,OpenVPN Client Config,ApplicationLogs,Users\*\OpenVPN\log\*.log,lazy_ntfs,Contains OpenVPN Logs for each Config(Profile)
+      380,PST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook\*.pst,lazy_ntfs,
+      381,OST XP,Communications,Documents and Settings\*\Local Settings\Application Data\Microsoft\Outlook\*.ost,lazy_ntfs,
+      382,PST (2013 or 2016),Communications,Users\*\Documents\Outlook Files\*.pst,lazy_ntfs,
+      383,OST (2013 or 2016),Communications,Users\*\Documents\Outlook Files\*.ost,lazy_ntfs,
+      384,PST,Communications,Users\*\AppData\Local\Microsoft\Outlook\*.pst,lazy_ntfs,"Outlook Data File: POP accounts, archives, older installations"
+      385,OST,Communications,Users\*\AppData\Local\Microsoft\Outlook\*.ost,lazy_ntfs,"Offline Outlook Data File: M365, Exchange, IMAP"
+      386,NST,Communications,Users\*\AppData\Local\Microsoft\Outlook\*.nst,lazy_ntfs,Outlook Group Storage File: Group conversations and calendar
+      387,Outlook Attachment Temporary Storage,Communications,Users\*\AppData\Local\Microsoft\Windows\INetCache\Content.Outlook\**10,lazy_ntfs,Outlook temporary storage folder for user attachments
+      388,PeaZip Configuration Files,FileKnowledge,Users\*\AppData\Roaming\PeaZip\**10,lazy_ntfs,
+      389,ProtonVPN - Connection Logs,ApplicationLogs,Users\*\AppData\Local\ProtonVPN\Logs,lazy_ntfs,Locates ProtonVPN connection logs.
+      390,Q-Dir - .ini File,Apps,Users\*\AppData\Roaming\Q-Dir\Q-Dir.ini,lazy_ntfs,Locates .ini file associated with Q-Dir which stores useful user activity information.
+      391,Q-Dir - .qdr file,Apps,Users\*\AppData\Roaming\Q-Dir\start.qdr,lazy_ntfs,"Locates .qdr file associated with Q-Dir which stores useful user activity information, including the last 4 folders opened (encoded, unfortunately)."
+      392,QFinderPro,Apps,Users\*\AppData\Local\QNAP\QfinderPro,lazy_ntfs,Locates a JSON file that provides network location information for any QNAP connected devices.
+      393,Radmin Server 32bit Log,ApplicationLogs,Windows\SysWOW64\rserver30\Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
+      394,Radmin Server 64bit Log,ApplicationLogs,Windows\System32\rserver30\Radm_log.htm,lazy_ntfs,Contains Application Log entries such as service start and incomming connections.
+      395,Radmin Server 32bit Chats,ApplicationLogs,Windows\SysWOW64\rserver30\CHATLOGS\*\*.htm,lazy_ntfs,Previous chat logs
+      396,Radmin Server 64bit Chats,ApplicationLogs,Windows\System32\rserver30\CHATLOGS\*\*.htm,lazy_ntfs,Previous chat logs
+      397,Radmin Viewer Chats,ApplicationLogs,Users\*\Documents\ChatLogs\*\*.htm,lazy_ntfs,Previous chat logs
+      398,ScreenConnect Session Database,ApplicationLogs,Program Files*\ScreenConnect\App_Data\Session.db,lazy_ntfs,SQLite database with session information
+      399,ScreenConnect Session Database,ApplicationLogs,Program Files*\ScreenConnect\App_Data\User.xml,lazy_ntfs,Contains each user's last authenticated time
+      400,ScreenConnect User Config,ApplicationLogs,ProgramData\ScreenConnect Client*\user.config,lazy_ntfs,Contains server domain and IP info
+      401,ShareX,Apps,Users\*\Documents\ShareX\**10,lazy_ntfs,Locates and captures all files within the default ShareX folder path
+      402,Signal Attachments cache,Communications,Users\*\AppData\Roaming\Signal\attachments.noindex\**10,lazy_ntfs,Profile pictures (and possibly attachments) for users who this individual has as contacts or has communicated with
+      403,Signal Logs,Communications,Users\*\AppData\Roaming\Signal\logs\**10,lazy_ntfs,"Logs for Signal. Most recent has the extension .log while old ones will have extension .log.0, .log.1 etc."
+      404,Signal config.json,Communications,Users\*\AppData\Roaming\Signal\config.json,lazy_ntfs,config.json holds the db.sqlite SQLCipher raw key
+      405,Signal Database,Communications,Users\*\AppData\Roaming\Signal\sql\db.sqlite,lazy_ntfs,"Stores attachment details, conversations, messages, and more"
+      406,main.db (App <v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*\main.db,lazy_ntfs,
+      407,skype.db (App +v12),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\*\skype.db,lazy_ntfs,
+      408,main.db XP,Communications,Documents and Settings\*\Application Data\Skype\*\main.db,lazy_ntfs,
+      409,main.db Win7+,Communications,Users\*\AppData\Roaming\Skype\*\main.db,lazy_ntfs,
+      410,s4l-[username].db (App +v8),Communications,Users\*\AppData\Local\Packages\Microsoft.SkypeApp_*\LocalState\s4l-*.db,lazy_ntfs,
+      411,leveldb (Skype for Desktop +v8),Communications,Users\*\AppData\Roaming\Microsoft\Skype for Desktop\IndexedDB\*.leveldb\**10,lazy_ntfs,
+      412,Skype for Destkop v8+ Chromium Cache,Communications,Users\*\AppData\Roaming\Microsoft\Skype for Desktop\Cache\**10,lazy_ntfs,Can be viewed with Nirsoft's ChromeCacheView
+      413,Slack - Chat Logs,Apps,Users\*\AppData\Roaming\Slack\IndexedDB\**10,lazy_ntfs,Locates Slack logs and copies them
+      414,Slack LevelDB Files,Apps,Users\*\AppData\Roaming\Slack\Local Storage\leveldb\**10,lazy_ntfs,
+      415,Slack Electron Logs,Apps,Users\*\AppData\Roaming\Slack\logs\**10,lazy_ntfs,Current Slack application is based on Electron and additional logging can be found here.
+      416,Slack Cache,Apps,Users\*\AppData\Roaming\Slack\Cache\**10,lazy_ntfs,Collects Slack cache files. This folder can be parsed like a Chrome Browser cache using a tool like Nirsoft ChromeCacheView
+      417,Slack Storage,Apps,Users\*\AppData\Roaming\Slack\storage\**10,lazy_ntfs,User activity logs can be present including slack-downloads log
+      418,Snagit - Captures,Apps,Users\*\AppData\Local\TechSmith\Snagit\DataStore,lazy_ntfs,Locates all Snagit captures
+      419,SpeedCommander - .ini File,Apps,Users\*\AppData\Roaming\SpeedProject\SpeedCommander 19\*,lazy_ntfs,Locates folder where all configuration files reside
+      420,SublimeText 2/3 Auto Save Session,Text Editor,Users\*\AppData\Roaming\Sublime Text*\Settings\Session.sublime_session,lazy_ntfs,Sublime Text 2/3 stores unsaved (temporary) files and its content in its Session.sublime_session file
+      421,SugarSync Log File,Apps,Users\*\AppData\Local\SugarSync\sc1.log,lazy_ntfs,Locates a log file the gives a play-by-play of what the user synced when.
+      422,SugarSync - Shared Folders (Default Location),Apps,Users\*\Documents\SugarSync Shared Folders\**10,lazy_ntfs,
+      423,SugarSync - My SugarSync (Default Location),Apps,Users\*\Documents\My SugarSync\**10,lazy_ntfs,
+      424,SumatraPDF Settings - SessionData,FileKnowledge,Users\*\AppData\Local\SumatraPDF\SumatraPDF-settings.txt,lazy_ntfs,Settings file which contains information about previous user session
+      425,SumatraPDF Cache,FileKnowledge,Users\*\AppData\Local\SumatraPDF\sumatrapdfcache,lazy_ntfs,Folder contains a PNG snapshot of each PDF file the user had open at the time of last application close
+      426,Supremo Connection Logs,Communications,ProgramData\SupremoRemoteDesktop\Log\*.log,lazy_ntfs,Includes Supremo.00.Client.log and Supremo.00.Incoming.log
+      427,Supremo File Transfer Inbox,Communications,ProgramData\SupremoRemoteDesktop\Inbox,lazy_ntfs,Includes all files transferred to the inbox folder during a remote session
+      428,Tablacus Explorer - remember.xml,Logs,Users\*\AppData\Local\Temp\*\config\**10\remember.xml,lazy_ntfs,
+      429,Tablacus Explorer - window.xml,Logs,Users\*\AppData\Local\Temp\*\config\**10\window.xml,lazy_ntfs,
+      430,Tablacus Explorer - window1.xml,Logs,Users\*\AppData\Local\Temp\*\config\**10\window1.xml,lazy_ntfs,
+      431,TeamViewer Connection Logs,Communications,Program Files*\TeamViewer\connections*.txt,lazy_ntfs,Includes connections_incoming.txt and connections.txt
+      432,TeamViewer Application Logs,ApplicationLogs,Program Files*\TeamViewer\TeamViewer*_Logfile*,lazy_ntfs,Includes TeamViewer<version>_Logfile.log and TeamViewer<version>_Logfile_OLD.log
+      433,TeamViewer Configuration Files,ApplicationLogs,Users\*\AppData\Roaming\TeamViewer\MRU\RemoteSupport\**10,lazy_ntfs,Includes miscellaneous config files
+      434,Telegram app folder,Apps,Users\*\AppData\Roaming\Telegram Desktop\**10,lazy_ntfs,Telegram app folder structure
+      435,Telegram downloaded files,Apps,Users\*\Downloads\Telegram Desktop\**10,lazy_ntfs,Chat Attachments
+      436,TeraCopy,TeraCopy,Users\*\AppData\Roaming\TeraCopy\**10,lazy_ntfs,
+      437,Mozilla Thunderbird Install Date,Apps,Users\*\AppData\Roaming\Thunderbird\Crash Reports\InstallTime*,lazy_ntfs,Holds install time in Unix Seconds timestamp
+      438,Mozilla Thunderbird Profiles.ini,Apps,Users\*\AppData\Roaming\Thunderbird\profiles.ini,lazy_ntfs,Profiles list - can hold references to other profiles held elsewhere on the device
+      439,Mozilla Thunderbird prefs.js,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\prefs.js,lazy_ntfs,User Preferences for that profile
+      440,Mozilla Thunderbird Global Messages Database,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\global-messages-db.sqlite,lazy_ntfs,"Holds list of contacts, emails, and other potentially useful artifacts"
+      441,Mozilla Thunderbird logins.json,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\logins.json,lazy_ntfs,"Holds last time online login used, last time password changed, hostname, HTTP(s) URL and more"
+      442,Mozilla Thunderbird places.sqlite,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\places.sqlite,lazy_ntfs,"Holds history for Thunderbird - as it contains portions of Firefox embedded, it can be used to visit websites too"
+      443,Mozilla Thunderbird ImapMail INBOX,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\ImapMail\**10\INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
+      444,Mozilla Thunderbird Mail INBOX,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\Mail\**10\INBOX,lazy_ntfs,"Holds all email files with headers, content etc"
+      445,Mozilla Thunderbird Calendar Data,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\calendar-data\local.sqlite,lazy_ntfs,Holds local calendar data
+      446,Mozilla Thunderbird Attachments,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\Attachments\*,lazy_ntfs,Holds attachments
+      447,Mozilla Thunderbird Address Book,Apps,Users\*\AppData\Roaming\Thunderbird\Profiles\*\abook.sqlite,lazy_ntfs,Holds local address book
+      448,Total Commander - .ini File,Apps,Users\*\AppData\Roaming\GHISLER\wincmd.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
+      449,Total Commander - Log File,Apps,**10\totalcmd.log,lazy_ntfs,Locates log file associated with Total Commander. NOTE: this log file is NOT enabled by default and the filename can be modified.
+      450,Total Commander - Temp Files Created During Folder Traversal,Apps,Users\*\AppData\Local\Temp\FTP*.tmp,lazy_ntfs,Locates .tmp files which are created during the user's folder traversal and provide insight into contents of each folder traversed.
+      451,Total Commander - FTP .ini File,Apps,Users\*\AppData\Roaming\GHISLER\wcx_ftp.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful FTP information.
+      452,Total Commander - File Tree,Apps,Users\*\AppData\Local\GHISLER\treeinfo*.wc,lazy_ntfs,Locates a file that contains an exhaustive file tree of a user's file system.
+      453,Total Commander - FTP Logs,Apps,Users\*\AppData\Local\Temp\tcftp.log,lazy_ntfs,Locates a file that contains the Total Commander FTP logs.
+      454,TreeSize - ScanHistory.XML,Apps,Users\*\AppData\Roaming\JAM Software\TreeSize\scanhistory.xml,lazy_ntfs,Locates XML file that provides a list of previously scanned directories by the user.
+      455,VLC Recently Opened Files,Apps,Users\*\AppData\Roaming\vlc\vlc-qt-interface.ini,lazy_ntfs,Configuration file for VLC. Holds [RecentsMRL] key which lists recently opened files as well as sometimes retaining timestamps for file opening
+      456,VLC Recorded Files,Apps,Users\*\Videos\vlc-*.avi,lazy_ntfs,"Recorded files in VLC. Sometimes the Record button may be pressed instead of Play by suspects, which can record them watching content with VLC"
+      457,VMware - Virtual Machine Inventory,Apps,Users\*\AppData\Roaming\VMware,lazy_ntfs,Locates an inventory of all Virtual Machines on disk.
+      458,VMware (Fusion/Workstation/Server/Player),Memory,**10\*.vmem,lazy_ntfs,Captures all raw memory from VMware virtual machines.
+      459,VMware (Fusion/Workstation/Server/Player),Memory,**10\*.vmss,lazy_ntfs,Captures all memory images from VMware virtual machines.
+      460,VMware (Fusion/Workstation/Server/Player),Memory,**10\*.vmsn,lazy_ntfs,Captures all memory images from VMware virtual machines.
+      461,RealVNC Log,ApplicationLogs,Users\*\AppData\Local\RealVNC\vncserver.log,lazy_ntfs,https://www.realvnc.com/en/connect/docs/logging.html#logging
+      462,Viber Config Database,Apps,Users\*\AppData\Roaming\ViberPC\config.db,lazy_ntfs,Configuration file for Viber
+      463,Viber Users Data Database,Apps,Users\*\AppData\Roaming\ViberPC\*\viber.db,lazy_ntfs,"Viber data for that user, containing Calls, Chat Messages, Contacts and more"
+      464,Viber Users Avatars Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Avatars,lazy_ntfs,Cache of the Avatars for other Viber users
+      465,Viber Users Backgrounds Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Backgrounds,lazy_ntfs,Store of the backgrounds
+      466,Viber Users Thumbnails Cache,Apps,Users\*\AppData\Roaming\ViberPC\*\Thumbnails,lazy_ntfs,Cache of the thumbnails for uploaded/downloaded images
+      467,VirtualBox VM configs,Apps,**10\*.vbox,lazy_ntfs,Locates all .vbox VM configuration files on disk
+      468,VirtualBox VM backup configs,Apps,**10\*.vbox-prev,lazy_ntfs,Locates all backup .vbox VM configuration files on disk
+      469,VirtualBox Logs,Apps,**10\VBox.log,lazy_ntfs,Locates all VBox.log files on disk
+      470,VirtualBox Backup Logs,Apps,**10\VBox.log.*,lazy_ntfs,Locates all backup VBox.log files on disk - these can show historic VM usage
+      471,VirtualBox Hardening Logs,Apps,**10\VBoxHardening.log,lazy_ntfs,Locates all VBoxHardening.log files on disk
+      472,VirtualBox,Memory,**10\*.sav,lazy_ntfs,Captures all partial memory images from VirtualBox.
+      473,WhatsApp Cache,Apps,Users\*\AppData\Roaming\WhatsApp\Cache,lazy_ntfs,"Copies the cache of WhatsApp. Can be opened with Chrome Cache Viewer for viewing embedded thumbnails and other image artefacts, as well as extracting .enc message files or other files"
+      474,WhatsApp Local Storage,Apps,Users\*\AppData\Roaming\WhatsApp\Local Storage\leveldb,lazy_ntfs,"Copies the Local Storage leveldb of WhatsApp. Contains phone model and name of user, plus encrypted base64 strings which can be viewed with LevelDBDumper"
+      475,WinSCP (.ini file),Logs,**10\WinSCP.ini,lazy_ntfs,
+      476,Windows Your Phone - All Databases,Apps,Users\*\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed\**10,lazy_ntfs,Locates all Your Phone database files
+      477,XYplorer - .ini file,Apps,Users\*\AppData\Roaming\XYplorer\XYplorer.ini,lazy_ntfs,Locates .ini file associated with Total Commander which stores useful user activity information.
+      478,XYplorer - .ini file for each respective pane,Apps,Users\*\AppData\Roaming\XYplorer\Panes\*\**10\pane.ini,lazy_ntfs,Locates the .ini file for the left and right pane.
+      479,XYplorer - AutoBackup folder,Apps,Users\*\AppData\Roaming\XYplorer\AutoBackup\**10,lazy_ntfs,Locates the AutoBackup folder and copies its contents.
+      480,XYplorer - .dat files,Apps,Users\*\AppData\Roaming\XYplorer\**10\*.dat,lazy_ntfs,"Locates the .dat files in the XYplorer's AppData folder, all of which are updated upon program's exit."
+      481,iTunes Backup Folder,Communications,Users\*\AppData\Roaming\Apple\Mobilesync\Backup\**10,lazy_ntfs,
+      482,iTunes Backup Folder,Communications,Users\*\AppData\Roaming\Apple Computer\Mobilesync\Backup\**10,lazy_ntfs,
+      483,iTunes Backup Folder - iOS13,Communications,Users\*\Apple\Mobilesync\Backup\*,lazy_ntfs,
+      484,mIRC Chat Logs (Vista+),Communications,Users\*\AppData\Roaming\mIRC\logs\**10,lazy_ntfs,
+      485,mIRC Chat Logs (2000/XP),Communications,Documents and Settings\*\Application Data\mIRC\logs\**10,lazy_ntfs,
+      486,mRemoteNG Logs,Communications,Users\*\AppData\Roaming\mRemoteNG\mRemoteNG.log,lazy_ntfs,Contains log entries for remote connections
+      487,mRemoteNG Connection Configuration and Backups,Communications,Users\*\AppData\Roaming\mRemoteNG\confCons.xml*,lazy_ntfs,"Contains connection config, often with obfuscated credentials"
+      488,mRemoteNG Program Settings,Communications,Users\*\AppData\*\mRemoteNG\**10\user.config,lazy_ntfs,Contains user-specific program settings
+      489,pCloud Database,Apps,Users\*\AppData\Local\pCloud\*.db,lazy_ntfs,Database contains all files sync'd with pCloud account.
+      490,pCloud Database WAL File,Apps,Users\*\AppData\Local\pCloud\*.db-wal,lazy_ntfs,Write-Ahead Log for pCloud database file.
+      491,pCloud Database Shared Memory File,Apps,Users\*\AppData\Local\pCloud\*.db-shm,lazy_ntfs,Shared Memory for the pCloud database file.
+      492,4K Video Downloader,SQLDatabases,Users\*\AppData\Local\4kdownload.com\4K Video Downloader\4K Video Downloader\*.sqlite,lazy_ntfs,Grabs database(s) that stores user download history
+      493,Microsoft OneNote - FullTextSearchIndex,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\*\FullTextSearchIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's text content
+      494,Microsoft OneNote - RecentNotebooks_SeenURLs,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\Notifications\RecentNotebooks_SeenURLs,lazy_ntfs,Grabs a file that appears to record recently seen OneNote notebooks
+      495,Microsoft OneNote - AccessibilityCheckerIndex,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\AccessibilityCheckerIndex,lazy_ntfs,Grabs database(s) comprising of each OneNote notebook's version sync error history
+      496,Microsoft OneNote - User NoteTags,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\NoteTags\*LiveId.db,lazy_ntfs,Grabs a database that stores the user specified tags within OneNote to be used application-wide
+      497,Microsoft OneNote - RecentSearches,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Office.OneNote_8wekyb3d8bbwe\LocalState\AppData\Local\OneNote\16.0\RecentSearches\RecentSearches.db,lazy_ntfs,Grabs a database that stores the user's recent searches within OneNote
+      498,Microsoft Sticky Notes - 1607 and later,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.MicrosoftStickyNotes*\LocalState\plum.sqlite*,lazy_ntfs,
+      499,Microsoft To Do - SQLite Database of To Do tasks,SQLDatabases,Users\*\AppData\Local\Packages\Microsoft.Todos_8wekyb3d8bbwe\LocalState\AccountsRoot\*\todosqlite.db*,lazy_ntfs,
+      500,TeraCopy - History Databases,SQLDatabases,Users\*\AppData\Roaming\TeraCopy\History\*.db,lazy_ntfs,
+      501,TeraCopy - Main Database,SQLDatabases,Users\*\AppData\Roaming\TeraCopy\main.db,lazy_ntfs,
+      502,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\filecache.db*,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
+      503,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\config.dbx,lazy_ntfs,Getting individual files because folder may contain very large extraneous files
+      504,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\home.db,lazy_ntfs,SQlite database which appears to keep track of the user's recent Dropbox activity
+      505,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\icon.db,lazy_ntfs,SQLite database which appears to keep track of icons in the user's Drobox sync history which can give an indication as to which files and folders are present
+      506,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\sync_history.db,lazy_ntfs,SQLite database which appears to keep track of the user's Drobox sync history
+      507,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\sync\nucleus.sqlite3*,lazy_ntfs,SQLite database which appears to contain a table for deleted files
+      508,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\host.db,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      509,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\host.dbx,lazy_ntfs,"SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+      510,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\sync\aggregation.dbx,lazy_ntfs,SQLite database which appears to contain snapshot table of the user's Dropbox contents in JSON with timestamps in UNIX Epoch
+      511,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
+      512,Dropbox Metadata,SQLDatabases,Users\*\AppData\Local\Dropbox\*\avatarcache.db,lazy_ntfs,SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed
+      513,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\cloud_graph\cloud_graph.db,lazy_ntfs,Windows_GoogleDrive_CloudGraphDB.smap
+      514,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\TempData\*\change_buffer\**10,lazy_ntfs,DB(s) with seemingly randomized filename(s) that track file system changes within Google Drive
+      515,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\snapshot.db,lazy_ntfs,Windows_GoogleDrive_SnapshotDB.smap
+      516,Google File Stream Metadata,SQLDatabases,Users\*\AppData\Local\Google\Drive\*\sync_config.db,lazy_ntfs,Windows_GoogleDrive_SyncConfigDB.smap
+      517,FileZilla SQLite3 Log Files,SQLDatabases,Users\*\AppData\Roaming\FileZilla\*.sqlite3*,lazy_ntfs,
+      518,Chrome bookmarks XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Bookmarks*,lazy_ntfs,
+      519,Chrome Cookies XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Cookies*,lazy_ntfs,
+      520,Chrome Current Session XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Current Session,lazy_ntfs,
+      521,Chrome Current Tabs XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Current Tabs,lazy_ntfs,
+      522,Chrome Favicons XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Favicons*,lazy_ntfs,
+      523,Chrome History XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\History*,lazy_ntfs,
+      524,Chrome Last Session XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Last Session,lazy_ntfs,
+      525,Chrome Last Tabs XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Last Tabs,lazy_ntfs,
+      526,Chrome Login Data XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Login Data,lazy_ntfs,
+      527,Chrome Preferences XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Preferences,lazy_ntfs,
+      528,Chrome Shortcuts XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Shortcuts*,lazy_ntfs,
+      529,Chrome Top Sites XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Top Sites*,lazy_ntfs,
+      530,Chrome Visited Links XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Visited Links,lazy_ntfs,
+      531,Chrome Web Data XP,SQLDatabases,Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Web Data*,lazy_ntfs,
+      532,Chrome bookmarks,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Bookmarks*,lazy_ntfs,
+      533,Chrome Cookies,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Cookies*,lazy_ntfs,
+      534,Chrome Current Session,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Current Session,lazy_ntfs,
+      535,Chrome Current Tabs,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Current Tabs,lazy_ntfs,
+      536,Chrome Download Metadata,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Download Metadata,lazy_ntfs,
+      537,Chrome Extension Cookies,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Extension Cookies,lazy_ntfs,
+      538,Chrome Favicons,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Favicons*,lazy_ntfs,
+      539,Chrome History,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\History*,lazy_ntfs,
+      540,Chrome Last Session,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Last Session,lazy_ntfs,
+      541,Chrome Last Tabs,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Last Tabs,lazy_ntfs,
+      542,Chrome Login Data,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Login Data,lazy_ntfs,
+      543,Chrome Media History,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Media History*,lazy_ntfs,
+      544,Chrome Network Action Predictor,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Network Action Predictor,lazy_ntfs,
+      545,Chrome Network Persistent State,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Network Persistent State,lazy_ntfs,
+      546,Chrome Preferences,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Preferences,lazy_ntfs,
+      547,Chrome Quota Manager,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\QuotaManager,lazy_ntfs,
+      548,Chrome Reporting and NEL,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Reporting and NEL,lazy_ntfs,
+      549,Chrome Shortcuts,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Shortcuts*,lazy_ntfs,
+      550,Chrome Top Sites,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Top Sites*,lazy_ntfs,
+      551,Chrome Trust Tokens,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Trust Tokens*,lazy_ntfs,
+      552,Chrome SyncData Database,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Sync Data\SyncData.sqlite3,lazy_ntfs,
+      553,Chrome Visited Links,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Visited Links,lazy_ntfs,
+      554,Chrome Web Data,SQLDatabases,Users\*\AppData\Local\Google\Chrome\User Data\*\Web Data*,lazy_ntfs,
+      555,Edge bookmarks,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Bookmarks*,lazy_ntfs,
+      556,Edge Collections,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Collections\collectionsSQLite,lazy_ntfs,
+      557,Edge Cookies,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Cookies*,lazy_ntfs,
+      558,Edge Current Session,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Current Session,lazy_ntfs,
+      559,Edge Current Tabs,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Current Tabs,lazy_ntfs,
+      560,Edge Favicons,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Favicons*,lazy_ntfs,
+      561,Edge History,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\History*,lazy_ntfs,
+      562,Edge Last Session,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Last Session,lazy_ntfs,
+      563,Edge Last Tabs,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Last Tabs,lazy_ntfs,
+      564,Edge Login Data,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Login Data,lazy_ntfs,
+      565,Edge Media History,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Media History*,lazy_ntfs,
+      566,Edge Network Action Predictor,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Network Action Predictor,lazy_ntfs,
+      567,Edge Preferences,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Preferences,lazy_ntfs,
+      568,Edge Shortcuts,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Shortcuts*,lazy_ntfs,
+      569,Edge Top Sites,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Top Sites*,lazy_ntfs,
+      570,Edge SyncData Database,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Sync Data\SyncData.sqlite3,lazy_ntfs,
+      571,Edge Bookmarks,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Bookmarks*,lazy_ntfs,
+      572,Edge Visited Links,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Visited Links,lazy_ntfs,
+      573,Edge Web Data,SQLDatabases,Users\*\AppData\Local\Microsoft\Edge\User Data\*\Web Data*,lazy_ntfs,
+      574,Addons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\addons.sqlite*,lazy_ntfs,
+      575,Bookmarks,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\weave\bookmarks.sqlite*,lazy_ntfs,
+      576,Cookies,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\cookies.sqlite*,lazy_ntfs,
+      577,Cookies,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\firefox_cookies.sqlite*,lazy_ntfs,
+      578,Downloads,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\downloads.sqlite*,lazy_ntfs,
+      579,Favicons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\favicons.sqlite*,lazy_ntfs,
+      580,Form history,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\formhistory.sqlite*,lazy_ntfs,
+      581,Permissions,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\permissions.sqlite*,lazy_ntfs,
+      582,Places,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\places.sqlite*,lazy_ntfs,
+      583,Protections,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\protections.sqlite*,lazy_ntfs,
+      584,Search,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\search.sqlite*,lazy_ntfs,
+      585,Signons,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\signons.sqlite*,lazy_ntfs,
+      586,Storage Sync,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\storage-sync.sqlite*,lazy_ntfs,
+      587,Webappstore,SQLDatabases,Users\*\AppData\Roaming\Mozilla\Firefox\Profiles\*\webappstore.sqlite*,lazy_ntfs,
+      588,Windows 10 Notification DB,SQLDatabases,Users\*\AppData\Local\Microsoft\Windows\Notifications\wpndatabase.db,lazy_ntfs,
+      589,Windows 10 Notification DB,SQLDatabases,Users\*\AppData\Local\Microsoft\Windows\Notifications\appdb.dat,lazy_ntfs,
+      590,ActivitiesCache.db,SQLDatabases,Users\*\AppData\Local\ConnectedDevicesPlatform\*\ActivitiesCache.db*,lazy_ntfs,
+      591,Update Store.db,OS Upgrade,ProgramData\USOPrivate\UpdateStore\store.db,lazy_ntfs,
+      592,Bitdefender SQLite DB Files,Antivirus,Program Files*\Bitdefender*\**10\regex:*.+\.(db|db-wal|db-shm),ntfs,Bitdefender SQLite databases
+      593,EventTranscript.db,SystemEvents,ProgramData\Microsoft\Diagnosis\EventTranscript\EventTranscript.db*,lazy_ntfs,
+      594,EventTranscript.db,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis\EventTranscript\EventTranscript.db*,lazy_ntfs,
+      595,Debian WSL /etc/debian_version,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\debian_version,lazy_ntfs,
+      596,Debian WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\fstab,lazy_ntfs,
+      597,Debian WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\os-release,lazy_ntfs,
+      598,Debian WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\passwd,lazy_ntfs,
+      599,Debian WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\group,lazy_ntfs,
+      600,Debian WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\shadow,lazy_ntfs,
+      601,Debian WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\timezone,lazy_ntfs,
+      602,Debian WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\hostname,lazy_ntfs,
+      603,Debian WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\hosts,lazy_ntfs,
+      604,Debian WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\crontab,lazy_ntfs,
+      605,Debian WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\bash.bashrc,lazy_ntfs,
+      606,Debian WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\profile,lazy_ntfs,
+      607,Debian WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\**10\.bash_history,lazy_ntfs,
+      608,Debian WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\**10\.bashrc,lazy_ntfs,
+      609,Debian WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\**10\.profile,lazy_ntfs,
+      610,Debian WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs\**10,lazy_ntfs,
+      611,Debian WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\log\apt\**10\*.log,lazy_ntfs,
+      612,Kali WSL /etc/debian_version,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\debian_version,lazy_ntfs,
+      613,Kali WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\fstab,lazy_ntfs,
+      614,Kali WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\os-release,lazy_ntfs,
+      615,Kali WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\passwd,lazy_ntfs,
+      616,Kali WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\group,lazy_ntfs,
+      617,Kali WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\shadow,lazy_ntfs,
+      618,Kali WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\timezone,lazy_ntfs,
+      619,Kali WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\hostname,lazy_ntfs,
+      620,Kali WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\hosts,lazy_ntfs,
+      621,Kali WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\crontab,lazy_ntfs,
+      622,Kali WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\bash.bashrc,lazy_ntfs,
+      623,Kali WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\etc\profile,lazy_ntfs,
+      624,Kali WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\**10\.bash_history,lazy_ntfs,
+      625,Kali WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\**10\.bashrc,lazy_ntfs,
+      626,Kali WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\**10\.profile,lazy_ntfs,
+      627,Kali WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\var\spool\cron\crontabs\**10,lazy_ntfs,
+      628,Kali WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\KaliLinux.54290C8133FEE_*\LocalState\rootfs\var\log\apt\**10\*.log,lazy_ntfs,
+      629,SUSE Linux Enterprise Server WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\os-release,lazy_ntfs,
+      630,SUSE Linux Enterprise Server WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\fstab,lazy_ntfs,
+      631,SUSE Linux Enterprise Server WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\passwd,lazy_ntfs,
+      632,SUSE Linux Enterprise Server WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\group,lazy_ntfs,
+      633,SUSE Linux Enterprise Server WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\shadow,lazy_ntfs,
+      634,SUSE Linux Enterprise Server WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\timezone,lazy_ntfs,
+      635,SUSE Linux Enterprise Server WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\hostname,lazy_ntfs,
+      636,SUSE Linux Enterprise Server WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\hosts,lazy_ntfs,
+      637,SUSE Linux Enterprise Server WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\bash.bashrc,lazy_ntfs,
+      638,SUSE Linux Enterprise Server WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\etc\profile,lazy_ntfs,
+      639,SUSE Linux Enterprise Server WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\**10\.bash_history,lazy_ntfs,
+      640,SUSE Linux Enterprise Server WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\**10\.bashrc,lazy_ntfs,
+      641,SUSE Linux Enterprise Server WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.SUSELinuxEnterpriseServer*\LocalState\rootfs\**10\.profile,lazy_ntfs,
+      642,Ubuntu WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\os-release,lazy_ntfs,
+      643,Ubuntu WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\fstab,lazy_ntfs,
+      644,Ubuntu WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\passwd,lazy_ntfs,
+      645,Ubuntu WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\group,lazy_ntfs,
+      646,Ubuntu WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\shadow,lazy_ntfs,
+      647,Ubuntu WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\timezone,lazy_ntfs,
+      648,Ubuntu WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\hostname,lazy_ntfs,
+      649,Ubuntu WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\hosts,lazy_ntfs,
+      650,Ubuntu WSL /etc/crontab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\crontab,lazy_ntfs,
+      651,Ubuntu WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\bash.bashrc,lazy_ntfs,
+      652,Ubuntu WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\profile,lazy_ntfs,
+      653,Ubuntu WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\**10\.bash_history,lazy_ntfs,
+      654,Ubuntu WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\**10\.bashrc,lazy_ntfs,
+      655,Ubuntu WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\**10\.profile,lazy_ntfs,
+      656,Ubuntu WSL User Crontabs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\spool\cron\crontabs\**10,lazy_ntfs,
+      657,Ubuntu WSL Apt Logs,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\log\apt\**10\*.log,lazy_ntfs,
+      658,openSUSE WSL /etc/os-release,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\os-release,lazy_ntfs,
+      659,openSUSE WSL /etc/fstab,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\fstab,lazy_ntfs,
+      660,openSUSE WSL /etc/passwd,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\passwd,lazy_ntfs,
+      661,openSUSE WSL /etc/group,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\group,lazy_ntfs,
+      662,openSUSE WSL /etc/shadow,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\shadow,lazy_ntfs,
+      663,openSUSE WSL /etc/timezone,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\timezone,lazy_ntfs,
+      664,openSUSE WSL /etc/hostname,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\hostname,lazy_ntfs,
+      665,openSUSE WSL /etc/hosts,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\hosts,lazy_ntfs,
+      666,openSUSE WSL /etc/bash.bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\bash.bashrc,lazy_ntfs,
+      667,openSUSE WSL /etc/profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\etc\profile,lazy_ntfs,
+      668,openSUSE WSL .bash_history,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\**10\.bash_history,lazy_ntfs,
+      669,openSUSE WSL .bashrc,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\**10\.bashrc,lazy_ntfs,
+      670,openSUSE WSL .profile,Windows Subsystem for Linux,Users\*\AppData\Local\Packages\46932SUSE.openSUSE*Leap*\LocalState\rootfs\**10\.profile,lazy_ntfs,
+      671,Diagnostic Logs for WSA,Windows Subsystem for Android,Users\*\AppData\Local\Packages\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\LocalState\diagnostics\logcat\*.log,lazy_ntfs,Filenames should be %timestamp%.log
+      672,App download artifacts (PNG),Windows Subsystem for Android,Users\*\AppData\Local\Packages\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\LocalCache\*.png,lazy_ntfs,Will provide examiners with indicators of which apps were downloaded
+      673,App download artifacts (ICO),Windows Subsystem for Android,Users\*\AppData\Local\Packages\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\LocalCache\*.ico,lazy_ntfs,Will provide examiners with indicators of which apps were downloaded WHEN since .ico files appear immediately when download of an application completes
+      674,Appcompatdb.json,Windows Subsystem for Android,Users\*\AppData\Local\Packages\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\LocalState\appcompatdb.json,lazy_ntfs,"Grabs the appcompatdb.json, unknown exactly what this is but further relevance could be uncovered after more research is conducted"
+      675,userdata.vhdx,Windows Subsystem for Android,Users\*\AppData\Local\Packages\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\LocalCache\userdata.vhdx,lazy_ntfs,Grabs the user's data which appears to be stored in a VHDX
+      676,$Boot,FileSystem,$Boot,ntfs,
+      677,$J,FileSystem,$Extend\$UsnJrnl:$J,ntfs,
+      678,$Max,FileSystem,$Extend\$UsnJrnl:$Max,ntfs,
+      679,$J,FileSystem,$Extend\$J,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      680,$Max,FileSystem,$Extend\$Max,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      681,$LogFile,FileSystem,$LogFile,ntfs,
+      682,$MFT,FileSystem,$MFT,ntfs,
+      683,$MFTMirr,FileSystem,$MFTMirr,ntfs,$MFTMirr is a redundant copy of the first four (4) records of the MFT.
+      684,$T,FileSystem,$Extend\$RmMetadata\$TxfLog\$Tops:$T,ntfs,
+      685,$T,FileSystem,$Extend\$RmMetadata\$TxfLog\$T,ntfs,This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Target is looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed
+      686,Amcache,ApplicationCompatibility,Windows\AppCompat\Programs\Amcache.hve,lazy_ntfs,
+      687,Amcache,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs\Amcache.hve,lazy_ntfs,
+      688,Amcache transaction files,ApplicationCompatibility,Windows\AppCompat\Programs\Amcache.hve.LOG*,lazy_ntfs,
+      689,Amcache transaction files,ApplicationCompatibility,Windows.old\Windows\AppCompat\Programs\Amcache.hve.LOG*,lazy_ntfs,
+      690,Application Event Log XP,EventLogs,Windows\System32\config\AppEvent.evt,lazy_ntfs,
+      691,Application Event Log XP,EventLogs,Windows.old\Windows\System32\config\AppEvent.evt,lazy_ntfs,
+      692,Application Event Log Win7+,EventLogs,Windows\System32\winevt\logs\application.evtx,lazy_ntfs,
+      693,Application Event Log Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs\application.evtx,lazy_ntfs,
+      694,BCD,Registry,Boot\BCD,lazy_ntfs,
+      695,BCD Logs,Registry,Boot\BCD.LOG*,lazy_ntfs,
+      696,BITS files,Persistence,ProgramData\Microsoft\Network\Downloader\**10,lazy_ntfs,
+      697,System CryptnetUrlCache,FileKnowledge,Windows\System32\config\systemprofile\AppData\LocalLow\Microsoft\CryptnetUrlCache\**10,lazy_ntfs,
+      698,User CryptnetUrlCache,FileKnowledge,Users\*\AppData\LocalLow\Microsoft\CryptnetUrlCache\**10,lazy_ntfs,
+      699,INetCache,FileKnowledge,Users\*\AppData\Local\Microsoft\Windows\INetCache\IE\**10,lazy_ntfs,
+      700,EncapsulationLogging,Executables,Windows\Appcompat\Programs\EncapsulationLogging.hve,lazy_ntfs,
+      701,EncapsulationLogging,Executables,Windows.old\Windows\Appcompat\Programs\EncapsulationLogging.hve,lazy_ntfs,
+      702,EncapsulationLogging Logs,Executables,Windows\Appcompat\Programs\EncapsulationLogging.hve.log*,lazy_ntfs,
+      703,EncapsulationLogging Logs,Executables,Windows.old\Windows\Appcompat\Programs\EncapsulationLogging.hve.log*,lazy_ntfs,
+      704,Event logs Win7+,EventLogs,Windows\System32\winevt\logs\System.evtx,lazy_ntfs,
+      705,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs\System.evtx,lazy_ntfs,
+      706,Event logs Win7+,EventLogs,Windows\System32\winevt\logs\Security.evtx,lazy_ntfs,
+      707,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs\Security.evtx,lazy_ntfs,
+      708,Event logs Win7+,EventLogs,Windows\System32\winevt\Logs\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx,lazy_ntfs,
+      709,Event logs Win7+,EventLogs,Windows\System32\winevt\Logs\Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx,lazy_ntfs,
+      710,Event logs XP,EventLogs,Windows\System32\config\*.evt,lazy_ntfs,
+      711,Event logs Win7+,EventLogs,Windows\System32\winevt\logs\*.evtx,lazy_ntfs,
+      712,Event logs Win7+,EventLogs,Windows.old\Windows\System32\winevt\logs\*.evtx,lazy_ntfs,
+      713,WDI Trace Logs 1,Event Trace Logs,Windows\System32\WDI\LogFiles\*.etl*,lazy_ntfs,
+      714,WDI Trace Logs 1,Event Trace Logs,Windows.old\Windows\System32\WDI\LogFiles\*.etl*,lazy_ntfs,
+      715,WDI Trace Logs 2,Event Trace Logs,Windows\System32\WDI\{*\**10,lazy_ntfs,
+      716,WDI Trace Logs 2,Event Trace Logs,Windows.old\Windows\System32\WDI\{*\**10,lazy_ntfs,
+      717,WMI Trace Logs,Event Trace Logs,Windows\System32\LogFiles\WMI\**10,lazy_ntfs,
+      718,WMI Trace Logs,Event Trace Logs,Windows.old\Windows\System32\LogFiles\WMI\**10,lazy_ntfs,
+      719,SleepStudy Trace Logs,Event Trace Logs,Windows\System32\SleepStudy\**10,lazy_ntfs,
+      720,SleepStudy Trace Logs,Event Trace Logs,Windows.old\Windows\System32\SleepStudy\**10,lazy_ntfs,
+      721,Energy-NTKL Trace Logs,Event Trace Logs,ProgramData\Microsoft\Windows\PowerEfficiency Diagnostics\energy-ntkl.etl,lazy_ntfs,
+      722,Delivery Optimization Trace Logs,Event Trace Logs,Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Logs\*.etl*,lazy_ntfs,
+      723,EventTranscript.db,SystemEvents,ProgramData\Microsoft\Diagnosis\EventTranscript\EventTranscript.db*,lazy_ntfs,
+      724,EventTranscript.db,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis\EventTranscript\EventTranscript.db*,lazy_ntfs,
+      725,Microsoft Office Diagnostic Logs,SystemEvents,Users\%User%\AppData\Local\Temp\Diagnostics\**10,lazy_ntfs,
+      726,Local Group Policy INI Files,Communication,Windows\System32\grouppolicy\*.ini,lazy_ntfs,
+      727,Local Group Policy INI Files,Communication,Windows.old\Windows\System32\grouppolicy\*.ini,lazy_ntfs,
+      728,Local Group Policy Files - Registry Policy Files,Communication,Windows\System32\grouppolicy\*.pol,lazy_ntfs,
+      729,Local Group Policy Files - Registry Policy Files,Communication,Windows.old\Windows\System32\grouppolicy\*.pol,lazy_ntfs,
+      730,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows\System32\grouppolicy\*\Scripts\**10,lazy_ntfs,
+      731,Local Group Policy Files - Startup/Shutdown Scripts,Communication,Windows.old\Windows\System32\grouppolicy\*\Scripts\**10,lazy_ntfs,
+      732,LNK Files from Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Windows\Recent\**10,lazy_ntfs,Also includes automatic and custom jumplist directories
+      733,LNK Files from Microsoft Office Recent,LNKFiles,Users\*\AppData\Roaming\Microsoft\Office\Recent\**10,lazy_ntfs,
+      734,LNK Files from Recent (XP),LNKFiles,Documents and Settings\*\Recent\**10,lazy_ntfs,
+      735,Desktop LNK Files XP,LNKFiles,Documents and Settings\*\Desktop\*.LNK,lazy_ntfs,
+      736,Desktop LNK Files,LNKFiles,Users\*\Desktop\*.LNK,lazy_ntfs,
+      737,Restore point LNK Files XP,LNKFiles,System Volume Information\_restore*\RP*\*.LNK,lazy_ntfs,
+      738,LNK Files from C:\ProgramData,LNKFiles,ProgramData\Microsoft\Windows\Start Menu\Programs\*.LNK,lazy_ntfs,
+      739,.bash_history,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*\.bash_history,lazy_ntfs,
+      740,.bash_logout,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*\.bash_logout,lazy_ntfs,
+      741,.bashrc,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*\.bashrc,lazy_ntfs,
+      742,.profile,Windows Linux Profile,Users\*\AppData\Local\Packages\*\LocalState\rootfs\home\*\.profile,lazy_ntfs,
+      743,LogFiles,Logs,Windows\System32\LogFiles\**10,lazy_ntfs,
+      744,LogFiles,Logs,Windows.old\Windows\System32\LogFiles\**10,lazy_ntfs,
+      745,MOF files,WMI,**10\*.MOF,lazy_ntfs,
+      746,hiberfil.sys,Memory,hiberfil.sys,lazy_ntfs,
+      747,pagefile.sys,Memory,pagefile.sys,lazy_ntfs,
+      748,swapfile.sys,Memory,swapfile.sys,lazy_ntfs,
+      749,Small Memory Dump directory,Memory,Windows\Minidump\*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
+      750,Small Memory Dump directory,Memory,Windows.old\Windows\Minidump\*.dmp,lazy_ntfs,https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump
+      751,Word Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Word\**10,lazy_ntfs,
+      752,Excel Autosave Location,ApplicationCompatibility,Users\*\AppData\Roaming\Microsoft\Excel\**10,lazy_ntfs,
+      753,Powerpoint Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Powerpoint\**10,lazy_ntfs,
+      754,Publisher Autosave Location,FileKnowledge,Users\*\AppData\Roaming\Microsoft\Publisher\**10,lazy_ntfs,
+      755,Office Document Cache,FileKnowledge,Users\*\AppData\Local\Microsoft\Office\*\OfficeFileCache\**10,lazy_ntfs,
+      756,Prefetch,Prefetch,Windows\prefetch\*.pf,lazy_ntfs,
+      757,Prefetch,Prefetch,Windows.old\Windows\prefetch\*.pf,lazy_ntfs,
+      758,RDP Cache Files,FileSystem,Users\*\AppData\Local\Microsoft\Terminal Server Client\Cache\*,lazy_ntfs,
+      759,RDP Cache Files,FileSystem,Documents and Settings\*\Local Settings\Application Data\Microsoft\Terminal Server Client\Cache\*,lazy_ntfs,
+      760,RemoteConnectionManager Event Logs,EventLogs,Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
+      761,RemoteConnectionManager Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-RemoteConnectionManager*,lazy_ntfs,
+      762,LocalSessionManager Event Logs,EventLogs,Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
+      763,LocalSessionManager Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-LocalSessionManager*,lazy_ntfs,
+      764,RDPClient Event Logs,EventLogs,Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
+      765,RDPClient Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs\Microsoft-Windows-TerminalServices-RDPClient*,lazy_ntfs,
+      766,RDPCoreTS Event Logs,EventLogs,Windows\System32\winevt\logs\Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
+      767,RDPCoreTS Event Logs,EventLogs,Windows.old\Windows\System32\winevt\logs\Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*,lazy_ntfs,Can be used to correlate RDP logon failures by originating IP
+      768,RecentFileCache,ApplicationCompatability,Windows\AppCompat\Programs\RecentFileCache.bcf,lazy_ntfs,
+      769,RecentFileCache,ApplicationCompatability,Windows.old\Windows\AppCompat\Programs\RecentFileCache.bcf,lazy_ntfs,
+      770,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin\**10\$R*,lazy_ntfs,
+      771,RECYCLER - WinXP,FileDeletion,RECYCLE*\**10\D*,lazy_ntfs,
+      772,Recycle Bin - Windows Vista+,FileDeletion,$Recycle.Bin\**10\$I*,lazy_ntfs,
+      773,RECYCLER - WinXP,FileDeletion,RECYCLE*\**10\INFO2,lazy_ntfs,
+      774,BBI registry hive,Registry,Windows\System32\config\BBI,lazy_ntfs,
+      775,BBI registry hive,Registry,Windows.old\Windows\System32\config\BBI,lazy_ntfs,
+      776,BBI registry transaction files,Registry,Windows\System32\config\BBI.LOG*,lazy_ntfs,
+      777,BBI registry transaction files,Registry,Windows.old\System32\config\BBI.LOG*,lazy_ntfs,
+      778,BCD-Template registry hive,Registry,Windows\System32\config\BCD-Template,lazy_ntfs,
+      779,BCD-Template registry hive,Registry,Windows.old\Windows\System32\config\BCD-Template,lazy_ntfs,
+      780,BCD-Template registry transaction files,Registry,Windows\System32\config\BCD-Template.LOG*,lazy_ntfs,
+      781,BCD-Template registry transaction files,Registry,Windows.old\System32\config\BCD-Template.LOG*,lazy_ntfs,
+      782,COMPONENTS registry hive,Registry,Windows\System32\config\COMPONENTS,lazy_ntfs,
+      783,COMPONENTS registry hive,Registry,Windows.old\Windows\System32\config\COMPONENTS,lazy_ntfs,
+      784,COMPONENTS registry transaction files,Registry,Windows\System32\config\COMPONENTS.LOG*,lazy_ntfs,
+      785,COMPONENTS registry transaction files,Registry,Windows.old\System32\config\COMPONENTS.LOG*,lazy_ntfs,
+      786,DRIVERS registry hive,Registry,Windows\System32\config\DRIVERS,lazy_ntfs,
+      787,DRIVERS registry hive,Registry,Windows.old\Windows\System32\config\DRIVERS,lazy_ntfs,
+      788,DRIVERS registry transaction files,Registry,Windows\System32\config\DRIVERS.LOG*,lazy_ntfs,
+      789,DRIVERS registry transaction files,Registry,Windows.old\System32\config\DRIVERS.LOG*,lazy_ntfs,
+      790,ELAM registry hive,Registry,Windows\System32\config\ELAM,lazy_ntfs,
+      791,ELAM registry hive,Registry,Windows.old\Windows\System32\config\ELAM,lazy_ntfs,
+      792,ELAM registry transaction files,Registry,Windows\System32\config\ELAM.LOG*,lazy_ntfs,
+      793,ELAM registry transaction files,Registry,Windows.old\System32\config\ELAM.LOG*,lazy_ntfs,
+      794,userdiff registry hive,Registry,Windows\System32\config\userdiff,lazy_ntfs,
+      795,userdiff registry hive,Registry,Windows.old\Windows\System32\config\userdiff,lazy_ntfs,
+      796,userdiff registry transaction files,Registry,Windows\System32\config\userdiff.LOG*,lazy_ntfs,
+      797,userdiff registry transaction files,Registry,Windows.old\System32\config\userdiff.LOG*,lazy_ntfs,
+      798,VSMIDK registry hive,Registry,Windows\System32\config\VSMIDK,lazy_ntfs,
+      799,VSMIDK registry hive,Registry,Windows.old\Windows\System32\config\VSMIDK,lazy_ntfs,
+      800,VSMIDK registry transaction files,Registry,Windows\System32\config\VSMIDK.LOG*,lazy_ntfs,
+      801,VSMIDK registry transaction files,Registry,Windows.old\System32\config\VSMIDK.LOG*,lazy_ntfs,
+      802,SAM registry transaction files,Registry,Windows\System32\config\SAM.LOG*,lazy_ntfs,
+      803,SAM registry transaction files,Registry,Windows.old\Windows\System32\config\SAM.LOG*,lazy_ntfs,
+      804,SECURITY registry transaction files,Registry,Windows\System32\config\SECURITY.LOG*,lazy_ntfs,
+      805,SECURITY registry transaction files,Registry,Windows.old\Windows\System32\config\SECURITY.LOG*,lazy_ntfs,
+      806,SOFTWARE registry transaction files,Registry,Windows\System32\config\SOFTWARE.LOG*,lazy_ntfs,
+      807,SOFTWARE registry transaction files,Registry,Windows.old\Windows\System32\config\SOFTWARE.LOG*,lazy_ntfs,
+      808,SYSTEM registry transaction files,Registry,Windows\System32\config\SYSTEM.LOG*,lazy_ntfs,
+      809,SYSTEM registry transaction files,Registry,Windows.old\Windows\System32\config\SYSTEM.LOG*,lazy_ntfs,
+      810,SAM registry hive,Registry,Windows\System32\config\SAM,lazy_ntfs,
+      811,SAM registry hive,Registry,Windows.old\Windows\System32\config\SAM,lazy_ntfs,
+      812,SECURITY registry hive,Registry,Windows\System32\config\SECURITY,lazy_ntfs,
+      813,SECURITY registry hive,Registry,Windows.old\Windows\System32\config\SECURITY,lazy_ntfs,
+      814,SOFTWARE registry hive,Registry,Windows\System32\config\SOFTWARE,lazy_ntfs,
+      815,SOFTWARE registry hive,Registry,Windows.old\Windows\System32\config\SOFTWARE,lazy_ntfs,
+      816,SYSTEM registry hive,Registry,Windows\System32\config\SYSTEM,lazy_ntfs,
+      817,SYSTEM registry hive,Registry,Windows.old\Windows\System32\config\SYSTEM,lazy_ntfs,
+      818,RegBack registry transaction files,Registry,Windows\System32\config\RegBack\*.LOG*,lazy_ntfs,
+      819,RegBack registry transaction files,Registry,Windows.old\Windows\System32\config\RegBack\*.LOG*,lazy_ntfs,
+      820,SAM registry hive (RegBack),Registry,Windows\System32\config\RegBack\SAM,lazy_ntfs,
+      821,SAM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack\SAM,lazy_ntfs,
+      822,SECURITY registry hive (RegBack),Registry,Windows\System32\config\RegBack\SECURITY,lazy_ntfs,
+      823,SECURITY registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack\SECURITY,lazy_ntfs,
+      824,SOFTWARE registry hive (RegBack),Registry,Windows\System32\config\RegBack\SOFTWARE,lazy_ntfs,
+      825,SOFTWARE registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack\SOFTWARE,lazy_ntfs,
+      826,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack\SYSTEM,lazy_ntfs,
+      827,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack\SYSTEM,lazy_ntfs,
+      828,SYSTEM registry hive (RegBack),Registry,Windows\System32\config\RegBack\SYSTEM1,lazy_ntfs,
+      829,SYSTEM registry hive (RegBack),Registry,Windows.old\Windows\System32\config\RegBack\SYSTEM1,lazy_ntfs,
+      830,System Profile registry hive,Registry,Windows\System32\config\systemprofile\NTUSER.DAT,lazy_ntfs,
+      831,System Profile registry hive,Registry,Windows.old\Windows\System32\config\systemprofile\NTUSER.DAT,lazy_ntfs,
+      832,System Profile registry transaction files,Registry,Windows\System32\config\systemprofile\NTUSER.DAT.LOG*,lazy_ntfs,
+      833,System Profile registry transaction files,Registry,Windows.old\Windows\System32\config\systemprofile\NTUSER.DAT.LOG*,lazy_ntfs,
+      834,Local Service registry hive,Registry,Windows\ServiceProfiles\LocalService\NTUSER.DAT,lazy_ntfs,
+      835,Local Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\LocalService\NTUSER.DAT,lazy_ntfs,
+      836,Local Service registry transaction files,Registry,Windows\ServiceProfiles\LocalService\NTUSER.DAT.LOG*,lazy_ntfs,
+      837,Local Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\LocalService\NTUSER.DAT.LOG*,lazy_ntfs,
+      838,Network Service registry hive,Registry,Windows\ServiceProfiles\NetworkService\NTUSER.DAT,lazy_ntfs,
+      839,Network Service registry hive,Registry,Windows.old\Windows\ServiceProfiles\NetworkService\NTUSER.DAT,lazy_ntfs,
+      840,Network Service registry transaction files,Registry,Windows\ServiceProfiles\NetworkService\NTUSER.DAT.LOG*,lazy_ntfs,
+      841,Network Service registry transaction files,Registry,Windows.old\Windows\ServiceProfiles\NetworkService\NTUSER.DAT.LOG*,lazy_ntfs,
+      842,System Restore Points Registry Hives (XP),Registry,System Volume Information\_restore*\RP*\snapshot\_REGISTRY_*,lazy_ntfs,
+      843,NTUSER.DAT registry hive XP,Registry,Documents and Settings\*\NTUSER.DAT,lazy_ntfs,
+      844,NTUSER.DAT registry hive,Registry,Users\*\NTUSER.DAT,lazy_ntfs,
+      845,NTUSER.DAT registry transaction files,Registry,Users\*\NTUSER.DAT.LOG*,lazy_ntfs,
+      846,NTUSER.DAT DEFAULT registry hive,Registry,Windows\System32\config\DEFAULT,lazy_ntfs,
+      847,NTUSER.DAT DEFAULT registry hive,Registry,Windows.old\Windows\System32\config\DEFAULT,lazy_ntfs,
+      848,NTUSER.DAT DEFAULT transaction files,Registry,Windows\System32\config\DEFAULT.LOG*,lazy_ntfs,
+      849,NTUSER.DAT DEFAULT transaction files,Registry,Windows.old\Windows\System32\config\DEFAULT.LOG*,lazy_ntfs,
+      850,UsrClass.dat registry hive,Registry,Users\*\AppData\Local\Microsoft\Windows\UsrClass.dat,lazy_ntfs,
+      851,UsrClass.dat registry transaction files,Registry,Users\*\AppData\Local\Microsoft\Windows\UsrClass.dat.LOG*,lazy_ntfs,
+      852,SDB Files,Executables,Windows\apppatch\Custom\*.sdb,lazy_ntfs,
+      853,SDB Files,Executables,Windows.old\Windows\apppatch\Custom\*.sdb,lazy_ntfs,
+      854,SDB Files x64,Executables,Windows\apppatch\Custom\Custom64\*.sdb,lazy_ntfs,
+      855,SDB Files x64,Executables,Windows.old\Windows\apppatch\Custom\Custom64\*.sdb,lazy_ntfs,
+      856,SRUM,Execution,Windows\System32\SRU\**10,lazy_ntfs,
+      857,SRUM,Execution,Windows.old\Windows\System32\SRU\**10,lazy_ntfs,
+      858,SOFTWARE registry hive,Registry,Windows\System32\config\SOFTWARE,lazy_ntfs,
+      859,SOFTWARE registry hive,Registry,Windows.old\Windows\System32\config\SOFTWARE,lazy_ntfs,
+      860,SOFTWARE registry transaction files,Registry,Windows\System32\config\SOFTWARE.LOG*,lazy_ntfs,
+      861,SOFTWARE registry transaction files,Registry,Windows.old\Windows\System32\config\SOFTWARE.LOG*,lazy_ntfs,
+      862,SUM Database (.mdb files),Logs,Windows\System32\LogFiles\SUM\*.mdb,lazy_ntfs,"Grabs Current.mdb, SystemIdentity.mdb, and [GUID].mdb"
+      863,at .job,Persistence,Windows\Tasks\*.job,lazy_ntfs,
+      864,at .job,Persistence,Windows.old\Windows\Tasks\*.job,lazy_ntfs,
+      865,at SchedLgU.txt,Persistence,Windows\SchedLgU.txt,lazy_ntfs,
+      866,at SchedLgU.txt,Persistence,Windows.old\Windows\SchedLgU.txt,lazy_ntfs,
+      867,XML,Persistence,Windows\System32\Tasks\**10,lazy_ntfs,
+      868,XML,Persistence,Windows.old\Windows\System32\Tasks\**10,lazy_ntfs,
+      869,SignatureCatalog,FileMetadata,Windows\System32\CatRoot\**10,lazy_ntfs,
+      870,SignatureCatalog,FileMetadata,Windows.old\Windows\System32\CatRoot\**10,lazy_ntfs,
+      871,StartupInfo XML Files,Persistence,Windows\System32\WDI\LogFiles\StartupInfo\*.xml,lazy_ntfs,
+      872,StartupInfo XML Files,Persistence,Windows.old\Windows\System32\WDI\LogFiles\StartupInfo\*.xml,lazy_ntfs,
+      873,Syscache,Program Execution,System Volume Information\Syscache.hve,lazy_ntfs,
+      874,Syscache transaction files,Program Execution,System Volume Information\Syscache.hve.LOG*,lazy_ntfs,
+      875,Thumbcache DB,FileKnowledge,Users\*\AppData\Local\Microsoft\Windows\Explorer\thumbcache_*.db,lazy_ntfs,
+      876,Setupapi.log XP,USBDevices,Windows\setupapi.log,lazy_ntfs,
+      877,Setupapi.log Win7+,USBDevices,Windows\inf\setupapi.dev.log,lazy_ntfs,
+      878,Setupapi.log Win7+,USBDevices,Windows.old\Windows\inf\setupapi.dev.log,lazy_ntfs,
+      879,VHD,Disk Images,**10\*.VHD,lazy_ntfs,
+      880,VHDX,Disk Images,**10\*.VHDX,lazy_ntfs,
+      881,VDI,Disk Images,**10\*.VDI,lazy_ntfs,
+      882,VMDK,Disk Images,**10\*.VMDK,lazy_ntfs,
+      883,WBEM,WBEM,Windows\System32\wbem\Repository\**10,lazy_ntfs,
+      884,WBEM,WBEM,Windows.old\Windows\System32\wbem\Repository\**10,lazy_ntfs,
+      885,WER Files,Executables,ProgramData\Microsoft\Windows\WER\**10,lazy_ntfs,
+      886,Crash Dumps,SQL Exploitation,Users\*\AppData\Local\CrashDumps\*.dmp,lazy_ntfs,
+      887,Crash Dumps,SQL Exploitation,Windows\*.dmp,lazy_ntfs,
+      888,Crash Dumps,SQL Exploitation,Windows.old\Windows\*.dmp,lazy_ntfs,
+      889,Windows Firewall Logs,WindowsFirewallLogs,Windows\System32\LogFiles\Firewall\pfirewall.*,lazy_ntfs,
+      890,Windows Firewall Logs,WindowsFirewallLogs,Windows.old\Windows\System32\LogFiles\Firewall\pfirewall.*,lazy_ntfs,
+      891,WindowsIndexSearch,FileKnowledge,programdata\microsoft\search\data\applications\windows\Windows.edb,lazy_ntfs,
+      892,Windows 10 Notification DB,Notifications,Users\*\AppData\Local\Microsoft\Windows\Notifications\wpndatabase.db,lazy_ntfs,
+      893,Windows 10 Notification DB,Notifications,Users\*\AppData\Local\Microsoft\Windows\Notifications\appdb.dat,lazy_ntfs,
+      894,MigLog.xml,OS Upgrade,Windows\Panther\MigLog.xml,lazy_ntfs,
+      895,Setupact.log,OS Upgrade,Windows\Panther\Setupact.log,lazy_ntfs,
+      896,HumanReadable.xml,OS Upgrade,Windows\Panther\*HumanReadable.xml,lazy_ntfs,
+      897,FolderMoveLog.txt,OS Upgrade,Windows\Panther\Rollback\FolderMoveLog.txt,lazy_ntfs,
+      898,Update Store.db,OS Upgrade,ProgramData\USOPrivate\UpdateStore\store.db,lazy_ntfs,
+      899,Windows Power Diagnostics,Diagnostics,ProgramData\Microsoft\Windows\Power Efficiency Diagnostics\**10,lazy_ntfs,
+      900,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,ProgramData\Microsoft\Diagnosis\events*.rbs,lazy_ntfs,
+      901,Legacy .rbs files relating to Windows Telemetry and Diagnostics,SystemEvents,Windows.old\ProgramData\Microsoft\Diagnosis\events*.rbs,lazy_ntfs,
+      902,ActivitiesCache.db,FileFolderAccess,Users\*\AppData\Local\ConnectedDevicesPlatform\*\ActivitiesCache.db*,lazy_ntfs,
+      903,System Volume Information,Folder capture,System Volume Information\**10,lazy_ntfs,
+      904,TorrentClients - BitTorrent,FileDownload,Users\*\AppData\Roaming\BitTorrent\*.dat,lazy_ntfs,
+      905,DC++ Chat Logs,FileDownload,Users\*\AppData\Local\DC++\Logs\**10,lazy_ntfs,Locates DC++ hub/chat logs and copies them. Current as of version 0.868.
+      906,Freenet,File Downloads,Users\*\AppData\Local\Freenet\node*,lazy_ntfs,
+      907,Freenet,File Downloads,Users\*\AppData\Local\Freenet\*completed.list.downloads,lazy_ntfs,
+      908,Freenet,File Downloads,Users\*\AppData\Local\Freenet\*completed.list.uploads,lazy_ntfs,
+      909,Freenet,File Downloads,Users\*\AppData\Local\Freenet\*.bak,lazy_ntfs,
+      910,Freenet,File Downloads,Users\*\AppData\Local\Freenet\downloads\**10,lazy_ntfs,
+      911,FrostWire Downloads,FileDownload,Users\*\Documents\FrostWire\Torrent Data\**10,lazy_ntfs,Locates files downloaded that land in the default location as specified by FrostWire
+      912,FrostWire AppData,FileDownload,Users\*\.frostwire5\frostwire.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
+      913,FrostWire AppData,FileDownload,Users\*\.frostwire5\itunes.props,lazy_ntfs,Locates a file that contains important information about the instance of FrostWire on the user's system
+      914,Gigatribe Files Windows Vista/7/8/10,FileDownload,Users\*\AppData\Local\Shalsoft\**10,lazy_ntfs,Locates Gigatribe files and copies them
+      915,Gigatribe Files Windows XP,FileDownload,Documents and Settings\*\*\Application Data\Gigatribe\**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Gigatribe
+      916,Gigatribe Files Windows XP,FileDownload,Documents and Settings\*\*\Application Data\Shalsoft\**10,lazy_ntfs,Locates Gigatribe files and copies them. Different path depending on the Operating System language. In Swedish the location is C:\Documents and Settings\<username>\Lokala Inställningar\Application Data\Shalsoft
+      917,Usenet Clients - NZBGet Log File,FileDownload,ProgramData\NZBGet\nzbget.log,lazy_ntfs,Locates NZBGet download log file
+      918,Usenet Clients - NZBGet NZBs,FileDownload,ProgramData\NZBGet\nzb\*,lazy_ntfs,Locates NZBGet NZB files that were used by the user
+      919,Usenet Clients - Newsbin Pro,FileDownload,Users\*\AppData\Local\Newsbin\Downloaded.db3,lazy_ntfs,Locates Newsbin Pro download log database
+      920,Usenet Clients - Newsleecher,FileDownload,Users\*\AppData\Roaming\NewsLeecher\downloaded.dat,lazy_ntfs,Locates Newsleecher download .dat file
+      921,Nicotine++ Logs,FileDownload,Users\%User%\AppData\Roaming\nicotine\logs\**10,lazy_ntfs,"Locates Nicotine++ chat logs, room logs, transfer logs, and debug logs (if enabled)"
+      922,Nicotine++ Incomplete Downloads,FileDownload,Users\%User%\AppData\Roaming\nicotine\incomplete\**10,lazy_ntfs,Locates files that did not finish downloading
+      923,Nicotine++ Buddyfiles.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddyfiles.db\**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
+      924,Nicotine++ Buddystreams.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddystreams.db\**10,lazy_ntfs,Locates a DB that appears to include shared files from a user's buddy list
+      925,Nicotine++ Buddymtimes.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddymtimes.db\**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a folder level"
+      926,Nicotine++ Buddyfileindex.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddyfileindex.db\**10,lazy_ntfs,"Locates a DB that appears to enumerate which files the user is sharing to their buddy list, from a file level"
+      927,Nicotine++ Buddywordindex.db,FileDownload,Users\%User%\AppData\Roaming\nicotine\buddywordindex.db\**10,lazy_ntfs,Unknown what this is for at this time
+      928,Nicotine++ Config Files,FileDownload,Users\%User%\AppData\Roaming\nicotine\config\**10,lazy_ntfs,Locates config files
+      929,Nicotine++ User Shares,FileDownload,Users\%User%\AppData\Roaming\nicotine\usershares\**10,lazy_ntfs,Locates a DB that appears to store a list of files per user that they are sharing within Nicotine++. Note: this requires the user to right-click -> browse files shared by that user
+      930,Nicotine++ Downloads.json,FileDownload,Users\%User%\AppData\Roaming\nicotine\downloads.json*,lazy_ntfs,Locates downloads.json
+      931,Nicotine++ Uploads.json,FileDownload,Users\%User%\AppData\Roaming\nicotine\uploads.json*,lazy_ntfs,Locates uploads.json
+      932,Usenet Clients - SABnzbd Download Logs,FileDownload,Users\*\AppData\Local\sabnzbd\logs\sabnzbd.log,lazy_ntfs,Locates SABnzbd download log
+      933,Usenet Clients - SABnzbd History.db,FileDownload,Users\*\AppData\Local\sabnzbd\admin\history1.db,lazy_ntfs,Locates SABnzbd history log
+      934,Shareaza Logs,FileDownload,Users\*\AppData\Roaming\Shareaza\**10,lazy_ntfs,Locates Shareaza logs and copies them.
+      935,Soulseek Chat Logs,FileDownload,Users\*\AppData\Local\SoulseekQt\Soulseek Chat Logs\**10,lazy_ntfs,Locates Soulseek chat logs and copies them. Chat logs are in plaintext. Current as of version 2019.7.22.
+      936,Soulseek Search History/Shared Folders/Settings,FileDownload,Users\*\AppData\Local\SoulseekQt\1\*.dat,lazy_ntfs,"Locates .dat file(s) containing: search history, active searches (search_record), current shared folders (shared_file_folder), and wish list items (wish_list_item)."
+      937,Torrents,FileDownload,**10\*.torrent,lazy_ntfs,
+      938,Usenet (NZB) Files,FileDownload,**10\*.nzb,lazy_ntfs,
+      939,TorrentClients - qBittorrent,FileDownload,Users\*\AppData\Roaming\qBittorrent\*.ini,lazy_ntfs,
+      940,TorrentClients - qBittorrent,FileDownload,Users\*\AppData\Local\qBittorrent\logs\*,lazy_ntfs,
+      941,TorrentClients - uTorrent,FileDownload,Users\*\AppData\Roaming\uTorrent\*.dat,lazy_ntfs,
   - name: KapeTargets
     type: hidden
     description: Each parameter above represents a group of rules to be triggered. This table specifies which rule IDs will be included when the parameter is checked.
     default: |
       Group,RuleIds
-      _BasicCollection,"[153, 608, 609, 610, 611, 612, 613, 614, 616, 617, 618, 619, 620, 621, 642, 643, 644, 664, 665, 666, 667, 668, 669, 670, 688, 689, 700, 701, 704, 705, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 788, 789, 790, 791, 792, 793, 795, 796, 797, 798, 799, 800, 805, 806, 807, 808, 809, 810, 823]"
-      _SANS_Triage,"[154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326]"
-      _Boot,[608]
-      _J,"[609, 610, 611, 612]"
-      _LogFile,[613]
-      _MFT,[614]
-      _MFTMirr,[615]
-      _T,"[616, 617]"
-      1Password,"[835, 836, 837]"
-      4KVideoDownloader,[838]
-      AVG,"[1, 2, 3, 4]"
-      AceText,[839]
-      AcronisTrueImage,"[840, 841, 842]"
-      Amcache,"[618, 619, 620, 621]"
-      Ammyy,[843]
-      Antivirus,"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 622, 623, 624, 625]"
-      AnyDesk,"[844, 845, 846, 847, 848, 849]"
-      ApacheAccessLog,[143]
-      AppData,[557]
-      ApplicationEvents,"[622, 623, 624, 625]"
-      AsperaConnect,"[850, 851]"
-      Avast,"[5, 6, 7, 8]"
-      AviraAVLogs,[9]
-      BCD,"[626, 627]"
-      BITS,[628]
-      BitTorrent,[570]
-      Bitdefender,"[10, 11, 12]"
-      BoxDrive,"[852, 853, 854, 855]"
-      BrowserCache,"[430, 431, 432, 433, 434, 435]"
-      CertUtil,"[629, 630, 631]"
-      Chrome,"[436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474]"
-      ChromeExtensions,"[475, 476]"
-      ChromeFileSystem,[477]
-      CiscoJabber,[856]
-      ClipboardMaster,"[857, 858, 859]"
-      CloudStorage,"[852, 853, 854, 855, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 918, 919, 920, 983, 984, 985, 1037, 1038, 1039, 1103, 1104, 1105]"
-      CombinedLogs,"[153, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 821, 822]"
-      ComboFix,[13]
-      ConfluenceLogs,"[860, 861]"
-      Cybereason,"[14, 15, 16]"
-      DC__,[571]
-      Debian,"[67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83]"
-      DirectoryOpus,"[862, 863, 864, 865, 866, 867, 868, 869, 870]"
-      DirectoryTraversalWildCardExample,[558]
-      DirectoryTraversal_AudioFiles,[559]
-      DirectoryTraversal_ExcelDocuments,[560]
-      DirectoryTraversal_PDFDocuments,[561]
-      DirectoryTraversal_PictureFiles,[562]
-      DirectoryTraversal_SQLiteDatabases,[563]
-      DirectoryTraversal_VideoFiles,[564]
-      DirectoryTraversal_WordDocuments,[565]
-      Discord,"[871, 872]"
-      DoubleCommander,"[873, 874, 875]"
-      Dropbox,"[876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888]"
-      EFCommander,[889]
-      ESET,"[17, 18]"
-      Edge,[478]
-      EdgeChromium,"[479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499]"
-      Emsisoft,[19]
-      EncapsulationLogging,"[632, 633, 634, 635]"
-      EventLogs_RDP,"[636, 637, 638, 639, 640, 641]"
-      EventLogs,"[642, 643, 644]"
-      EventTraceLogs,"[645, 646, 647, 648, 649, 650, 651, 652, 653, 654]"
-      EventTranscriptDB,"[655, 656, 657]"
-      Evernote,"[890, 891, 892]"
-      Everything__VoidTools_,"[893, 894, 895]"
-      EvidenceOfExecution,"[618, 619, 620, 621, 688, 689, 700, 701, 805, 806]"
-      Exchange,"[896, 901]"
-      ExchangeClientAccess,[896]
-      ExchangeCve_2021_26855,"[897, 898, 899, 900]"
-      ExchangeTransport,[901]
-      FSecure,"[20, 21, 22]"
-      FTPClients,"[903, 904, 905, 906, 1089]"
-      Fences,[902]
-      FileExplorerReplacements,"[862, 863, 864, 865, 866, 867, 868, 869, 870, 873, 874, 875, 889, 907, 908, 909, 910, 911, 912, 913, 973, 974, 975, 976, 977, 978, 981, 982, 1010, 1011, 1035, 1042, 1043, 1044, 1062, 1063, 1064, 1065, 1066, 1067, 1091, 1092, 1093, 1094]"
-      FileSystem,"[608, 609, 610, 611, 612, 613, 614, 616, 617]"
-      FileZillaClient,"[903, 904]"
-      FileZillaServer,"[905, 906]"
-      Firefox,"[500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534]"
-      FreeCommander,"[907, 908, 909, 910, 911, 912, 913]"
-      FreeDownloadManager,"[914, 915, 916]"
-      FreeFileSync,[917]
-      Freenet,"[572, 573, 574, 575, 576]"
-      FrostWire,"[577, 578, 579]"
-      Gigatribe,"[580, 581, 582]"
-      GoogleDrive,"[918, 919, 920]"
-      GroupPolicy,"[658, 659, 660, 661, 662, 663]"
-      HeidiSQL,"[921, 922]"
-      HexChat,[923]
-      HitmanPro,"[23, 24, 25]"
-      IISLogFiles,"[144, 145, 146, 147, 148]"
-      IRCClients,"[923, 924, 1098, 1099]"
-      IceChat,[924]
-      InternetExplorer,"[535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547]"
-      IrfanView,[925]
-      JDownloader2,"[926, 927, 928, 929, 930]"
-      JavaWebCache,"[931, 932, 933, 934, 935, 936, 937, 938, 939, 940, 941]"
-      Kali,"[84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]"
-      KapeTriage,"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 153, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 608, 609, 610, 611, 612, 613, 614, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 642, 643, 644, 664, 665, 666, 667, 668, 669, 670, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 704, 705, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 805, 806, 833, 843, 844, 845, 846, 847, 848, 849, 942, 943, 944, 945, 946, 947, 948, 949, 950, 951, 952, 1013, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1045, 1046, 1047, 1075, 1100, 1101, 1102]"
-      Kaseya,"[942, 943, 944, 945, 946, 947, 948, 949, 950]"
-      LNKFilesAndJumpLists,"[664, 665, 666, 667, 668, 669, 670]"
-      LinuxOnWindowsProfileFiles,"[671, 672, 673, 674]"
-      LiveUserFiles,"[566, 567, 568, 569]"
-      LogFiles,"[675, 676]"
-      LogMeIn,"[622, 623, 624, 625, 951, 952]"
-      MOF,[677]
-      MSSQLErrorLog,"[149, 150]"
-      MacriumReflect,"[953, 954, 955]"
-      Malwarebytes,"[26, 27, 28, 29]"
-      ManageEngineLogs,[151]
-      Mattermost,[956]
-      McAfee,"[30, 31, 32, 33, 34]"
-      McAfee_ePO,[35]
-      MediaMonkey,"[957, 958]"
-      MemoryFiles,"[678, 679, 680, 681, 682]"
-      MessagingClients,"[856, 871, 872, 923, 924, 956, 966, 967, 968, 969, 970, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1048, 1049, 1076, 1077, 1078, 1079, 1080, 1087, 1088, 1098, 1099]"
-      MicrosoftOneNote,"[959, 960, 961, 962, 963]"
-      MicrosoftStickyNotes,"[964, 965]"
-      MicrosoftTeams,"[966, 967, 968, 969, 970]"
-      MicrosoftToDo,"[971, 972]"
-      MidnightCommander,[973]
-      MiniTimelineCollection,"[608, 609, 610, 611, 612, 613, 614, 616, 617, 642, 643, 644, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783]"
-      MultiCommander,"[974, 975, 976, 977, 978]"
-      NGINXLogs,[152]
-      NZBGet,"[583, 584]"
-      NewsbinPro,[585]
-      Newsleecher,[586]
-      Nicotine__,"[587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597]"
-      Notepad__,"[979, 980]"
-      OfficeAutosave,"[683, 684, 685, 686]"
-      OfficeDocumentCache,[687]
-      OneCommander,"[981, 982]"
-      OneDrive,"[983, 984, 985]"
-      OpenSSHClient,"[986, 987, 988, 989]"
-      OpenSSHServer,"[990, 991, 992, 993, 994, 995, 996, 997, 998]"
-      OpenVPNClient,"[999, 1000, 1001]"
-      Opera,"[548, 549]"
-      OutlookPSTOST,"[1002, 1003, 1004, 1005, 1006, 1007]"
-      P2PClients,"[571, 577, 578, 579, 580, 581, 582, 600, 601, 602]"
-      PeaZip,[1008]
-      PowerShellConsole,[153]
-      Prefetch,"[688, 689]"
-      ProtonVPN,[1009]
-      PuffinSecureBrowser,"[550, 551, 552, 553, 554, 555, 556]"
-      Q_Dir,"[1010, 1011]"
-      QFinderPro__QNAP_,[1012]
-      RDPCache,"[690, 691]"
-      RDPLogs,"[692, 693, 694, 695, 696, 697, 698, 699]"
-      Radmin,"[1013, 1014, 1015, 1016, 1017]"
-      RecentFileCache,"[700, 701]"
-      RecycleBin,"[702, 703, 704, 705]"
-      RecycleBin_DataFiles,"[702, 703]"
-      RecycleBin_InfoFiles,"[704, 705]"
-      RegistryHives,"[734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783]"
-      RegistryHivesOther,"[706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733]"
-      RegistryHivesSystem,"[734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774]"
-      RegistryHivesUser,"[775, 776, 777, 778, 779, 780, 781, 782, 783]"
-      RemoteAdmin,"[622, 623, 624, 625, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 843, 844, 845, 846, 847, 848, 849, 942, 943, 944, 945, 946, 947, 948, 949, 950, 951, 952, 1013, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1045, 1046, 1047, 1075, 1100, 1101, 1102]"
-      RogueKiller,[36]
-      SABnbzd,"[598, 599]"
-      SDB,"[784, 785, 786, 787]"
-      SOFELK,"[608, 609, 610, 611, 612, 613, 614, 616, 617, 618, 619, 620, 621, 642, 643, 644, 664, 665, 666, 667, 668, 669, 670, 688, 689, 700, 701, 805, 806]"
-      SQLiteDatabases,"[327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429]"
-      SRUM,"[788, 789, 790, 791, 792, 793]"
-      SUM,[794]
-      SUPERAntiSpyware,[37]
-      SUSELinuxEnterpriseServer,"[101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113]"
-      ScheduledTasks,"[795, 796, 797, 798, 799, 800]"
-      ScreenConnect,"[622, 623, 624, 625, 1018, 1019, 1020]"
-      SecureAge,[38]
-      SentinelOne,[39]
-      ServerTriage,"[143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 860, 861, 896, 901, 905, 906, 990, 991, 992, 993, 994, 995, 996, 997, 998]"
-      ShareX,[1021]
-      Shareaza,[600]
-      Signal,"[1022, 1023, 1024, 1025]"
-      SignatureCatalog,"[801, 802]"
-      Skype,"[1026, 1027, 1028, 1029, 1030, 1031, 1032]"
-      Slack,[1033]
-      Snagit,[1034]
-      Sophos,"[40, 41, 622, 623, 624, 625]"
-      Soulseek,"[601, 602]"
-      SpeedCommander,[1035]
-      StartupInfo,"[803, 804]"
-      SublimeText,[1036]
-      SugarSync,"[1037, 1038, 1039]"
-      SumatraPDF,"[1040, 1041]"
-      Symantec_AV_Logs,"[42, 43, 44, 45, 46, 47, 48, 49, 50, 622, 623, 624, 625]"
-      Syscache,"[805, 806]"
-      TablacusExplorer,"[1042, 1043, 1044]"
-      TeamViewerLogs,"[1045, 1046, 1047]"
-      Telegram,"[1048, 1049]"
-      TeraCopy,[1050]
-      ThumbCache,[807]
-      Thunderbird,"[1051, 1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061]"
-      TorrentClients,"[570, 605, 606, 607]"
-      Torrents,[603]
-      TotalAV,"[51, 52]"
-      TotalCommander,"[1062, 1063, 1064, 1065, 1066, 1067]"
-      TreeSize,[1068]
-      TrendMicro,"[53, 54, 55]"
-      USBDetective,"[618, 619, 620, 621, 642, 643, 644, 664, 665, 666, 667, 668, 669, 670, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 808, 809, 810]"
-      USBDevicesLogs,"[808, 809, 810]"
-      Ubuntu,"[114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129]"
-      Usenet,[604]
-      UsenetClients,"[583, 584, 585, 586, 598, 599]"
-      VIPRE,"[56, 57, 58, 59]"
-      VLC_Media_Player,"[1069, 1070]"
-      VMware,"[811, 812, 813, 814, 1071, 1072, 1073, 1074]"
-      VMwareInventory,[1071]
-      VMwareMemory,"[1072, 1073, 1074]"
-      VNCLogs,"[622, 623, 624, 625, 1075]"
-      Viber,"[1076, 1077, 1078, 1079, 1080]"
-      VirtualBox,"[811, 812, 813, 814, 1081, 1082, 1083, 1084, 1085, 1086]"
-      VirtualBoxConfig,"[1081, 1082]"
-      VirtualBoxLogs,"[1083, 1084, 1085]"
-      VirtualBoxMemory,[1086]
-      VirtualDisks,"[811, 812, 813, 814]"
-      WBEM,"[815, 816]"
-      WER,"[817, 818, 819, 820]"
-      WSL,"[67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142]"
-      WebBrowsers,"[436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556]"
-      WebServers,"[143, 144, 145, 146, 147, 148, 149, 150, 152]"
-      Webroot,[60]
-      WhatsApp,"[1087, 1088]"
-      WinSCP,[1089]
-      WindowsDefender,"[61, 62, 63, 64, 65, 66]"
-      WindowsFirewall,"[821, 822]"
-      WindowsIndexSearch,[823]
-      WindowsNotificationsDB,"[824, 825]"
-      WindowsOSUpgradeArtifacts,"[826, 827, 828, 829, 830]"
-      WindowsTelemetryDiagnosticsLegacy,"[831, 832]"
-      WindowsTimeline,[833]
-      WindowsYourPhone,[1090]
-      XPRestorePoints,[834]
-      XYplorer,"[1091, 1092, 1093, 1094]"
-      iTunesBackup,"[1095, 1096, 1097]"
-      mIRC,"[1098, 1099]"
-      mRemoteNG,"[1100, 1101, 1102]"
-      openSUSE,"[130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142]"
-      pCloudDatabase,"[1103, 1104, 1105]"
-      qBittorrent,"[605, 606]"
-      uTorrent,[607]
+      _BasicCollection,"[138, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 863, 864, 865, 866, 867, 868, 873, 874, 875, 876, 877, 878, 891]"
+      _SANS_Triage,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 226, 227, 228, 229, 230, 231, 232, 235, 236, 239, 254, 255, 259, 260, 261, 262, 263, 295, 296, 299, 300, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 332, 342, 343, 344, 345, 346, 361, 362, 393, 394, 395, 396, 397, 398, 399, 400, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 426, 427, 431, 432, 433, 434, 435, 461, 462, 463, 464, 465, 466, 473, 474, 484, 485, 486, 487, 488, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 873, 874, 875, 883, 884, 891, 902]"
+      _Boot,[676]
+      _J,"[677, 678, 679, 680]"
+      _LogFile,[681]
+      _MFT,[682]
+      _MFTMirr,[683]
+      _T,"[684, 685]"
+      1Password,"[218, 219, 220]"
+      4KVideoDownloader,[221]
+      AVG,"[139, 140, 141, 142]"
+      AceText,[222]
+      AcronisTrueImage,"[223, 224, 225]"
+      Amcache,"[686, 687, 688, 689]"
+      Ammyy,[226]
+      Antivirus,"[139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 690, 691, 692, 693]"
+      AnyDesk,"[227, 228, 229, 230, 231, 232]"
+      ApacheAccessLog,[128]
+      AppData,[205]
+      ApplicationEvents,"[690, 691, 692, 693]"
+      AsperaConnect,"[233, 234]"
+      Avast,"[143, 144, 145, 146]"
+      AviraAVLogs,[147]
+      BCD,"[694, 695]"
+      BITS,[696]
+      BitTorrent,[904]
+      Bitdefender,"[148, 149, 150]"
+      BoxDrive_Metadata,"[235, 236]"
+      BoxDrive_UserFiles,"[237, 238]"
+      BrowserCache,"[1, 2, 3, 4, 5, 6]"
+      CertUtil,"[697, 698, 699]"
+      Chrome,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]"
+      ChromeExtensions,"[46, 47]"
+      ChromeFileSystem,[48]
+      CiscoJabber,[239]
+      ClipboardMaster,"[240, 241, 242]"
+      CloudStorage_All,"[235, 236, 237, 238, 259, 260, 261, 262, 263, 264, 294, 295, 296, 361, 362, 363, 421, 422, 423, 489, 490, 491]"
+      CloudStorage_Metadata,"[235, 236, 259, 260, 261, 262, 263, 295, 296, 361, 362]"
+      CombinedLogs,"[138, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 876, 877, 878, 889, 890]"
+      ComboFix,[151]
+      ConfluenceLogs,"[243, 244]"
+      Cybereason,"[152, 153, 154]"
+      DC__,[905]
+      Debian,"[595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611]"
+      DirectoryOpus,"[245, 246, 247, 248, 249, 250, 251, 252, 253]"
+      DirectoryTraversal_AudioFiles,[206]
+      DirectoryTraversal_ExcelDocuments,[207]
+      DirectoryTraversal_PDFDocuments,[208]
+      DirectoryTraversal_PictureFiles,[209]
+      DirectoryTraversal_SQLiteDatabases,[210]
+      DirectoryTraversal_VideoFiles,[211]
+      DirectoryTraversal_WildCardExample,[212]
+      DirectoryTraversal_WordDocuments,[213]
+      Discord,"[254, 255]"
+      DoubleCommander,"[256, 257, 258]"
+      Dropbox_Metadata,"[259, 260, 261, 262, 263]"
+      Dropbox_UserFiles,[264]
+      EFCommander,[265]
+      ESET,"[155, 156]"
+      Edge,[49]
+      EdgeChromium,"[50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]"
+      Emsisoft,[157]
+      EncapsulationLogging,"[700, 701, 702, 703]"
+      EventLogs_RDP,"[704, 705, 706, 707, 708, 709]"
+      EventLogs,"[710, 711, 712]"
+      EventTraceLogs,"[713, 714, 715, 716, 717, 718, 719, 720, 721, 722]"
+      EventTranscriptDB,"[723, 724, 725]"
+      Evernote,"[266, 267, 268]"
+      Everything__VoidTools_,"[269, 270, 271]"
+      EvidenceOfExecution,"[686, 687, 688, 689, 756, 757, 768, 769, 873, 874]"
+      Exchange,"[272, 277]"
+      ExchangeClientAccess,[272]
+      ExchangeCve_2021_26855,"[273, 274, 275, 276]"
+      ExchangeTransport,[277]
+      FSecure,"[158, 159, 160]"
+      FTPClients,"[279, 280, 281, 282, 475]"
+      Fences,[278]
+      FileExplorerReplacements,"[245, 246, 247, 248, 249, 250, 251, 252, 253, 256, 257, 258, 265, 283, 284, 285, 286, 287, 288, 289, 349, 350, 351, 352, 353, 354, 359, 360, 390, 391, 419, 428, 429, 430, 448, 449, 450, 451, 452, 453, 477, 478, 479, 480]"
+      FileSystem,"[676, 677, 678, 679, 680, 681, 682, 684, 685]"
+      FileZillaClient,"[279, 280]"
+      FileZillaServer,"[281, 282]"
+      Firefox,"[71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105]"
+      FreeCommander,"[283, 284, 285, 286, 287, 288, 289]"
+      FreeDownloadManager,"[290, 291, 292]"
+      FreeFileSync,[293]
+      Freenet,"[906, 907, 908, 909, 910]"
+      FrostWire,"[911, 912, 913]"
+      Gigatribe,"[914, 915, 916]"
+      GoogleDriveBackupSync_UserFiles,[294]
+      GoogleDrive_Metadata,"[295, 296]"
+      GroupPolicy,"[726, 727, 728, 729, 730, 731]"
+      HeidiSQL,"[297, 298]"
+      HexChat,[299]
+      HitmanPro,"[161, 162, 163]"
+      IISLogFiles,"[129, 130, 131, 132, 133]"
+      IRCClients,"[299, 300, 484, 485]"
+      IceChat,[300]
+      InternetExplorer,"[106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118]"
+      IrfanView,[301]
+      JDownloader2,"[302, 303, 304, 305, 306]"
+      JavaWebCache,"[307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317]"
+      Kali,"[612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628]"
+      KapeTriage,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 226, 227, 228, 229, 230, 231, 232, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 393, 394, 395, 396, 397, 398, 399, 400, 426, 427, 431, 432, 433, 461, 486, 487, 488, 676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 772, 773, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 873, 874, 902]"
+      Kaseya,"[318, 319, 320, 321, 322, 323, 324, 325, 326]"
+      LNKFilesAndJumpLists,"[732, 733, 734, 735, 736, 737, 738]"
+      LinuxOnWindowsProfileFiles,"[739, 740, 741, 742]"
+      LiveUserFiles,"[214, 215, 216, 217]"
+      LogFiles,"[743, 744]"
+      LogMeIn,"[327, 328, 690, 691, 692, 693]"
+      MOF,[745]
+      MSSQLErrorLog,"[134, 135]"
+      MacriumReflect,"[329, 330, 331]"
+      Malwarebytes,"[164, 165, 166, 167]"
+      ManageEngineLogs,[136]
+      Mattermost,[332]
+      McAfee,"[168, 169, 170, 171, 172]"
+      McAfee_ePO,[173]
+      MediaMonkey,"[333, 334]"
+      MemoryFiles,"[746, 747, 748, 749, 750]"
+      MessagingClients,"[239, 254, 255, 299, 300, 332, 342, 343, 344, 345, 346, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 434, 435, 462, 463, 464, 465, 466, 473, 474, 484, 485]"
+      MicrosoftOneNote,"[335, 336, 337, 338, 339]"
+      MicrosoftStickyNotes,"[340, 341]"
+      MicrosoftTeams,"[342, 343, 344, 345, 346]"
+      MicrosoftToDo,"[347, 348]"
+      MidnightCommander,[349]
+      MiniTimelineCollection,"[676, 677, 678, 679, 680, 681, 682, 684, 685, 710, 711, 712, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      MultiCommander,"[350, 351, 352, 353, 354]"
+      NGINXLogs,[137]
+      NZBGet,"[917, 918]"
+      Nessus,"[355, 356]"
+      NewsbinPro,[919]
+      Newsleecher,[920]
+      Nicotine__,"[921, 922, 923, 924, 925, 926, 927, 928, 929, 930, 931]"
+      Notepad__,"[357, 358]"
+      OfficeAutosave,"[751, 752, 753, 754]"
+      OfficeDocumentCache,[755]
+      OneCommander,"[359, 360]"
+      OneDrive_Metadata,"[361, 362]"
+      OneDrive_UserFiles,[363]
+      OpenSSHClient,"[364, 365, 366, 367]"
+      OpenSSHServer,"[368, 369, 370, 371, 372, 373, 374, 375, 376]"
+      OpenVPNClient,"[377, 378, 379]"
+      Opera,"[119, 120]"
+      OutlookPSTOST,"[380, 381, 382, 383, 384, 385, 386, 387]"
+      P2PClients,"[905, 911, 912, 913, 914, 915, 916, 934, 935, 936]"
+      PeaZip,[388]
+      PowerShellConsole,[138]
+      Prefetch,"[756, 757]"
+      ProtonVPN,[389]
+      PuffinSecureBrowser,"[121, 122, 123, 124, 125, 126, 127]"
+      Q_Dir,"[390, 391]"
+      QFinderPro__QNAP_,[392]
+      RDPCache,"[758, 759]"
+      RDPLogs,"[760, 761, 762, 763, 764, 765, 766, 767]"
+      Radmin,"[393, 394, 395, 396, 397]"
+      RecentFileCache,"[768, 769]"
+      RecycleBin,"[770, 771, 772, 773]"
+      RecycleBin_DataFiles,"[770, 771]"
+      RecycleBin_InfoFiles,"[772, 773]"
+      RegistryHives,"[802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      RegistryHivesOther,"[774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801]"
+      RegistryHivesSystem,"[802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842]"
+      RegistryHivesUser,"[843, 844, 845, 846, 847, 848, 849, 850, 851]"
+      RemoteAdmin,"[226, 227, 228, 229, 230, 231, 232, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 393, 394, 395, 396, 397, 398, 399, 400, 426, 427, 431, 432, 433, 461, 486, 487, 488, 690, 691, 692, 693, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767]"
+      RogueKiller,[174]
+      SABnbzd,"[932, 933]"
+      SDB,"[852, 853, 854, 855]"
+      SOFELK,"[676, 677, 678, 679, 680, 681, 682, 684, 685, 686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 756, 757, 768, 769, 873, 874]"
+      SQLiteDatabases,"[492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594]"
+      SRUM,"[856, 857, 858, 859, 860, 861]"
+      SUM,[862]
+      SUPERAntiSpyware,[175]
+      SUSELinuxEnterpriseServer,"[629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641]"
+      ScheduledTasks,"[863, 864, 865, 866, 867, 868]"
+      ScreenConnect,"[398, 399, 400, 690, 691, 692, 693]"
+      SecureAge,[176]
+      SentinelOne,[177]
+      ServerTriage,"[128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 243, 244, 272, 277, 281, 282, 368, 369, 370, 371, 372, 373, 374, 375, 376]"
+      ShareX,[401]
+      Shareaza,[934]
+      Signal,"[402, 403, 404, 405]"
+      SignatureCatalog,"[869, 870]"
+      Skype,"[406, 407, 408, 409, 410, 411, 412]"
+      Slack,"[413, 414, 415, 416, 417]"
+      Snagit,[418]
+      Sophos,"[178, 179, 690, 691, 692, 693]"
+      Soulseek,"[935, 936]"
+      SpeedCommander,[419]
+      StartupInfo,"[871, 872]"
+      SublimeText,[420]
+      SugarSync,"[421, 422, 423]"
+      SumatraPDF,"[424, 425]"
+      SupremoRemoteDesktop,"[426, 427]"
+      Symantec_AV_Logs,"[180, 181, 182, 183, 184, 185, 186, 187, 188, 690, 691, 692, 693]"
+      Syscache,"[873, 874]"
+      TablacusExplorer,"[428, 429, 430]"
+      TeamViewerLogs,"[431, 432, 433]"
+      Telegram,"[434, 435]"
+      TeraCopy,[436]
+      ThumbCache,[875]
+      Thunderbird,"[437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447]"
+      TorrentClients,"[904, 939, 940, 941]"
+      Torrents,[937]
+      TotalAV,"[189, 190]"
+      TotalCommander,"[448, 449, 450, 451, 452, 453]"
+      TreeSize,[454]
+      TrendMicro,"[191, 192, 193]"
+      USBDetective,"[686, 687, 688, 689, 710, 711, 712, 732, 733, 734, 735, 736, 737, 738, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 876, 877, 878]"
+      USBDevicesLogs,"[876, 877, 878]"
+      Ubuntu,"[642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657]"
+      Usenet,[938]
+      UsenetClients,"[917, 918, 919, 920, 932, 933]"
+      VIPRE,"[194, 195, 196, 197]"
+      VLC_Media_Player,"[455, 456]"
+      VMware,"[457, 458, 459, 460, 879, 880, 881, 882]"
+      VMwareInventory,[457]
+      VMwareMemory,"[458, 459, 460]"
+      VNCLogs,"[461, 690, 691, 692, 693]"
+      Viber,"[462, 463, 464, 465, 466]"
+      VirtualBox,"[467, 468, 469, 470, 471, 472, 879, 880, 881, 882]"
+      VirtualBoxConfig,"[467, 468]"
+      VirtualBoxLogs,"[469, 470, 471]"
+      VirtualBoxMemory,[472]
+      VirtualDisks,"[879, 880, 881, 882]"
+      WBEM,"[883, 884]"
+      WER,"[885, 886, 887, 888]"
+      WSL,"[595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670]"
+      WebBrowsers,"[7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]"
+      WebServers,"[128, 129, 130, 131, 132, 133, 134, 135, 137]"
+      Webroot,[198]
+      WhatsApp,"[473, 474]"
+      WinSCP,[475]
+      WindowsDefender,"[199, 200, 201, 202, 203, 204]"
+      WindowsFirewall,"[889, 890]"
+      WindowsIndexSearch,[891]
+      WindowsNotificationsDB,"[892, 893]"
+      WindowsOSUpgradeArtifacts,"[894, 895, 896, 897, 898]"
+      WindowsPowerDiagnostics,[899]
+      WindowsSubsystemforAndroid,"[671, 672, 673, 674, 675]"
+      WindowsTelemetryDiagnosticsLegacy,"[900, 901]"
+      WindowsTimeline,[902]
+      WindowsYourPhone,[476]
+      XPRestorePoints,[903]
+      XYplorer,"[477, 478, 479, 480]"
+      iTunesBackup,"[481, 482, 483]"
+      mIRC,"[484, 485]"
+      mRemoteNG,"[486, 487, 488]"
+      openSUSE,"[658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670]"
+      pCloudDatabase,"[489, 490, 491]"
+      qBittorrent,"[939, 940]"
+      uTorrent,[941]
   - name: DontBeLazy
     description: Normally we prefer to use lazy_ntfs for speed. Sometimes this might miss stuff so setting this will fallback to the regular ntfs accessor.
     type: bool
@@ -2171,8 +2043,8 @@ sources:
                a={
 
                    -- Special files we access with the ntfs parser.
-                   SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device,
+                   SELECT * FROM Artifact.Generic.Collectors.File(
+                      Root=Device,
                       Accessor="ntfs",
                       collectionSpec=rule_specs_ntfs)
                }, b={
@@ -2180,8 +2052,8 @@ sources:
                    -- Prefer the auto accessor if possible since it
                    -- will fall back to ntfs if required but otherwise
                    -- will be faster.
-                   SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device,
+                   SELECT * FROM Artifact.Generic.Collectors.File(
+                      Root=Device,
                       Accessor=if(condition=UseAutoAccessor,
                                   then="auto", else="lazy_ntfs"),
                       collectionSpec=rule_specs_lazy_ntfs)
@@ -2248,5 +2120,4 @@ reports:
       {{ end }}
 
       {{ Query $query | Table }}
-
 

--- a/artifacts/testdata/server/testcases/artifacts.out.yaml
+++ b/artifacts/testdata/server/testcases/artifacts.out.yaml
@@ -84,7 +84,7 @@ SELECT *, basename(path=file_store(path=vfs_path)) FROM uploads(client_id='C.4f5
  }
 ]SELECT name FROM artifact_definitions(names='Windows.KapeFiles.Targets') ORDER BY name[
  {
-  "name": "Windows.Collectors.File"
+  "name": "Generic.Collectors.File"
  },
  {
   "name": "Windows.Collectors.VSS"

--- a/scripts/kape_files.py
+++ b/scripts/kape_files.py
@@ -33,11 +33,22 @@ BLACKLISTED = ["!ALL.tkape",
 NOT_NTFS = ["$Recycle.Bin"]
 
 
+def pathsep_converter_win(path):
+    return path.replace("/", "\\")
+
+def pathsep_converter_nix(path):
+    return path.replace("\\", "/")
+
+def pathsep_converter_identity(path):
+    return path
+
+
 class KapeContext:
     groups = {}
     rows = [["Id", "Name", "Category", "Glob", "Accessor", "Comment"]]
     kape_files = []
     kape_data = OrderedDict()
+    pathsep_converter = pathsep_converter_identity
 
 def read_targets(ctx, project_path):
     for root, dirs, files in os.walk(
@@ -82,6 +93,7 @@ def read_targets(ctx, project_path):
 
             glob = strip_drive(glob)
             glob = remove_fluff(glob)
+            glob = ctx.pathsep_converter(glob)
             ctx.rows.append([
                 row_id,
                 target["Name"],
@@ -152,184 +164,6 @@ def remove_fluff(glob):
     return glob.replace('%user%', '*')
 
 def format(ctx):
-    template = """name: Windows.KapeFiles.Targets
-description: |
-
-    Kape is a popular bulk collector tool for triaging a system
-    quickly. While KAPE itself is not an opensource tool, the logic it
-    uses to decide which files to collect is encoded in YAML files
-    hosted on the KapeFiles project
-    (https://github.com/EricZimmerman/KapeFiles) and released under an
-    MIT license.
-
-    This artifact is automatically generated from these YAML files,
-    contributed and maintained by the community. This artifact only
-    encapsulates the KAPE "Targets" - basically a bunch of glob
-    expressions used for collecting files on the endpoint. We do not
-    do any post processing these files - we just collect them.
-
-    We recommend that timeouts and upload limits be used
-    conservatively with this artifact because we can upload really
-    vast quantities of data very quickly.
-
-reference:
-  - https://www.kroll.com/en/insights/publications/cyber/kroll-artifact-parser-extractor-kape
-  - https://github.com/EricZimmerman/KapeFiles
-
-parameters:
-  - name: UseAutoAccessor
-    description: Uses file accessor when possible instead of ntfs parser - this is much faster.
-    type: bool
-    default: Y
-  - name: Device
-    description: Name of the drive letter to search.
-    default: "C:"
-  - name: VSSAnalysis
-    type: bool
-    default:
-    description: If set we run the collection across all VSS and collect only unique changes.
-
-%(parameters)s
-  - name: KapeRules
-    type: hidden
-    description: A CSV file controlling the different Kape Target Rules
-    default: |
-%(csv)s
-  - name: KapeTargets
-    type: hidden
-    description: Each parameter above represents a group of rules to be triggered. This table specifies which rule IDs will be included when the parameter is checked.
-    default: |
-%(rules)s
-  - name: DontBeLazy
-    description: Normally we prefer to use lazy_ntfs for speed. Sometimes this might miss stuff so setting this will fallback to the regular ntfs accessor.
-    type: bool
-
-sources:
-  - name: All File Metadata
-    query: |
-      -- Select all the rule Ids to be included depending on the group
-      -- selection.
-      LET targets <= SELECT * FROM parse_csv(
-           filename=KapeTargets, accessor="data")
-      WHERE get(member=Group) AND log(message="Selecting " + Group)
-
-      -- Filter only the rules in the rule table that have an Id we
-      -- want. Targets with $ in their name probably refer to ntfs
-      -- special files and so they are designated as ntfs
-      -- accessor. Other targets may need ntfs parsing but not
-      -- necessary - they are designated with the lazy_ntfs accessor.
-      LET rule_specs_ntfs <= SELECT Id, Glob
-        FROM parse_csv(filename=KapeRules, accessor="data")
-        WHERE Id in array(array=targets.RuleIds) AND Accessor='ntfs'
-        AND log(message="ntfs: Selecting glob " + Glob)
-
-      LET rule_specs_lazy_ntfs <= SELECT Id, Glob
-        FROM parse_csv(filename=KapeRules, accessor="data")
-        WHERE Id in array(array=targets.RuleIds) AND Accessor='lazy_ntfs'
-        AND log(message="auto: Selecting glob " + Glob)
-
-      -- Call the generic VSS file collector with the globs we want in
-      -- a new CSV file.
-      LET all_results <= SELECT * FROM if(
-           condition=VSSAnalysis,
-           then={
-             SELECT * FROM chain(
-               a={
-                   -- For VSS we always need to parse NTFS
-                   SELECT * FROM Artifact.Windows.Collectors.VSS(
-                      RootDevice=Device, Accessor="ntfs",
-                      collectionSpec=rule_specs_ntfs)
-               }, b={
-                   SELECT * FROM Artifact.Windows.Collectors.VSS(
-                      RootDevice=Device,
-                      Accessor=if(condition=DontBeLazy,
-                                  then="ntfs", else="lazy_ntfs"),
-                      collectionSpec=rule_specs_lazy_ntfs)
-               })
-           }, else={
-             SELECT * FROM chain(
-               a={
-
-                   -- Special files we access with the ntfs parser.
-                   SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device,
-                      Accessor="ntfs",
-                      collectionSpec=rule_specs_ntfs)
-               }, b={
-
-                   -- Prefer the auto accessor if possible since it
-                   -- will fall back to ntfs if required but otherwise
-                   -- will be faster.
-                   SELECT * FROM Artifact.Windows.Collectors.File(
-                      RootDevice=Device,
-                      Accessor=if(condition=UseAutoAccessor,
-                                  then="auto", else="lazy_ntfs"),
-                      collectionSpec=rule_specs_lazy_ntfs)
-               })
-           })
-
-      SELECT * FROM all_results WHERE _Source =~ "Metadata"
-
-  - name: Uploads
-    query: |
-      SELECT * FROM all_results WHERE _Source =~ "Uploads"
-
-reports:
-  - type: CLIENT
-    template: |
-      {{ import "Reporting.Default" "Templates" }}
-
-      <!-- Default report in case the artifact does not have one -->
-      ## {{ .Name }}
-
-      {{ $name := .Name }}
-
-      {{ template "hidden_paragraph_start" dict "description" "View Artifact Description" }}
-
-      {{ Markdown .Description }}
-
-      ### References</h3>
-
-      {{ range .Reference }}
-      * [{{ . }}]({{.}})
-      {{- end }}
-
-      {{ template "hidden_paragraph_end" }}
-
-      {{ $query := print "SELECT SourceFile, Size, Modified, LastAccessed, Created \\
-          FROM source(source='All File Metadata')" }}
-
-      <!-- There could be a huge number of rows just to get the count, so we cap at 10000 -->
-      {{ $count := Get ( Query (print "LET X = " $query " LIMIT 10000 " \\
-         " SELECT 1 AS ALL, count() AS Count FROM X Group BY ALL") | Expand ) \\
-         "0.Count" 0 }}
-
-      <!-- If this is a flow show the parameters. -->
-      {{ $flow := Query "LET X = SELECT Request.Parameters.env AS \\
-         Env FROM flows(client_id=ClientId, flow_id=FlowId)" \\
-         "SELECT * FROM foreach(row=X[0].Env, query={ \\
-             SELECT Key, Value FROM scope()})" | Expand }}
-
-      {{ if $flow }}
-
-      ### Selected Targets
-
-      {{- range $flow -}}{{- if eq (Get . "Value") "Y" }}
-      * {{ Get . "Key" }}
-      {{- end -}}{{- end }}
-      {{ end }}
-
-      ## Files collected
-
-      {{ if gt $count 9999 }}
-      Collected more than {{ $count }} files.
-      {{ else }}
-      Collected a total of {{ $count }} files.
-      {{ end }}
-
-      {{ Query $query | Table }}
-
-"""
     parameters_str = ""
     rules = [["Group", "RuleIds"]]
 
@@ -344,6 +178,9 @@ reports:
         if len(ids) > 0:
             rules.append([sanitize(k), sorted(v)])
 
+    with open(os.path.dirname(__file__) + "/" + ctx.template, "r") as fp:
+        template = fp.read()
+
     print (template % dict(
         parameters=parameters_str,
         rules="\n".join(["      " + x for x in get_csv(rules).splitlines()]),
@@ -354,9 +191,22 @@ reports:
 if __name__ == "__main__":
     argument_parser = argparse.ArgumentParser()
     argument_parser.add_argument("kape_file_path", help="Path to the KapeFiles project")
+    argument_parser.add_argument("-t", "--target", choices=("win", "nix"), help="Which template to fill with data")
 
     args = argument_parser.parse_args()
 
     ctx = KapeContext()
+
+    if args.target == "win":
+        ctx.pathsep_converter = pathsep_converter_win
+        ctx.template = "templates/kape_files_win.yaml.tpl"
+    elif args.target == "nix":
+        ctx.pathsep_converter = pathsep_converter_nix
+        ctx.template = "templates/kape_files_nix.yaml.tpl"
+    else:
+        # fallback to former default behavior
+        ctx.pathsep_converter = pathsep_converter_identity
+        ctx.template = "templates/kape_files_win.yaml.tpl"
+
     read_targets(ctx, args.kape_file_path)
     format(ctx)

--- a/scripts/templates/kape_files_nix.yaml.tpl
+++ b/scripts/templates/kape_files_nix.yaml.tpl
@@ -1,0 +1,128 @@
+name: Linux.KapeFiles.CollectFromDirectory
+description: |
+
+    Kape is a popular bulk collector tool for triaging a system
+    quickly. While KAPE itself is not an opensource tool, the logic it
+    uses to decide which files to collect is encoded in YAML files
+    hosted on the KapeFiles project
+    (https://github.com/EricZimmerman/KapeFiles) and released under an
+    MIT license.
+
+    This artifact is automatically generated from these YAML files,
+    contributed and maintained by the community. This artifact only
+    encapsulates the KAPE "Targets" - basically a bunch of glob
+    expressions used for collecting files on the endpoint. We do not
+    do any post processing these files - we just collect them.
+
+    We recommend that timeouts and upload limits be used
+    conservatively with this artifact because we can upload really
+    vast quantities of data very quickly.
+
+reference:
+  - https://www.kroll.com/en/insights/publications/cyber/kroll-artifact-parser-extractor-kape
+  - https://github.com/EricZimmerman/KapeFiles
+
+type: client
+
+parameters:
+  - name: Device
+    description: Path from where to start the search.
+    default: "/mnt/windows_mount"
+
+%(parameters)s
+  - name: KapeRules
+    type: hidden
+    description: A CSV file controlling the different Kape Target Rules
+    default: |
+%(csv)s
+  - name: KapeTargets
+    type: hidden
+    description: Each parameter above represents a group of rules to be triggered. This table specifies which rule IDs will be included when the parameter is checked.
+    default: |
+%(rules)s
+
+sources:
+  - name: All File Metadata
+    query: |
+      -- Select all the rule Ids to be included depending on the group
+      -- selection.
+      LET targets <= SELECT * FROM parse_csv(
+           filename=KapeTargets, accessor="data")
+      WHERE get(member=Group) AND log(message="Selecting " + Group)
+
+      -- Filter only the rules in the rule table that have an Id we
+      -- want. Targets with $ in their name probably refer to ntfs
+      -- special files and so they are designated as ntfs
+      -- accessor. Other targets may need ntfs parsing but not
+      -- necessary - they are designated with the lazy_ntfs accessor.
+      LET rule_specs <= SELECT Id, Glob
+        FROM parse_csv(filename=KapeRules, accessor="data")
+        WHERE Id in array(array=targets.RuleIds)
+        AND log(message="file: Selecting glob " + Glob)
+
+      -- Call the generic VSS file collector with the globs we want in
+      -- a new CSV file.
+      LET all_results <= SELECT * FROM Artifact.Generic.Collectors.File(
+        Root=Device, Separator="/", Accessor="file", collectionSpec=rule_specs)
+
+      SELECT * FROM all_results WHERE _Source =~ "Metadata"
+
+  - name: Uploads
+    query: |
+      SELECT * FROM all_results WHERE _Source =~ "Uploads"
+
+reports:
+  - type: CLIENT
+    template: |
+      {{ import "Reporting.Default" "Templates" }}
+
+      <!-- Default report in case the artifact does not have one -->
+      ## {{ .Name }}
+
+      {{ $name := .Name }}
+
+      {{ template "hidden_paragraph_start" dict "description" "View Artifact Description" }}
+
+      {{ Markdown .Description }}
+
+      ### References</h3>
+
+      {{ range .Reference }}
+      * [{{ . }}]({{.}})
+      {{- end }}
+
+      {{ template "hidden_paragraph_end" }}
+
+      {{ $query := print "SELECT SourceFile, Size, Modified, LastAccessed, Created \
+          FROM source(source='All File Metadata')" }}
+
+      <!-- There could be a huge number of rows just to get the count, so we cap at 10000 -->
+      {{ $count := Get ( Query (print "LET X = " $query " LIMIT 10000 " \
+         " SELECT 1 AS ALL, count() AS Count FROM X Group BY ALL") | Expand ) \
+         "0.Count" 0 }}
+
+      <!-- If this is a flow show the parameters. -->
+      {{ $flow := Query "LET X = SELECT Request.Parameters.env AS \
+         Env FROM flows(client_id=ClientId, flow_id=FlowId)" \
+         "SELECT * FROM foreach(row=X[0].Env, query={ \
+             SELECT Key, Value FROM scope()})" | Expand }}
+
+      {{ if $flow }}
+
+      ### Selected Targets
+
+      {{- range $flow -}}{{- if eq (Get . "Value") "Y" }}
+      * {{ Get . "Key" }}
+      {{- end -}}{{- end }}
+      {{ end }}
+
+      ## Files collected
+
+      {{ if gt $count 9999 }}
+      Collected more than {{ $count }} files.
+      {{ else }}
+      Collected a total of {{ $count }} files.
+      {{ end }}
+
+      {{ Query $query | Table }}
+

--- a/scripts/templates/kape_files_win.yaml.tpl
+++ b/scripts/templates/kape_files_win.yaml.tpl
@@ -1,0 +1,176 @@
+name: Windows.KapeFiles.Targets
+description: |
+
+    Kape is a popular bulk collector tool for triaging a system
+    quickly. While KAPE itself is not an opensource tool, the logic it
+    uses to decide which files to collect is encoded in YAML files
+    hosted on the KapeFiles project
+    (https://github.com/EricZimmerman/KapeFiles) and released under an
+    MIT license.
+
+    This artifact is automatically generated from these YAML files,
+    contributed and maintained by the community. This artifact only
+    encapsulates the KAPE "Targets" - basically a bunch of glob
+    expressions used for collecting files on the endpoint. We do not
+    do any post processing these files - we just collect them.
+
+    We recommend that timeouts and upload limits be used
+    conservatively with this artifact because we can upload really
+    vast quantities of data very quickly.
+
+reference:
+  - https://www.kroll.com/en/insights/publications/cyber/kroll-artifact-parser-extractor-kape
+  - https://github.com/EricZimmerman/KapeFiles
+
+parameters:
+  - name: UseAutoAccessor
+    description: Uses file accessor when possible instead of ntfs parser - this is much faster.
+    type: bool
+    default: Y
+  - name: Device
+    description: Name of the drive letter to search.
+    default: "C:"
+  - name: VSSAnalysis
+    type: bool
+    default:
+    description: If set we run the collection across all VSS and collect only unique changes.
+
+%(parameters)s
+  - name: KapeRules
+    type: hidden
+    description: A CSV file controlling the different Kape Target Rules
+    default: |
+%(csv)s
+  - name: KapeTargets
+    type: hidden
+    description: Each parameter above represents a group of rules to be triggered. This table specifies which rule IDs will be included when the parameter is checked.
+    default: |
+%(rules)s
+  - name: DontBeLazy
+    description: Normally we prefer to use lazy_ntfs for speed. Sometimes this might miss stuff so setting this will fallback to the regular ntfs accessor.
+    type: bool
+
+sources:
+  - name: All File Metadata
+    query: |
+      -- Select all the rule Ids to be included depending on the group
+      -- selection.
+      LET targets <= SELECT * FROM parse_csv(
+           filename=KapeTargets, accessor="data")
+      WHERE get(member=Group) AND log(message="Selecting " + Group)
+
+      -- Filter only the rules in the rule table that have an Id we
+      -- want. Targets with $ in their name probably refer to ntfs
+      -- special files and so they are designated as ntfs
+      -- accessor. Other targets may need ntfs parsing but not
+      -- necessary - they are designated with the lazy_ntfs accessor.
+      LET rule_specs_ntfs <= SELECT Id, Glob
+        FROM parse_csv(filename=KapeRules, accessor="data")
+        WHERE Id in array(array=targets.RuleIds) AND Accessor='ntfs'
+        AND log(message="ntfs: Selecting glob " + Glob)
+
+      LET rule_specs_lazy_ntfs <= SELECT Id, Glob
+        FROM parse_csv(filename=KapeRules, accessor="data")
+        WHERE Id in array(array=targets.RuleIds) AND Accessor='lazy_ntfs'
+        AND log(message="auto: Selecting glob " + Glob)
+
+      -- Call the generic VSS file collector with the globs we want in
+      -- a new CSV file.
+      LET all_results <= SELECT * FROM if(
+           condition=VSSAnalysis,
+           then={
+             SELECT * FROM chain(
+               a={
+                   -- For VSS we always need to parse NTFS
+                   SELECT * FROM Artifact.Windows.Collectors.VSS(
+                      RootDevice=Device, Accessor="ntfs",
+                      collectionSpec=rule_specs_ntfs)
+               }, b={
+                   SELECT * FROM Artifact.Windows.Collectors.VSS(
+                      RootDevice=Device,
+                      Accessor=if(condition=DontBeLazy,
+                                  then="ntfs", else="lazy_ntfs"),
+                      collectionSpec=rule_specs_lazy_ntfs)
+               })
+           }, else={
+             SELECT * FROM chain(
+               a={
+
+                   -- Special files we access with the ntfs parser.
+                   SELECT * FROM Artifact.Generic.Collectors.File(
+                      Root=Device,
+                      Accessor="ntfs",
+                      collectionSpec=rule_specs_ntfs)
+               }, b={
+
+                   -- Prefer the auto accessor if possible since it
+                   -- will fall back to ntfs if required but otherwise
+                   -- will be faster.
+                   SELECT * FROM Artifact.Generic.Collectors.File(
+                      Root=Device,
+                      Accessor=if(condition=UseAutoAccessor,
+                                  then="auto", else="lazy_ntfs"),
+                      collectionSpec=rule_specs_lazy_ntfs)
+               })
+           })
+
+      SELECT * FROM all_results WHERE _Source =~ "Metadata"
+
+  - name: Uploads
+    query: |
+      SELECT * FROM all_results WHERE _Source =~ "Uploads"
+
+reports:
+  - type: CLIENT
+    template: |
+      {{ import "Reporting.Default" "Templates" }}
+
+      <!-- Default report in case the artifact does not have one -->
+      ## {{ .Name }}
+
+      {{ $name := .Name }}
+
+      {{ template "hidden_paragraph_start" dict "description" "View Artifact Description" }}
+
+      {{ Markdown .Description }}
+
+      ### References</h3>
+
+      {{ range .Reference }}
+      * [{{ . }}]({{.}})
+      {{- end }}
+
+      {{ template "hidden_paragraph_end" }}
+
+      {{ $query := print "SELECT SourceFile, Size, Modified, LastAccessed, Created \
+          FROM source(source='All File Metadata')" }}
+
+      <!-- There could be a huge number of rows just to get the count, so we cap at 10000 -->
+      {{ $count := Get ( Query (print "LET X = " $query " LIMIT 10000 " \
+         " SELECT 1 AS ALL, count() AS Count FROM X Group BY ALL") | Expand ) \
+         "0.Count" 0 }}
+
+      <!-- If this is a flow show the parameters. -->
+      {{ $flow := Query "LET X = SELECT Request.Parameters.env AS \
+         Env FROM flows(client_id=ClientId, flow_id=FlowId)" \
+         "SELECT * FROM foreach(row=X[0].Env, query={ \
+             SELECT Key, Value FROM scope()})" | Expand }}
+
+      {{ if $flow }}
+
+      ### Selected Targets
+
+      {{- range $flow -}}{{- if eq (Get . "Value") "Y" }}
+      * {{ Get . "Key" }}
+      {{- end -}}{{- end }}
+      {{ end }}
+
+      ## Files collected
+
+      {{ if gt $count 9999 }}
+      Collected more than {{ $count }} files.
+      {{ else }}
+      Collected a total of {{ $count }} files.
+      {{ end }}
+
+      {{ Query $query | Table }}


### PR DESCRIPTION
This MR adds an artifact which collects KapeFile targets from a mounted windows drive on a Linux host. It also modifies the generator script to reflect the changes to the Artifacts.