### PR TITLE
SysmonInstall artifact now skips install if not needed

### DIFF
--- a/artifacts/definitions/Windows/Events/TrackProcesses.yaml
+++ b/artifacts/definitions/Windows/Events/TrackProcesses.yaml
@@ -22,14 +22,33 @@ parameters:
     type: int64
     description: Maximum size of the in memory process cache (default 10k)
 
+  - name: SysmonFileLocation
+    description: If set, we check this location first for sysmon installed.
+    default: C:/Windows/sysmon64.exe
+
+tools:
+  - name: SysmonBinary
+    url: https://live.sysinternals.com/tools/sysmon64.exe
+    serve_locally: true
+
+  - name: SysmonConfig
+    url: https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml
+    serve_locally: true
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
 
     query: |
-        LET UpdateQuery =
+      // Make sure sysmon is installed.
+      LET _ <= SELECT * FROM Artifact.Windows.Sysinternals.SysmonInstall(
+         SysmonFileLocation=SysmonFileLocation)
+
+      LET UpdateQuery =
             SELECT * FROM foreach(row={
-              SELECT * FROM watch_etw(guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}')
+              SELECT *,
+                     get(member='EventData') AS EventData
+              FROM watch_etw(guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}')
             }, query={
               SELECT * FROM switch(
               start={
@@ -57,7 +76,7 @@ sources:
             })
 
 
-        LET Tracker <= process_tracker(sync_query={
+      LET Tracker <= process_tracker(sync_query={
               SELECT Pid AS id,
                  Ppid AS parent_id,
                  CreateTime AS start_time,
@@ -68,5 +87,5 @@ sources:
               FROM pslist()
         }, update_query=UpdateQuery, sync_period=600000)
 
-        SELECT * FROM process_tracker_updates()
-        WHERE update_type = "stats" OR AlsoForwardUpdates
+      SELECT * FROM process_tracker_updates()
+      WHERE update_type = "stats" OR AlsoForwardUpdates

--- a/artifacts/definitions/Windows/Sysinternals/SysmonInstall.yaml
+++ b/artifacts/definitions/Windows/Sysinternals/SysmonInstall.yaml
@@ -37,8 +37,16 @@ sources:
        ToolName="SysmonBinary")
     })
 
-    LET sysmon_config <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(
+    LET existing_hash = SELECT lowcase(
+       string=parse_string_with_regex(
+          string=Stdout, regex="hash:.+SHA256=([^\\n\\r]+)").g1) AS Hash
+    FROM execve(argv=[bin[0].FullPath, "-c"])
+
+    LET sysmon_config = SELECT * FROM Artifact.Generic.Utils.FetchBinary(
        ToolName="SysmonConfig", IsExecutable=FALSE)
+
+    LET ensure_service_running =
+       SELECT * FROM execve(argv=["sc.exe", "start", "sysmon64"])
 
     LET doit = SELECT * FROM chain(
     a={
@@ -47,6 +55,21 @@ sources:
     }, b={
        SELECT * FROM execve(argv= [ bin[0].FullPath,
            "-accepteula", "-i", sysmon_config[0].FullPath ], length=10000000)
-    })
+    }, c=ensure_service_running)
 
-    SELECT * FROM if(condition=bin AND sysmon_config, then=doit)
+    // Only install sysmon if the existing config hash is not the same
+    // as the specified hash.
+    SELECT * FROM if(
+    condition=if(
+        condition=bin AND sysmon_config,
+        else=log(message="Failed to fetch sysmon tools!"),
+        then=if(
+           condition=existing_hash[0].Hash != Tool_SysmonConfig_HASH,
+           then=log(message="Sysmon config hash has changed (%v vs %v) - reinstalling",
+                    args=[existing_hash[0].Hash, Tool_SysmonConfig_HASH]),
+           else=log(message="Existing sysmon config hash has not changed (%v) - skipping reinstall",
+                    args=Tool_SysmonConfig_HASH) AND FALSE
+          )
+        ),
+    then={ SELECT * FROM doit },
+    else={ SELECT * FROM ensure_service_running })

--- a/artifacts/definitions/Windows/Sysinternals/SysmonLogForward.yaml
+++ b/artifacts/definitions/Windows/Sysinternals/SysmonLogForward.yaml
@@ -6,14 +6,29 @@ type: CLIENT_EVENT
 
 precondition: SELECT OS From info() where OS = 'windows'
 
+tools:
+  - name: SysmonBinary
+    url: https://live.sysinternals.com/tools/sysmon64.exe
+    serve_locally: true
+
+  - name: SysmonConfig
+    url: https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml
+    serve_locally: true
+
+parameters:
+  - name: SysmonFileLocation
+    description: If set, we check this location first for sysmon installed.
+    default: C:/Windows/sysmon64.exe
+
 sources:
 - query: |
     // First ensure that sysmon is actually installed.
-    LET _ <= SELECT * FROM Artifact.Windows.Sysinternals.SysmonInstall()
+    LET _ <= SELECT * FROM Artifact.Windows.Sysinternals.SysmonInstall(
+        SysmonFileLocation=SysmonFileLocation)
 
     // Just parse and forward events. Use ETW rather than watch_evtx()
     // because it is a little bit faster.
     SELECT System.ID AS ID,
            System.TimeStamp AS Timestamp,
-           EventData
+           get(member='EventData') AS EventData
     FROM watch_etw(guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}')


### PR DESCRIPTION
We can ask sysmon what hash it has for its installed config, if it is
already configured the same way, we can skip the install