### PR TITLE
Set ACE completers per editor to avoid global state.

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -154,7 +154,9 @@ sources:
                  -- Standard string form
                  "2021-08-10T15:34:50Z" AS Time4,
 
-                 FlowId, ClientId, Data, URL, URL AS SafeURL, Base64Data
+                 FlowId, ClientId, URL, URL AS SafeURL, Base64Data,
+
+                 "Hello" AS Data
           FROM scope()
 
       - type: Markdown

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -1365,10 +1365,10 @@
     description: Run this query for each row.
   - name: async
     type: bool
-    description: If set we run all queries asyncronously (implies workers=1000).
+    description: If set we run all queries asynchronously (implies workers=1000).
   - name: workers
     type: int64
-    description: Total number of asyncronous workers.
+    description: Total number of asynchronous workers.
   - name: column
     type: string
     description: If set we only extract the column from row.
@@ -2825,7 +2825,7 @@
     ]
     ```
 
-    The profile is compiled and overlayed on top of the offset specified,
+    The profile is compiled and overlaid on top of the offset specified,
     then the object is emitted with its required fields.
 
     You can read more about profiles here https://github.com/Velocidex/vtypes
@@ -5192,8 +5192,8 @@
     When the rule is provided in the above form, the plugin will
     automatically generate a yara rule which matches any of the specified
     keywords. The specification before the `:` means the same thing as the
-    yara DSL and the following combinations are supported `wide`, `wide
-    ascii`, `wide nocase`, `wide nocase ascii`.
+    yara DSL and the following combinations are supported `wide`,
+    `wide ascii`, `wide nocase`, `wide nocase ascii`.
 
 
     {{% notice note %}}

--- a/gui/velociraptor/src/components/core/ace.js
+++ b/gui/velociraptor/src/components/core/ace.js
@@ -95,7 +95,6 @@ import api from '../core/api-service.js';
 import axios from 'axios';
 
 
-
 export class SettingsButton extends Component {
     static propTypes = {
         ace: PropTypes.object,
@@ -220,12 +219,14 @@ export default class VeloAce extends Component {
         let options = this.getUserOptions();
         let mode = this.props.mode || 'sql';
         let focus = this.props.focus;
+
         if (_.isUndefined(focus)) {
             focus = true;
         }
         return (
             <>
-              <div className={classNames(
+              <div
+                className={classNames(
                   "col-12",
                   "velo-ace-editor",
                   this.props.className)}>
@@ -236,6 +237,7 @@ export default class VeloAce extends Component {
                   focus={focus}
                   mode={mode}
                   theme="github"
+                  placeholder={this.props.placeholder}
                   value={this.props.text || ''}
                   onChange={this.props.onChange}
                   style={

--- a/gui/velociraptor/src/components/forms/regex.js
+++ b/gui/velociraptor/src/components/forms/regex.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import VeloAce from '../core/ace.js';
-import language_tools from 'ace-builds/src-min-noconflict/ext-language_tools.js';
 import Overlay from 'react-bootstrap/Overlay';
 import Tooltip from 'react-bootstrap/Tooltip';
 import "./regex.css";
@@ -154,17 +153,14 @@ export default class RegEx extends React.Component {
     }
 
     aceConfig = (ace) => {
-        language_tools.setCompleters();
-        language_tools.addCompleter(Completer);
-
+        ace.completers = [Completer];
         ace.setOptions({
             maxLines: 5,
             enableLiveAutocompletion: true,
             enableBasicAutocompletion: true,
-            placeholder: "Regular Expression or ? for suggestions",
             showGutter: false,
+            placeholder: "? for suggestions",
         });
-
         this.setState({ace: ace});
     };
 

--- a/gui/velociraptor/src/components/forms/yara.js
+++ b/gui/velociraptor/src/components/forms/yara.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import VeloAce from '../core/ace.js';
 import language_tools from 'ace-builds/src-min-noconflict/ext-language_tools.js';
-import Overlay from 'react-bootstrap/Overlay';
-import Tooltip from 'react-bootstrap/Tooltip';
 import "./regex.css";
 
 import _ from 'lodash';
@@ -81,25 +79,16 @@ export default class YaraEditor extends React.Component {
         error: "",
     };
 
-    constructor(props) {
-        super(props);
-        this.myRef = React.createRef();
-    }
-
     aceConfig = (ace) => {
-        language_tools.setCompleters();
-        language_tools.addCompleter(Completer);
-        language_tools.addCompleter(language_tools.textCompleter);
-
+        ace.completers = [Completer, language_tools.textCompleter];
         ace.setOptions({
             enableLiveAutocompletion: true,
             enableBasicAutocompletion: true,
             autoScrollEditorIntoView: true,
+            placeholder: "? for suggestions",
             showGutter: false,
             maxLines: 25,
-            placeholder: "Paste Yara rule or type ? for template",
         });
-
         this.setState({ace: ace});
     };
 
@@ -111,22 +100,13 @@ export default class YaraEditor extends React.Component {
     render() {
         return (
             <>
-              <div ref={this.myRef}>
-                <Overlay target={this.myRef}
-                         show={!_.isEmpty(this.state.error)}
-                         placement="top">
-                {(props) => (
-                    <Tooltip className="regex-syntax-error" {...props}>
-                      {this.state.error}
-                    </Tooltip>
-                )}
-              </Overlay>
-              <VeloAce text={this.props.value}
-                       focus={false}
-                       className="regex-form"
-                       aceConfig={this.aceConfig}
-                       onChange={this.setValue}
-                       mode="yara" />
+              <div>
+                <VeloAce text={this.props.value}
+                         focus={false}
+                         className="regex-form"
+                         aceConfig={this.aceConfig}
+                         onChange={this.setValue}
+                         mode="yara" />
               </div>
             </>
         );


### PR DESCRIPTION
Avoid use of language_tools which uses global state for all editors.