### PR TITLE
Only pass client config in the client VQL scope.

### DIFF
--- a/actions/vql.go
+++ b/actions/vql.go
@@ -124,7 +124,9 @@ func (self VQLClientAction) StartQuery(
 	}
 
 	builder := services.ScopeBuilder{
-		Config: config_obj,
+		// Only provide the client config since we are running in
+		// client context.
+		ClientConfig: config_obj.Client,
 		// Disable ACLs on the client.
 		ACLManager: vql_subsystem.NullACLManager{},
 		Env:        ordereddict.NewDict(),

--- a/services/repository.go
+++ b/services/repository.go
@@ -65,12 +65,17 @@ func RegisterRepositoryManager(repository RepositoryManager) {
 // Make it easier to build a query scope using the aritfact
 // repository.
 type ScopeBuilder struct {
-	Config     *config_proto.Config
-	ACLManager vql_subsystem.ACLManager
-	Uploader   api.Uploader
-	Logger     *log.Logger
-	Env        *ordereddict.Dict
-	Repository Repository
+	// In server context this contains the full server config required
+	// for server plugins.
+	Config *config_proto.Config
+
+	// If running in client context we only present the client config.
+	ClientConfig *config_proto.ClientConfig
+	ACLManager   vql_subsystem.ACLManager
+	Uploader     api.Uploader
+	Logger       *log.Logger
+	Env          *ordereddict.Dict
+	Repository   Repository
 }
 
 // An artifact repository holds definitions for artifacts.

--- a/services/repository/plugin.go
+++ b/services/repository/plugin.go
@@ -31,6 +31,7 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -87,8 +88,7 @@ func (self *ArtifactRepositoryPlugin) Call(
 
 		config_obj, ok := vql_subsystem.GetServerConfig(scope)
 		if !ok {
-			scope.Log("Failed to get config_obj")
-			return
+			config_obj = &config_proto.Config{}
 		}
 
 		// If the ctx is done do nothing.

--- a/services/repository/scope.go
+++ b/services/repository/scope.go
@@ -40,6 +40,12 @@ func _build(wg *sync.WaitGroup, self services.ScopeBuilder, from_scratch bool) v
 		}
 	}
 
+	// Builder can contain only the client config if it is running on
+	// the client.
+	if self.ClientConfig != nil {
+		env.Set(constants.SCOPE_CONFIG, self.ClientConfig)
+	}
+
 	if self.ACLManager != nil {
 		env.Set(vql_subsystem.ACL_MANAGER_VAR, self.ACLManager)
 	}


### PR DESCRIPTION
Fixed crash in using server VQL plugins in some situations (named inside velociraptor GUI client context).