### PR TITLE
Revert "fix: upgrade ace-builds from 1.5.2 to 1.5.3 (#1899)"

### DIFF
--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -11,7 +11,7 @@
                 "@fortawesome/fontawesome-svg-core": "^1.3.0",
                 "@fortawesome/free-solid-svg-icons": "^5.15.4",
                 "@fortawesome/react-fontawesome": "^0.1.18",
-                "ace-builds": "^1.5.3",
+                "ace-builds": "^1.5.2",
                 "axios": ">=0.27.2",
                 "bootstrap": "^4.6.1",
                 "cacache": "^15.0.6",
@@ -4245,9 +4245,9 @@
             }
         },
         "node_modules/ace-builds": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.5.3.tgz",
-            "integrity": "sha512-WN5BKR2aTSuBmisO8jo3Fytk6sOmJGki82v/Boeic81IgYN8pFHNkXq2anDF0XkmfDWMqLbRoW9sjc/GtKzQbQ=="
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.5.2.tgz",
+            "integrity": "sha512-E/h9JRtcTwzXYKZ4Ucnw9Eit0gEWQSFrjSCQQER/qIavrVbWNM4w21WqyyOqSVs+jtMjpSO11mg2ZZTExXbltQ=="
         },
         "node_modules/acorn": {
             "version": "8.7.0",
@@ -25094,9 +25094,9 @@
             }
         },
         "ace-builds": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.5.3.tgz",
-            "integrity": "sha512-WN5BKR2aTSuBmisO8jo3Fytk6sOmJGki82v/Boeic81IgYN8pFHNkXq2anDF0XkmfDWMqLbRoW9sjc/GtKzQbQ=="
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.5.2.tgz",
+            "integrity": "sha512-E/h9JRtcTwzXYKZ4Ucnw9Eit0gEWQSFrjSCQQER/qIavrVbWNM4w21WqyyOqSVs+jtMjpSO11mg2ZZTExXbltQ=="
         },
         "acorn": {
             "version": "8.7.0",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -6,7 +6,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.3.0",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "ace-builds": "^1.5.3",
+        "ace-builds": "^1.5.2",
         "axios": ">=0.27.2",
         "bootstrap": "^4.6.1",
         "cacache": "^15.0.6",


### PR DESCRIPTION
This reverts commit 5397a3b74f0970c8c49fc13f248c8ee765dba0fd as it
broke the ACE edit's tooltips