### PR TITLE
Fixed the --remap flag

### DIFF
--- a/artifacts/definitions/Generic/System/Pstree.yaml
+++ b/artifacts/definitions/Generic/System/Pstree.yaml
@@ -8,8 +8,19 @@ description: |
   a number of intemediary processes) it could mean word was
   compromised.
 
+  This artifact uses the process tracker which was introduced in
+  release 0.6.5. (Import an older version of this artifact using the
+  Server.Import.PreviousReleases if your client is older than this).
+
+  A more accurate call chain will be available when the
+  Windows.Events.TrackProcesses artifact is collected (required
+  Sysmon) or Windows.Events.TrackProcessesBasic (does not require
+  Sysmon)
+
+  Minimum Version: 0.6.5
+
 parameters:
-  - name: ProcessNameRegex
+  - name: CommandlineRegex
     default: .
     type: regex
 
@@ -23,56 +34,13 @@ parameters:
     type: regex
 
   - name: CallChainSep
-    default: " <- "
+    default: " -> "
 
 sources:
   - query: |
-      // Cache the process listing in memory as we will be going
-      // through it many times.
-      LET processes <= SELECT Name, Pid, Ppid FROM pslist() WHERE Pid > 0
-
-      LET m <= memoize(query={ SELECT Name, Pid, Ppid FROM pslist()}, key="Pid", period=1)
-
-      // Recursive function to find process parent (clients > 0.4.9).
-      // Catch recursion loops by limiting the depth of traversal to 10 deep.
-      LET pstree_memoized(LookupPid, Depth) = SELECT * FROM foreach(
-      row=if(condition=Depth < 10, then=get(item=m, field=LookupPid)),
-        query={
-           SELECT * FROM chain(
-           a={
-             SELECT Name, Pid, Ppid FROM scope()
-           },
-           b={
-             SELECT Name, Pid, Ppid FROM pstree_memoized(
-                    LookupPid=Ppid, Depth=Depth + 1)
-           })
-        })
-
-      // Recursive function to find process parent (clients < 0.4.9).
-      LET pstree_legacy(LookupPid) = SELECT * FROM foreach(
-         row={
-           SELECT Name, Pid, Ppid FROM processes
-           WHERE Pid = LookupPid
-         },
-         query={
-           SELECT * FROM chain(
-           b={
-             SELECT Name, Pid, Ppid FROM pstree(LookupPid=Ppid)
-           },
-           a={
-             SELECT Name, Pid, Ppid FROM scope()
-           })
-      })
-
-      // Select which version we should use
-      LET pstree(LookupPid) = SELECT * FROM if(
-        condition=version(function="memoize") >= 0,
-        then={ SELECT * FROM pstree_memoized(LookupPid=LookupPid, Depth=0) },
-        else={ SELECT * FROM pstree_legacy})
-
-      SELECT Name, Pid, Ppid,
-             join(array=pstree(LookupPid=Pid).Name, sep=CallChainSep) AS CallChain
-      FROM processes
-      WHERE Name =~ ProcessNameRegex
+      SELECT Pid, Ppid, Name, Username, Exe, CommandLine, StartTime, EndTime,
+          join(array=process_tracker_callchain(id=Pid).Data.Name, sep=CallChainSep) AS CallChain
+      FROM process_tracker_pslist()
+      WHERE CommandLine =~ CommandlineRegex
         AND CallChain =~ CallChainFilter
-        AND str(str=Pid) =~ str(str=PidFilter)
+        AND Pid =~ PidFilter

--- a/artifacts/definitions/Server/Import/PreviousReleases.yaml
+++ b/artifacts/definitions/Server/Import/PreviousReleases.yaml
@@ -23,12 +23,13 @@ parameters:
     description: |
       The Velociraptor Release to import.
     type: choices
-    default: v0.6.3
+    default: v0.6.4
     choices:
       - v0.6.0
       - v0.6.1
       - v0.6.2
       - v0.6.3
+      - v0.6.4
 
 sources:
   - query: |

--- a/artifacts/definitions/Windows/Events/TrackProcessesBasic.yaml
+++ b/artifacts/definitions/Windows/Events/TrackProcessesBasic.yaml
@@ -1,0 +1,42 @@
+name: Windows.Events.TrackProcessesBasic
+description: |
+  This artifact is a basic Process tracker using a simple polled
+  pslist(). The Process Tracker keeps track of exited processes, and
+  resolves process callchains from it in memory cache.
+
+  This event artifact enables the global process tracker and makes it
+  possible to run many other artifacts that depend on the process
+  tracker.
+
+  This tracker DOES NOT require sysmon and is **incompatible** with
+  Windows.Events.TrackProcesses (only one should be running).
+
+type: CLIENT_EVENT
+
+parameters:
+  - name: MaxSize
+    type: int64
+    description: Maximum size of the in memory process cache (default 10k)
+  - name: PollPeriod
+    type: int64
+    description: How often to run pslist to track processes (in Seconds)
+    default: 60
+
+sources:
+  - query: |
+      LET SyncQuery =
+              SELECT Pid AS id,
+                 Ppid AS parent_id,
+                 CreateTime AS start_time,
+                 dict(
+                   Name=Name,
+                   Username=Username,
+                   Exe=Exe,
+                   CommandLine=CommandLine) AS data
+              FROM pslist()
+
+      LET Tracker <= process_tracker(
+        sync_query=SyncQuery, sync_period=1000 * PollPeriod)
+
+      SELECT * FROM process_tracker_updates()
+      WHERE update_type = "stats"

--- a/bin/main.go
+++ b/bin/main.go
@@ -211,5 +211,5 @@ func makeDefaultConfigLoader() *config.Loader {
 		WithOverride(*override_flag).
 		WithConfigMutator(applyMinionRole).
 		WithCustomValidator(ensureProxy).
-		WithCustomValidator(applyAnalysisTarget)
+		WithConfigMutator(applyAnalysisTarget)
 }

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -834,6 +834,15 @@
     description: Rc4 key (1-256bytes).
     required: true
   category: plugin
+- name: delete_flow
+  description: Delete all the files that make up a flow.
+  type: Plugin
+  args:
+  - name: client_id
+    type: string
+    required: true
+  - name: flow_id
+    type: string
 - name: dict
   description: |
     Construct a dict from arbitrary keyword args.
@@ -1154,6 +1163,9 @@
   - name: env
     type: LazyExpr
     description: Environment variables to launch with.
+  - name: cwd
+    type: string
+    description: If specified we change to this working directory first.
   category: plugin
 - name: expand
   description: |
@@ -2153,6 +2165,12 @@
   - name: hunt_id
     type: string
     description: A hunt id to read, if not specified we list all of them.
+  - name: offset
+    type: uint64
+    description: Start offset.
+  - name: count
+    type: uint64
+    description: Max number of results to return.
   category: server
 - name: if
   description: |
@@ -5438,8 +5456,8 @@
   type: Plugin
   args:
   - name: device
-    type: accessors.OSPath
-    description: The device file to open.
+    type: string
+    description: The device file to open (as an NTFS device).
     required: true
   category: event
 - name: whoami
@@ -5618,3 +5636,4 @@
     type: string
     description: If set use this key to cache the  yara rules.
   category: plugin
+

--- a/services/client_info.go
+++ b/services/client_info.go
@@ -78,6 +78,8 @@ type ClientInfoManager interface {
 
 	Get(client_id string) (*ClientInfo, error)
 
+	Remove(client_id string)
+
 	GetStats(client_id string) (*Stats, error)
 	UpdateStats(client_id string, stats *Stats) error
 

--- a/services/client_info/client_info.go
+++ b/services/client_info/client_info.go
@@ -532,6 +532,10 @@ func (self *ClientInfoManager) Clear() {
 	self.lru.Purge()
 }
 
+func (self *ClientInfoManager) Remove(client_id string) {
+	self.lru.Remove(client_id)
+}
+
 func (self *ClientInfoManager) Get(client_id string) (*services.ClientInfo, error) {
 	cached_info, err := self.GetCacheInfo(client_id)
 	if err != nil {

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -39,6 +39,7 @@ type ShellPluginArgs struct {
 	Sep    string           `vfilter:"optional,field=sep,doc=The separator that will be used to split the stdout into rows."`
 	Length int64            `vfilter:"optional,field=length,doc=Size of buffer to capture output per row."`
 	Env    vfilter.LazyExpr `vfilter:"optional,field=env,doc=Environment variables to launch with."`
+	Cwd    string           `vfilter:"optional,field=cwd,doc=If specified we change to this working directory first."`
 }
 
 type ShellResult struct {
@@ -116,6 +117,7 @@ func (self ShellPlugin) Call(
 				}
 			}
 		}
+		command.Dir = arg.Cwd
 
 		stdout_pipe, err := command.StdoutPipe()
 		if err != nil {

--- a/vql/golang/profile.go
+++ b/vql/golang/profile.go
@@ -16,6 +16,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/actions"
 	"www.velocidex.com/golang/velociraptor/logging"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/tools/process"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
@@ -273,6 +274,9 @@ func (self *ProfilePlugin) Call(ctx context.Context,
 
 		if arg.Metrics {
 			writeMetrics(scope, output_chan)
+			output_chan <- ordereddict.NewDict().
+				Set("Type", "process_tracker").
+				Set("Line", process.GetGlobalTracker().Stats())
 		}
 
 		if arg.Logs {

--- a/vql/server/clients/delete.go
+++ b/vql/server/clients/delete.go
@@ -159,6 +159,13 @@ func reallyDeleteClient(ctx context.Context,
 	config_obj *config_proto.Config, scope vfilter.Scope,
 	db datastore.DataStore, arg *DeleteClientArgs) error {
 
+	client_info_manager, err := services.GetClientInfoManager()
+	if err != nil {
+		return err
+	}
+
+	client_info_manager.Remove(arg.ClientId)
+
 	indexer, err := services.GetIndexer()
 	if err != nil {
 		return err

--- a/vql/server/clients/delete.go
+++ b/vql/server/clients/delete.go
@@ -132,12 +132,21 @@ func (self DeleteClientPlugin) Call(ctx context.Context,
 				return nil
 			})
 
-		// Finally remove the containing directory
-		err = db.DeleteSubject(
-			config_obj,
-			paths.NewClientPathManager(arg.ClientId).Path().SetDir())
-		if err != nil {
-			scope.Log("client_delete: %s", err)
+		// Delete the actual client record.
+		if arg.ReallyDoIt {
+			err = reallyDeleteClient(ctx, config_obj, scope, db, arg)
+			if err != nil {
+				scope.Log("client_delete: %s", err)
+				return
+			}
+
+			// Finally remove the containing directory
+			err = db.DeleteSubject(
+				config_obj,
+				paths.NewClientPathManager(arg.ClientId).Path().SetDir())
+			if err != nil {
+				scope.Log("client_delete: %s", err)
+			}
 		}
 
 		// Notify the client to force it to disconnect in case

--- a/vql/server/clients/delete.go
+++ b/vql/server/clients/delete.go
@@ -91,16 +91,6 @@ func (self DeleteClientPlugin) Call(ctx context.Context,
 			return
 		}
 
-		// Delete the actual client record.
-		if arg.ReallyDoIt {
-			err = reallyDeleteClient(ctx, config_obj, scope, db, arg)
-			if err != nil {
-				scope.Log("client_delete: %s", err)
-				return
-			}
-
-		}
-
 		// Delete the filestore files.
 		err = api.Walk(file_store_factory,
 			client_path_manager.Path().AsFilestorePath(),

--- a/vql/tools/process/api.go
+++ b/vql/tools/process/api.go
@@ -3,12 +3,14 @@ package process
 import (
 	"context"
 
+	"github.com/Velocidex/ttlcache/v2"
 	"www.velocidex.com/golang/vfilter"
 )
 
 type IProcessTracker interface {
 	Get(ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool)
 	Enrich(ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool)
+	Stats() ttlcache.Metrics
 	Processes(ctx context.Context, scope vfilter.Scope) []*ProcessEntry
 	Children(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry
 	CallChain(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry

--- a/vql/tools/process/dummy.go
+++ b/vql/tools/process/dummy.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/Velocidex/ordereddict"
+	"github.com/Velocidex/ttlcache/v2"
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/functions"
 	"www.velocidex.com/golang/vfilter"
@@ -40,6 +41,10 @@ func (self *DummyProcessTracker) Get(ctx context.Context,
 		}
 	}
 	return nil, false
+}
+
+func (self *DummyProcessTracker) Stats() ttlcache.Metrics {
+	return ttlcache.Metrics{}
 }
 
 func (self *DummyProcessTracker) Enrich(

--- a/vql/tools/process/pslist.go
+++ b/vql/tools/process/pslist.go
@@ -32,7 +32,11 @@ func (self _ProcessTrackerPsList) Call(
 			case <-ctx.Done():
 				return
 
-			case output_chan <- proc.Data:
+			case output_chan <- proc.Data.
+				Set("Pid", proc.Id).
+				Set("Ppid", proc.ParentId).
+				Set("StartTime", proc.StartTime).
+				Set("EndTime", proc.EndTime):
 			}
 		}
 	}()

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -83,6 +83,10 @@ func (self *ProcessTracker) Get(
 	return pe, true
 }
 
+func (self *ProcessTracker) Stats() ttlcache.Metrics {
+	return self.lookup.GetMetrics()
+}
+
 func (self *ProcessTracker) Enrich(
 	ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool) {
 	any, err := self.lookup.Get(id)


### PR DESCRIPTION
Previously this took an actual JSON object but this is not intuitive -
it now takes a path to the remapping file as created by the deaddisk
command.

* The deaddisk command now takes an offset avoiding the need for
  reading the partition table

* Refactored pstree to use the process tracker.

* Added a Windows.Events.TrackProcessesBasic to track processes based
  on pslist only - no need for sysmon to get basic process tracking.

* Allow the execve plugin to specify the workig directory for tools that must
   work in a certain directory