### PR TITLE
Fixed bug in UserAccessLog artifact

### DIFF
--- a/artifacts/definitions/Windows/Forensics/UserAccessLogs.yaml
+++ b/artifacts/definitions/Windows/Forensics/UserAccessLogs.yaml
@@ -11,11 +11,24 @@ reference:
   - https://docs.microsoft.com/en-us/windows-server/administration/user-access-logging/manage-user-access-logging
   - https://www.crowdstrike.com/blog/user-access-logging-ual-overview/
 
+export: |
+    LET IPProfile = '''[
+      ["X", 0, [
+        ["A", 0, "uint8"],
+        ["B", 1, "uint8"],
+        ["C", 2, "uint8"],
+        ["D", 3, "uint8"],
+        ["IP", 0, "Value", {
+           value: "x=> format(format='%d.%d.%d.%d', args=[x.A, x.B, x.C, x.D])"
+        }]
+      ]]
+    ]'''
+
 parameters:
    - name: SUMGlob
      description: The SUM ESE files to search for.
-     default: |
-       C:\Windows\System32\LogFiles\SUM\*.mdb
+     default: >-
+       C:/Windows/System32/LogFiles/SUM/*.mdb
 
 sources:
   - query: |
@@ -46,7 +59,9 @@ sources:
         LET FormatAddress(x) = if(condition=len(list=x) = 4,
 
          -- IPv4 address should be formatted in dot notation
-         then=format(format="%d.%d.%d.%d", args=[x[0], x[1], x[2], x[3]]),
+         then=parse_binary(accessor="data",
+                           filename=Address, struct="X",
+                           profile=IPProfile).IP,
          else=if(condition=len(list=x)=16,
            -- IPv6 addresses are usually shortened
            then=regex_replace(source=format(format="%x", args=x),
@@ -55,9 +70,10 @@ sources:
            -- We dont know what kind of address it is.
            else=format(format="%x", args=x)))
 
-        LET ParseESE = SELECT FullPath AS _FullPath, RoleGuid,
+        LET ParseESE = SELECT OSPath AS _OSPath, RoleGuid,
                GetRoleName(guid=RoleGuid)[0].RoleName AS RoleName,
                TenantId, TotalAccesses, InsertDate, LastAccess,
+               format(format="%02x", args=Address) AS RawAddress,
                FormatAddress(x=Address) AS Address,
                AuthenticatedUserName,
                -- Only show the days that have something in them.
@@ -68,9 +84,9 @@ sources:
                  FROM range(start=0, end=366, step=1)
                  WHERE _value
                }) AS Days
-        FROM parse_ese(file=FullPath, table="CLIENTS")
+        FROM parse_ese(file=OSPath, table="CLIENTS", accessor="auto")
 
         SELECT * FROM foreach(row={
-          SELECT FullPath
-          FROM glob(globs=SUMGlob)
+          SELECT OSPath
+          FROM glob(globs=SUMGlob, accessor="auto")
         }, query=ParseESE)

--- a/artifacts/testdata/server/testcases/protocols.in.yaml
+++ b/artifacts/testdata/server/testcases/protocols.in.yaml
@@ -1,0 +1,7 @@
+Parameters:
+  TestString: This is a test
+
+Queries:
+  - SELECT TestString, TestString[0], TestString[-1],
+           TestString[0:5], TestString[:5], TestString[5:]
+    FROM scope()

--- a/artifacts/testdata/server/testcases/protocols.out.yaml
+++ b/artifacts/testdata/server/testcases/protocols.out.yaml
@@ -1,0 +1,10 @@
+SELECT TestString, TestString[0], TestString[-1], TestString[0:5], TestString[:5], TestString[5:] FROM scope()[
+ {
+  "TestString": "This is a test",
+  "TestString[0]": 84,
+  "TestString[-1]": 116,
+  "TestString[0 : 5]": "This ",
+  "TestString[ : 5]": "This ",
+  "TestString[5 : ]": "is a test"
+ }
+]

--- a/artifacts/testdata/server/testcases/ual.in.yaml
+++ b/artifacts/testdata/server/testcases/ual.in.yaml
@@ -1,5 +1,5 @@
 Queries:
-  - SELECT *, basename(path=_FullPath) AS _FullPath
+  - SELECT *, basename(path=_OSPath) AS _FullPath
     FROM Artifact.Windows.Forensics.UserAccessLogs(
       SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb")
     LIMIT 1

--- a/artifacts/testdata/server/testcases/ual.in.yaml
+++ b/artifacts/testdata/server/testcases/ual.in.yaml
@@ -1,5 +1,5 @@
 Queries:
-  - SELECT *, basename(path=_OSPath) AS _FullPath
+  - SELECT *, basename(path=_OSPath) AS _OSPath
     FROM Artifact.Windows.Forensics.UserAccessLogs(
       SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb")
     LIMIT 1

--- a/artifacts/testdata/server/testcases/ual.out.yaml
+++ b/artifacts/testdata/server/testcases/ual.out.yaml
@@ -1,6 +1,5 @@
-SELECT *, basename(path=_OSPath) AS _FullPath FROM Artifact.Windows.Forensics.UserAccessLogs( SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb") LIMIT 1[
+SELECT *, basename(path=_OSPath) AS _OSPath FROM Artifact.Windows.Forensics.UserAccessLogs( SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb") LIMIT 1[
  {
-  "_OSPath": "/home/mic/projects/velociraptor/artifacts/testdata/files/{03A01CC5-91BB-4936-B685-63697785D39E}.mdb",
   "RoleGuid": "{ad495fc3-0eaa-413d-ba7d-8b13fa7ec598}",
   "RoleName": "Active Directory Domain Services",
   "TenantId": "{5e210c24-fb44-45c2-996d-4139d5b7fc4c}",
@@ -15,6 +14,6 @@ SELECT *, basename(path=_OSPath) AS _FullPath FROM Artifact.Windows.Forensics.Us
    "Day164": 249
   },
   "_Source": "Windows.Forensics.UserAccessLogs",
-  "_FullPath": "{03A01CC5-91BB-4936-B685-63697785D39E}.mdb"
+  "_OSPath": "{03A01CC5-91BB-4936-B685-63697785D39E}.mdb"
  }
 ]

--- a/artifacts/testdata/server/testcases/ual.out.yaml
+++ b/artifacts/testdata/server/testcases/ual.out.yaml
@@ -1,11 +1,13 @@
-SELECT *, basename(path=_FullPath) AS _FullPath FROM Artifact.Windows.Forensics.UserAccessLogs( SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb") LIMIT 1[
+SELECT *, basename(path=_OSPath) AS _FullPath FROM Artifact.Windows.Forensics.UserAccessLogs( SUMGlob=srcDir+"/artifacts/testdata/files/*03A01CC5*.mdb") LIMIT 1[
  {
+  "_OSPath": "/home/mic/projects/velociraptor/artifacts/testdata/files/{03A01CC5-91BB-4936-B685-63697785D39E}.mdb",
   "RoleGuid": "{ad495fc3-0eaa-413d-ba7d-8b13fa7ec598}",
   "RoleName": "Active Directory Domain Services",
   "TenantId": "{5e210c24-fb44-45c2-996d-4139d5b7fc4c}",
   "TotalAccesses": 310,
   "InsertDate": "2021-06-12T23:47:21Z",
   "LastAccess": "2021-06-13T15:48:08Z",
+  "RawAddress": "00000000000000000000000000000001",
   "Address": ":01",
   "AuthenticatedUserName": "lab\\dc-1$",
   "Days": {

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20220801101854-338dbe61982a
 	www.velocidex.com/golang/oleparse v0.0.0-20220617011920-94df2342d0b7
 	www.velocidex.com/golang/regparser v0.0.0-20220803120500-8e74df808b0a
-	www.velocidex.com/golang/vfilter v0.0.0-20220818065523-acba7ec562fc
+	www.velocidex.com/golang/vfilter v0.0.0-20220821025017-911b14d15652
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1042,7 +1042,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20220617011920-94df2342d0b7/go.mod h1:R
 www.velocidex.com/golang/regparser v0.0.0-20220803120500-8e74df808b0a h1:vwxkG8OtUHo5vOUaSXjc0FWvbGvjAjfy79hIQRjisOU=
 www.velocidex.com/golang/regparser v0.0.0-20220803120500-8e74df808b0a/go.mod h1:pxSECT5mWM3goJ4sxB4HCJNKnKqiAlpyT8XnvBwkLGU=
 www.velocidex.com/golang/vfilter v0.0.0-20220103082604-85bb38175cb7/go.mod h1:eEFMhAmoFHWGCKF39j+iOhTH8REpqBndc3OsdPsxqo8=
-www.velocidex.com/golang/vfilter v0.0.0-20220818065523-acba7ec562fc h1:xL6hfdfWRdtU6C92cobPQhc69K7M9TOspIuDlWlDWoQ=
-www.velocidex.com/golang/vfilter v0.0.0-20220818065523-acba7ec562fc/go.mod h1:HVtgbXGQZxVN3eR3q6PD46ZoIJkyfT7E62SvCVNg5+A=
+www.velocidex.com/golang/vfilter v0.0.0-20220821025017-911b14d15652 h1:IjTOHob38dvgPUzSgyKRGdWxc1MWg71KdWrQxSFUO5Q=
+www.velocidex.com/golang/vfilter v0.0.0-20220821025017-911b14d15652/go.mod h1:HVtgbXGQZxVN3eR3q6PD46ZoIJkyfT7E62SvCVNg5+A=
 www.velocidex.com/golang/vtypes v0.0.0-20220816192452-6a27ae078f12 h1:8azOLd/l6sPy1/ug03ueA7jLfsVwE1sI3oHg9q/nkqQ=
 www.velocidex.com/golang/vtypes v0.0.0-20220816192452-6a27ae078f12/go.mod h1:gpuRaiyhcuPmZYvI/zw+rjlDXklR2ORaLQBuzCXe84o=

--- a/vql/parsers/ese/ese.go
+++ b/vql/parsers/ese/ese.go
@@ -202,7 +202,7 @@ func (self _ESEPlugin) Call(
 		}
 
 		if arg.Accessor == "" {
-			arg.Accessor = "file"
+			arg.Accessor = "auto"
 		}
 
 		err = vql_subsystem.CheckFilesystemAccess(scope, arg.Accessor)


### PR DESCRIPTION
- IP field was not properly parsed - replaced with a parse_binary()
  version to ensure backwards compatibility.
- By default parse_ese() was using the "file" accessor which in 0.6.5
  was changed to not fallback to NTFS parsing. This means that since
  UAL files are locked, the parser was unable to access them. This PR
  sets the accessor to be "auto" explicitly thereby forcing the ntfs
  parsing if needed.