### PR TITLE
Fix deadlock in hunt dispatcher

### DIFF
--- a/artifacts/definitions/Windows/System/LocalAdmins.yaml
+++ b/artifacts/definitions/Windows/System/LocalAdmins.yaml
@@ -7,6 +7,9 @@ reference:
 
 type: CLIENT
 
+required_permissions:
+  - EXECVE
+
 parameters:
   - name: groupname
     default: Administrators

--- a/gui/velociraptor/src/components/i8n/de.js
+++ b/gui/velociraptor/src/components/i8n/de.js
@@ -130,7 +130,6 @@ const Deutsch = {
     "Artifact Collection": "Sammlung von Artefakten",
     "Uploaded Files": "Hochgeladene Dateien",
     "Results": "Ergebnisse",
-    "Log":"Logdatei",
     "Flow Details": "Flow-Details",
     "Notebook for Collection": name=>"Notizbuch für die Sammlung "+name,
     "Please click a collection in the above table":"Bitte klicken Sie auf eine Sammlung in der obigen Tabelle",
@@ -327,7 +326,6 @@ const Deutsch = {
     "client_time":"Client-Zeit",
     "level":"Ebene",
     "message":"Nachricht",
-    "Type":"Typ",
 
     "RecursiveVFSMessage": path=><>
     Sie sind dabei, alle Dateien in <b>{path}</b> rekursiv abzurufen.

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -290,6 +290,7 @@ func (self *HuntDispatcher) ModifyHuntObject(
 	self.mu.Lock()
 	hunt_obj, pres := self.hunts[hunt_id]
 	if !pres {
+		self.mu.Unlock()
 		return services.HuntUnmodified
 	}
 

--- a/vql/vql.go
+++ b/vql/vql.go
@@ -46,9 +46,18 @@ var (
 	})
 )
 
+// Used when we deliberately want to override a registered plugin.
 func OverridePlugin(plugin vfilter.PluginGeneratorInterface) {
 	name := plugin.Info(nil, nil).Name
 	exportedPlugins[name] = plugin
+
+	ResetGlobalScopeCache()
+}
+
+// Used when we deliberately want to override a registered function.
+func OverrideFunction(function vfilter.FunctionInterface) {
+	name := function.Info(nil, nil).Name
+	exportedFunctions[name] = function
 
 	ResetGlobalScopeCache()
 }


### PR DESCRIPTION
If an invalid hunt id is queried, error path did not remove lock.