### PR TITLE
Flush index from memory to disk 

### DIFF
--- a/bin/index.go
+++ b/bin/index.go
@@ -9,6 +9,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/search"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/client_info"
+	"www.velocidex.com/golang/velociraptor/services/indexing"
 )
 
 var (
@@ -47,9 +48,14 @@ func doRebuildIndex() error {
 		return fmt.Errorf("Starting services: %w", err)
 	}
 
+	err = sm.Start(indexing.StartIndexingService)
+	if err != nil {
+		return fmt.Errorf("Starting index service: %w", err)
+	}
+
 	client_info_manager, err := services.GetClientInfoManager()
 	if err != nil {
-		return fmt.Errorf("Starting services: %w", err)
+		return fmt.Errorf("Starting client info service: %w", err)
 	}
 
 	labeler := services.GetLabeler()
@@ -110,6 +116,7 @@ func doRebuildIndex() error {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/file_store/api/file_store.go
+++ b/file_store/api/file_store.go
@@ -59,6 +59,9 @@ type FileStore interface {
 	ListDirectory(dirname FSPathSpec) ([]FileInfo, error)
 	Delete(filename FSPathSpec) error
 	Move(src, dest FSPathSpec) error
+
+	// Clean up any filestore connections
+	Close() error
 }
 
 type Flusher interface {

--- a/file_store/directory/directory.go
+++ b/file_store/directory/directory.go
@@ -97,6 +97,10 @@ func (self *DirectoryFileStore) Move(src, dest api.FSPathSpec) error {
 	return os.Rename(src_path, dest_path)
 }
 
+func (self *DirectoryFileStore) Close() error {
+	return nil
+}
+
 func (self *DirectoryFileStore) ListDirectory(dirname api.FSPathSpec) (
 	[]api.FileInfo, error) {
 

--- a/file_store/memcache/memcache.go
+++ b/file_store/memcache/memcache.go
@@ -246,6 +246,11 @@ func (self *MemcacheFileStore) Flush() {
 	self.data_cache.Flush()
 }
 
+func (self *MemcacheFileStore) Close() error {
+	self.Flush()
+	return nil
+}
+
 func (self *MemcacheFileStore) Move(src, dest api.FSPathSpec) error {
 	defer api.Instrument("move", "MemcacheFileStore", src)()
 

--- a/file_store/memory/memory.go
+++ b/file_store/memory/memory.go
@@ -391,6 +391,11 @@ func (self *MemoryFileStore) Clear() {
 	self.Paths = ordereddict.NewDict()
 }
 
+func (self *MemoryFileStore) Close() error {
+	self.Clear()
+	return nil
+}
+
 func pathSpecToPath(
 	p api.FSPathSpec, config_obj *config_proto.Config) string {
 	return cleanPathForWindows(p.AsFilestoreFilename(config_obj))

--- a/paths/index.go
+++ b/paths/index.go
@@ -31,6 +31,12 @@ func (self IndexPathManager) EnumerateTerms(term string) api.DSPathSpec {
 	return CLIENT_INDEX_URN.AddUnsafeChild(splitTermToParts(term)...)
 }
 
+func (self IndexPathManager) Snapshot() api.FSPathSpec {
+	return CLIENT_INDEX_URN.AddChild("snapshot").
+		AsFilestorePath().
+		SetType(api.PATH_TYPE_FILESTORE_JSON)
+}
+
 func (self IndexPathManager) TermPartitions(term string) []string {
 	return splitTermToParts(term)
 }

--- a/services/indexing/indexing.go
+++ b/services/indexing/indexing.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/search"
 )
 
@@ -12,6 +13,19 @@ func StartIndexingService(ctx context.Context, wg *sync.WaitGroup,
 	config_obj *config_proto.Config) error {
 
 	search.LoadIndex(ctx, wg, config_obj)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// For the context to be cancelled.
+		<-ctx.Done()
+
+		// Store a snapshot if needed when we terminate
+		file_store_factory := file_store.GetFileStore(config_obj)
+		search.SnapshotIndex(config_obj)
+		file_store_factory.Close()
+	}()
 
 	return nil
 }


### PR DESCRIPTION
Reading and writing result sets is much faster than iterating over
directories. We flush the index into a single result set file periodically so that loading it is much faster.