### PR TITLE
Elastic.Events.Clients: synchronize parameters with Elastic.Flows.Upload

### DIFF
--- a/artifacts/definitions/Elastic/Events/Clients.yaml
+++ b/artifacts/definitions/Elastic/Events/Clients.yaml
@@ -24,6 +24,9 @@ parameters:
     type: bool
   - name: ElasticAddresses
     default: http://127.0.0.1:9200/
+  - name: Username
+  - name: Password
+  - name: Apikey
   - name: artifactParameterMap
     type: hidden
     default: |
@@ -52,5 +55,9 @@ sources:
 
       SELECT * FROM elastic_upload(
           query=events,
-          type="ClientEvents",
-          addresses=split(string=ElasticAddresses, sep=","))
+          addresses=split(string=ElasticAddresses, sep=","),
+          index="velociraptor",
+          password=Password,
+          username=Username,
+          api_key=APIKey,
+          type="ClientEvents")


### PR DESCRIPTION
The Elastic.Events.Clients artifact can only connect to an
unauthenticated endpoint while the Elastic.Flows.Upload
artifact can connect to authenticated endpoints via api key or
username/password basic auth.  This commit syncs the configuration
options with Elastic.Flows.Upload so that the authentication parameters
are properly passed.  It also uses the velociraptor index.