### PR TITLE
Bugfix: Setting notebook index did not escape username

### DIFF
--- a/search/simple.go
+++ b/search/simple.go
@@ -33,7 +33,7 @@ func SetSimpleIndex(
 		// The entity and keywords are not trusted because
 		// they are user provided.
 		keyword = strings.ToLower(keyword)
-		subject := index_urn.AddChild(keyword, entity)
+		subject := index_urn.AddUnsafeChild(keyword, entity)
 		err := db.SetSubjectWithCompletion(
 			config_obj, subject, &emptypb.Empty{}, nil)
 		if err != nil {


### PR DESCRIPTION
For usernames with email addresses this broke adding notebooks