### PR TITLE
Bugfix: Switch GUI to first available org

### DIFF
--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -32,7 +32,6 @@ import (
 	context "golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"www.velocidex.com/golang/velociraptor/acls"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
@@ -273,14 +272,14 @@ func authenticateUserHandle(
 		// Now check if the user is allowed to log in.
 		users := services.GetUserManager()
 		user_record, err := users.GetUser(username)
-		if err != nil {
+		if err != nil || user_record.Name != username {
 			reject_cb(w, r, errors.New("Invalid user"), username)
 			return
 		}
 
-		// Must have at least reader permission.
-		perm, err := acls.CheckAccess(config_obj, username, acls.READ_RESULTS)
-		if !perm || err != nil || user_record.Locked || user_record.Name != username {
+		// Does the user have access to the specified org?
+		err = CheckOrgAccess(r, user_record)
+		if err != nil {
 			reject_cb(w, r, errors.New("Insufficient permissions"), username)
 			return
 		}

--- a/api/authenticators/orgs.go
+++ b/api/authenticators/orgs.go
@@ -1,0 +1,74 @@
+package authenticators
+
+import (
+	"errors"
+	"net/http"
+
+	"www.velocidex.com/golang/velociraptor/acls"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	"www.velocidex.com/golang/velociraptor/services"
+)
+
+func CheckOrgAccess(r *http.Request, user_record *api_proto.VelociraptorUser) error {
+
+	// Now we have to determine which org the user wants to
+	// use. First let's check if the user specified an org in the
+	// header.
+	org_id := "root"
+	current_orgid_array := r.Header.Get("Grpc-Metadata-Orgid")
+	if len(current_orgid_array) == 1 {
+		org_id = string(current_orgid_array[0])
+	}
+
+	err := _checkOrgAccess(r, org_id, user_record)
+	if err == nil {
+		return nil
+	}
+
+	// Redirect the user to the first org they have access to
+	for _, org := range user_record.Orgs {
+		err := _checkOrgAccess(r, org.Id, user_record)
+		if err == nil {
+			r.Header.Set("Grpc-Metadata-Orgid", org.Id)
+
+			// Update the user's org preferences
+			user_manager := services.GetUserManager()
+			user_options, err := user_manager.GetUserOptions(user_record.Name)
+			if err == nil {
+				user_options.Org = org.Id
+			} else {
+				user_options = &api_proto.SetGUIOptionsRequest{
+					Org: org.Id,
+				}
+			}
+			user_manager.SetUserOptions(user_record.Name, user_options)
+
+			return nil
+		}
+	}
+
+	return errors.New("Unauthorized username")
+}
+
+func _checkOrgAccess(r *http.Request, org_id string, user_record *api_proto.VelociraptorUser) error {
+	org_manager, err := services.GetOrgManager()
+	if err != nil {
+		return err
+	}
+
+	org_config_obj, err := org_manager.GetOrgConfig(org_id)
+	if err != nil {
+		return err
+	}
+
+	perm, err := acls.CheckAccess(org_config_obj, user_record.Name, acls.READ_RESULTS)
+	if err != nil {
+		return err
+	}
+
+	if !perm || user_record.Locked {
+		return errors.New("Unauthorized username")
+	}
+
+	return nil
+}

--- a/services/vfs_service/vfs_service.go
+++ b/services/vfs_service/vfs_service.go
@@ -80,7 +80,6 @@ func (self *VFSService) ProcessDownloadFile(
 	artifact_path_manager, err := artifacts.NewArtifactPathManager(config_obj,
 		client_id, flow_id, "System.VFS.DownloadFile")
 	if err != nil {
-		utils.Debug(err)
 		logger.Error("Unable to read artifact: %v", err)
 		return
 	}


### PR DESCRIPTION
When a user is created with no access to the root org, the GUI did not
automatically switch the user to their own org. This caused an issue
where the user was rejected (because by default they were trying to
access the root org) but there was no way to switch even manually to
the correct org.

This PR updates the user's preferences to the first available org
automatically allowing the user to log in and select other orgs
manually.