### PR TITLE
Add explicit check of sticky keys

### DIFF
--- a/artifacts/definitions/Windows/Detection/BinaryRename.yaml
+++ b/artifacts/definitions/Windows/Detection/BinaryRename.yaml
@@ -81,6 +81,10 @@ sources:
       FROM glob(globs=TargetGlob)
       WHERE
         NOT IsDir AND NOT IsLink
-        AND ( lowcase(string=VersionInformation.OriginalFilename) in bins.Original
-            OR lowcase(string=VersionInformation.OriginalFilename) in bins.Internal )
-        AND NOT lowcase(string=Name) in bins.Filename
+        AND (
+            (( lowcase(string=VersionInformation.OriginalFilename) in bins.Original
+                OR lowcase(string=VersionInformation.InternalName) in bins.Internal )
+                AND NOT lowcase(string=Name) in bins.Filename )
+        OR FullPath =~ 'C:\\\\Windows\\\\System32\\\\(osk|Magnify|Narrator|DisplaySwitch).exe$'
+            AND NOT VersionInformation.OriginalFilename =~ '^(osk|SR|ScreenMagnifier|DisplaySwitch)\.exe$'
+        )

--- a/artifacts/definitions/Windows/Detection/BinaryRename.yaml
+++ b/artifacts/definitions/Windows/Detection/BinaryRename.yaml
@@ -59,6 +59,7 @@ parameters:
         XXXXX,MEGAcmdShell.exe,MEGAcmdShell,MEGAcmdShell
         XXXXX,pCloud.exe,pCloud.exe,pCloud cloud storage
         XXXXX,,pCloud Drive.exe,pCloud setup
+        XXXXX,mimikatz,mimikatz.exe,Top 5 tool: Mimikatz
         procdump.exe,ProcDump,procdump,Sysinternals process dump utility
         procdump64.exe,ProcDump,procdump,Sysinternals process dump utility
 


### PR DESCRIPTION
Add additional check explicitly for sticky keys paths and checking for known sticky keys original filenames.

Fixed secondary check for internal name that was pointing at original name.