### PR TITLE
Bugfix: Hunt stats were not properly incremented

### DIFF
--- a/services/hunt_manager/hunt_manager.go
+++ b/services/hunt_manager/hunt_manager.go
@@ -343,7 +343,7 @@ func (self *HuntManager) ProcessFlowCompletion(
 		return err
 	}
 
-	if flow.Request == nil || len(flow.Request.Artifacts) == 0 {
+	if flow.Request == nil {
 		return nil
 	}
 
@@ -362,10 +362,10 @@ func (self *HuntManager) ProcessFlowCompletion(
 		Stats:  &api_proto.HuntStats{},
 	}
 
-	if len(flow.ArtifactsWithResults) > 0 {
-		mutation.Stats.TotalClientsWithResults = 1
-	}
+	// All completions increment this counter.
+	mutation.Stats.TotalClientsWithResults = 1
 
+	// Only errored completions increment this one.
 	if flow.State == flows_proto.ArtifactCollectorContext_ERROR {
 		mutation.Stats.TotalClientsWithErrors = 1
 	}

--- a/services/hunt_manager/hunt_manager_test.go
+++ b/services/hunt_manager/hunt_manager_test.go
@@ -664,8 +664,10 @@ func (self *HuntTestSuite) TestHuntManagerMutations() {
 	// System.Flow.Completion event, the hunt manager should
 	// increment the total clients completed.
 	flow_obj := &flows_proto.ArtifactCollectorContext{
-		Request:              proto.Clone(hunt_obj.StartRequest).(*flows_proto.ArtifactCollectorArgs),
-		ArtifactsWithResults: hunt_obj.StartRequest.Artifacts,
+		Request: proto.Clone(
+			hunt_obj.StartRequest).(*flows_proto.ArtifactCollectorArgs),
+		// No actual results but the collection is done. See #1743.
+		ArtifactsWithResults: nil,
 		State:                flows_proto.ArtifactCollectorContext_FINISHED,
 	}
 


### PR DESCRIPTION
Instead of counting all flow completions into the Finished Clients
counter, only flows with results were added. This meant flows that
produced no results did not count as finished.