### PR TITLE
Make GitHub actions more flexible on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         echo %PATH%
         echo %GOPATH%
+        subst X: %CD%
         mklink c:\Users\link c:\Windows
         mkdir "C:\Program Files\Velociraptor"
         mkdir c:\tmp
@@ -99,14 +100,14 @@ jobs:
         vssadmin create shadow /for=c:
 
         echo Running OS generic tests.
-        output\velociraptor.exe -v golden D:\a\velociraptor\velociraptor\artifacts\testdata\server\testcases\ --env srcDir=d:\a\velociraptor\velociraptor\ --config D:\a\velociraptor\velociraptor\artifacts\testdata\windows\github_actions.config.yaml
+        output\velociraptor.exe -v golden X:\artifacts\testdata\server\testcases\ --env srcDir=X:\ --config X:\artifacts\testdata\windows\github_actions.config.yaml
 
     - name: Test Golden Windows
       shell: cmd
       if: always()
       run: |
         echo Running windows specific tests.
-        output\velociraptor.exe -v golden D:\a\velociraptor\velociraptor\artifacts\testdata\windows\ --env srcDir=d:\a\velociraptor\velociraptor\ --config D:\a\velociraptor\velociraptor\artifacts\testdata\windows\github_actions.config.yaml
+        output\velociraptor.exe -v golden X:\artifacts\testdata\windows\ --env srcDir=X:\ --config X:\artifacts\testdata\windows\github_actions.config.yaml
 
     - name: Upload Build Artifacts
       if: always()

--- a/artifacts/testdata/windows/evtx.out.yaml
+++ b/artifacts/testdata/windows/evtx.out.yaml
@@ -62,7 +62,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "TransmittedServices": "-",
   "IpAddress": "::ffff:192.168.63.1",
   "IpPort": "52562",
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4769_Kerbroasting.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\EID4769_Kerbroasting.evtx",
   "_Source": "Windows.EventLogs.Kerbroasting"
  },
  {
@@ -79,7 +79,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "TransmittedServices": "-",
   "IpAddress": "::ffff:192.168.63.1",
   "IpPort": "52564",
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4769_Kerbroasting.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\EID4769_Kerbroasting.evtx",
   "_Source": "Windows.EventLogs.Kerbroasting"
  }
 ]SELECT * FROM Artifact.Windows.EventLogs.PowershellScriptblock(EvtxGlob=srcDir + "/artifacts/testdata/files/EID4104_PowershellScriptblock.evtx", LogLevel="All")[
@@ -97,7 +97,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "Level": 5,
   "Opcode": 15,
   "Task": 2,
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
   "_Source": "Windows.EventLogs.PowershellScriptblock"
  },
  {
@@ -114,7 +114,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "Level": 5,
   "Opcode": 15,
   "Task": 2,
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
   "_Source": "Windows.EventLogs.PowershellScriptblock"
  }
 ]SELECT * FROM Artifact.Windows.EventLogs.PowershellModule(EventLog=srcDir + "/artifacts/testdata/files/EID4103_PowershellModule.evtx" )[
@@ -130,7 +130,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "Level": 4,
   "Opcode": 20,
   "Task": 106,
-  "Source": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4103_PowershellModule.evtx",
+  "Source": "X:\\artifacts\\testdata\\files\\EID4103_PowershellModule.evtx",
   "_Source": "Windows.EventLogs.PowershellModule"
  }
 ]SELECT Message FROM parse_evtx( filename=srcDir + "/artifacts/testdata/files/EID4104_PowershellScriptblock.evtx") LIMIT 1[
@@ -155,7 +155,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   },
   "UserData": null,
   "Message": "Creating Scriptblock text (1 of 1):\nGet-Service | select *\n\nScriptBlock ID: c434040f-afc8-4754-8d7e-b041dd6ad509\nPath: \r\n",
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\EID4104_PowershellScriptblock.evtx",
   "_Source": "Windows.EventLogs.EvtxHunter"
  }
 ]SELECT * FROM Artifact.Windows.EventLogs.ScheduledTasks( Security=srcDir + '/artifacts/testdata/files/SecurityTasks.evtx', TaskScheduler= srcDir + '/artifacts/testdata/files/TaskScheduler.evtx', TaskNameRegex='T1053_005_powershell' )[
@@ -229,7 +229,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
    "RpcCallClientLocality": 0,
    "FQDN": "RE-Dev"
   },
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\SecurityTasks.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\SecurityTasks.evtx",
   "_Source": "Windows.EventLogs.ScheduledTasks"
  },
  {
@@ -255,7 +255,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
    "RpcCallClientLocality": 0,
    "FQDN": "RE-Dev"
   },
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\SecurityTasks.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\SecurityTasks.evtx",
   "_Source": "Windows.EventLogs.ScheduledTasks"
  },
  {
@@ -272,7 +272,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
    "TaskName": "\\T1053_005_powershell",
    "UserName": "RE-DEV\\yolo"
   },
-  "FullPath": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\TaskScheduler.evtx",
+  "FullPath": "X:\\artifacts\\testdata\\files\\TaskScheduler.evtx",
   "_Source": "Windows.EventLogs.ScheduledTasks"
  }
 ]SELECT EventID, DomainName, UserName, LogonType, SourceIP, Description FROM Artifact.Windows.EventLogs.RDPAuth( Security=srcDir + '/artifacts/testdata/files/RDPAuth_Security.evtx', System= srcDir + '/artifacts/testdata/files/RDPAuth_System.evtx', LocalSessionManager= srcDir + '/artifacts/testdata/files/RDPAuth_LocalSessionManager.evtx', RemoteConnectionManager= srcDir + '/artifacts/testdata/files/RDPAuth_RemoteConnectionManager.evtx') WHERE NOT LogonType = 3 GROUP BY EventID[

--- a/artifacts/testdata/windows/github_actions.config.yaml
+++ b/artifacts/testdata/windows/github_actions.config.yaml
@@ -141,4 +141,4 @@ Frontend:
 
 Datastore:
   implementation: FileBaseDataStore
-  filestore_directory: d:\a\velociraptor\velociraptor\artifacts\testdata\server
+  filestore_directory: x:\artifacts\testdata\server

--- a/artifacts/testdata/windows/localhashes.out.yaml
+++ b/artifacts/testdata/windows/localhashes.out.yaml
@@ -6,13 +6,13 @@ SELECT basename(path=FullPath) AS Name, Size, Hash FROM Artifact.Generic.Forensi
  }
 ]SELECT Path, MD5, Size FROM Artifact.Generic.Forensic.LocalHashes.Query( CommaDelimitedHashes="39985be74b8bb4ee716ab55b5f6dfbd4")[
  {
-  "Path": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\Security_1_record.evtx",
+  "Path": "X:\\artifacts\\testdata\\files\\Security_1_record.evtx",
   "MD5": "39985be74b8bb4ee716ab55b5f6dfbd4",
   "Size": 69632
  }
 ]SELECT Path, MD5, Size FROM Artifact.Generic.Forensic.LocalHashes.Query( Hashes="Hash\n39985be74b8bb4ee716ab55b5f6dfbd4")[
  {
-  "Path": "D:\\a\\velociraptor\\velociraptor\\artifacts\\testdata\\files\\Security_1_record.evtx",
+  "Path": "X:\\artifacts\\testdata\\files\\Security_1_record.evtx",
   "MD5": "39985be74b8bb4ee716ab55b5f6dfbd4",
   "Size": 69632
  }

--- a/artifacts/testdata/windows/ntfs.out.yaml
+++ b/artifacts/testdata/windows/ntfs.out.yaml
@@ -6,6 +6,9 @@ SELECT FullPath FROM glob(globs="/*", accessor="ntfs")[
   "FullPath": "\\\\.\\D:"
  },
  {
+  "FullPath": "\\\\.\\X:"
+ },
+ {
   "FullPath": "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1"
  },
  {
@@ -17,6 +20,9 @@ SELECT FullPath FROM glob(globs="/*", accessor="ntfs")[
  },
  {
   "FullPath": "\\\\.\\D:"
+ },
+ {
+  "FullPath": "\\\\.\\X:"
  },
  {
   "FullPath": "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1"
@@ -65,6 +71,9 @@ SELECT FullPath FROM glob(globs="/*", accessor="ntfs")[
   "FullPath": "\\\\.\\D:"
  },
  {
+  "FullPath": "\\\\.\\X:"
+ },
+ {
   "FullPath": "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1"
  },
  {
@@ -76,6 +85,9 @@ SELECT FullPath FROM glob(globs="/*", accessor="ntfs")[
  },
  {
   "FullPath": "\\\\.\\D:"
+ },
+ {
+  "FullPath": "\\\\.\\X:"
  },
  {
   "FullPath": "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1"


### PR DESCRIPTION
There are a number of pathnames that depend on the $GITHUB_WORKSPACE
path being d:\a\velociraptor\velociraptor.  This works for the main
project repository but breaks when the repository uses a different name.

This commit uses drive substitution to map $GITHUB_WORKSPACE to a new X:
drive that can be used directly.