### PR TITLE
Improve the Windows.Sys.StartupItems artifact

### DIFF
--- a/artifacts/definitions/Windows/Sys/StartupItems.yaml
+++ b/artifacts/definitions/Windows/Sys/StartupItems.yaml
@@ -1,63 +1,104 @@
 name: Windows.Sys.StartupItems
-description: Applications that will be started up from the various run key locations.
+description: |
+    Applications that will be started up from the various run key
+    locations.
+
 reference:
   - https://docs.microsoft.com/en-us/windows/desktop/setupapi/run-and-runonce-registry-keys
 
+imports:
+ - Windows.Forensics.Lnk
+
 parameters:
+  - name: AlsoUpload
+    type: bool
+    description: If set we also upload the files in the startup folders
+
   - name: runKeyGlobs
-    default: >
-      HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*\*,
-      HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run*\*,
+    type: csv
+    default: |
+      KeyGlobs
+      HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*\*
+      HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run*\*
       HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run*\*
-      HKEY_USERS\*\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*\*,
-      HKEY_USERS\*\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run*\*,
+      HKEY_USERS\*\SOFTWARE\Microsoft\Windows\CurrentVersion\Run*\*
+      HKEY_USERS\*\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run*\*
       HKEY_USERS\*\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run*\*
+
   - name: startupApprovedGlobs
-    default: >
-      HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\**,
+    type: csv
+    default: |
+      KeyGlobs
+      HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\**
       HKEY_USERS\*\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\**
+
   - name: startupFolderDirectories
-    default: >
-      C:/ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/**,
+    type: csv
+    default: |
+      FileGlobs
+      C:/ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/**
       C:/Users/*/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/Startup/**
 
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
+
     query: |
-        /* We need to search this multiple times so we materialize it
-           into a variable (using the <= operator)
-         */
         LET approved <=
            SELECT Name as ApprovedName,
                   encode(string=Data, type="hex") as Enabled
-           FROM glob(globs=split(string=startupApprovedGlobs, sep="[, ]+"),
+           FROM glob(globs=startupApprovedGlobs.KeyGlobs,
                      accessor="registry")
            WHERE Enabled =~ "^0[0-9]0+$"
 
         LET registry_runners = SELECT Name,
-          FullPath, Data.value as Command,
+          OSPath, Data.value as Details,
           if(
            condition={
                 SELECT Enabled from approved
                 WHERE Name = ApprovedName
            },
-           then="enabled", else="disabled") as Enabled
+           then="enabled", else="disabled") as Enabled,
+           "" AS Upload
           FROM glob(
-           globs=split(string=runKeyGlobs, sep="[, ]+"),
+           globs=runKeyGlobs.KeyGlobs,
            accessor="registry")
 
-        LET file_runners = SELECT * FROM foreach(
-           row={
-              SELECT Name, FullPath
-              FROM glob(
-                 globs=split(string=startupFolderDirectories, sep=",\\s*"))
-           }, query={
-              SELECT Name, FullPath, "enable" as Enabled,
-                  encode(string=Data, type='utf16') as Command
-              FROM read_file(filenames=FullPath)
-           })
+        LET enrich_file(OSPath) = SELECT * FROM switch(
+        ini={
+            SELECT regex_replace(re="[^0-9a-z_]", replace=".",
+                 source=read_file(filename=OSPath, length=1024)) AS Details
+            FROM scope()
+            WHERE OSPath.Basename =~ ".(bat|ini|ps1)$"
+        }, lnk={
+            SELECT dict(
+               _Parsed=_value,
+               HeaderCreationTime=_value.CreationTime,
+               HeaderAccessTime=_value.AccessTime,
+               HeaderWriteTime=_value.WriteTime,
+               FileSize=_value.FileSize,
+               Target=_value.LinkInfo.Target,
+               Name=_value.NameInfo.Name,
+               RelativePath=_value.RelativePathInfo.RelativePath,
+               WorkingDir=_value.WorkingDirInfo.WorkingDir,
+               Arguments=_value.ArgumentInfo.Arguments,
+               Icons=_value.IconInfo.IconLocations) AS Details
+            FROM foreach(row=parse_binary(
+               filename=OSPath, profile=Profile, struct="ShellLinkHeader"))
+            WHERE OSPath.Basename =~ ".lnk"
+        }, default={
+            SELECT hash(path=OSPath) AS Details
+            FROM scope()
+        })
 
-        SELECT * from chain(
+        LET file_runners =
+          SELECT Name, OSPath,
+                 enrich_file(OSPath=OSPath)[0].Details AS Details,
+                 "enable" as Enabled,
+                 if(condition=AlsoUpload, then=upload(file=OSPath)) AS Upload
+          FROM glob(globs=startupFolderDirectories.FileGlobs)
+
+        SELECT *
+        FROM chain(
            first=registry_runners,
            second=file_runners)

--- a/artifacts/testdata/windows/startup.in.yaml
+++ b/artifacts/testdata/windows/startup.in.yaml
@@ -1,4 +1,4 @@
 Queries:
-  - SELECT *
+  - SELECT Name, Details, Enabled
     FROM Artifact.Windows.Sys.StartupItems()
     WHERE Name =~ 'msht' ORDER BY Name

--- a/artifacts/testdata/windows/startup.in.yaml
+++ b/artifacts/testdata/windows/startup.in.yaml
@@ -1,4 +1,4 @@
 Queries:
-  - SELECT Name, Command, Enabled, _Source
+  - SELECT *
     FROM Artifact.Windows.Sys.StartupItems()
     WHERE Name =~ 'msht' ORDER BY Name

--- a/artifacts/testdata/windows/startup.out.yaml
+++ b/artifacts/testdata/windows/startup.out.yaml
@@ -1,8 +1,10 @@
-SELECT Name, Command, Enabled, _Source FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' ORDER BY Name[
+SELECT * FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' ORDER BY Name[
  {
   "Name": "c:\\windows\\system32\\msht.exe",
-  "Command": "Hello",
+  "OSPath": "HKEY_USERS\\S-1-5-21-3026640767-601176999-3470186877-500\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\\"c:\\windows\\system32\\msht.exe\"",
+  "Details": "Hello",
   "Enabled": "disabled",
+  "Upload": "",
   "_Source": "Windows.Sys.StartupItems"
  }
 ]

--- a/artifacts/testdata/windows/startup.out.yaml
+++ b/artifacts/testdata/windows/startup.out.yaml
@@ -1,10 +1,7 @@
-SELECT * FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' ORDER BY Name[
+SELECT Name, Details, Enabled FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' ORDER BY Name[
  {
   "Name": "c:\\windows\\system32\\msht.exe",
-  "OSPath": "HKEY_USERS\\S-1-5-21-3026640767-601176999-3470186877-500\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\\"c:\\windows\\system32\\msht.exe\"",
   "Details": "Hello",
-  "Enabled": "disabled",
-  "Upload": "",
-  "_Source": "Windows.Sys.StartupItems"
+  "Enabled": "disabled"
  }
 ]


### PR DESCRIPTION
Present relevant details per startup item type:

ini,bat,ps1 present a preview of the file
lnk: parse the link file out
exe: calculate hash

Also allow for automatic upload of the startup files.

Sample output:

![Windows_11_Test_VM_2022_2](https://user-images.githubusercontent.com/3856546/174650431-9000c786-0c7e-423d-8ebd-9a62316a2d1d.png)

