### PR TITLE
rework protobuf message generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ config/ab0x.go
 .eslintcache
 **/.DS_Store
 .DS_Store
+/googleapis

--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,8 @@ require (
 	www.velocidex.com/golang/vtypes v0.0.0-20211203065440-c0c4ffabf7ad
 )
 
+require google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
+
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1 // indirect
 	github.com/PuerkitoBio/goquery v1.6.1 // indirect
@@ -150,6 +152,8 @@ require (
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,7 @@ github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239/go.mod h1:Gdwt2ce0
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -953,6 +954,7 @@ google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/make_proto.sh
+++ b/make_proto.sh
@@ -4,17 +4,33 @@
 
 # This script requires protoc 3.6 +
 
+set -e
+
 CWD=$PWD
 
 if [ -z "$GOPATH" ]; then
     GOPATH="$HOME/go"
 fi
 
-# Stupid workaround due to
-# https://github.com/grpc-ecosystem/grpc-gateway/issues/1065 May need
-# to adjust version - luckily we check in generated go files so we
-# only need to do this once on dev box.
-GOOGLEAPIS=~/go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.14.7/third_party/googleapis/
+GOOGLEAPIS_PATH=$CWD/googleapis/
+GOOGLEAPIS_COMMIT="82a542279"
+
+if [ ! -d "$GOOGLEAPIS_PATH" ]; then
+    git clone https://github.com/googleapis/googleapis/ $GOOGLEAPIS_PATH
+    (cd googleapis && git checkout $GOOGLEAPIS_COMMIT)
+fi
+
+if ! command -v protoc-gen-go > /dev/null; then
+    go install google.golang.org/protobuf/cmd/protoc-gen-go
+fi
+
+if ! command -v protoc-gen-go-grpc > /dev/null; then
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+fi
+
+if ! command -v protoc-gen-grpc-gateway > /dev/null; then
+    go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+fi
 
 for i in $CWD/proto/ $CWD/crypto/proto/ \
                      $CWD/artifacts/proto/ \
@@ -25,27 +41,27 @@ for i in $CWD/proto/ $CWD/crypto/proto/ \
                      $CWD/acls/proto/ \
                      $CWD/flows/proto/ ; do
     echo Building protos in $i
-    echo protoc -I$i -I$GOPATH/src/ -I/usr/local/include/ -I$GOOGLEAPIS -I$CWD --go_out=paths=source_relative:$i $i/*.proto
-    protoc -I$i -I$GOPATH/src/ -I/usr/local/include/ -I$GOOGLEAPIS -I$CWD --go_out=paths=source_relative:$i $i/*.proto
+    echo protoc -I$i -I$GOPATH/src/ -I/usr/local/include/ -I$GOOGLEAPIS_PATH -I$CWD --go_out=paths=source_relative:$i $i/*.proto
+    protoc -I$i -I$GOPATH/src/ -I/usr/local/include/ -I$GOOGLEAPIS_PATH -I$CWD --go_out=paths=source_relative:$i $i/*.proto
 done
 
 # Build GRPC servers.
 for i in  $CWD/api/proto/ ; do
     echo Building protos in $i
     echo protoc -I$i -I. -I$GOPATH/src/ -I/usr/local/include/ \
-           -I$GOOGLEAPIS \
+           -I$GOOGLEAPIS_PATH \
            -I$CWD $i/*.proto --go-grpc_out=paths=source_relative:$i --go_out=paths=source_relative:$i
 
     protoc -I$i -I. -I$GOPATH/src/ -I/usr/local/include/ \
-           -I$GOOGLEAPIS \
+           -I$GOOGLEAPIS_PATH \
            -I$CWD $i/*.proto --go-grpc_out=paths=source_relative:$i --go_out=paths=source_relative:$i
 
     echo protoc -I$i -I. -I$GOPATH/src/ -I/usr/local/include/ \
-           -I$GOOGLEAPIS \
+           -I$GOOGLEAPIS_PATH \
            --grpc-gateway_out=paths=source_relative,logtostderr=true:$i $i/*.proto
 
     protoc -I$i -I. -I$GOPATH/src/ -I/usr/local/include/ \
-           -I$GOOGLEAPIS \
+           -I$GOOGLEAPIS_PATH \
            --grpc-gateway_out=paths=source_relative,logtostderr=true:$i $i/*.proto
 
 done

--- a/tools/grpc-gateway.go
+++ b/tools/grpc-gateway.go
@@ -1,0 +1,11 @@
+// +build tools
+
+package tools
+
+// Imports necessary packages for generating the .pb.go files. Only used
+// to have `go mod tidy' resolve these packages consistently.
+import (
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+)


### PR DESCRIPTION
I am currently trying to work on #1425 and needed to regenerate some protobuf files. Since I could not manage to make the existing way of generating these files work, I upgraded it to a more generic solution. 

For me, this generates the same `.pb.go` files as currently present in the git (minus a change in the file header because I use a version of protoc different to the protoc the files were originally created with). I would be glad if you could confirm that these changes don't break anything.