### PR TITLE
Windows.Attack.IncorrectImagePath

### DIFF
--- a/artifacts/definitions/Windows/Attack/IncorrectImagePath.yaml
+++ b/artifacts/definitions/Windows/Attack/IncorrectImagePath.yaml
@@ -1,0 +1,127 @@
+name: Windows.Attack.IncorrectImagePath
+
+Description: |
+  Some malware are hiding in plain text by masqurading a legitimate executable name.
+
+  This artifact looks for processes with known names that are being loaded from unexcpected 
+  locations.
+
+reference: 
+  - https://www.sans.org/posters/hunt-evil/
+  - https://github.com/teoseller/osquery-attck/blob/master/windows-incorrect_path_process.conf
+
+author: Amged Wageh
+
+parameters:
+   - name: expected_
+     type: json_array
+     default: |
+        [
+          {
+            "ProcessName": "system",
+            "ImagePaths": []
+          },
+          {
+            "ProcessName": "csrss.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\csrss.exe"
+            ]
+          },
+          {
+            "ProcessName": "smss.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\smss.exe"
+            ]
+          },
+          {
+            "ProcessName": "services.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\services.exe"
+            ]
+          },
+          {
+            "ProcessName": "wininit.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\wininit.exe"
+            ]
+          },
+          {
+            "ProcessName": "svchost.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\svchost.exe",
+              "c:\\windows\\syswow64\\svchost.exe"
+            ]
+          },
+          {
+            "ProcessName": "runtimebroker.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\runtimebroker.exe"
+            ]
+          },
+          {
+            "ProcessName": "lsaiso.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\lsaiso.exe"
+            ]
+          },
+          {
+            "ProcessName": "taskhostw.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\taskhostw.exe"
+            ]
+          },
+          {
+            "ProcessName": "lsass.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\lsass.exe"
+            ]
+          },
+          {
+            "ProcessName": "winlogon.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\winlogon.exe"
+            ]
+          },
+          {
+            "ProcessName": "explorer.exe",
+            "ImagePaths": [
+              "c:\\windows\\explorer.exe",
+              "c:\\windows\\syswow64\\explorer.exe"
+            ]
+          },
+          {
+            "ProcessName": "conhost.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\conhost.exe"
+            ]
+          },
+          {
+            "ProcessName": "dllhost.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\dllhost.exe",
+              "c:\\windows\\syswow64\\dllhost.exe"
+            ]
+          },
+          {
+            "ProcessName": "wmiprvse.exe",
+            "ImagePaths": [
+              "c:\\windows\\system32\\wbem\\wmiprvse.exe",
+              "c:\\windows\\syswow64\\wbem\\wmiprvse.exe"
+            ]
+          }
+        ]
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+      LET running_processes <= SELECT Name, Pid, Ppid, {SELECT Name FROM pslist(pid=Ppid)} AS ParentProcessName, Exe, CommandLine, Username, CreateTime FROM pslist()
+      
+      SELECT * FROM foreach(
+          row={SELECT ProcessName, ImagePaths FROM expected_paths},
+          query={
+              SELECT * FROM running_processes 
+              WHERE Exe!="" AND lowcase(string=Name)=ProcessName AND NOT lowcase(string=Exe) in ImagePaths
+          }
+      )


### PR DESCRIPTION
It is for creating an artifact that looks for processes with known names that are being loaded from unexpected locations.