### PR TITLE
windows.application to windows.applications merge. New firefox history artefact

### DIFF
--- a/artifacts/definitions/Windows/Applications/Firefox/Downloads.yaml
+++ b/artifacts/definitions/Windows/Applications/Firefox/Downloads.yaml
@@ -1,0 +1,67 @@
+name: Custom.Windows.Application.Firefox.Downloads
+description: |
+  Enumerate the users Firefox downloads.
+author: Angry-Bender @angry-bender, based on Custom.Windows.Application.Firefox.History by Zach Stanford @svch0st
+parameters:
+  - name: placesGlobs
+    default: \AppData\Roaming\Mozilla\Firefox\Profiles\*\places.sqlite
+  - name: urlSQLQuery
+    default: |
+        SELECT * FROM moz_annos,moz_anno_attributes,moz_places WHERE moz_annos.place_id=moz_places.id AND moz_annos.anno_attribute_id=moz_anno_attributes.id 
+  - name: userRegex
+    default: .
+    type: regex
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+sources:
+  - query: |
+        LET places_files = SELECT * from foreach(
+          row={
+             SELECT Uid, Name AS User, Directory
+             FROM Artifact.Windows.Sys.Users()
+             WHERE Name =~ userRegex
+          },
+          query={
+             SELECT User, FullPath, Mtime from glob(
+               globs=Directory + placesGlobs)
+          })
+          
+        LET metadata = SELECT * FROM foreach(row=places_files,
+          query={
+            SELECT parse_json(data=content)
+            FROM sqlite(
+              file=FullPath,
+              query=urlSQLQuery)
+             WHERE name = 'downloads/metaData'
+          })
+          
+        SELECT * FROM foreach(row=places_files,
+          query={
+            SELECT User,
+                   timestamp(epoch=dateAdded) as startTime,
+                   if(condition=name=~'metaData',
+                    then=timestamp(epoch=parse_json(data=content).endTime)
+                    ) AS endTime,
+                   timestamp(epoch=lastModified) as last_modified,
+                   id,
+                   name,
+                   url,
+                   place_id,
+                   if(condition=name=~'metaData',
+                    then=parse_json(data=content).fileSize
+                    ) AS fileSize,
+                   if(condition=name=~'metaData',
+                    then=parse_json(data=content).state
+                    ) AS state,
+                   if(condition=name=~'destinationFileURI',
+                    then=content
+                    ) AS localDirectory,
+                   flags,
+                   expiration,
+                   type
+            FROM sqlite(
+              file=FullPath,
+              query=urlSQLQuery)
+            ORDER BY last_modified DESC
+          })

--- a/artifacts/definitions/Windows/Applications/Firefox/Downloads.yaml
+++ b/artifacts/definitions/Windows/Applications/Firefox/Downloads.yaml
@@ -1,4 +1,4 @@
-name: Custom.Windows.Application.Firefox.Downloads
+name: Windows.Application.Firefox.Downloads
 description: |
   Enumerate the users Firefox downloads.
 author: Angry-Bender @angry-bender, based on Custom.Windows.Application.Firefox.History by Zach Stanford @svch0st

--- a/artifacts/definitions/Windows/Applications/Firefox/History.yaml
+++ b/artifacts/definitions/Windows/Applications/Firefox/History.yaml
@@ -1,4 +1,4 @@
-name: Windows.Application.Firefox.History
+name: Windows.Applications.Firefox.History
 description: |
   Enumerate the users Firefox history.
 author: Zach Stanford @svch0st

--- a/artifacts/definitions/Windows/Applications/IISLogs.yaml
+++ b/artifacts/definitions/Windows/Applications/IISLogs.yaml
@@ -1,4 +1,4 @@
-name: Windows.Application.IISLogs
+name: Windows.Applications.IISLogs
 description: |
   This artifact enables grep of IISLogs.
   Parameters include SearchRegex and WhitelistRegex as regex terms.

--- a/artifacts/definitions/Windows/Applications/MegaSync.yaml
+++ b/artifacts/definitions/Windows/Applications/MegaSync.yaml
@@ -1,4 +1,4 @@
-name: Windows.Application.MegaSync
+name: Windows.Applications.MegaSync
 description: |
   This artifact will parse MEGASync logs and enables using regex to search for
   entries of interest.


### PR DESCRIPTION
Merged the file structure from windows.application.firefox to windows.applications.firefox for consistency.

Created a windows.applications.firefox.history artefact. 

![image](https://user-images.githubusercontent.com/18164137/151949309-b7d77ab1-fd96-42d5-84d9-eaec0230cadc.png)
