### PR TITLE
Format timestamps opportunistically.

### DIFF
--- a/gui/velociraptor/src/components/utils/value.js
+++ b/gui/velociraptor/src/components/utils/value.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import ReactJson from 'react-json-view';
 import UserConfig from '../core/user.js';
+import VeloTimestamp from "./time.js";
+
+const timestamp_regex = new RegExp('^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.+$');
 
 const defaultTheme = {
     scheme: 'rjv-default',
@@ -71,11 +74,20 @@ export default class VeloValueRenderer extends React.Component {
         }
     }
 
+    // If the cell contains something that looks like a timestamp,
+    // format it as such.
+    maybeFormatTime = x => {
+        if (timestamp_regex.test(x)) {
+            return <VeloTimestamp iso={x} />;
+        }
+        return x;
+    }
+
     render() {
         let v = this.props.value;
 
         if (_.isString(v)) {
-            return <>{v}</>;
+            return <>{this.maybeFormatTime(v)}</>;
         }
 
         if (_.isNumber(v)) {

--- a/gui/velociraptor/src/components/vfs/file-hex-view.js
+++ b/gui/velociraptor/src/components/vfs/file-hex-view.js
@@ -62,6 +62,7 @@ export default class FileHexView extends React.Component {
         }
         fileComponents.push(name);
 
+        let vfs_path = selectedRow.Download && selectedRow.Download.vfs_path;
         var chunkSize = this.state.rows * this.state.columns;
         var url = 'v1/DownloadVFSFile';
 
@@ -71,6 +72,7 @@ export default class FileHexView extends React.Component {
             length: chunkSize,
             components: fileComponents,
             client_id: client_id,
+            vfs_path: vfs_path,
         };
 
         this.setState({loading: true});

--- a/gui/velociraptor/src/components/vfs/file-text-view.js
+++ b/gui/velociraptor/src/components/vfs/file-text-view.js
@@ -66,12 +66,15 @@ export default class FileTextView extends React.Component {
         }
         fileComponents.push(name);
 
+        let vfs_path = selectedRow.Download && selectedRow.Download.vfs_path;
+
         var url = 'v1/DownloadVFSFile';
         var params = {
             offset: page * pagesize,
             length: pagesize,
             components: fileComponents,
             client_id: client_id,
+            vfs_path: vfs_path,
         };
 
         this.setState({loading: true});


### PR DESCRIPTION
When the UI formats a table cell that looks like an ISO timestamp, we
parse it and convert to the user's desired timezone. This covers cases
like notebook output and VQL output which may output times in
arbitrary timezone.