### PR TITLE
Bugfix: Write one index item per JSONL record.

### DIFF
--- a/artifacts/definitions/Elastic/Events/Clients.yaml
+++ b/artifacts/definitions/Elastic/Events/Clients.yaml
@@ -50,6 +50,7 @@ sources:
           query={
              SELECT *, "Artifact_" + Artifact as _index,
                     Artifact,
+                    client_info(client_id=ClientId).os_info.hostname AS Hostname,
                     timestamp(epoch=now()) AS timestamp
              FROM watch_monitoring(artifact=Artifact)
           })

--- a/artifacts/definitions/Elastic/Flows/Upload.yaml
+++ b/artifacts/definitions/Elastic/Flows/Upload.yaml
@@ -48,6 +48,7 @@ sources:
                  row=Flow.artifacts_with_results,
                  query={
                      SELECT *, _value AS Artifact,
+                            client_info(client_id=ClientId).os_info.hostname AS Hostname,
                             timestamp(epoch=now()) AS timestamp,
                             ClientId, Flow.session_id AS FlowId,
                             "artifact_" + regex_replace(source=_value,

--- a/flows/monitoring.go
+++ b/flows/monitoring.go
@@ -2,7 +2,6 @@ package flows
 
 import (
 	"bytes"
-	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/prometheus/client_golang/prometheus"
@@ -110,7 +109,6 @@ func flushContextLogsMonitoring(
 		}
 
 		rs_writer.Write(ordereddict.NewDict().
-			Set("_ts", int(time.Now().Unix())).
 			Set("client_time", int64(row.Timestamp)/1000000).
 			Set("level", row.Level).
 			Set("message", row.Message))


### PR DESCRIPTION
When writing multiple JSONL lines it is more efficient to write a
batch without parsing the JSONL using
TimedResultSetWriterImpl.WriteJSONL but this function previously only
wrote a single index item.

However since the JSONL may contain multiple rows, we need to write
multiple index items.