### PR TITLE
Update usn.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	howett.net/plist v0.0.0-20201203080718-1454fab16a06
 	www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e
 	www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671
-	www.velocidex.com/golang/go-ntfs v0.1.2-0.20220506011637-ec1ee7499352
+	www.velocidex.com/golang/go-ntfs v0.1.2-0.20220616022946-852572498c13
 	www.velocidex.com/golang/go-pe v0.1.1-0.20220506020923-9fac492a9b0d
 	www.velocidex.com/golang/go-prefetch v0.0.0-20200722101157-37e4751dd5ca
 	www.velocidex.com/golang/oleparse v0.0.0-20211013063943-0334d69593c1

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,8 @@ www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e h1:AhcXPgNKhJ
 www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e/go.mod h1:ykEQ7AUF9AL+mfCefDmLwmZOnU2So6wM3qKM8xdsHhU=
 www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671 h1:pfvo7NFo0eJj6Zr7d+4vMx/Zr2JriMMPEWRHUf1YjUw=
 www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671/go.mod h1:qnzHyB9yD2khtYO+wf3ck9FQxX3wFhXeJHFBnuUIZcc=
-www.velocidex.com/golang/go-ntfs v0.1.2-0.20220506011637-ec1ee7499352 h1:hOlKJFKaey3VuzdX5GzFJ26N0Q4yHdDzZK2f5SGe4DU=
-www.velocidex.com/golang/go-ntfs v0.1.2-0.20220506011637-ec1ee7499352/go.mod h1:Ha0bxCjZeLVvNM7zU6B7bj5nWkWn2UyHs2QWSj3OspQ=
+www.velocidex.com/golang/go-ntfs v0.1.2-0.20220616022946-852572498c13 h1:FHcUvOaYKJTjW94hIVBfes1+VXerEF7x1VHw3sRJQpg=
+www.velocidex.com/golang/go-ntfs v0.1.2-0.20220616022946-852572498c13/go.mod h1:Ha0bxCjZeLVvNM7zU6B7bj5nWkWn2UyHs2QWSj3OspQ=
 www.velocidex.com/golang/go-pe v0.1.1-0.20220107093716-e91743c801de/go.mod h1:j9Xy8Z9wxzY2SCB8CqDkkoSzy+eUwevnOrRm/XM2q/A=
 www.velocidex.com/golang/go-pe v0.1.1-0.20220506020923-9fac492a9b0d h1:OQKwxK0O4a/8YTmfkQNzUspyrvlpRbLi318L08DC0oY=
 www.velocidex.com/golang/go-pe v0.1.1-0.20220506020923-9fac492a9b0d/go.mod h1:TPJ3phbAuZIu7XuPyNqgoP2k3P+eNHfHHGcivhcsxaA=

--- a/vql/parsers/usn/usn.go
+++ b/vql/parsers/usn/usn.go
@@ -120,8 +120,13 @@ func (self WatchUSNPlugin) Call(
 		}
 
 		// Register our interest in the log.
-		cancel := GlobalEventLogService.Register(
+		cancel, err := GlobalEventLogService.Register(
 			ntfs_device, "ntfs", ctx, config_obj, scope, event_channel)
+		if err != nil {
+			scope.Log("watch_usn: %v", err)
+			return
+		}
+
 		defer cancel()
 
 		for {

--- a/vql/parsers/usn/usn.go
+++ b/vql/parsers/usn/usn.go
@@ -70,6 +70,7 @@ func (self USNPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfil
 
 type WatchUSNPluginArgs struct {
 	Device *accessors.OSPath `vfilter:"required,field=device,doc=The device file to open."`
+	Accessor string          `vfilter:"optional,field=accessor,doc=The accessor to use."`
 }
 
 type WatchUSNPlugin struct{}

--- a/vql/parsers/usn/usn.go
+++ b/vql/parsers/usn/usn.go
@@ -38,6 +38,17 @@ func (self USNPlugin) Call(
 			return
 		}
 
+		// If an accessor is not specified we interpret the path as an
+		// NTFS path.
+		if arg.Accessor == "" {
+			arg.Accessor = "ntfs"
+			arg.Device, err = accessors.NewWindowsNTFSPath(arg.Device.String())
+			if err != nil {
+				scope.Log("parse_usn: %v", err)
+				return
+			}
+		}
+
 		device, accessor, err := readers.GetRawDeviceAndAccessor(
 			scope, arg.Device, arg.Accessor)
 		if err != nil {
@@ -69,8 +80,7 @@ func (self USNPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfil
 }
 
 type WatchUSNPluginArgs struct {
-	Device *accessors.OSPath `vfilter:"required,field=device,doc=The device file to open."`
-	Accessor string          `vfilter:"optional,field=accessor,doc=The accessor to use."`
+	Device string `vfilter:"required,field=device,doc=The device file to open (as an NTFS device)."`
 }
 
 type WatchUSNPlugin struct{}
@@ -100,9 +110,18 @@ func (self WatchUSNPlugin) Call(
 
 		event_channel := make(chan vfilter.Row)
 
+		// We need to interpret the device as an NTFS path in all
+		// cases because we can only really watch a raw NTFS partition
+		// (it does not make sense to watch a static file).
+		ntfs_device, err := accessors.NewWindowsNTFSPath(arg.Device)
+		if err != nil {
+			scope.Log("watch_usn: %v", err)
+			return
+		}
+
 		// Register our interest in the log.
 		cancel := GlobalEventLogService.Register(
-			arg.Device, ctx, config_obj, scope, event_channel)
+			ntfs_device, "ntfs", ctx, config_obj, scope, event_channel)
 		defer cancel()
 
 		for {

--- a/vql/parsers/usn/watcher.go
+++ b/vql/parsers/usn/watcher.go
@@ -46,6 +46,7 @@ func NewUSNWatcherService() *USNWatcherService {
 
 func (self *USNWatcherService) Register(
 	device *accessors.OSPath,
+	accessor string,
 	ctx context.Context,
 	config_obj *config_proto.Config,
 	scope vfilter.Scope,
@@ -54,9 +55,9 @@ func (self *USNWatcherService) Register(
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	ntfs_ctx, err := readers.GetNTFSContext(scope, device, "ntfs")
+	ntfs_ctx, err := readers.GetNTFSContext(scope, device, accessor)
 	if err != nil {
-		scope.Log("watch_usn: %v", err)
+		scope.Log("watch_usn: while opening device %v: %v", device, err)
 		return func() {}
 	}
 


### PR DESCRIPTION
The watch_usn() and parse_usn() plugins are unable to read the $J file when invoked following the examples in https://docs.velociraptor.app/blog/2020/2020-11-13-the-windows-usn-journal-f0c55c9010e/

Example 1: In the VQL shell, try 'query select * from parse_usn(device="c:/") LIMIT 10'.  The log will contain the error "parse_usn: seek c:: The handle is invalid". 

Example 2: try 'query select * from watch_usn(device='c:/')'.  The log will contain the error " watch_usn: file does not exist".

In a recent commit, the option to specify an accessor arg was added to the parse_usn() plugin, but not to watch_usn(). It seems that the default accessor for both plugins is "auto", and for some reason it doesn't fall back to raw access when api fails.  The parse_usn() plugin will throw the same error as above when provided the "auto" arg directly.

With the Accessor arg copied to the WatchUSNPluginArgs function, both plugins return expected results when given the args '(device="c:/", accessor="ntfs")'.  If there's a way to make these default in vfilter, that might be preferable since the blog examples don't work as written.