### PR TITLE
Add HashHunter hash() update for performance

### DIFF
--- a/artifacts/definitions/Generic/Detection/HashHunter.yaml
+++ b/artifacts/definitions/Generic/Detection/HashHunter.yaml
@@ -53,7 +53,7 @@ sources:
                         then= split(sep='\\s+',string=SHA256List), else=Null)
       
       -- set hash selector for optimised hash calculation
-      LET HashSelector = SELECT * FROM chain(
+      LET HashSelector <= SELECT * FROM chain(
             a={SELECT "MD5" AS Hash FROM scope() WHERE MD5List},
             b={SELECT "SHA1" AS Hash FROM scope() WHERE SHA1List},
             c={SELECT "SHA256" AS Hash FROM scope() WHERE SHA256List})

--- a/artifacts/definitions/Generic/Detection/HashHunter.yaml
+++ b/artifacts/definitions/Generic/Detection/HashHunter.yaml
@@ -54,9 +54,9 @@ sources:
       
       -- set hash selector for optimised hash calculation
       LET HashSelector <= SELECT * FROM chain(
-            a={SELECT "MD5" AS Hash FROM scope() WHERE MD5List},
-            b={SELECT "SHA1" AS Hash FROM scope() WHERE SHA1List},
-            c={SELECT "SHA256" AS Hash FROM scope() WHERE SHA256List})
+          a={ SELECT "MD5" AS Hash FROM scope() WHERE MD5List },
+          b={ SELECT "SHA1" AS Hash FROM scope() WHERE SHA1List },
+          c={ SELECT "SHA256" AS Hash FROM scope() WHERE SHA256List })
       
       -- firstly find files in scope with performance
       LET find_files = SELECT * FROM if(condition=DateBefore AND DateAfter,
@@ -98,7 +98,4 @@ sources:
             hash(path=OSPath,hashselect=HashSelector.Hash) as Hash
         FROM if(condition= HashSelector.Hash, then= find_files)
         WHERE 
-            (   if(condition= MD5List,then= Hash.MD5 in MD5List)
-             OR if(condition= SHA1List,then= Hash.SHA1 in SHA1List)
-             OR if(condition= SHA256List, then= Hash.SHA256 in SHA256List)
-            )
+            ( Hash.MD5 in MD5List OR Hash.SHA1 in SHA1List OR Hash.SHA256 in SHA256List )

--- a/artifacts/definitions/Generic/Detection/HashHunter.yaml
+++ b/artifacts/definitions/Generic/Detection/HashHunter.yaml
@@ -53,15 +53,10 @@ sources:
                         then= split(sep='\\s+',string=SHA256List), else=Null)
       
       -- set hash selector for optimised hash calculation
-      LET HashSelector <= split(string=
-              if(condition= MD5List AND SHA1List AND SHA256List, then= 'MD5 SHA1 SHA256',
-        else= if(condition= MD5List AND SHA1List, then= 'MD5 SHA1',
-        else= if(condition= SHA1List AND SHA256List, then= 'SHA1 SHA256',
-        else= if(condition= MD5List AND SHA256List, then= 'MD5 SHA256',
-        else= if(condition= MD5List, then= 'MD5',
-        else= if(condition= SHA1List, then= 'SHA1',
-        else= if(condition= SHA256List, then= 'SHA256',
-        else= Null ))))))), sep=' ')
+      LET HashSelector = SELECT * FROM chain(
+            a={SELECT "MD5" AS Hash FROM scope() WHERE MD5List},
+            b={SELECT "SHA1" AS Hash FROM scope() WHERE SHA1List},
+            c={SELECT "SHA256" AS Hash FROM scope() WHERE SHA256List})
       
       -- firstly find files in scope with performance
       LET find_files = SELECT * FROM if(condition=DateBefore AND DateAfter,
@@ -100,8 +95,8 @@ sources:
       -- lookup hash and run finl filters
       SELECT OSPath,Name,Size,
             dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
-            hash(path=OSPath,hashselect=HashSelector) as Hash
-        FROM if(condition= HashSelector, then= find_files)
+            hash(path=OSPath,hashselect=HashSelector.Hash) as Hash
+        FROM if(condition= HashSelector.Hash, then= find_files)
         WHERE 
             (   if(condition= MD5List,then= Hash.MD5 in MD5List)
              OR if(condition= SHA1List,then= Hash.SHA1 in SHA1List)

--- a/artifacts/definitions/Generic/Detection/HashHunter.yaml
+++ b/artifacts/definitions/Generic/Detection/HashHunter.yaml
@@ -45,14 +45,28 @@ parameters:
 sources:
   - query: |
       -- setup hash lists
-      LET MD5Array <= split(sep='\\s+',string=MD5List)
-      LET SHA1Array <=  split(sep='\\s+',string=SHA1List)
-      LET SHA256Array <= split(sep='\\s+',string=SHA256List)
+      LET MD5List <= if(condition= MD5List,
+                        then= split(sep='\\s+',string=MD5List), else=Null)
+      LET SHA1List <= if(condition= SHA1List,
+                        then= split(sep='\\s+',string=SHA1List), else=Null)
+      LET SHA256List <= if(condition= SHA256List,
+                        then= split(sep='\\s+',string=SHA256List), else=Null)
+      
+      -- set hash selector for optimised hash calculation
+      LET HashSelector <= split(string=
+              if(condition= MD5List AND SHA1List AND SHA256List, then= 'MD5 SHA1 SHA256',
+        else= if(condition= MD5List AND SHA1List, then= 'MD5 SHA1',
+        else= if(condition= SHA1List AND SHA256List, then= 'SHA1 SHA256',
+        else= if(condition= MD5List AND SHA256List, then= 'MD5 SHA256',
+        else= if(condition= MD5List, then= 'MD5',
+        else= if(condition= SHA1List, then= 'SHA1',
+        else= if(condition= SHA256List, then= 'SHA256',
+        else= Null ))))))), sep=' ')
       
       -- firstly find files in scope with performance
       LET find_files = SELECT * FROM if(condition=DateBefore AND DateAfter,
             then={
-                SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                SELECT OSPath, Name, Size,Mtime,Atime,Ctime,Btime
                 FROM glob(globs=TargetGlob,accessor=Accessor,nosymlink='True')
                 WHERE NOT IsDir AND NOT IsLink
                     AND Size > SizeMin AND Size < SizeMax
@@ -61,22 +75,22 @@ sources:
             }, 
             else={ SELECT * FROM  if(condition=DateBefore,
                 then={
-                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
-                    FROM glob(globs=FullPath,accessor=Accessor)
+                    SELECT OSPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    FROM glob(globs=OSPath,accessor=Accessor)
                     WHERE NOT IsDir AND NOT IsLink
                         AND Size > SizeMin AND Size < SizeMax
                         AND ( Mtime < DateBefore OR Ctime < DateBefore OR Btime < DateBefore )
                 },
                 else={ SELECT * FROM  if(condition=DateAfter,
                 then={
-                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    SELECT OSPath, Name, Size,Mtime,Atime,Ctime,Btime
                     FROM glob(globs=TargetGlob,accessor=Accessor)
                     WHERE NOT IsDir AND NOT IsLink
                         AND Size > SizeMin AND Size < SizeMax
                         AND ( Mtime > DateAfter OR Ctime > DateAfter OR Btime > DateAfter )
                 },
                 else={
-                    SELECT FullPath, Name, Size,Mtime,Atime,Ctime,Btime
+                    SELECT OSPath, Name, Size,Mtime,Atime,Ctime,Btime
                     FROM glob(globs=TargetGlob,accessor=Accessor)
                     WHERE NOT IsDir AND NOT IsLink
                         AND Size > SizeMin AND Size < SizeMax
@@ -84,12 +98,12 @@ sources:
       
       
       -- lookup hash and run finl filters
-      SELECT FullPath,Name,Size,
-        dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
-        hash(path=FullPath) as Hash
-      FROM if(condition= MD5List OR SHA1List OR SHA256List, then= find_files)
-      WHERE 
-        (   if(condition= MD5List,then= Hash.MD5 in MD5Array)
-         OR if(condition= SHA1List,then= Hash.SHA1 in SHA1Array)
-         OR if(condition= SHA256List, then= Hash.SHA256 in SHA256Array)
-        )
+      SELECT OSPath,Name,Size,
+            dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
+            hash(path=OSPath,hashselect=HashSelector) as Hash
+        FROM if(condition= HashSelector, then= find_files)
+        WHERE 
+            (   if(condition= MD5List,then= Hash.MD5 in MD5List)
+             OR if(condition= SHA1List,then= Hash.SHA1 in SHA1List)
+             OR if(condition= SHA256List, then= Hash.SHA256 in SHA256List)
+            )

--- a/artifacts/testdata/server/testcases/detection.out.yaml
+++ b/artifacts/testdata/server/testcases/detection.out.yaml
@@ -3,27 +3,27 @@ SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcD
   "Name": "1.lnk",
   "Size": 399,
   "Hash": {
-   "MD5": "533091d08258bf618871bf5d51858566",
+   "MD5": "",
    "SHA1": "c7ccf7f7c65e24137798b2af967620896bdc032c",
-   "SHA256": "162e56481955b032cd7b146e0fb08f943dc6bb5ec135a47714de77604b3e032d"
+   "SHA256": ""
   }
  },
  {
   "Name": "CSDump.bin",
   "Size": 22000,
   "Hash": {
-   "MD5": "81d9b0a5308f6e46e06567ef9b889496",
+   "MD5": "",
    "SHA1": "ba4a435cff1897ac653b4c6af43c40b4d01c154c",
-   "SHA256": "2227d7bd3c7a36a4d1d103e41df9a18798bf0d22b3e6357ee689d320fd318a24"
+   "SHA256": ""
   }
  },
  {
   "Name": "CSShellcode.bin",
   "Size": 888,
   "Hash": {
-   "MD5": "b173bd1934797444b0f8658495ab0765",
+   "MD5": "",
    "SHA1": "75082bb8c6c3529a298b5e3432a2769362efe451",
-   "SHA256": "771e8bef3711e8327b5ddb9c6109bd23e494488cccd31097e91033a427e413ef"
+   "SHA256": ""
   }
  }
 ]SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", MD5List=MD5s,SizeMin=20000,SizeMax=30000)[
@@ -32,8 +32,8 @@ SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcD
   "Size": 22000,
   "Hash": {
    "MD5": "81d9b0a5308f6e46e06567ef9b889496",
-   "SHA1": "ba4a435cff1897ac653b4c6af43c40b4d01c154c",
-   "SHA256": "2227d7bd3c7a36a4d1d103e41df9a18798bf0d22b3e6357ee689d320fd318a24"
+   "SHA1": "",
+   "SHA256": ""
   }
  }
 ]SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcDir + "/artifacts/testdata/files/*", SHA256List=SHA256s,SizeMax=1000)[
@@ -41,8 +41,8 @@ SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcD
   "Name": "1.lnk",
   "Size": 399,
   "Hash": {
-   "MD5": "533091d08258bf618871bf5d51858566",
-   "SHA1": "c7ccf7f7c65e24137798b2af967620896bdc032c",
+   "MD5": "",
+   "SHA1": "",
    "SHA256": "162e56481955b032cd7b146e0fb08f943dc6bb5ec135a47714de77604b3e032d"
   }
  },
@@ -50,8 +50,8 @@ SELECT Name,Size,Hash FROM Artifact.Generic.Detection.HashHunter(TargetGlob=srcD
   "Name": "CSShellcode.bin",
   "Size": 888,
   "Hash": {
-   "MD5": "b173bd1934797444b0f8658495ab0765",
-   "SHA1": "75082bb8c6c3529a298b5e3432a2769362efe451",
+   "MD5": "",
+   "SHA1": "",
    "SHA256": "771e8bef3711e8327b5ddb9c6109bd23e494488cccd31097e91033a427e413ef"
   }
  }


### PR DESCRIPTION
Added update to take advantage of hash() algorithm targeting. 
The hash() function will only process hash types that have been requested a match.
Added OSPath notation.