### PR TITLE
Added hashselect arg option to hash()

### DIFF
--- a/artifacts/testdata/server/testcases/hash.in.yaml
+++ b/artifacts/testdata/server/testcases/hash.in.yaml
@@ -1,0 +1,7 @@
+Queries:
+  - SELECT hash(path=srcDir+"/artifacts/testdata/files/hello.zip") AS AllHashes,
+     hash(path=srcDir+"/artifacts/testdata/files/hello.zip",
+          hashselect="md5") AS MD5HashOnly,
+     hash(path=srcDir+"/artifacts/testdata/files/hello.zip",
+          hashselect=["md5", "sha256"]) AS MDHashAndSha256
+    FROM scope()

--- a/artifacts/testdata/server/testcases/hash.out.yaml
+++ b/artifacts/testdata/server/testcases/hash.out.yaml
@@ -1,0 +1,19 @@
+SELECT hash(path=srcDir+"/artifacts/testdata/files/hello.zip") AS AllHashes, hash(path=srcDir+"/artifacts/testdata/files/hello.zip", hashselect="md5") AS MD5HashOnly, hash(path=srcDir+"/artifacts/testdata/files/hello.zip", hashselect=["md5", "sha256"]) AS MDHashAndSha256 FROM scope()[
+ {
+  "AllHashes": {
+   "MD5": "cf2b61489d0564ec415caaa298c5cdd4",
+   "SHA1": "1f7e03e2b3b3225a2e3a9f54daef7d3799f2a4d6",
+   "SHA256": "3726e4d9af228eb0506913c15e0d2db20ec9c0b584d9d698a2254ef537dcf674"
+  },
+  "MD5HashOnly": {
+   "MD5": "cf2b61489d0564ec415caaa298c5cdd4",
+   "SHA1": "",
+   "SHA256": ""
+  },
+  "MDHashAndSha256": {
+   "MD5": "cf2b61489d0564ec415caaa298c5cdd4",
+   "SHA1": "",
+   "SHA256": "3726e4d9af228eb0506913c15e0d2db20ec9c0b584d9d698a2254ef537dcf674"
+  }
+ }
+]

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -1785,6 +1785,9 @@
   - name: accessor
     type: string
     description: The accessor to use
+  - name: hashselect
+    type: []string
+    description: The hash function to use (MD5,SHA1,SHA256)
   category: plugin
 - name: http_client
   description: |


### PR DESCRIPTION
## Created an optional arg for hash() 
### ***hashselect***
Can be used to select one or more hash functions to use rather defaulting to all three.  Could be used to save time when hashing large files when multiple different hashes are not required.

Let me know if any formatting is required.
No testcase added yet. 
`hash(path=FullPath, accessor="auto", hashselect=[SHA1, SHA256])`