### PR TITLE
Fix "last_visit_time" timestamp

### DIFF
--- a/artifacts/definitions/Windows/Applications/Chrome/History.yaml
+++ b/artifacts/definitions/Windows/Applications/Chrome/History.yaml
@@ -39,7 +39,7 @@ sources:
                    timestamp(winfiletime=visit_time * 10) AS visit_time,
                    url as visited_url,
                    title,visit_count,typed_count,
-                   timestamp(epoch=last_visit_time) AS last_visit_time,
+                   timestamp(winfiletime=last_visit_time * 10) AS last_visit_time,
                    hidden,
                    from_visit AS from_url_id,
                    visit_duration,transition,


### PR DESCRIPTION
Fixed an issue with the `last_visit_time` column's timestamp in **Windows.Applications.Chrome.History**. This timestamp is recorded in the database as a WebKit timestamp (microseconds since Jan 1, 1601 00:00 UTC) and is being parsed as an epoch timestamp.

Validated with the latest Chrome 104.0.5112.81 version

<img width="820" alt="chromehistory_old" src="https://user-images.githubusercontent.com/108568200/184289161-ca20f7bf-f240-4084-9663-25f9ec1ec030.png">

<img width="821" alt="chromehistory_fix" src="https://user-images.githubusercontent.com/108568200/184289185-5b8a0de4-476d-4898-9057-864912f3a05f.png">

