### PR TITLE
add limitations to description and key path to query

### DIFF
--- a/artifacts/definitions/Windows/Sys/Programs.yaml
+++ b/artifacts/definitions/Windows/Sys/Programs.yaml
@@ -3,6 +3,9 @@ description: |
   Represents products as they are installed by Windows Installer. A product generally
   correlates to one installation package on Windows. Some fields may be blank as Windows
   installation details are left to the discretion of the product author.
+  
+  Limitations: This key parses the live registry hives - if a user is not logged in then their data will not be resident in HKU and therefore you should parse the hives on disk (including within VSS/Regback).
+  
 reference:
   - https://github.com/facebook/osquery/blob/master/specs/windows/programs.table
 
@@ -16,9 +19,10 @@ parameters:
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
-    query: |
-        SELECT Key.Name as Name,
-               Key.Mtime AS MTime,
+    queries:
+      - |
+        SELECT Key.Name as KeyName,
+               Key.Mtime AS KeyLastWriteTimestamp,
                DisplayName,
                DisplayVersion,
                InstallLocation,
@@ -26,6 +30,8 @@ sources:
                Language,
                Publisher,
                UninstallString,
-               InstallDate
+               InstallDate,
+               Key.FullPath as KeyPath
         FROM read_reg_key(globs=split(string=programKeys, sep=',[\\s]*'),
                           accessor="reg")
+                          


### PR DESCRIPTION
Added a limitations section as this artifact parses the live registry. If a user is not logged in their NTUSER will not be parsed. Similarly there is no current support for parsing VSS/Regback stored data.

Also included the keypath to the query to allow examiners to quickly identify which value the key was located in (for ex user and software hive).