### PR TITLE
Added Generic.System.ProcessSiblings

### DIFF
--- a/api/notebooks.go
+++ b/api/notebooks.go
@@ -450,7 +450,7 @@ func exportZipNotebook(
 			logger.WithFields(logrus.Fields{
 				"notebook_id": notebook.NotebookId,
 				"export_file": filename,
-				"error":       err,
+				"error":       err.Error(),
 			}).Error("CreateNotebookDownloadFile")
 			return
 		}
@@ -511,7 +511,7 @@ func exportHTMLNotebook(config_obj *config_proto.Config,
 			logger.WithFields(logrus.Fields{
 				"notebook_id": notebook.NotebookId,
 				"export_file": filename,
-				"error":       err,
+				"error":       err.Error(),
 			}).Error("CreateNotebookDownloadFile")
 			return
 		}

--- a/artifacts/definitions/Generic/System/ProcessSiblings.yaml
+++ b/artifacts/definitions/Generic/System/ProcessSiblings.yaml
@@ -1,0 +1,43 @@
+name: Generic.System.ProcessSiblings
+description: |
+  This artifact queries the process tracker to display all known
+  sibling processes of the target process (i.e. all other processes
+  from the same parent).
+
+  This is useful to reveal the complete interaction that included
+  the process in question (e.g. previous shell commands etc).
+
+  Minimum Version: 0.6.6
+
+parameters:
+  - name: CommandlineRegex
+    default: .
+    description: Target process by this command line
+    type: regex
+
+  - name: PidFilter
+    description: Filter pids by this regex
+    default: .
+    type: regex
+
+sources:
+  - query: |
+        LET GetDetails(Records) = SELECT
+            Id AS ChildPid,
+            Data.CommandLine AS CommandLine,
+            Data.Username AS Username,
+            StartTime, EndTime
+          FROM Records
+          ORDER BY StartTime
+
+        SELECT * FROM foreach(row={
+          SELECT Pid, Ppid, Name
+          FROM process_tracker_pslist()
+          WHERE CommandLine =~  CommandlineRegex
+            AND Pid =~ PidFilter
+        }, query={
+          SELECT Pid,Ppid, Name, ChildPid,
+                 CommandLine, Username, StartTime, EndTime
+          FROM foreach(row=GetDetails(
+              Records=process_tracker_children(id=Ppid)))
+        })

--- a/artifacts/definitions/Windows/Events/TrackProcesses.yaml
+++ b/artifacts/definitions/Windows/Events/TrackProcesses.yaml
@@ -56,7 +56,10 @@ sources:
                        EventData.ParentProcessId AS parent_id,
                        "start" AS update_type,
                        EventData + dict(
+                           Name=split(sep_string="\\", string=EventData.Image)[-1],
+                           Username=EventData.User,
                            CreateTime=EventData.UtcTime,
+                           Exe=EventData.Image,
                            Hashes=parse_string_with_regex(regex=[
                              "SHA256=(?P<SHA256>[^,]+)",
                              "MD5=(?P<MD5>[^,]+)",
@@ -85,12 +88,11 @@ sources:
                  Ppid AS parent_id,
                  CreateTime AS start_time,
                  dict(
-                   Image=Exe,
-                   CommandLine=CommandLine,
-                   CreateTime=CreateTime) AS data
+                   Name=Name,
+                   Username=Username,
+                   Exe=Exe,
+                   CommandLine=CommandLine) AS data
               FROM pslist()
-
-
 
       LET Tracker <= process_tracker(
          enrichments=[

--- a/bin/gui.go
+++ b/bin/gui.go
@@ -119,6 +119,13 @@ func doGUI() error {
 		config_obj.Defaults.EventMaxWaitJitter = 1
 		config_obj.Defaults.EventChangeNotifyAllClients = true
 
+		// Load the "fs" accessor this time (It will be loaded
+		// automatically after restart).
+		err = initFilestoreAccessor(config_obj)
+		if err != nil {
+			return err
+		}
+
 		// Create a user with default password
 		user_record, err := users.NewUserRecord("admin")
 		if err != nil {

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -965,6 +965,10 @@ message Config {
     // host's own file system.
     repeated RemappingConfig remappings = 35;
 
+    // These should **not** be set by the user - they are tags
+    // internally that mark each org's config object. They should
+    // definitely not be set on the client's config because the client
+    // does not know or use its own org id.
     string org_id = 36;
     string org_name = 37;
 }

--- a/services/journal/utils.go
+++ b/services/journal/utils.go
@@ -91,7 +91,7 @@ func WatchQueueWithCB(ctx context.Context,
 					logger.WithFields(logrus.Fields{
 						"Owner":    watcher_name,
 						"Artifact": artifact,
-						"Error":    err,
+						"Error":    err.Error(),
 					}).Debug("Event Processor Error")
 				}
 

--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -149,21 +149,16 @@ func (self *OrgManager) makeNewConfigObj(
 
 	result := proto.Clone(self.config_obj).(*config_proto.Config)
 
-	// The Root org is untouched.
-	if record.OrgId == "" {
-		return result
-	}
+	result.OrgId = record.OrgId
+	result.OrgName = record.Name
 
 	if result.Client != nil {
-		result.OrgId = record.OrgId
-		result.OrgName = record.Name
-
 		// Client config does not leak org id! We use the nonce to tie
 		// org id back to the org.
 		result.Client.Nonce = record.Nonce
 	}
 
-	if result.Datastore != nil {
+	if result.Datastore != nil && record.OrgId != "" {
 		if result.Datastore.Location != "" {
 			result.Datastore.Location = filepath.Join(
 				result.Datastore.Location, "orgs", record.OrgId)

--- a/vql/server/downloads/downloads.go
+++ b/vql/server/downloads/downloads.go
@@ -510,7 +510,7 @@ func createHuntDownloadFile(
 				logging.GetLogger(config_obj, &logging.GUIComponent).
 					WithFields(logrus.Fields{
 						"artifact": artifact,
-						"error":    err,
+						"error":    err.Error(),
 					}).Error("ExportHuntArtifact")
 			}
 

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -101,9 +101,10 @@ func (self *ProcessTracker) SetEntry(id string, entry *ProcessEntry) (old_id str
 	}
 
 	// Use the start time to identify the same process entry. If the
-	// start times are identical then it is the same record.
-	if item.Id == entry.Id &&
-		item.StartTime.Equal(entry.StartTime) {
+	// start times are identical (within one second) then it is the
+	// same record.
+	time_diff := item.StartTime.Unix() - entry.StartTime.Unix()
+	if item.Id == entry.Id && time_diff < 2 && time_diff > -2 {
 		entry.ParentId = item.ParentId
 		self.lookup.Set(id, entry)
 		return id, false


### PR DESCRIPTION
Loosen pid reuse detection - sometimes the start time delivered by
pslist and sysmon may defer due to round off.