### PR TITLE
fix APIConfigLoader not applying command line args

### DIFF
--- a/bin/main.go
+++ b/bin/main.go
@@ -161,6 +161,9 @@ func main() {
 		WithFileLoader(*config_path).
 		WithEmbedded().
 		WithEnvLoader("VELOCIRAPTOR_CONFIG").
+		WithConfigMutator(func(config_obj *config_proto.Config) error {
+			return mergeFlagConfig(config_obj, default_config)
+		}).
 		WithCustomValidator(initFilestoreAccessor).
 		WithCustomValidator(initDebugServer).
 		WithCustomValidator(applyMinionRole).


### PR DESCRIPTION
The APIConfigLoader appeared to be missing the mutator which applies overridden command line args. Any flag with the `--config.` prefix was therefore not applied to the generated config object.