### PR TITLE
Bugfix: VFS viewer was unable to access files with \ in name

### DIFF
--- a/accessors/vql_arg_parser.go
+++ b/accessors/vql_arg_parser.go
@@ -56,6 +56,28 @@ func parseOSPath(ctx context.Context,
 		}
 		return MustNewFileStorePath("ds:").Append(components...), nil
 
+		// WHERE version(plugin="glob") > 2:
+		// Initializer can be a list of components. In this case we
+		// take the base pathspec (which is accessor determined) and
+		// add the components to it.
+	case []types.Any:
+		components := make([]string, 0, len(t))
+		for _, i := range t {
+			i_str, ok := i.(string)
+			if ok {
+				components = append(components, i_str)
+			}
+		}
+
+		// Build a pathspec from the accessor and the components.
+		base, err := accessor.ParsePath("")
+		if err != nil {
+			return nil, err
+		}
+
+		base.Components = append(base.Components, components...)
+		return base, nil
+
 	case string:
 		return accessor.ParsePath(t)
 

--- a/accessors/vql_arg_parser.go
+++ b/accessors/vql_arg_parser.go
@@ -78,6 +78,16 @@ func parseOSPath(ctx context.Context,
 		base.Components = append(base.Components, components...)
 		return base, nil
 
+	case []string:
+		// Build a pathspec from the accessor and the components.
+		base, err := accessor.ParsePath("")
+		if err != nil {
+			return nil, err
+		}
+
+		base.Components = append(base.Components, t...)
+		return base, nil
+
 	case string:
 		return accessor.ParsePath(t)
 

--- a/api/vfs.go
+++ b/api/vfs.go
@@ -302,10 +302,16 @@ func vfsRefreshDirectory(
 	vfs_components []string,
 	depth uint64) (*flows_proto.ArtifactCollectorResponse, error) {
 
+	var components string
+	if len(vfs_components) > 0 {
+		components = json.MustMarshalString(vfs_components[1:])
+	}
+
 	client_path, accessor := GetClientPath(vfs_components)
 	request := MakeCollectorRequest(
 		client_id, "System.VFS.ListDirectory",
 		"Path", client_path,
+		"Components", components,
 		"Accessor", accessor,
 		"Depth", fmt.Sprintf("%v", depth))
 

--- a/artifacts/definitions/System/VFS/DownloadFile.yaml
+++ b/artifacts/definitions/System/VFS/DownloadFile.yaml
@@ -12,6 +12,9 @@ parameters:
   - name: Path
     description: The path of the file to download.
     default: /
+  - name: Components
+    type: json_array
+    description: Alternatively, this is an explicit list of components.
   - name: Accessor
     default: file
   - name: Recursively
@@ -22,14 +25,33 @@ parameters:
 
 sources:
   - query: |
-      LET download_one_file = SELECT FullPath AS Path, Accessor,
-          Size, upload(file=FullPath, accessor=Accessor) AS Upload
-      FROM stat(filename=Path, accessor=Accessor)
+      LET download_one_file = if(
+         condition=version(plugin="stat") > 1,
+         then= {
+           SELECT OSPath AS Path, Accessor,
+              Size, upload(file=OSPath, accessor=Accessor) AS Upload
+           FROM stat(filename=Components, accessor=Accessor)
+        },
+        else= {
+           SELECT FullPath AS Path, Accessor,
+              Size, upload(file=FullPath, accessor=Accessor) AS Upload
+          FROM stat(filename=Path, accessor=Accessor)
+        })
 
-      LET download_recursive = SELECT FullPath AS Path, Accessor,
-          Size, upload(file=FullPath, accessor=Accessor) AS Upload
-      FROM glob(globs="**", root=Path, accessor=Accessor)
-      WHERE Mode.IsRegular
+      LET download_recursive = if(
+         condition=version(plugin="stat") > 1,
+         then= {
+           SELECT OSPath AS Path, Accessor,
+              Size, upload(file=OSPath, accessor=Accessor) AS Upload
+           FROM glob(globs="**", root=Components, accessor=Accessor)
+           WHERE Mode.IsRegular
+        },
+        else={
+          SELECT FullPath AS Path, Accessor,
+            Size, upload(file=FullPath, accessor=Accessor) AS Upload
+          FROM glob(globs="**", root=Path, accessor=Accessor)
+          WHERE Mode.IsRegular
+       })
 
       SELECT Path, Accessor,
              Upload.Size AS Size,

--- a/artifacts/definitions/System/VFS/ListDirectory.yaml
+++ b/artifacts/definitions/System/VFS/ListDirectory.yaml
@@ -10,6 +10,10 @@ parameters:
     description: The path of the file to download.
     default: "/"
 
+  - name: Components
+    type: json_array
+    description: Alternatively, this is an explicit list of components.
+
   - name: Accessor
     default: file
 
@@ -19,6 +23,10 @@ parameters:
 
 sources:
   - query: |
+      // Glob > v2 accepts a component list for the root parameter.
+      LET Path <= if(condition=version(plugin="glob") > 2 AND Components,
+        then=Components, else=Path)
+
       // Old versions do not have the root parameter to glob()
       // Fixes https://github.com/Velocidex/velociraptor/issues/322
       LET LegacyQuery = SELECT FullPath as _FullPath,

--- a/artifacts/testdata/server/testcases/vfs.in.yaml
+++ b/artifacts/testdata/server/testcases/vfs.in.yaml
@@ -2,24 +2,26 @@ Queries:
   # Non recursive download
   - SELECT basename(path=Path) AS Name
     FROM Artifact.System.VFS.DownloadFile(
-       Path=srcDir+"/artifacts/testdata/server/testcases/vfs.in.yaml")
+       Components=pathspec(
+         Path=srcDir+"/artifacts/testdata/server/testcases/vfs.in.yaml").Components)
 
   # Recursive download
   - SELECT basename(path=Path) AS Name
     FROM Artifact.System.VFS.DownloadFile(
        Recursively=TRUE,
-       Path=srcDir+"/artifacts/definitions/System/VFS")
+       Components=pathspec(
+         Path=srcDir+"/artifacts/definitions/System/VFS").Components)
     WHERE Name =~ "DownloadFile.yaml$"
 
   # List directory with one level
   - SELECT Name
     FROM Artifact.System.VFS.ListDirectory(
-       Path=srcDir+"/artifacts/definitions/System")
+       Components=pathspec(Path=srcDir+"/artifacts/definitions/System").Components)
     WHERE Name =~ "VFS"
 
   # List directory with more depth
   - SELECT Name
     FROM Artifact.System.VFS.ListDirectory(
        Depth=10,
-       Path=srcDir+"/artifacts/definitions/System/")
+       Components=pathspec(Path=srcDir+"/artifacts/definitions/System/").Components)
     WHERE _FullPath =~ "ListDirectory.yaml$"

--- a/artifacts/testdata/server/testcases/vfs.out.yaml
+++ b/artifacts/testdata/server/testcases/vfs.out.yaml
@@ -1,16 +1,16 @@
-SELECT basename(path=Path) AS Name FROM Artifact.System.VFS.DownloadFile( Path=srcDir+"/artifacts/testdata/server/testcases/vfs.in.yaml")[
+SELECT basename(path=Path) AS Name FROM Artifact.System.VFS.DownloadFile( Components=pathspec( Path=srcDir+"/artifacts/testdata/server/testcases/vfs.in.yaml").Components)[
  {
   "Name": "vfs.in.yaml"
  }
-]SELECT basename(path=Path) AS Name FROM Artifact.System.VFS.DownloadFile( Recursively=TRUE, Path=srcDir+"/artifacts/definitions/System/VFS") WHERE Name =~ "DownloadFile.yaml$"[
+]SELECT basename(path=Path) AS Name FROM Artifact.System.VFS.DownloadFile( Recursively=TRUE, Components=pathspec( Path=srcDir+"/artifacts/definitions/System/VFS").Components) WHERE Name =~ "DownloadFile.yaml$"[
  {
   "Name": "DownloadFile.yaml"
  }
-]SELECT Name FROM Artifact.System.VFS.ListDirectory( Path=srcDir+"/artifacts/definitions/System") WHERE Name =~ "VFS"[
+]SELECT Name FROM Artifact.System.VFS.ListDirectory( Components=pathspec(Path=srcDir+"/artifacts/definitions/System").Components) WHERE Name =~ "VFS"[
  {
   "Name": "VFS"
  }
-]SELECT Name FROM Artifact.System.VFS.ListDirectory( Depth=10, Path=srcDir+"/artifacts/definitions/System/") WHERE _FullPath =~ "ListDirectory.yaml$"[
+]SELECT Name FROM Artifact.System.VFS.ListDirectory( Depth=10, Components=pathspec(Path=srcDir+"/artifacts/definitions/System/").Components) WHERE _FullPath =~ "ListDirectory.yaml$"[
  {
   "Name": "ListDirectory.yaml"
  }

--- a/gui/velociraptor/src/components/i8n/por.js
+++ b/gui/velociraptor/src/components/i8n/por.js
@@ -1,4 +1,4 @@
-﻿import Alert from 'react-bootstrap/Alert';
+import Alert from 'react-bootstrap/Alert';
 import humanizeDuration from "humanize-duration";
 
 const Portuguese = {

--- a/gui/velociraptor/src/components/vfs/file-stats.js
+++ b/gui/velociraptor/src/components/vfs/file-stats.js
@@ -59,6 +59,14 @@ class VeloFileStats extends Component {
             return;
         }
 
+        let new_path = [...this.props.node.path];
+
+        // The accessor is the first top level.
+        let accessor = new_path.shift();
+
+        // Add the filename to the node.
+        new_path.push(selectedRow.Name);
+
         api.post("v1/CollectArtifact", {
             urgent: true,
             client_id: this.props.client.client_id,
@@ -66,7 +74,8 @@ class VeloFileStats extends Component {
             specs: [{artifact: "System.VFS.DownloadFile",
                      parameters: {
                          env: [{key: "Path", value: selectedRow._FullPath},
-                               {key: "Accessor", value: selectedRow._Accessor}],
+                               {key: "Components", value: JSON.stringify(new_path)},
+                               {key: "Accessor", value: accessor}],
                      }}],
         }, this.source.token).then(response => {
             let flow_id = response.data.flow_id;

--- a/services/launcher/compiler.go
+++ b/services/launcher/compiler.go
@@ -111,12 +111,10 @@ LET %v <= if(
 		case "json_array":
 			result.Query = append(result.Query, &actions_proto.VQLRequest{
 				VQL: fmt.Sprintf(`
-
 LET %v <= if(
     condition=format(format="%%T", args=%v) = "string",
     then=parse_json_array(data=%v),
     else=%v)
-
 `,
 					escaped_name, escaped_name, escaped_name, escaped_name),
 			})

--- a/services/launcher/compiler.go
+++ b/services/launcher/compiler.go
@@ -111,10 +111,12 @@ LET %v <= if(
 		case "json_array":
 			result.Query = append(result.Query, &actions_proto.VQLRequest{
 				VQL: fmt.Sprintf(`
+
 LET %v <= if(
-    condition=format(format="%%T", args=%v) =~ "string",
+    condition=format(format="%%T", args=%v) = "string",
     then=parse_json_array(data=%v),
     else=%v)
+
 `,
 					escaped_name, escaped_name, escaped_name, escaped_name),
 			})

--- a/vql/filesystem/filesystem.go
+++ b/vql/filesystem/filesystem.go
@@ -85,13 +85,19 @@ func (self GlobPlugin) Call(
 		// Get the root of the glob. If not provided we use the
 		// default root for the accessor.
 		root := arg.Root
+		accessor_root, err := accessor.ParsePath("")
+		if err != nil {
+			scope.Log("glob: %v", err)
+			return
+		}
+
+		// Ensure the root has the require pathspec type by copying
+		// the null manipulator.
 		if root == nil {
 			// Get the default top level path for this accessor.
-			root, err = accessor.ParsePath("")
-			if err != nil {
-				scope.Log("glob: %v", err)
-				return
-			}
+			root = accessor_root
+		} else {
+			root.Manipulator = accessor_root.Manipulator
 		}
 
 		options := glob.GlobOptions{

--- a/vql/filesystem/pathspec.go
+++ b/vql/filesystem/pathspec.go
@@ -115,6 +115,7 @@ func (self *PathSpecFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMa
 		Name:    "pathspec",
 		Doc:     "Create a structured path spec to pass to certain accessors.",
 		ArgType: type_map.AddType(scope, &PathSpecArgs{}),
+		Version: 1,
 	}
 }
 

--- a/vql/tools/fixtures/TestSimpleCollection.golden
+++ b/vql/tools/fixtures/TestSimpleCollection.golden
@@ -149,10 +149,10 @@
      "VQL": "\nLET CSVData2 \u003c= SELECT * FROM if(\n    condition=format(format=\"%T\", args=CSVData2) =~ \"string\",\n    then={SELECT * FROM parse_csv(filename=CSVData2, accessor='data')},\n    else=CSVData2)\n"
     },
     {
-     "VQL": "\nLET JSONData \u003c= if(\n    condition=format(format=\"%T\", args=JSONData) =~ \"string\",\n    then=parse_json_array(data=JSONData),\n    else=JSONData)\n"
+     "VQL": "\nLET JSONData \u003c= if(\n    condition=format(format=\"%T\", args=JSONData) = \"string\",\n    then=parse_json_array(data=JSONData),\n    else=JSONData)\n"
     },
     {
-     "VQL": "\nLET JSONData2 \u003c= if(\n    condition=format(format=\"%T\", args=JSONData2) =~ \"string\",\n    then=parse_json_array(data=JSONData2),\n    else=JSONData2)\n"
+     "VQL": "\nLET JSONData2 \u003c= if(\n    condition=format(format=\"%T\", args=JSONData2) = \"string\",\n    then=parse_json_array(data=JSONData2),\n    else=JSONData2)\n"
     },
     {
      "VQL": "LET FileUpload1_ \u003c= if(condition=FileUpload1, then={\n   SELECT Content FROM http_client(url=FileUpload1)\n})"


### PR DESCRIPTION
On Linux the path separator is '/' and '\\' is allowed in side file
names. Within VQL this is handled properly using the OSPath
abstraction - all paths a just a list of components regardless of
the path separator.

The VFS GUI however was still creating collections for
System.VFS.DownloadFile and System.VFS.ListDirectory with a serialized
string path. This leads to VQL having to parse the string back into an
OSPath object which can create confusion in edge cases.

This PR sidesteps the entire issue by extending these artifacts to
accept a list of components instead of a serialized path. The GUI can
then maintain this list and launch the artifacts with the components
already split.

This PR also adds the ability to pass a list of components to any
OSPath VQL parameter which will just build the right OSPath object
from these.