### PR TITLE
Bugfix: Maintain field order in sysmon based tracker

### DIFF
--- a/artifacts/definitions/Windows/Detection/Usn.yaml
+++ b/artifacts/definitions/Windows/Detection/Usn.yaml
@@ -33,5 +33,5 @@ sources:
       LET NTFS_CACHE_TIME = 30
       LET USN_FREQUENCY = 60
 
-      SELECT * FROM watch_usn(device=Device, accessor="ntfs")
+      SELECT * FROM watch_usn(device=Device)
       WHERE FullPath =~ PathRegex

--- a/artifacts/definitions/Windows/Events/TrackProcesses.yaml
+++ b/artifacts/definitions/Windows/Events/TrackProcesses.yaml
@@ -59,11 +59,27 @@ sources:
                 SELECT EventData.ProcessId AS id,
                        EventData.ParentProcessId AS parent_id,
                        "start" AS update_type,
-                       EventData + dict(
+
+                       -- We need to manually build the dict here so
+                       -- we can maintain column ordering.
+                       dict(
+                           Pid=EventData.ProcessId,
+                           Ppid=EventData.ParentProcessId,
                            Name=split(sep_string="\\", string=EventData.Image)[-1],
+                           StartTime=EventData.UtcTime,
+                           EndTime=NULL,
                            Username=EventData.User,
-                           CreateTime=EventData.UtcTime,
                            Exe=EventData.Image,
+                           CommandLine= EventData.CommandLine,
+                           CurrentDirectory= EventData.CurrentDirectory,
+                           FileVersion=EventData.FileVersion,
+                           Description= EventData.Description,
+                           Company= EventData.Company,
+                           Product= EventData.Product,
+                           ParentImage= EventData.ParentImage,
+                           ParentCommandLine= EventData.ParentCommandLine,
+                           TerminalSessionId= EventData.TerminalSessionId,
+                           IntegrityLevel= EventData.IntegrityLevel,
                            Hashes=parse_string_with_regex(regex=[
                              "SHA256=(?P<SHA256>[^,]+)",
                              "MD5=(?P<MD5>[^,]+)",

--- a/vql/tools/process/pslist.go
+++ b/vql/tools/process/pslist.go
@@ -33,10 +33,10 @@ func (self _ProcessTrackerPsList) Call(
 				return
 
 			case output_chan <- proc.Data.
-				Set("Pid", proc.Id).
-				Set("Ppid", proc.ParentId).
-				Set("StartTime", proc.StartTime).
-				Set("EndTime", proc.EndTime):
+				Update("Pid", proc.Id).
+				Update("Ppid", proc.ParentId).
+				Update("StartTime", proc.StartTime).
+				Update("EndTime", proc.EndTime):
 			}
 		}
 	}()

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -187,7 +187,7 @@ func (self *ProcessTracker) Enrich(
 		if ok {
 			for _, k := range update_dict.Keys() {
 				v, _ := update_dict.Get(k)
-				pe.Data.Set(k, v)
+				pe.Data.Update(k, v)
 			}
 		}
 	}


### PR DESCRIPTION
When following ETW the EventData is an unordered map so we need to
explicitly build a dict() to maintain consistent ordering.