### PR TITLE
Add Generic.Detection.HashHunter and tests

### DIFF
--- a/artifacts/definitions/Generic/Detection/HashHunter.yaml
+++ b/artifacts/definitions/Generic/Detection/HashHunter.yaml
@@ -1,0 +1,95 @@
+name: Generic.Detection.HashHunter
+author: "Matt Green - @mgreen27"
+description: |
+    This artifact enables searching for hashes.
+    
+    The artifact takes a glob targetting input, then generates a hash for each 
+    file in scope to compare to several types of hash lists provided by the user.
+    
+    Note: this artifacts filters are cumulative so a hash based hit will return 
+    no results if the file is filtered out by other filters.  
+    For most performant searches leverage path, size and and date filters. By default 
+    the artifact leverages the 'auto' data accessor but can also be changed as desired.  
+
+parameters:
+  - name: TargetGlob
+    description: Glob to target.
+    default: "C:/Users/**/*"
+  - name: Accessor
+    description: Velociraptor accessor to use. Changing to ntfs will increase scan time.
+    default: auto
+  - name: DateAfter
+    description: Search for binaries with timestamps after this date. YYYY-MM-DDTmm:hh:ssZ
+    type: timestamp
+  - name: DateBefore
+    description: Search for binaries with timestamps before this date. YYYY-MM-DDTmm:hh:ssZ
+    type: timestamp
+  - name: SizeMax
+    description: Return binaries only under this size in bytes.
+    type: int64
+    default: 4294967296
+  - name: SizeMin
+    description: Return binaries only over this size in bytes.
+    type: int64
+    default: 0
+  - name: MD5List
+    description: MD5 hash list to hunt for. New MD5 hash on each line
+    default:
+  - name: SHA1List
+    description: SHA1 hash list to hunt for. New SHA1 hash on each line
+    default:
+  - name: SHA256List
+    description: SHA256 hash list to hunt for. New SHA256 hash on each line
+    default:
+
+sources:
+  - query: |
+      -- setup hash lists
+      LET MD5Array <= split(sep='\\s+',string=MD5List)
+      LET SHA1Array <=  split(sep='\\s+',string=SHA1List)
+      LET SHA256Array <= split(sep='\\s+',string=SHA256List)
+      
+      -- firstly find files in scope with performance
+      LET find_files = SELECT * FROM if(condition=DateBefore AND DateAfter,
+            then={
+                SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                FROM glob(globs=TargetGlob,accessor=Accessor,nosymlink='True')
+                WHERE NOT IsDir AND NOT IsLink
+                    AND Size > SizeMin AND Size < SizeMax
+                    AND ( Mtime < DateBefore OR Ctime < DateBefore OR Btime < DateBefore )
+                    AND ( Mtime > DateAfter OR Ctime > DateAfter OR Btime > DateAfter )
+            }, 
+            else={ SELECT * FROM  if(condition=DateBefore,
+                then={
+                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    FROM glob(globs=FullPath,accessor=Accessor)
+                    WHERE NOT IsDir AND NOT IsLink
+                        AND Size > SizeMin AND Size < SizeMax
+                        AND ( Mtime < DateBefore OR Ctime < DateBefore OR Btime < DateBefore )
+                },
+                else={ SELECT * FROM  if(condition=DateAfter,
+                then={
+                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    FROM glob(globs=TargetGlob,accessor=Accessor)
+                    WHERE NOT IsDir AND NOT IsLink
+                        AND Size > SizeMin AND Size < SizeMax
+                        AND ( Mtime > DateAfter OR Ctime > DateAfter OR Btime > DateAfter )
+                },
+                else={
+                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    FROM glob(globs=TargetGlob,accessor=Accessor)
+                    WHERE NOT IsDir AND NOT IsLink
+                        AND Size > SizeMin AND Size < SizeMax
+                })})})
+      
+      
+      -- lookup hash and run finl filters
+      SELECT FullPath,Name,Size,
+        dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
+        hash(path=FullPath) as Hash
+      FROM if(condition= MD5List OR SHA1List OR SHA256List, then= find_files)
+      WHERE 
+        (   if(condition= MD5List,then= Hash.MD5 in MD5Array)
+         OR if(condition= SHA1List,then= Hash.SHA1 in SHA1Array)
+         OR if(condition= SHA256List, then= Hash.SHA256 in SHA256Array)
+        )

--- a/artifacts/testdata/server/testcases/detection.in.yaml
+++ b/artifacts/testdata/server/testcases/detection.in.yaml
@@ -1,0 +1,20 @@
+Parameters:
+  MD5s: |
+      81d9b0a5308f6e46e06567ef9b889496
+      b173bd1934797444b0f8658495ab0765
+      533091d08258bf618871bf5d51858566
+  SHA1s: |
+      c7ccf7f7c65e24137798b2af967620896bdc032c
+      ba4a435cff1897ac653b4c6af43c40b4d01c154c
+      75082bb8c6c3529a298b5e3432a2769362efe451
+  SHA256s: |
+      162e56481955b032cd7b146e0fb08f943dc6bb5ec135a47714de77604b3e032d
+      2227d7bd3c7a36a4d1d103e41df9a18798bf0d22b3e6357ee689d320fd318a24
+      771e8bef3711e8327b5ddb9c6109bd23e494488cccd31097e91033a427e413ef
+
+Queries:
+  # HashHunter Detection
+  - SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", SHA1List=SHA1s,SizeMax=30000)
+  - SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", MD5List=MD5s,SizeMin=20000,SizeMax=30000)
+  - SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", SHA256List=SHA256s,SizeMax=1000)
+ 

--- a/artifacts/testdata/server/testcases/detection.out.yaml
+++ b/artifacts/testdata/server/testcases/detection.out.yaml
@@ -1,0 +1,58 @@
+SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", SHA1List=SHA1s,SizeMax=30000)[
+ {
+  "Name": "1.lnk",
+  "Size": 399,
+  "Hash": {
+   "MD5": "533091d08258bf618871bf5d51858566",
+   "SHA1": "c7ccf7f7c65e24137798b2af967620896bdc032c",
+   "SHA256": "162e56481955b032cd7b146e0fb08f943dc6bb5ec135a47714de77604b3e032d"
+  }
+ },
+ {
+  "Name": "CSDump.bin",
+  "Size": 22000,
+  "Hash": {
+   "MD5": "81d9b0a5308f6e46e06567ef9b889496",
+   "SHA1": "ba4a435cff1897ac653b4c6af43c40b4d01c154c",
+   "SHA256": "2227d7bd3c7a36a4d1d103e41df9a18798bf0d22b3e6357ee689d320fd318a24"
+  }
+ },
+ {
+  "Name": "CSShellcode.bin",
+  "Size": 888,
+  "Hash": {
+   "MD5": "b173bd1934797444b0f8658495ab0765",
+   "SHA1": "75082bb8c6c3529a298b5e3432a2769362efe451",
+   "SHA256": "771e8bef3711e8327b5ddb9c6109bd23e494488cccd31097e91033a427e413ef"
+  }
+ }
+]SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", MD5List=MD5s,SizeMin=20000,SizeMax=30000)[
+ {
+  "Name": "CSDump.bin",
+  "Size": 22000,
+  "Hash": {
+   "MD5": "81d9b0a5308f6e46e06567ef9b889496",
+   "SHA1": "ba4a435cff1897ac653b4c6af43c40b4d01c154c",
+   "SHA256": "2227d7bd3c7a36a4d1d103e41df9a18798bf0d22b3e6357ee689d320fd318a24"
+  }
+ }
+]SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", SHA256List=SHA256s,SizeMax=1000)[
+ {
+  "Name": "1.lnk",
+  "Size": 399,
+  "Hash": {
+   "MD5": "533091d08258bf618871bf5d51858566",
+   "SHA1": "c7ccf7f7c65e24137798b2af967620896bdc032c",
+   "SHA256": "162e56481955b032cd7b146e0fb08f943dc6bb5ec135a47714de77604b3e032d"
+  }
+ },
+ {
+  "Name": "CSShellcode.bin",
+  "Size": 888,
+  "Hash": {
+   "MD5": "b173bd1934797444b0f8658495ab0765",
+   "SHA1": "75082bb8c6c3529a298b5e3432a2769362efe451",
+   "SHA256": "771e8bef3711e8327b5ddb9c6109bd23e494488cccd31097e91033a427e413ef"
+  }
+ }
+]


### PR DESCRIPTION
This artifact enables searching for hashes with best performance.
The artifact takes a glob targeting input, then generates a hash for each file in scope to compare to several types of hash lists provided by the user.

NOTE: I noticed there is also a hash optimisation PR, will aim to also update once included.