### PR TITLE
Fixed bug in client_delete()

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -218,6 +218,7 @@ func (self BaseTestSuite) TestListChildren() {
 	visited := []api.DSPathSpec{}
 	Walk(self.config_obj, self.datastore,
 		path_specs.NewSafeDatastorePath("a", "b"),
+		WalkWithoutDirectories,
 		func(path_name api.DSPathSpec) error {
 			visited = append(visited, path_name)
 			return nil
@@ -259,6 +260,7 @@ func (self BaseTestSuite) TestListChildrenTypes() {
 	visited := []api.DSPathSpec{}
 	Walk(self.config_obj, self.datastore,
 		path_specs.NewSafeDatastorePath("a", "b"),
+		WalkWithoutDirectories,
 		func(path_name api.DSPathSpec) error {
 			visited = append(visited, path_name)
 			return nil
@@ -306,6 +308,7 @@ func (self BaseTestSuite) TestUnsafeListChildren() {
 	visited := []api.DSPathSpec{}
 	Walk(self.config_obj, self.datastore,
 		root,
+		WalkWithoutDirectories,
 		func(path_name api.DSPathSpec) error {
 			visited = append(visited, path_name)
 			return nil

--- a/datastore/filebased.go
+++ b/datastore/filebased.go
@@ -271,19 +271,23 @@ func (self *FileBaseDataStore) ListChildren(
 	for _, child := range children {
 		var child_pathspec api.DSPathSpec
 
-		// Strip data store extensions
-		spec_type, name := api.GetDataStorePathTypeFromExtension(
-			utils.UnsanitizeComponent(child.Name()))
-		if name == "" {
+		if child.IsDir() {
+			name := utils.UnsanitizeComponent(child.Name())
+			result = append(result, urn.AddUnsafeChild(name).SetDir())
 			continue
 		}
 
-		if child.IsDir() {
-			child_pathspec = urn.AddUnsafeChild(name).
-				SetType(api.PATH_TYPE_DATASTORE_DIRECTORY).SetDir()
+		// Strip data store extensions
+		spec_type, extension := api.GetDataStorePathTypeFromExtension(
+			child.Name())
+		if spec_type == api.PATH_TYPE_DATASTORE_UNKNOWN {
+			continue
+		}
 
-			// Skip over files that do not belong in the data store.
-		} else if spec_type == api.PATH_TYPE_DATASTORE_UNKNOWN {
+		name := utils.UnsanitizeComponent(child.Name()[:len(extension)])
+
+		// Skip over files that do not belong in the data store.
+		if spec_type == api.PATH_TYPE_DATASTORE_UNKNOWN {
 			continue
 
 		} else {

--- a/file_store/directory/directory.go
+++ b/file_store/directory/directory.go
@@ -128,7 +128,7 @@ func (self *DirectoryFileStore) ListDirectory(dirname api.FSPathSpec) (
 		name_type, name := api.GetFileStorePathTypeFromExtension(name)
 		result = append(result, file_store_accessor.NewFileStoreFileInfo(
 			self.config_obj,
-			dirname.AddChild(
+			dirname.AddUnsafeChild(
 				utils.UnsanitizeComponent(name)).
 				SetType(name_type),
 			fileinfo))

--- a/gui/velociraptor/src/components/vfs/file-stats.js
+++ b/gui/velociraptor/src/components/vfs/file-stats.js
@@ -88,7 +88,7 @@ class VeloFileStats extends Component {
                     client_id: this.props.client.client_id,
                     flow_id: flow_id,
                 }, this.source.token).then((response) => {
-                    if (response.data.context.state !== "RUNNING") {
+                    if (response.data && response.data.context.state !== "RUNNING") {
                         this.source.cancel("unmounted");
                         clearInterval(this.interval);
 

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -98,8 +98,17 @@ func (self *Launcher) DeleteFlow(
 
 	r.emit_ds("Notebook", flow_path_manager.Notebook().Path())
 	datastore.Walk(config_obj, db, flow_path_manager.Notebook().DSDirectory(),
+		datastore.WalkWithoutDirectories,
 		func(path api.DSPathSpec) error {
 			r.emit_ds("NotebookData", path)
+			return nil
+		})
+
+	// Clean the empty directories
+	datastore.Walk(config_obj, db, flow_path_manager.Notebook().DSDirectory(),
+		datastore.WalkWithDirectories,
+		func(path api.DSPathSpec) error {
+			_ = db.DeleteSubject(config_obj, path)
 			return nil
 		})
 

--- a/services/sanity/index_migration.go
+++ b/services/sanity/index_migration.go
@@ -40,6 +40,7 @@ func maybeMigrateClientIndex(
 
 	// Migrate the old index to the new index.
 	err = datastore.Walk(config_obj, db, paths.CLIENT_INDEX_URN_DEPRECATED,
+		datastore.WalkWithoutDirectories,
 		func(path api.DSPathSpec) error {
 			client_id := path.Base()
 			term := path.Dir().Base()

--- a/services/server_artifacts/logger.go
+++ b/services/server_artifacts/logger.go
@@ -9,6 +9,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/result_sets"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -25,11 +26,12 @@ func (self *serverLogger) Close() {
 }
 
 func (self *serverLogger) Write(b []byte) (int, error) {
-	msg := artifacts.DeobfuscateString(self.config_obj, string(b))
+	level, msg := logging.SplitIntoLevelAndLog(b)
+	msg = artifacts.DeobfuscateString(self.config_obj, msg)
 
 	self.writer.Write(ordereddict.NewDict().
 		Set("Timestamp", time.Now().UTC().UnixNano()/1000).
-		Set("time", time.Now().UTC().String()).
+		Set("Level", level).
 		Set("message", msg))
 
 	// Increment the log count.

--- a/vql/server/clients/delete.go
+++ b/vql/server/clients/delete.go
@@ -91,6 +91,16 @@ func (self DeleteClientPlugin) Call(ctx context.Context,
 			return
 		}
 
+		// Delete the actual client record.
+		if arg.ReallyDoIt {
+			err = reallyDeleteClient(ctx, config_obj, scope, db, arg)
+			if err != nil {
+				scope.Log("client_delete: %s", err)
+				return
+			}
+
+		}
+
 		// Delete the filestore files.
 		err = api.Walk(file_store_factory,
 			client_path_manager.Path().AsFilestorePath(),

--- a/vql/server/clients/fixtures/TestDeleteClient.golden
+++ b/vql/server/clients/fixtures/TestDeleteClient.golden
@@ -1,169 +1,212 @@
 {
  "Before filestore": [
-  "/clients/C.123/collections/F.1234/uploads/ntfs/%5C%5C.%5CC%3A/Windows/notepad.exe",
-  "/clients/C.123/collections/F.1234/logs",
-  "/clients/C.123/collections/F.1234/logs.json.index",
-  "/clients/C.123/collections/F.1234/uploads.json",
-  "/clients/C.123/collections/F.1234/uploads.json.index",
-  "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json",
-  "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index",
-  "/clients/C.123/monitoring_logs/Generic.Client.Stats/2021-08-14.json",
-  "/clients/C.123/monitoring_logs/Generic.Client.Stats/2021-08-14.json.tidx",
-  "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json",
-  "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json.index",
-  "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json",
-  "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json.index"
+  "",
+  "/clients",
+  "/clients/C.12312",
+  "/clients/C.12312/artifacts",
+  "/clients/C.12312/artifacts/Generic.Client.Info",
+  "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E",
+  "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json",
+  "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json.index",
+  "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json",
+  "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json.index",
+  "/clients/C.12312/collections",
+  "/clients/C.12312/collections/F.1234",
+  "/clients/C.12312/collections/F.1234/logs",
+  "/clients/C.12312/collections/F.1234/logs.json.index",
+  "/clients/C.12312/collections/F.1234/notebook",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db",
+  "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123.json.db",
+  "/clients/C.12312/collections/F.1234/task.db",
+  "/clients/C.12312/collections/F.1234/uploads",
+  "/clients/C.12312/collections/F.1234/uploads/ntfs",
+  "/clients/C.12312/collections/F.1234/uploads/ntfs/%5C%5C.%5CC%3A",
+  "/clients/C.12312/collections/F.1234/uploads/ntfs/%5C%5C.%5CC%3A/Windows",
+  "/clients/C.12312/collections/F.1234/uploads/ntfs/%5C%5C.%5CC%3A/Windows/notepad.exe",
+  "/clients/C.12312/collections/F.1234/uploads.json",
+  "/clients/C.12312/collections/F.1234/uploads.json.index",
+  "/clients/C.12312/labels.json.db",
+  "/clients/C.12312/monitoring_logs",
+  "/clients/C.12312/monitoring_logs/Generic.Client.Stats",
+  "/clients/C.12312/monitoring_logs/Generic.Client.Stats/2021-08-14.json",
+  "/clients/C.12312/monitoring_logs/Generic.Client.Stats/2021-08-14.json.tidx",
+  "/clients/C.12312/ping.db",
+  "/clients/C.12312/ping.json.db",
+  "/clients/C.12312/tasks",
+  "/clients/C.12312/tasks/task1123.db",
+  "/clients/C.12312/vfs",
+  "/clients/C.12312/vfs/file",
+  "/clients/C.12312/vfs/file/C%253A",
+  "/clients/C.12312/vfs/file/C%253A/Users.db",
+  "/clients/C.12312/vfs/file/C%253A.db",
+  "/clients/C.12312/vfs/file.db",
+  "/clients/C.12312/vfs_files",
+  "/clients/C.12312/vfs_files/file",
+  "/clients/C.12312/vfs_files/file/C%253A",
+  "/clients/C.12312/vfs_files/file/C%253A/Users",
+  "/clients/C.12312/vfs_files/file/C%253A/Users/mike",
+  "/clients/C.12312/vfs_files/file/C%253A/Users/mike/test",
+  "/clients/C.12312/vfs_files/file/C%253A/Users/mike/test/1.txt.db",
+  "/clients/C.12312.db"
  ],
- "After filestore": [],
+ "After filestore": [
+  "",
+  "/clients"
+ ],
  "Files deleted": [
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json",
+   "vfs_path": "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json.index",
+   "vfs_path": "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/BasicInformation.json.index",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json",
+   "vfs_path": "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json.index",
+   "vfs_path": "/clients/C.12312/artifacts/Generic.Client.Info/F.C49TC44OSO62E/Users.json.index",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/logs",
+   "vfs_path": "/clients/C.12312/collections/F.1234/logs",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/logs.json.index",
+   "vfs_path": "/clients/C.12312/collections/F.1234/logs.json.index",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123.json.db",
+   "vfs_path": "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123.json.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db",
+   "vfs_path": "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json",
+   "vfs_path": "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index",
+   "vfs_path": "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db",
+   "vfs_path": "/clients/C.12312/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/collections/F.1234/task.db",
+   "vfs_path": "/clients/C.12312/collections/F.1234/task.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/uploads.json",
+   "vfs_path": "/clients/C.12312/collections/F.1234/uploads.json",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/uploads.json.index",
+   "vfs_path": "/clients/C.12312/collections/F.1234/uploads.json.index",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/collections/F.1234/uploads/ntfs/\"\\\\.\\C:\"/Windows/notepad.exe",
+   "vfs_path": "/clients/C.12312/collections/F.1234/uploads/ntfs/\"\\\\.\\C:\"/Windows/notepad.exe",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/labels.json.db",
+   "vfs_path": "/clients/C.12312/labels.json.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/monitoring_logs/Generic.Client.Stats/2021-08-14.json",
+   "vfs_path": "/clients/C.12312/monitoring_logs/Generic.Client.Stats/2021-08-14.json",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Filestore",
-   "vfs_path": "/clients/C.123/monitoring_logs/Generic.Client.Stats/2021-08-14.json.tidx",
+   "vfs_path": "/clients/C.12312/monitoring_logs/Generic.Client.Stats/2021-08-14.json.tidx",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/ping.db",
+   "vfs_path": "/clients/C.12312/ping.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/ping.json.db",
+   "vfs_path": "/clients/C.12312/ping.json.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/tasks/task1123.db",
+   "vfs_path": "/clients/C.12312/tasks/task1123.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/vfs/file.db",
+   "vfs_path": "/clients/C.12312/vfs/file.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/vfs/file/C%3A.db",
+   "vfs_path": "/clients/C.12312/vfs/file/C%3A.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/vfs/file/C%3A/Users.db",
+   "vfs_path": "/clients/C.12312/vfs/file/C%3A/Users.db",
    "really_do_it": true
   },
   {
-   "client_id": "C.123",
+   "client_id": "C.12312",
    "type": "Datastore",
-   "vfs_path": "/clients/C.123/vfs_files/file/C%3A/Users/mike/test/1.txt.db",
+   "vfs_path": "/clients/C.12312/vfs_files/file/C%3A/Users/mike/test/1.txt.db",
    "really_do_it": true
   }
  ]


### PR DESCRIPTION
Error in underializing filenames from filestore caused problems
removing files with encoded characters.

Also ensure that empty directories are removed now - all client files
should be properly removed.