### PR TITLE
Cater for unknown parents in process tracker.

### DIFF
--- a/vql/tools/process/fixtures/TestProcessTracker.golden
+++ b/vql/tools/process/fixtures/TestProcessTracker.golden
@@ -4,7 +4,7 @@
    "process_tracker_callchain(id=2)": [
     {
      "Id": "5",
-     "ParentId": "1",
+     "ParentId": "1-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T10:30:00Z",
@@ -32,7 +32,7 @@
    "process_tracker_callchain(id=2)": [
     {
      "Id": "1",
-     "ParentId": "0",
+     "ParentId": "0-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T12:30:00Z",
@@ -60,7 +60,7 @@
    "process_tracker_callchain(id=2)": [
     {
      "Id": "1",
-     "ParentId": "0",
+     "ParentId": "0-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T12:30:00Z",
@@ -94,7 +94,7 @@
    "process_tracker_callchain(id=2)": [
     {
      "Id": "5",
-     "ParentId": "1",
+     "ParentId": "1-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T10:30:00Z",
@@ -128,7 +128,7 @@
    "process_tracker_callchain(id=2)": [
     {
      "Id": "5-1609497000",
-     "ParentId": "1",
+     "ParentId": "1-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T10:30:00Z",
@@ -151,12 +151,34 @@
    ]
   }
  ],
+ "Pid reuse with missing parent": [
+  {
+   "process_tracker_callchain(id=2).Data.Name": [
+    "NewProcess5"
+   ]
+  },
+  {
+   "process_tracker_callchain(id=2)": [
+    {
+     "Id": "2",
+     "ParentId": "5-?",
+     "RealParentId": "",
+     "UpdateType": "",
+     "StartTime": "2021-01-01T12:30:00Z",
+     "EndTime": "2022-04-26TZ",
+     "Data": {
+      "Name": "NewProcess5"
+     }
+    }
+   ]
+  }
+ ],
  "Spoof (update)": [
   {
    "process_tracker_callchain(id=2)": [
     {
      "Id": "5-1609497000",
-     "ParentId": "1",
+     "ParentId": "1-?",
      "RealParentId": "",
      "UpdateType": "",
      "StartTime": "2021-01-01T10:30:00Z",

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -16,6 +16,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -329,6 +330,16 @@ func (self *ProcessTracker) doFullSync(
 			// set - update that now.
 			item.EndTime = now
 			self.lookup.Set(id, item)
+		}
+
+		// If a process has no valid parent at this time we must mark
+		// its parent id so as to prevent a new process with the same
+		// pid being added in future and clashing with it.
+		if !strings.Contains(item.ParentId, "-") {
+			_, pres := self.get(item.ParentId)
+			if !pres {
+				item.ParentId = fmt.Sprintf("%s-?", item.ParentId)
+			}
 		}
 	}
 

--- a/vql/tools/process/tracker_test.go
+++ b/vql/tools/process/tracker_test.go
@@ -147,6 +147,25 @@ FROM scope()
 		},
 
 		{
+			Name: "Pid reuse with missing parent",
+			// First sync has a process with the missing parent (pid 5
+			// is not known). On the second sync that process is
+			// reused with a new process with pid 5 (and a different
+			// parent 10). The tracker should **not** associate the
+			// 2->5->10 chain sincce this is not correct.
+			Mock: `
+[
+ [{"Pid":2,"Name":"Process2","Ppid":5,"CreateTime": "2021-01-01T12:30Z"}
+ ],
+ [{"Pid":5,"Name":"Process2","Ppid":10,"CreateTime": "2021-01-01T12:30Z"},
+  {"Pid":2,"Name":"NewProcess5","Ppid":5,"CreateTime": "2021-01-01T12:30Z"}
+ ]
+]`,
+			Query: stockSyncTest,
+			Clock: &utils.IncClock{NowTime: 1651000000},
+		},
+
+		{
 			Name: "Spoof (update)",
 			Mock: `
 [


### PR DESCRIPTION
When performing a full sync (e.g. pslist), some of the processes have
no valid parent at this time (because the parent e.g. exited).

We need to mark those unknown parents in case a new process reuses
those pids - in this case the process call chain can accidentally
include those parents.