### PR TITLE
Update descriptions and keypath

### DIFF
--- a/artifacts/definitions/Windows/Registry/UserAssist.yaml
+++ b/artifacts/definitions/Windows/Registry/UserAssist.yaml
@@ -9,6 +9,8 @@ description: |
   statistical data on the applications launched by the user via
   Windows Explorer. Programs launched via the command­line (cmd.exe)
   do not appear in these registry keys.
+  
+  Additional data not parsed by Velociraptor is the FocusTime and FocusCount however these are not reliable.
 
   From a forensics perspective, being able to decode this information
   can be very useful.
@@ -21,8 +23,7 @@ precondition: SELECT OS From info() where OS = 'windows'
 parameters:
   - name: UserFilter
     default: ""
-    description: If specified we filter by this user ID.
-    type: regex
+    description: If specified we filter by this username.
 
   - name: ExecutionTimeAfter
     default: ""
@@ -32,19 +33,18 @@ parameters:
   - name: UserAssistKey
     default: Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist\*\Count\*
 
-export:
-  LET userAssistProfile = '''
+  - name: userAssistProfile
+    default: |
       [
         ["Header", 0, [
           ["NumberOfExecutions", 4, "uint32"],
           ["LastExecution", 60, "uint64"]
         ]]
       ]
-    '''
 
 sources:
-  - query: |
-      LET TMP = SELECT parse_string_with_regex(
+  - queries:
+      - LET TMP = SELECT url(parse=FullPath).Fragment as _KeyPath, parse_string_with_regex(
                 string=url(parse=FullPath).Fragment,
                 regex="^.+Count\\\\\"?(?P<Name>.+?)\"?$") AS Name, FullPath,
              parse_binary(
@@ -56,9 +56,9 @@ sources:
              parse_string_with_regex(
                string=FullPath,
                regex="Users/(?P<User>[^/]+)/NTUSER").User AS User
-      FROM Artifact.Windows.Registry.NTUser(KeyGlob=UserAssistKey)
+        FROM Artifact.Windows.Registry.NTUser(KeyGlob=UserAssistKey)
 
-      LET UserAssist = SELECT if(condition=Name.Name,
+      - LET UserAssist = SELECT _KeyPath, if(condition=Name.Name,
                    then=rot13(string=Name.Name),
                    else=url(parse=FullPath).Fragment) AS Name,
                User,
@@ -66,16 +66,13 @@ sources:
                timestamp(winfiletime=ParsedUserAssist.LastExecution).Unix AS LastExecutionTS,
                ParsedUserAssist.NumberOfExecutions AS NumberOfExecutions
         FROM TMP
-      LET A1 = SELECT * FROM if(
+      - LET A1 = SELECT * FROM if(
           condition=UserFilter,
           then={
             SELECT * FROM UserAssist WHERE User =~ UserFilter
-          },
-          else={ SELECT * FROM UserAssist})
-
-      SELECT * FROM if(
+          }, else=UserAssist)
+      - SELECT * FROM if(
           condition=ExecutionTimeAfter,
           then={
             SELECT * FROM A1 WHERE LastExecutionTS > ExecutionTimeAfter
-          },
-          else={ SELECT * FROM A1})
+          }, else=A1)


### PR DESCRIPTION
Added description to describe that two fields are not being parsed but are also unreliable so it's ok.
Changed the description of userfilter to 'username' instead of 'user id' in case analysts confuse this for the user SID
Also included the KeyPath as a hidden field as it may be valuable to an investigator.