### PR TITLE
Added a default process tracker

### DIFF
--- a/artifacts/definitions/Windows/ETW/Registry.yaml
+++ b/artifacts/definitions/Windows/ETW/Registry.yaml
@@ -1,0 +1,69 @@
+name: Windows.ETW.Registry
+description: |
+  Windows Registry access is a great source of visibility into system
+  activity.
+
+  There are many ways of gaining visibility into this, the most
+  reliable being Sysmon. However it is also possible to gain some
+  visibility using ETW. The Microsoft-Windows-Kernel-Registry provides
+  ETW events for registry modifications.
+
+  This artifact parses these events and ties them back to the
+  accessing process. It is recommended to run this artifact with the
+  process tracker.
+
+  NOTE: Experience shows this ETW provider is not very reliable and
+  seems to miss a lot of registry events.
+
+  This artifact is experimental.
+
+type: CLIENT_EVENT
+
+precondition: SELECT * FROM info() WHERE OS = "windows"
+
+parameters:
+- name: KeyNameRegex
+  type: regex
+  default: .
+- name: ProcessRegex
+  type: regex
+  default: .
+
+sources:
+- query: |
+    LET Cache <= lru(size=1000)
+    LET EventLookup <= dict(
+        `1`="CreateKey",
+        `2`="OpenKey",
+        `3`="DeleteKey",
+        `4`="QueryKey",
+        `5`="SetValueKey",
+        `6`="DeleteValueKey",
+        `7`="QueryValue",
+        `8`="EnumerateKey",
+        `9`="EnumerateValueKey"
+    )
+
+    LET registry_access = SELECT System, EventData,
+       get(item=EventLookup, field=str(str=System.ID)) AS EventType,
+       get(item=Cache, field=EventData.KeyObject) || EventData.KeyName AS KeyName
+    FROM watch_etw(guid="{70EB4F03-C1DE-4F73-A051-33D13D5413BD}", any=0x7720)
+    WHERE System.ProcessID != getpid() -- exclude ourselves
+        AND EventType  -- we only care about these events
+        AND if(condition=System.ID in (1, 2, 4),
+              then=set(item=Cache, field=EventData.KeyObject,
+                       value=EventData.RelativeName),
+              else=TRUE) -- set KeyName in the lru
+
+    LET hits = SELECT System.TimeStamp AS Timestamp,
+       process_tracker_get(id=System.ProcessID).Data AS Process,
+       EventType, KeyName, EventData
+    FROM registry_access
+    WHERE KeyName =~ KeyNameRegex
+
+    SELECT Timestamp, EventType,
+       Process.Name AS ProcessName, Process.Username AS Owner,
+       Process.CommandLine AS CommandLine,
+       KeyName, EventData.ValueName AS ValueName
+    FROM hits
+    WHERE ProcessName =~ ProcessRegex

--- a/artifacts/testdata/server/testcases/process_tracker.in.yaml
+++ b/artifacts/testdata/server/testcases/process_tracker.in.yaml
@@ -1,0 +1,5 @@
+Queries:
+  # A default process tracker always exists and it is equivalent to pslist().
+  - |
+    SELECT process_tracker_get(id=str(str=getpid())).Id = str(str=getpid())
+    FROM scope()

--- a/artifacts/testdata/server/testcases/process_tracker.out.yaml
+++ b/artifacts/testdata/server/testcases/process_tracker.out.yaml
@@ -1,0 +1,7 @@
+SELECT process_tracker_get(id=str(str=getpid())).Id = str(str=getpid())
+FROM scope()
+[
+ {
+  "process_tracker_get(id=str(str=getpid())).Id = str(str=getpid())": true
+ }
+]

--- a/artifacts/testdata/server/testcases/regex.in.yaml
+++ b/artifacts/testdata/server/testcases/regex.in.yaml
@@ -1,0 +1,8 @@
+Queries:
+  - LET URLEscaped = "my%2Fcool%2Bescaped%2y6string%2Cwith%2cmalform"
+
+  # Test lambda replace target: Unescape the URL string with a simple
+  # dumb replace (not correct but resilient to malformed strings)
+  - SELECT regex_replace(source=URLEscaped,
+       replace_lambda="x=>unhex(string=x[1:]) || x", re="%..")
+    FROM scope()

--- a/artifacts/testdata/server/testcases/regex.out.yaml
+++ b/artifacts/testdata/server/testcases/regex.out.yaml
@@ -1,0 +1,5 @@
+LET URLEscaped = "my%2Fcool%2Bescaped%2y6string%2Cwith%2cmalform"[]SELECT regex_replace(source=URLEscaped, replace_lambda="x=>unhex(string=x[1:]) || x", re="%..") FROM scope()[
+ {
+  "regex_replace(source=URLEscaped, replace_lambda=\"x=\u003eunhex(string=x[1:]) || x\", re=\"%..\")": "my/cool+escaped%2y6string,with,malform"
+ }
+]

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2516,6 +2516,9 @@
   - name: args
     type: Any
     description: An array of elements to apply into the format string.
+  - name: level
+    type: string
+    description: Level to log at (DEFAULT, WARN, ERROR, INFO).
   category: basic
 - name: lookupSID
   description: Get information about the SID.
@@ -2556,7 +2559,6 @@
 
     Note how `set()` can be used to add items to the cache and `get()`
     is used to retrieve items.
-
   type: Function
   args:
   - name: size
@@ -3845,6 +3847,9 @@
     type: string
     description: Process ID.
     required: true
+- name: process_tracker_pslist
+  description: List all processes from the process tracker.
+  type: Plugin
 - name: process_tracker_updates
   description: Get the process tracker update events from the global process tracker.
   type: Plugin
@@ -4094,7 +4099,9 @@
   - name: replace
     type: string
     description: The substitute string.
-    required: true
+  - name: replace_lambda
+    type: string
+    description: Optionally the replacement can be a lambda.
   - name: re
     type: string
     description: A regex to apply
@@ -5599,3 +5606,4 @@
     type: string
     description: If set use this key to cache the  yara rules.
   category: plugin
+

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20200722101157-37e4751dd5ca
 	www.velocidex.com/golang/oleparse v0.0.0-20211013063943-0334d69593c1
 	www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500
-	www.velocidex.com/golang/vfilter v0.0.0-20220603152449-16a33ae8eb8d
+	www.velocidex.com/golang/vfilter v0.0.0-20220606015754-7f03acba2fc4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1038,9 +1038,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20211013063943-0334d69593c1/go.mod h1:4
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500 h1:XqZddiAbjPIsTZcEPbqqqABS/ZV5SB7j33eczNsqD60=
 www.velocidex.com/golang/regparser v0.0.0-20190625082115-b02dc43c2500/go.mod h1:DVzloLH8L+oF3zma1Jisaat5bGF+4VLggDcYlIp00ns=
 www.velocidex.com/golang/vfilter v0.0.0-20220103082604-85bb38175cb7/go.mod h1:eEFMhAmoFHWGCKF39j+iOhTH8REpqBndc3OsdPsxqo8=
-www.velocidex.com/golang/vfilter v0.0.0-20220526150756-9e8c9cccd67e h1:ZiQR6hgpZA+toz/P2Z8PjcPoHCyuaTcLlO5AN+8545Y=
-www.velocidex.com/golang/vfilter v0.0.0-20220526150756-9e8c9cccd67e/go.mod h1:HVtgbXGQZxVN3eR3q6PD46ZoIJkyfT7E62SvCVNg5+A=
-www.velocidex.com/golang/vfilter v0.0.0-20220603152449-16a33ae8eb8d h1:/s1aMrrigVU0WaW3AUZQsgXppHys4ky/Ko/uQpSKD4g=
-www.velocidex.com/golang/vfilter v0.0.0-20220603152449-16a33ae8eb8d/go.mod h1:HVtgbXGQZxVN3eR3q6PD46ZoIJkyfT7E62SvCVNg5+A=
+www.velocidex.com/golang/vfilter v0.0.0-20220606015754-7f03acba2fc4 h1:k+juwYypOcGO3zt6lUHC77lNhVyhHzfi3KhyRM2Ccmk=
+www.velocidex.com/golang/vfilter v0.0.0-20220606015754-7f03acba2fc4/go.mod h1:HVtgbXGQZxVN3eR3q6PD46ZoIJkyfT7E62SvCVNg5+A=
 www.velocidex.com/golang/vtypes v0.0.0-20220107071957-49947f744c34 h1:4lnDIznMHDrd1irccF3HSh843/T7kzwCVXw0dWokzoE=
 www.velocidex.com/golang/vtypes v0.0.0-20220107071957-49947f744c34/go.mod h1:gpuRaiyhcuPmZYvI/zw+rjlDXklR2ORaLQBuzCXe84o=

--- a/vql/parsers/regexparser.go
+++ b/vql/parsers/regexparser.go
@@ -262,10 +262,6 @@ func (self _RegexReplace) Call(
 		return vfilter.Null{}
 	}
 
-	if arg.Replace != "" {
-		return re.ReplaceAllString(arg.Source, arg.Replace)
-	}
-
 	if arg.ReplaceLambda != "" {
 		var lambda *vfilter.Lambda
 
@@ -292,8 +288,7 @@ func (self _RegexReplace) Call(
 			})
 	}
 
-	scope.Log("regex_replace: Either of 'replace' or 'replace_lambda' should be specified")
-	return vfilter.Null{}
+	return re.ReplaceAllString(arg.Source, arg.Replace)
 }
 
 func (self _RegexReplace) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {

--- a/vql/tools/process/api.go
+++ b/vql/tools/process/api.go
@@ -1,0 +1,18 @@
+package process
+
+import (
+	"context"
+
+	"www.velocidex.com/golang/vfilter"
+)
+
+type IProcessTracker interface {
+	Get(ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool)
+	Enrich(ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool)
+	Processes(ctx context.Context, scope vfilter.Scope) []*ProcessEntry
+	Children(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry
+	CallChain(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry
+
+	// Listen to the update stream from the tracker.
+	Updates() chan *ProcessEntry
+}

--- a/vql/tools/process/callchain.go
+++ b/vql/tools/process/callchain.go
@@ -34,7 +34,7 @@ func (self getChain) Call(ctx context.Context,
 		return &vfilter.Null{}
 	}
 
-	return tracker.CallChain(arg.Id)
+	return tracker.CallChain(ctx, scope, arg.Id)
 }
 
 func (self getChain) Info(scope types.Scope,

--- a/vql/tools/process/children.go
+++ b/vql/tools/process/children.go
@@ -28,7 +28,7 @@ func (self getChildren) Call(ctx context.Context,
 		return &vfilter.Null{}
 	}
 
-	return tracker.Children(arg.Id)
+	return tracker.Children(ctx, scope, arg.Id)
 }
 
 func (self getChildren) Info(scope types.Scope,
@@ -51,7 +51,7 @@ func (self getAll) Call(ctx context.Context,
 		return &vfilter.Null{}
 	}
 
-	return tracker.Processes()
+	return tracker.Processes(ctx, scope)
 }
 
 func (self getAll) Info(scope types.Scope,

--- a/vql/tools/process/dummy.go
+++ b/vql/tools/process/dummy.go
@@ -1,0 +1,141 @@
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/vfilter"
+)
+
+// This is the dummy process tracker implementation. It does **not**
+// self update but instead invoke the pslist() plugin for fresh data
+// each time. This makes it exactly equivalent to just using pslist()
+// as before, so it becomes possible to substitute calls to the
+// process tracker in all places where previously pslist() was used.
+
+// If a proper process tracker is installed these artifacts will
+// suddenly become much more useful.
+
+type DummyProcessTracker struct{}
+
+func (self *DummyProcessTracker) Get(ctx context.Context,
+	scope vfilter.Scope, id string) (*ProcessEntry, bool) {
+
+	pslist, pres := scope.GetPlugin("pslist")
+	if !pres {
+		return nil, false
+	}
+
+	pid, err := strconv.ParseInt(id, 0, 64)
+	if err == nil {
+
+		for row := range pslist.Call(
+			ctx, scope, ordereddict.NewDict().Set("pid", pid)) {
+			return getProcessEntry(vfilter.RowToDict(ctx, scope, row))
+		}
+	}
+	return nil, false
+}
+
+func (self *DummyProcessTracker) Enrich(
+	ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool) {
+	return self.Get(ctx, scope, id)
+}
+
+func (self *DummyProcessTracker) Processes(
+	ctx context.Context, scope vfilter.Scope) []*ProcessEntry {
+
+	pslist, pres := scope.GetPlugin("pslist")
+	if !pres {
+		return nil
+	}
+
+	result := []*ProcessEntry{}
+	for row := range pslist.Call(ctx, scope, ordereddict.NewDict()) {
+		item, ok := getProcessEntry(vfilter.RowToDict(ctx, scope, row))
+		if ok {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}
+
+func (self *DummyProcessTracker) CallChain(
+	ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry {
+
+	lookup := make(map[string]*ProcessEntry)
+	for _, proc := range self.Processes(ctx, scope) {
+		lookup[proc.Id] = proc
+	}
+
+	result := []*ProcessEntry{}
+
+	for depth := 0; depth < 10; depth++ {
+		proc, pres := lookup[id]
+		if !pres {
+			// Cant find the process return what we have.
+			return reverse(result)
+		}
+
+		result = append(result, proc)
+		id = proc.ParentId
+	}
+
+	return reverse(result)
+}
+
+func (self *DummyProcessTracker) Children(
+	ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry {
+
+	result := []*ProcessEntry{}
+	for _, proc := range self.Processes(ctx, scope) {
+		if proc.ParentId == id {
+			result = append(result, proc)
+		}
+	}
+
+	return result
+}
+
+func (self *DummyProcessTracker) Updates() chan *ProcessEntry {
+	output_chan := make(chan *ProcessEntry)
+	close(output_chan)
+
+	return output_chan
+}
+
+type ProcessInfoWindows struct {
+	Pid       int    `json:"Pid"`
+	PPid      int    `json:"PPid"`
+	StartTime string `json:"CreateTime"`
+}
+
+// Parses the output of various pslist implementations to give a
+// ProcessEntry item.
+func getProcessEntry(row *ordereddict.Dict) (*ProcessEntry, bool) {
+	serialized, err := row.MarshalJSON()
+	if err != nil {
+		return nil, false
+	}
+
+	windows_item := &ProcessInfoWindows{}
+	err = json.Unmarshal(serialized, windows_item)
+	if err != nil {
+		return nil, false
+	}
+
+	create_time := time.Time{}
+	_ = json.Unmarshal([]byte(windows_item.StartTime), &create_time)
+
+	return &ProcessEntry{
+		Id:        fmt.Sprintf("%v", windows_item.Pid),
+		ParentId:  fmt.Sprintf("%v", windows_item.PPid),
+		StartTime: create_time,
+		Data:      row,
+	}, true
+}

--- a/vql/tools/process/protocols.go
+++ b/vql/tools/process/protocols.go
@@ -29,20 +29,14 @@ func (self ProcessTrackerUpdater) Call(
 	output_chan := make(chan types.Row)
 
 	tracker := GetGlobalTracker()
-
-	tracker.mu.Lock()
-	if tracker.update_notifications == nil {
-		tracker.update_notifications = make(chan *ProcessEntry)
-	}
-	update_notifications := tracker.update_notifications
-	tracker.mu.Unlock()
+	update_notifications := tracker.Updates()
 
 	go func() {
 		defer close(output_chan)
 
 		// First message is a full sync message.
 		update := ordereddict.NewDict()
-		for _, p := range tracker.Processes() {
+		for _, p := range tracker.Processes(ctx, scope) {
 			update.Set(p.Id, p)
 		}
 		event := &ProcessEntry{

--- a/vql/tools/process/pslist.go
+++ b/vql/tools/process/pslist.go
@@ -1,0 +1,45 @@
+package process
+
+import (
+	"context"
+
+	"github.com/Velocidex/ordereddict"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+type _ProcessTrackerPsList struct{}
+
+func (self _ProcessTrackerPsList) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.PluginInfo {
+	return &vfilter.PluginInfo{
+		Name: "process_tracker_pslist",
+		Doc:  "List all processes from the process tracker.",
+	}
+}
+
+func (self _ProcessTrackerPsList) Call(
+	ctx context.Context, scope types.Scope,
+	args *ordereddict.Dict) <-chan types.Row {
+
+	output_chan := make(chan types.Row)
+
+	go func() {
+		defer close(output_chan)
+
+		for _, proc := range GetGlobalTracker().Processes(ctx, scope) {
+			select {
+			case <-ctx.Done():
+				return
+
+			case output_chan <- proc.Data:
+			}
+		}
+	}()
+
+	return output_chan
+}
+
+func init() {
+	vql_subsystem.RegisterPlugin(&_ProcessTrackerPsList{})
+}


### PR DESCRIPTION
If no process tracker event monitoring rule is used, the process
tracker is set to the default one. The default tracker is equivalent
to a `pslist()` for each access.

Existing artifacts may access the process tracker instead of calling
pslist() for enrichments. Then if the user elects to have an active
tracker installed all existing artifacts will benefit automatically.