### PR TITLE
Refactor completion routine calls

### DIFF
--- a/actions/events.go
+++ b/actions/events.go
@@ -294,7 +294,9 @@ func InitializeEventTable(ctx context.Context, service_wg *sync.WaitGroup) {
 		<-ctx.Done()
 
 		mu.Lock()
-		close(GlobalEventTable.Done)
+		if GlobalEventTable.Done != nil {
+			close(GlobalEventTable.Done)
+		}
 		mu.Unlock()
 	}()
 

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -236,8 +236,8 @@ func doClientRPM() error {
 			Name:  "/etc/velociraptor/client.config.yaml",
 			Mode:  0600,
 			Body:  config_file_yaml,
-			Owner: "velociraptor",
-			Group: "velociraptor",
+			Owner: "root",
+			Group: "root",
 		})
 
 	r.AddFile(
@@ -356,8 +356,8 @@ func doClientSysVRPM() error {
 			Name:  "/etc/velociraptor/client.config.yaml",
 			Mode:  0600,
 			Body:  config_file_yaml,
-			Owner: "velociraptor",
-			Group: "velociraptor",
+			Owner: "root",
+			Group: "root",
 		})
 	r.AddFile(
 		rpmpack.RPMFile{

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -636,6 +636,10 @@ message DatastoreConfig {
     // How long to expire the memcache (default 10 min)
     uint64 memcache_expiration_sec = 4;
 
+    // How many mutations to queue up ahead of busy writers. By
+    // default 0 means writes will be blocked until they are handed
+    // off to a writer thread. Set to -1 to disable asynchronous
+    // writes.
     int64 memcache_write_mutation_buffer = 5;
 
     // Number of writing threads - increase for high latency

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"sort"
 	"sync"
@@ -180,7 +179,6 @@ func (self BaseTestSuite) TestSetGetSubject() {
 	vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
 		read_message := &crypto_proto.VeloMessage{}
 		err = self.datastore.GetSubject(self.config_obj, urn, read_message)
-		fmt.Printf("GetSubject %v: %v\n", urn.AsClientPath(), err)
 		return errors.Is(err, os.ErrNotExist)
 	})
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"os"
 	"sort"
 	"sync"
@@ -174,9 +175,12 @@ func (self BaseTestSuite) TestSetGetSubject() {
 	err = self.datastore.DeleteSubject(self.config_obj, urn)
 	assert.NoError(self.T(), err)
 
-	// It should now be cleared
-	err = self.datastore.GetSubject(self.config_obj, urn, read_message)
-	assert.Error(self.T(), err, os.ErrNotExist)
+	// It should eventually be cleared
+	vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
+		read_message := &crypto_proto.VeloMessage{}
+		err = self.datastore.GetSubject(self.config_obj, urn, read_message)
+		return errors.Is(err, os.ErrNotExist)
+	})
 }
 
 func (self BaseTestSuite) TestListChildren() {

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"sort"
 	"sync"
@@ -179,6 +180,7 @@ func (self BaseTestSuite) TestSetGetSubject() {
 	vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
 		read_message := &crypto_proto.VeloMessage{}
 		err = self.datastore.GetSubject(self.config_obj, urn, read_message)
+		fmt.Printf("GetSubject %v: %v\n", urn.AsClientPath(), err)
 		return errors.Is(err, os.ErrNotExist)
 	})
 }

--- a/datastore/memcache.go
+++ b/datastore/memcache.go
@@ -362,8 +362,8 @@ func (self *MemcacheDatastore) GetSubject(
 		}
 
 		if err != nil {
-			return errors.WithMessage(os.ErrNotExist,
-				fmt.Sprintf("While opening %v: not found", urn.AsClientPath()))
+			return fmt.Errorf(
+				"While opening %v: %w", urn.AsClientPath(), os.ErrNotExist)
 		}
 	}
 

--- a/datastore/memcache.go
+++ b/datastore/memcache.go
@@ -373,12 +373,17 @@ func (self *MemcacheDatastore) GetSubject(
 		return internalError
 	}
 
-	serialized_content := bulk_data.data
+	return unmarshalData(bulk_data.data, urn, message)
+}
+
+func unmarshalData(serialized_content []byte,
+	urn api.DSPathSpec, message proto.Message) error {
 	if len(serialized_content) == 0 {
 		return nil
 	}
 
 	// It is really a JSON blob
+	var err error
 	if serialized_content[0] == '{' {
 		err = protojson.Unmarshal(serialized_content, message)
 	} else {
@@ -387,7 +392,7 @@ func (self *MemcacheDatastore) GetSubject(
 
 	if err != nil {
 		return errors.WithMessage(os.ErrNotExist,
-			fmt.Sprintf("While opening %v: %v",
+			fmt.Sprintf("While decoding %v: %v",
 				urn.AsClientPath(), err))
 	}
 	return nil
@@ -420,6 +425,14 @@ func (self *MemcacheDatastore) SetSubjectWithCompletion(
 
 	defer Instrument("write", "MemcacheDatastore", urn)()
 
+	// Make sure to call the completer on all exit points
+	// (MemcacheDatastore is actually synchronous).
+	defer func() {
+		if completion != nil {
+			completion()
+		}
+	}()
+
 	var value []byte
 	var err error
 
@@ -436,11 +449,7 @@ func (self *MemcacheDatastore) SetSubjectWithCompletion(
 		return err
 	}
 
-	err = self.SetData(config_obj, urn, value)
-	if completion != nil {
-		completion()
-	}
-	return err
+	return self.SetData(config_obj, urn, value)
 }
 
 func (self *MemcacheDatastore) SetData(

--- a/datastore/memcache_file.go
+++ b/datastore/memcache_file.go
@@ -43,7 +43,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"strings"
 	"sync"
@@ -214,7 +213,6 @@ func (self *MemcacheFileDataStore) StartWriter(
 						// Call the completion function once we hit
 						// the directory datastore.
 						if mutation.completion != nil {
-							fmt.Printf("Calling completion\n")
 							mutation.completion()
 						}
 					}

--- a/datastore/memcache_file.go
+++ b/datastore/memcache_file.go
@@ -43,6 +43,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"strings"
 	"sync"
@@ -206,12 +207,14 @@ func (self *MemcacheFileDataStore) StartWriter(
 						}
 
 					case MUTATION_OP_DEL_SUBJECT:
+						time.Sleep(100 * time.Millisecond)
 						file_based_imp.DeleteSubject(config_obj, mutation.urn)
 						self.invalidateDirCache(config_obj, mutation.urn.Dir())
 
 						// Call the completion function once we hit
 						// the directory datastore.
 						if mutation.completion != nil {
+							fmt.Printf("Calling completion\n")
 							mutation.completion()
 						}
 					}
@@ -370,7 +373,8 @@ func (self *MemcacheFileDataStore) DeleteSubject(
 	urn api.DSPathSpec) error {
 	defer Instrument("delete", "MemcacheFileDataStore", urn)()
 
-	// Remove immediately from the cache
+	// Remove immediately from the cache memcache as soon as the file
+	// is removed from disk.
 	completion := func() {
 		_ = self.cache.DeleteSubject(config_obj, urn)
 	}

--- a/datastore/memcache_file_test.go
+++ b/datastore/memcache_file_test.go
@@ -53,7 +53,6 @@ func (self *MemcacheFileTestSuite) SetupTest() {
 	self.datastore = db
 
 	db.Clear()
-	fmt.Printf("Starting writers\n")
 	db.StartWriter(self.ctx, &self.wg, self.config_obj)
 }
 
@@ -61,7 +60,6 @@ func (self *MemcacheFileTestSuite) TearDownTest() {
 	self.cancel()
 	self.wg.Wait()
 	os.RemoveAll(self.dirname) // clean up
-	fmt.Printf("Cleanup\n")
 }
 
 func (self MemcacheFileTestSuite) TestSetOnFileSystem() {

--- a/datastore/memcache_file_test.go
+++ b/datastore/memcache_file_test.go
@@ -41,7 +41,7 @@ func (self *MemcacheFileTestSuite) SetupTest() {
 
 	self.config_obj = config.GetDefaultConfig()
 	self.config_obj.Datastore.Implementation = "MemcacheFileDataStore"
-	self.config_obj.Datastore.MemcacheWriteMutationBuffer = -1
+	self.config_obj.Datastore.MemcacheWriteMutationBuffer = 1000
 	self.config_obj.Datastore.FilestoreDirectory = self.dirname
 	self.config_obj.Datastore.Location = self.dirname
 	self.BaseTestSuite.config_obj = self.config_obj

--- a/datastore/memcache_file_test.go
+++ b/datastore/memcache_file_test.go
@@ -53,6 +53,7 @@ func (self *MemcacheFileTestSuite) SetupTest() {
 	self.datastore = db
 
 	db.Clear()
+	fmt.Printf("Starting writers\n")
 	db.StartWriter(self.ctx, &self.wg, self.config_obj)
 }
 
@@ -60,6 +61,7 @@ func (self *MemcacheFileTestSuite) TearDownTest() {
 	self.cancel()
 	self.wg.Wait()
 	os.RemoveAll(self.dirname) // clean up
+	fmt.Printf("Cleanup\n")
 }
 
 func (self MemcacheFileTestSuite) TestSetOnFileSystem() {

--- a/file_store/api/utils.go
+++ b/file_store/api/utils.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+var (
+	// Set this to convert completion functions to synchronous calls.
+	SyncCompleter = func() {
+		fmt.Printf("SyncCompleter should never be called! %v",
+			string(debug.Stack()))
+	}
+)

--- a/file_store/directory/queue.go
+++ b/file_store/directory/queue.go
@@ -187,8 +187,9 @@ func (self *DirectoryQueueManager) Broadcast(
 func (self *DirectoryQueueManager) PushEventRows(
 	path_manager api.PathManager, dict_rows []*ordereddict.Dict) error {
 
+	// Writes are asyncronous.
 	rs_writer, err := result_sets.NewTimedResultSetWriter(
-		self.FileStore, path_manager, nil)
+		self.FileStore, path_manager, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/file_store/memcache/memcache.go
+++ b/file_store/memcache/memcache.go
@@ -17,6 +17,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/directory"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 var (
@@ -43,7 +44,12 @@ type MemcacheFileWriter struct {
 	buffer bytes.Buffer
 	size   int64
 
-	completion func()
+	// We keep a list of completions so we can call them all when a
+	// file is flushed to disk. We keep the file open for a short time
+	// to combine writes to the underlying storage, but if a file is
+	// opened, closed then opened again, we need to fire all the
+	// completions without losing any.
+	completions []func()
 }
 
 func (self *MemcacheFileWriter) Size() (int64, error) {
@@ -104,6 +110,19 @@ func (self *MemcacheFileWriter) Close() error {
 	defer self.mu.Unlock()
 
 	self.closed = true
+
+	// Wait for sync completion outside function lock!
+	wg := sync.WaitGroup{}
+
+	for idx, c := range self.completions {
+		if utils.CompareFuncs(c, api.SyncCompleter) {
+			wg.Add(1)
+
+			defer wg.Wait()
+			self.completions[idx] = wg.Done
+		}
+	}
+
 	return nil
 }
 
@@ -119,6 +138,11 @@ func (self *MemcacheFileWriter) Flush() error {
 }
 
 func (self *MemcacheFileWriter) _Flush() error {
+	defer func() {
+		for _, c := range self.completions {
+			c()
+		}
+	}()
 
 	// Skip a noop action.
 	if !self.truncated && len(self.buffer.Bytes()) == 0 {
@@ -140,10 +164,6 @@ func (self *MemcacheFileWriter) _Flush() error {
 	// Reset the writer for reuse
 	self.truncated = false
 	self.buffer.Truncate(0)
-
-	if self.completion != nil {
-		self.completion()
-	}
 
 	return err
 }
@@ -207,6 +227,7 @@ func (self *MemcacheFileStore) WriteFile(path api.FSPathSpec) (api.FileWriter, e
 func (self *MemcacheFileStore) WriteFileWithCompletion(
 	path api.FSPathSpec, completion func()) (api.FileWriter, error) {
 	defer api.Instrument("write_open", "MemcacheFileStore", path)()
+
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
@@ -217,16 +238,19 @@ func (self *MemcacheFileStore) WriteFileWithCompletion(
 	result_any, err := self.data_cache.Get(key)
 	if err != nil {
 		result = &MemcacheFileWriter{
-			delegate:   self.delegate,
-			key:        key,
-			filename:   path,
-			size:       -1,
-			completion: completion,
+			delegate: self.delegate,
+			key:      key,
+			filename: path,
+			size:     -1,
 		}
 	} else {
 		result = result_any.(*MemcacheFileWriter)
-		result.completion = completion
 		result.closed = false
+	}
+
+	// Add the completion to the writer.
+	if completion != nil {
+		result.completions = append(result.completions, completion)
 	}
 
 	// Always set it so the time can be extended.

--- a/file_store/memcache/memcache.go
+++ b/file_store/memcache/memcache.go
@@ -111,9 +111,9 @@ func (self *MemcacheFileWriter) Close() error {
 
 	self.closed = true
 
-	// Wait for sync completion outside function lock!
+	// Convert all api.SyncCompleter calls to sync waits on return
+	// from Close(). The writer pool will release us when done.
 	wg := sync.WaitGroup{}
-
 	for idx, c := range self.completions {
 		if utils.CompareFuncs(c, api.SyncCompleter) {
 			wg.Add(1)

--- a/file_store/memory/queue.go
+++ b/file_store/memory/queue.go
@@ -174,8 +174,9 @@ func (self *MemoryQueueManager) Broadcast(
 func (self *MemoryQueueManager) PushEventRows(
 	path_manager api.PathManager, dict_rows []*ordereddict.Dict) error {
 
+	// Writes are asyncronous
 	rs_writer, err := result_sets.NewTimedResultSetWriter(
-		self.FileStore, path_manager, nil)
+		self.FileStore, path_manager, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/flows/monitoring.go
+++ b/flows/monitoring.go
@@ -99,8 +99,10 @@ func flushContextLogsMonitoring(
 				return err
 			}
 
+			// Write the logs asynchronously
 			rs_writer, err = result_sets.NewTimedResultSetWriter(
-				file_store_factory, log_path_manager, nil)
+				file_store_factory, log_path_manager, nil,
+				nil /* completion */)
 			if err != nil {
 				return err
 			}

--- a/gui/velociraptor/Makefile
+++ b/gui/velociraptor/Makefile
@@ -1,7 +1,9 @@
 all:
+	echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.16" > 'node_modules/go.mod'
 	npm run start
 
 build: FORCE
+	echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.16" > 'node_modules/go.mod'
 	npm run build
 	echo > build/static/.keep
 

--- a/reporting/gui.go
+++ b/reporting/gui.go
@@ -495,7 +495,9 @@ func (self *GuiTemplateEngine) Query(queries ...string) interface{} {
 
 			rs_writer, err := result_sets.NewResultSetWriter(
 				file_store_factory, path.Path(),
-				opts, true /* truncate */)
+				opts,
+				nil, /* completion - async write */
+				true /* truncate */)
 			if err != nil {
 				self.Error("Error: %v\n", err)
 				return nil

--- a/result_sets/api.go
+++ b/result_sets/api.go
@@ -14,9 +14,6 @@ type ResultSetWriter interface {
 	Flush()
 	Close()
 
-	// Will be called when the result set is flushed to hard storage.
-	SetCompletion(fn func())
-
 	// Ensures that results are flushed to storage as soon as the
 	// writer is closed.
 	SetSync()
@@ -26,9 +23,6 @@ type TimedResultSetWriter interface {
 	Write(row *ordereddict.Dict)
 	Flush()
 	Close()
-
-	// Will be called when the result set is flushed to hard storage.
-	SetCompletion(fn func())
 }
 
 type ResultSetReader interface {

--- a/result_sets/registration.go
+++ b/result_sets/registration.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/Velocidex/json"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
@@ -18,12 +18,14 @@ type TimedFactory interface {
 	NewTimedResultSetWriter(
 		file_store_factory api.FileStore,
 		path_manager api.PathManager,
-		opts *json.EncOpts) (TimedResultSetWriter, error)
+		opts *json.EncOpts,
+		completion func()) (TimedResultSetWriter, error)
 
 	NewTimedResultSetWriterWithClock(
 		file_store_factory api.FileStore,
 		path_manager api.PathManager,
-		opts *json.EncOpts, clock utils.Clock) (TimedResultSetWriter, error)
+		opts *json.EncOpts,
+		completion func(), clock utils.Clock) (TimedResultSetWriter, error)
 
 	NewTimedResultSetReader(
 		ctx context.Context,
@@ -34,23 +36,25 @@ type TimedFactory interface {
 func NewTimedResultSetWriter(
 	file_store_factory api.FileStore,
 	path_manager api.PathManager,
-	opts *json.EncOpts) (TimedResultSetWriter, error) {
+	opts *json.EncOpts,
+	completion func()) (TimedResultSetWriter, error) {
 	if timed_rs_factory == nil {
 		panic(errors.New("TimedFactory not initialized"))
 	}
 	return timed_rs_factory.NewTimedResultSetWriter(file_store_factory,
-		path_manager, opts)
+		path_manager, opts, completion)
 }
 
 func NewTimedResultSetWriterWithClock(
 	file_store_factory api.FileStore,
 	path_manager api.PathManager,
-	opts *json.EncOpts, clock utils.Clock) (TimedResultSetWriter, error) {
+	opts *json.EncOpts,
+	completion func(), clock utils.Clock) (TimedResultSetWriter, error) {
 	if timed_rs_factory == nil {
 		panic(errors.New("TimedFactory not initialized"))
 	}
 	return timed_rs_factory.NewTimedResultSetWriterWithClock(file_store_factory,
-		path_manager, opts, clock)
+		path_manager, opts, completion, clock)
 }
 
 func NewTimedResultSetReader(
@@ -69,6 +73,7 @@ type Factory interface {
 		file_store_factory api.FileStore,
 		log_path api.FSPathSpec,
 		opts *json.EncOpts,
+		completion func(),
 		truncate bool) (ResultSetWriter, error)
 
 	NewResultSetReader(
@@ -81,12 +86,13 @@ func NewResultSetWriter(
 	file_store_factory api.FileStore,
 	log_path api.FSPathSpec,
 	opts *json.EncOpts,
+	completion func(),
 	truncate bool) (ResultSetWriter, error) {
 	if rs_factory == nil {
 		panic(errors.New("ResultSetFactory not initialized"))
 	}
 	return rs_factory.NewResultSetWriter(file_store_factory,
-		log_path, opts, truncate)
+		log_path, opts, completion, truncate)
 
 }
 

--- a/result_sets/simple/simple.go
+++ b/result_sets/simple/simple.go
@@ -54,16 +54,7 @@ type ResultSetWriterImpl struct {
 	fd       api.FileWriter
 	index_fd api.FileWriter
 
-	completion func()
-
 	sync bool
-}
-
-func (self *ResultSetWriterImpl) SetCompletion(completion func()) {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-
-	self.completion = completion
 }
 
 func (self *ResultSetWriterImpl) SetSync() {
@@ -176,6 +167,7 @@ func (self ResultSetFactory) NewResultSetWriter(
 	file_store_factory api.FileStore,
 	log_path api.FSPathSpec,
 	opts *json.EncOpts,
+	completion func(),
 	truncate bool) (result_sets.ResultSetWriter, error) {
 
 	result := &ResultSetWriterImpl{opts: opts}
@@ -186,11 +178,7 @@ func (self ResultSetFactory) NewResultSetWriter(
 	}
 
 	fd, err := file_store_factory.WriteFileWithCompletion(
-		log_path, func() {
-			if result.completion != nil {
-				result.completion()
-			}
-		})
+		log_path, completion)
 	if err != nil {
 		return nil, err
 	}

--- a/result_sets/timed/factory.go
+++ b/result_sets/timed/factory.go
@@ -16,17 +16,19 @@ type TimedFactory struct{}
 func (self TimedFactory) NewTimedResultSetWriter(
 	file_store_factory api.FileStore,
 	path_manager api.PathManager,
-	opts *json.EncOpts) (result_sets.TimedResultSetWriter, error) {
+	opts *json.EncOpts,
+	completion func()) (result_sets.TimedResultSetWriter, error) {
 	return NewTimedResultSetWriter(
-		file_store_factory, path_manager, opts)
+		file_store_factory, path_manager, opts, completion)
 }
 
 func (self TimedFactory) NewTimedResultSetWriterWithClock(
 	file_store_factory api.FileStore,
 	path_manager api.PathManager,
-	opts *json.EncOpts, clock utils.Clock) (result_sets.TimedResultSetWriter, error) {
+	opts *json.EncOpts,
+	completion func(), clock utils.Clock) (result_sets.TimedResultSetWriter, error) {
 	return NewTimedResultSetWriterWithClock(
-		file_store_factory, path_manager, opts, clock)
+		file_store_factory, path_manager, opts, completion, clock)
 }
 
 func (self TimedFactory) NewTimedResultSetReader(

--- a/result_sets/timed/reader.go
+++ b/result_sets/timed/reader.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 	"time"
 
 	"github.com/Velocidex/ordereddict"
@@ -156,15 +155,15 @@ func (self *TimedResultSetReader) maybeUpgradeIndex(
 	// Read all the lines from the json and write them to a new
 	// tmp file.
 	ctx := context.Background()
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
 	new_path := path_manager.Path().
 		SetType(api.PATH_TYPE_FILESTORE_TMP)
 	tmp_path_manager := paths.NewTimelinePathManager("", new_path)
+
+	// Write the tmp file synchronously and then read it again with
+	// the benefit of the index.
 	tmp_writer, err := timelines.NewTimelineWriter(
 		self.file_store_factory, tmp_path_manager,
-		wg.Done, /* completion */
+		api.SyncCompleter, /* completion */
 		true /* truncate */)
 	if err != nil {
 		return nil, err
@@ -178,9 +177,6 @@ func (self *TimedResultSetReader) maybeUpgradeIndex(
 	}
 
 	tmp_writer.Close()
-
-	// Wait until the tmp file is done.
-	wg.Wait()
 
 	// Update the json file itself, and leave the new index
 	// around.

--- a/result_sets/timed/reader_test.go
+++ b/result_sets/timed/reader_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sebdah/goldie"
 	"github.com/stretchr/testify/assert"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/paths/artifacts"
 	"www.velocidex.com/golang/velociraptor/result_sets"
@@ -39,7 +40,7 @@ func (self *TimedResultSetTestSuite) TestTimedResultSetMigration() {
 
 		writer, err := result_sets.NewResultSetWriter(
 			file_store_factory, path_manager.Path(),
-			nil, false /* truncate */)
+			nil, api.SyncCompleter, false /* truncate */)
 		assert.NoError(self.T(), err)
 
 		writer.Write(ordereddict.NewDict().

--- a/services/journal/journal.go
+++ b/services/journal/journal.go
@@ -102,7 +102,9 @@ func (self *JournalService) AppendToResultSet(
 
 	// Append the data to the end of the file.
 	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
-		path, nil, false /* truncate */)
+		path, nil,
+		nil, /* completion - async write */
+		false /* truncate */)
 	if err != nil {
 		return err
 	}

--- a/services/journal/replication.go
+++ b/services/journal/replication.go
@@ -337,7 +337,10 @@ func (self *ReplicationService) AppendToResultSet(
 	file_store_factory := file_store.GetFileStore(config_obj)
 
 	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
-		path, nil, false /* truncate */)
+		path,
+		nil, /* opts */
+		nil, /* completion - async write */
+		false /* truncate */)
 	if err != nil {
 		return err
 	}

--- a/services/notifications/notifications.go
+++ b/services/notifications/notifications.go
@@ -279,9 +279,16 @@ func (self *Notifier) IsClientConnected(
 	}))
 	defer timer.ObserveDuration()
 
-	// Shotcut if the client is directly connected.
+	// Shortcut if the client is directly connected.
 	if self.IsClientDirectlyConnected(client_id) {
 		return true
+	}
+
+	// No directly connected minions right now, and the client is not
+	// connected to us - therefore the client is not available.
+	minion_count := services.GetFrontendManager().GetMinionCount()
+	if minion_count == 0 {
+		return false
 	}
 
 	// Get a unique id for this request.
@@ -299,7 +306,7 @@ func (self *Notifier) IsClientConnected(
 	self.mu.Lock()
 	// Install a tracker to keep track of this request.
 	self.client_connection_tracker[id] = tracker{
-		count: services.GetFrontendManager().GetMinionCount(),
+		count: minion_count,
 		done:  done,
 	}
 	self.mu.Unlock()

--- a/services/server_artifacts/server_artifacts.go
+++ b/services/server_artifacts/server_artifacts.go
@@ -457,7 +457,9 @@ func (self *ServerArtifactsRunner) runQuery(
 			file_store_factory := file_store.GetFileStore(self.config_obj)
 			rs_writer, err = result_sets.NewResultSetWriter(
 				file_store_factory, path_manager.Path(),
-				opts, false /* truncate */)
+				opts,
+				nil, /* completion */
+				false /* truncate */)
 			if err != nil {
 				return err
 			}

--- a/services/server_monitoring/logger.go
+++ b/services/server_monitoring/logger.go
@@ -1,6 +1,8 @@
 package server_monitoring
 
 import (
+	"sync"
+
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -21,8 +23,12 @@ type serverLogger struct {
 func (self *serverLogger) Write(b []byte) (int, error) {
 	file_store_factory := file_store.GetFileStore(self.config_obj)
 
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	wg.Add(1)
 	writer, err := timed.NewTimedResultSetWriterWithClock(
-		file_store_factory, self.path_manager, nil, self.Clock)
+		file_store_factory, self.path_manager, nil, wg.Done, self.Clock)
 	if err != nil {
 		return 0, err
 	}

--- a/services/server_monitoring/logger.go
+++ b/services/server_monitoring/logger.go
@@ -1,8 +1,6 @@
 package server_monitoring
 
 import (
-	"sync"
-
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -23,12 +21,9 @@ type serverLogger struct {
 func (self *serverLogger) Write(b []byte) (int, error) {
 	file_store_factory := file_store.GetFileStore(self.config_obj)
 
-	wg := sync.WaitGroup{}
-	defer wg.Wait()
-
-	wg.Add(1)
 	writer, err := timed.NewTimedResultSetWriterWithClock(
-		file_store_factory, self.path_manager, nil, wg.Done, self.Clock)
+		file_store_factory, self.path_manager, nil,
+		api.SyncCompleter, self.Clock)
 	if err != nil {
 		return 0, err
 	}

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -18,6 +18,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
@@ -255,7 +256,7 @@ func (self *EventTable) RunQuery(
 	scope.Log("server_monitoring: Collecting <green>%v</>", artifact_name)
 
 	rs_writer, err := result_sets.NewTimedResultSetWriterWithClock(
-		file_store_factory, path_manager, opts, self.clock)
+		file_store_factory, path_manager, opts, api.SyncCompleter, self.clock)
 	if err != nil {
 		scope.Close()
 		return err

--- a/timelines/supertimeline.go
+++ b/timelines/supertimeline.go
@@ -171,8 +171,12 @@ func (self *SuperTimelineWriter) Close() {
 func (self *SuperTimelineWriter) AddChild(name string) (*TimelineWriter, error) {
 	new_timeline_path_manager := self.path_manager.GetChild(name)
 	file_store_factory := file_store.GetFileStore(self.config_obj)
+
 	writer, err := NewTimelineWriter(
-		file_store_factory, new_timeline_path_manager, true /* truncate */)
+		file_store_factory,
+		new_timeline_path_manager,
+		nil, /* completion */
+		true /* truncate */)
 	if err != nil {
 		return nil, err
 	}

--- a/timelines/timelines_test.go
+++ b/timelines/timelines_test.go
@@ -96,7 +96,8 @@ func (self *TimelineTestSuite) TestTimelineWriter() {
 		SuperTimeline("T.1234").GetChild("Test")
 
 	file_store_factory := file_store.GetFileStore(self.config_obj)
-	timeline, err := NewTimelineWriter(file_store_factory, path_manager, true /* truncate */)
+	timeline, err := NewTimelineWriter(file_store_factory, path_manager,
+		api.SyncCompleter, true /* truncate */)
 	assert.NoError(self.T(), err)
 
 	for i := int64(0); i <= 10; i++ {

--- a/timelines/writer.go
+++ b/timelines/writer.go
@@ -27,15 +27,10 @@ type IndexRecord struct {
 }
 
 type TimelineWriter struct {
-	last_time  time.Time
-	opts       *json.EncOpts
-	fd         api.FileWriter
-	index_fd   api.FileWriter
-	completion func()
-}
-
-func (self *TimelineWriter) SetCompletion(completion func()) {
-	self.completion = completion
+	last_time time.Time
+	opts      *json.EncOpts
+	fd        api.FileWriter
+	index_fd  api.FileWriter
 }
 
 func (self *TimelineWriter) Write(
@@ -89,16 +84,13 @@ func (self *TimelineWriter) Close() {
 func NewTimelineWriter(
 	file_store_factory api.FileStore,
 	path_manager paths.TimelinePathManagerInterface,
+	completion func(),
 	truncate bool) (*TimelineWriter, error) {
 
 	result := &TimelineWriter{}
 
 	fd, err := file_store_factory.WriteFileWithCompletion(
-		path_manager.Path(), func() {
-			if result.completion != nil {
-				result.completion()
-			}
-		})
+		path_manager.Path(), completion)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/nil.go
+++ b/utils/nil.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"reflect"
+	"runtime"
 
 	"www.velocidex.com/golang/vfilter/types"
 )
@@ -16,4 +17,17 @@ func IsNil(v interface{}) bool {
 		return v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr &&
 			reflect.ValueOf(v).IsNil())
 	}
+}
+
+// Compare two functions by name. This allows setting a constant func
+// as a parameter.
+func CompareFuncs(a func(), b func()) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	name_a := runtime.FuncForPC(reflect.ValueOf(a).Pointer()).Name()
+	name_b := runtime.FuncForPC(reflect.ValueOf(b).Pointer()).Name()
+
+	return name_a == name_b
 }

--- a/vql/server/flows/parallel_test.go
+++ b/vql/server/flows/parallel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sebdah/goldie"
 	"github.com/stretchr/testify/suite"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/logging"
@@ -55,7 +56,7 @@ func (self *TestSuite) TestArtifactSource() {
 	// Append logs to messages from previous packets.
 	rs_writer, err := result_sets.NewResultSetWriter(
 		file_store_factory, path_manager.Path(),
-		nil, true /* truncate */)
+		nil, api.SyncCompleter, true /* truncate */)
 	assert.NoError(self.T(), err)
 
 	for i := 0; i < 100; i++ {
@@ -128,7 +129,8 @@ func (self *TestSuite) TestHuntsSource() {
 	hunt_id := "H.123"
 	hunt_path_manager := paths.NewHuntPathManager(hunt_id).Clients()
 	hunt_rs_writer, err := result_sets.NewResultSetWriter(
-		file_store_factory, hunt_path_manager, nil, true /* truncate */)
+		file_store_factory, hunt_path_manager, nil,
+		api.SyncCompleter, true /* truncate */)
 
 	// Write a bunch of flows in a hunt
 	for client_number := 0; client_number < 10; client_number++ {
@@ -149,7 +151,7 @@ func (self *TestSuite) TestHuntsSource() {
 		// Append logs to messages from previous packets.
 		rs_writer, err := result_sets.NewResultSetWriter(
 			file_store_factory, path_manager.Path(),
-			nil, true /* truncate */)
+			nil, api.SyncCompleter, true /* truncate */)
 		assert.NoError(self.T(), err)
 
 		for i := 0; i < 100; i++ {

--- a/vql/tools/import.go
+++ b/vql/tools/import.go
@@ -17,6 +17,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/glob"
 	"www.velocidex.com/golang/velociraptor/paths"
@@ -146,7 +147,7 @@ func (self ImportCollectionFunction) Call(ctx context.Context,
 
 	uploaded_files_result_set, err := result_sets.NewResultSetWriter(
 		file_store_factory, path_manager.UploadMetadata(),
-		nil, true /* truncate */)
+		nil, api.SyncCompleter, true /* truncate */)
 	if err != nil {
 		scope.Log("import_collection: %v", err)
 		return vfilter.Null{}
@@ -155,7 +156,7 @@ func (self ImportCollectionFunction) Call(ctx context.Context,
 
 	log_result_set, err := result_sets.NewResultSetWriter(
 		file_store_factory, path_manager.Log(),
-		nil, true /* truncate */)
+		nil, api.SyncCompleter, true /* truncate */)
 	if err != nil {
 		scope.Log("import_collection: %v", err)
 		return vfilter.Null{}
@@ -218,7 +219,7 @@ func (self ImportCollectionFunction) Call(ctx context.Context,
 				rs_writer, err := result_sets.NewResultSetWriter(
 					file_store_factory,
 					artifact_path_manager.Path(),
-					nil, true /* truncate */)
+					nil, api.SyncCompleter, true /* truncate */)
 				if err != nil {
 					log("Error copying %v", err)
 					return


### PR DESCRIPTION
- [ ] Make sure that asynchronous operations call completion routines on all

erros paths and in all cases. Failing to do so manifests in missed
events - for example VFSListDirectory of a large directory was failing
to trigger the vfs_service because some completion functions were not
properly called.