### PR TITLE
Split server sanity checks into root org and other orgs

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -262,7 +262,9 @@ sources:
           /*
           ## Adding timelines
 
-          Add a timeline from this time series data
+          Add a timeline from this time series data. (This only works
+          for root org because it relies on server health events).
+
           */
           SELECT timestamp(epoch=_ts) AS Timestamp, CPUPercent
           FROM monitoring(
@@ -325,9 +327,11 @@ sources:
           These apply to notebooks automatically without needing to
           define them again.
 
+          Hash column should right click to VT
+
           */
 
           LET ColumnTypes = dict(`StartDate`='timestamp')
 
-          SELECT Hex, StartDate
+          SELECT Hex, StartDate, hash(accessor="data", path="Hello") AS Hash
           FROM source()

--- a/datastore/filebased.go
+++ b/datastore/filebased.go
@@ -146,7 +146,8 @@ func (self *FileBaseDataStore) SetSubjectWithCompletion(
 	// Make sure to call the completer on all exit points
 	// (FileBaseDataStore is actually synchronous).
 	defer func() {
-		if completion != nil {
+		if completion != nil &&
+			!utils.CompareFuncs(completion, utils.SyncCompleter) {
 			completion()
 		}
 	}()
@@ -174,7 +175,8 @@ func (self *FileBaseDataStore) DeleteSubjectWithCompletion(
 	urn api.DSPathSpec, completion func()) error {
 
 	err := self.DeleteSubject(config_obj, urn)
-	if completion != nil {
+	if completion != nil &&
+		!utils.CompareFuncs(completion, utils.SyncCompleter) {
 		completion()
 	}
 
@@ -419,8 +421,8 @@ func (self *FileBaseDataStore) SetBuffer(
 	urn api.DSPathSpec, data []byte, completion func()) error {
 
 	err := writeContentToFile(config_obj, urn, data)
-
-	if completion != nil {
+	if completion != nil &&
+		!utils.CompareFuncs(completion, utils.SyncCompleter) {
 		completion()
 	}
 	return err

--- a/datastore/remote.go
+++ b/datastore/remote.go
@@ -18,6 +18,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/grpc_client"
 	"www.velocidex.com/golang/velociraptor/logging"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 var (
@@ -147,7 +148,8 @@ func (self *RemoteDataStore) SetSubjectWithCompletion(
 	// Make sure to always call the completion regardless of error
 	// paths.
 	defer func() {
-		if completion != nil {
+		if completion != nil &&
+			!utils.CompareFuncs(completion, utils.SyncCompleter) {
 			completion()
 		}
 	}()

--- a/gui/velociraptor/src/components/core/keyboard-help.js
+++ b/gui/velociraptor/src/components/core/keyboard-help.js
@@ -24,8 +24,8 @@ const helpTextCol1 = [
         ["alt+p", T("Parameters configuration Step")],
         ["alt+r", T("Collection resource specification")],
         ["ctrl+l", T("Launch artifact")],
-        ["ctrl+right", T("Go to next step")],
-        ["ctrl+left", T("Go to previous step")],
+        ["ctrl+shift+right", T("Go to next step")],
+        ["ctrl+shift+left", T("Go to previous step")],
     ]],
 ];
 

--- a/gui/velociraptor/src/components/flows/new-collection.js
+++ b/gui/velociraptor/src/components/flows/new-collection.js
@@ -1014,8 +1014,10 @@ class NewCollectionWizard extends React.Component {
             GOTO_PREVIEW: "alt+v",
             GOTO_RESOURCES: "alt+r",
             GOTO_LAUNCH: "ctrl+l",
-            NEXT_STEP: "ctrl+right",
-            PREV_STEP: "ctrl+left",
+
+            // These do not work inside text entries.
+            NEXT_STEP: "ctrl+shift+right",
+            PREV_STEP: "ctrl+shift+left",
         };
         let handlers={
             GOTO_ARTIFACTS: this.gotoStep(1),

--- a/gui/velociraptor/src/components/forms/form.js
+++ b/gui/velociraptor/src/components/forms/form.js
@@ -21,6 +21,7 @@ import BootstrapTable from 'react-bootstrap-table-next';
 import cellEditFactory, { Type } from 'react-bootstrap-table2-editor';
 import { parseCSV, serializeCSV } from '../utils/csv.js';
 import "./validated.css";
+import "./forms.css";
 
 const numberRegex = RegExp("^[0-9]+$");
 

--- a/gui/velociraptor/src/components/forms/forms.css
+++ b/gui/velociraptor/src/components/forms/forms.css
@@ -1,0 +1,24 @@
+/* react calendar */
+.react-calendar {
+    background: var(--color-calendar-background);
+}
+
+.react-calendar .react-calendar__navigation button,
+.react-calendar .react-calendar__tile {
+    color: var(--color-foreground-dimmed);
+}
+
+.react-calendar .react-calendar__tile--now {
+    background: var(--background-calendar-tile-now);
+    color: var(--color-calendar-tile);
+}
+
+.react-calendar .react-calendar__tile--active,
+.react-calendar .react-calendar__tile--active:hover {
+    background: var(--background-calendar-tile-active);
+    color: var(--color-calendar-tile);
+}
+
+.react-calendar .react-calendar__month-view__days__day--weekend {
+    color: var(--accent-color);
+}

--- a/gui/velociraptor/src/css/_variables.css
+++ b/gui/velociraptor/src/css/_variables.css
@@ -11,6 +11,11 @@
     --font-json: roboto-mono, Menlo, Monaco, Consolas, "Courier New", monospace;
     --font-monospace: roboto-mono, "Courier New", Courier, monospace;
 
+    --color-calendar-background: #f0f0f0;
+    --background-calendar-tile-now: #feffe0;
+    --background-calendar-tile-active: var(--color-table-row-selected);
+    --color-calendar-tile: var(--color-foreground);
+
     --color-canvas-background: #ffffff;
     --color-foreground: #000;
     --color-foreground-inverse: #fff;

--- a/gui/velociraptor/src/themes/coolgray-dark.css
+++ b/gui/velociraptor/src/themes/coolgray-dark.css
@@ -103,7 +103,7 @@
   --color-timeline-7: #471ecb;
 
   --color-vfs-files-timestomped: #ed5d40;
-  --color-calendar-background: #121212;
+  --color-calendar-background: var(--color-canvas-background);
   --color-level-error: #ff0000;
 }
 
@@ -838,7 +838,7 @@ body.coolgray-dark {
 
 /* react timelines */
 .coolgray-dark .react-calendar-timeline .rct-sidebar {
-  color: var(--color-foreground);
+    color: var(--color-foreground);
 }
 
 /* file tree */
@@ -890,7 +890,7 @@ body.coolgray-dark {
 
 .coolgray-dark .react-datetime-picker__inputGroup__input,
 .coolgray-dark .react-datetime-picker__button {
-  filter: invert(0);
+  filter: invert(0.7);
 }
 
 .coolgray-dark .react-datepicker-popper {

--- a/gui/velociraptor/src/themes/github-dimmed-dark.css
+++ b/gui/velociraptor/src/themes/github-dimmed-dark.css
@@ -95,6 +95,10 @@
 
   --color-vfs-files-timestomped: #ed5d40;
   --color-calendar-background: #121212;
+  --color-calendar-background: var(--color-canvas-background);
+
+  --background-calendar-tile-now: #feffe0;
+
   --color-level-error: #aa0000;
 }
 
@@ -740,19 +744,9 @@ body.github-dimmed-dark {
   background: var(--color-accent-50);
 }
 
-/* Datepicker */
-.github-dimmed-dark .react-datepicker,
-.github-dimmed-dark .react-datetime-picker input,
-.github-dimmed-dark .react-datetime-picker select,
-.github-dimmed-dark .react-datetime-picker button,
-.github-dimmed-dark .react-datetime-picker {
-  background: var(--color-canvas-background);
-  color: var(--color-foreground);
-}
-
 .github-dimmed-dark .react-datetime-picker__inputGroup__input,
 .github-dimmed-dark .react-datetime-picker__button {
-  filter: invert(0);
+  filter: invert(0.7);
 }
 
 .github-dimmed-dark .react-datepicker-popper {
@@ -925,19 +919,4 @@ input[type="radio"] {
 .github-dimmed-dark .alert {
   text-shadow: none;
   box-shadow: none;
-}
-
-
-/* react calendar */
-.github-dimmed-dark .react-calendar {
-    background: var(--color-calendar-background);
-}
-
-.github-dimmed-dark .react-calendar .react-calendar__navigation button,
-.github-dimmed-dark .react-calendar .react-calendar__tile {
-    color: var(--color-foreground-dimmed);
-}
-
-.github-dimmed-dark .react-calendar .react-calendar__month-view__days__day--weekend {
-    color: var(--accent-color);
 }

--- a/gui/velociraptor/src/themes/veloci-dark.css
+++ b/gui/velociraptor/src/themes/veloci-dark.css
@@ -77,7 +77,9 @@
   --color-card-heading-background: #444444;
   --color-table-heading-background: #444444;
   --color-monospace-color: #eeeeee;
+
   --color-calendar-background: #121212;
+  --color-calendar-tile: #121212;
 
   --color-timeline-header: #cdcdcd20;
   --color-timeline-table-shown: #dd4b3920;
@@ -599,20 +601,6 @@ body.veloci-dark {
 /* react timelines */
 .veloci-dark .react-calendar-timeline .rct-sidebar {
   color: var(--color-foreground);
-}
-
-/* react calendar */
-.veloci-dark .react-calendar {
-    background: var(--color-calendar-background);
-}
-
-.veloci-dark .react-calendar .react-calendar__navigation button,
-.veloci-dark .react-calendar .react-calendar__tile {
-    color: var(--color-foreground-dimmed);
-}
-
-.veloci-dark .react-calendar .react-calendar__month-view__days__day--weekend {
-    color: var(--accent-color);
 }
 
 /* file tree */

--- a/gui/velociraptor/src/themes/veloci-light.css
+++ b/gui/velociraptor/src/themes/veloci-light.css
@@ -74,6 +74,8 @@
   --color-table-row-hover: rgba(0, 0, 0, 0.01);
   --color-code: #990000;
 
+  --background-calendar-tile-active: #5cd00a80;
+
   --color-timeline-header: #cdcdcd20;
   --color-timeline-table-shown: #5cd00a80;
   --color-timeline-1: #dff0d820;

--- a/services/orgs/services.go
+++ b/services/orgs/services.go
@@ -281,8 +281,7 @@ func (self *OrgManager) startRootOrgServices(
 
 	// The user manager is global across all orgs.
 	if spec.UserManager {
-		err := users.StartUserManager(
-			ctx, wg, org_config)
+		err := users.StartUserManager(ctx, wg, org_config)
 		if err != nil {
 			return err
 		}

--- a/services/orgs/services.go
+++ b/services/orgs/services.go
@@ -536,13 +536,6 @@ func (self *OrgManager) startOrgFromContext(org_ctx *OrgContext) (err error) {
 		service_container.mu.Unlock()
 	}
 
-	if spec.SanityChecker {
-		err = sanity.NewSanityCheckService(ctx, wg, org_config)
-		if err != nil {
-			return err
-		}
-	}
-
 	if spec.ServerArtifacts {
 		err = server_artifacts.NewServerArtifactService(ctx, wg, org_config)
 		if err != nil {
@@ -570,6 +563,14 @@ func (self *OrgManager) startOrgFromContext(org_ctx *OrgContext) (err error) {
 		service_container.mu.Lock()
 		service_container.server_event_manager = server_event_manager
 		service_container.mu.Unlock()
+	}
+
+	// Must be run after all the other services are up
+	if spec.SanityChecker {
+		err = sanity.NewSanityCheckService(ctx, wg, org_config)
+		if err != nil {
+			return err
+		}
 	}
 
 	return maybeFlushFilesOnClose(ctx, wg, org_config)

--- a/services/sanity/server_artifacts.go
+++ b/services/sanity/server_artifacts.go
@@ -36,6 +36,7 @@ func maybeStartInitialArtifacts(
 	if err != nil {
 		return err
 	}
+
 	// Start any initial artifact collections.
 	if config_obj.Frontend != nil &&
 		len(config_obj.Frontend.InitialServerArtifacts) > 0 {

--- a/services/server_artifacts/logger.go
+++ b/services/server_artifacts/logger.go
@@ -37,6 +37,12 @@ func (self *serverLogger) Write(b []byte) (int, error) {
 	// Increment the log count.
 	self.collection_context.Modify(func(context *flows_proto.ArtifactCollectorContext) {
 		context.TotalLogs++
+
+		// If an error occured mark the collection failed.
+		if level == "ERROR" {
+			context.State = flows_proto.ArtifactCollectorContext_ERROR
+			context.Status = msg
+		}
 	})
 
 	return len(b), nil

--- a/services/users/users.go
+++ b/services/users/users.go
@@ -33,6 +33,7 @@ import (
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	datastore "www.velocidex.com/golang/velociraptor/datastore"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 )
@@ -324,6 +325,9 @@ func StartUserManager(
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) error {
 
+	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	logger.Info("<green>Starting</> user manager service for org %v", config_obj.OrgId)
+
 	CA_Pool := x509.NewCertPool()
 	if config_obj.Client != nil {
 		CA_Pool.AppendCertsFromPEM([]byte(config_obj.Client.CaCertificate))
@@ -341,7 +345,8 @@ func StartUserManager(
 // Make sure there is always something available.
 func init() {
 	service := &UserManager{
-		ca_pool: x509.NewCertPool(),
+		ca_pool:    x509.NewCertPool(),
+		config_obj: &config_proto.Config{},
 	}
 	services.RegisterUserManager(service)
 }

--- a/vql/parsers/event_logs/watcher.go
+++ b/vql/parsers/event_logs/watcher.go
@@ -92,9 +92,10 @@ func (self *EventLogWatcherService) StartMonitoring(
 	scope.Log("StartMonitoring")
 	defer utils.CheckForPanic("StartMonitoring")
 
-	// By default check every 3 seconds.
+	// By default check every 15 seconds. Event logs are not flushed
+	// that often so checking more frequently does not help much.
 	if frequency == 0 {
-		frequency = 3
+		frequency = 15
 	}
 
 	// A resolver for messages

--- a/vql/server/orgs/create.go
+++ b/vql/server/orgs/create.go
@@ -36,6 +36,11 @@ func (self OrgCreateFunction) Call(
 		return vfilter.Null{}
 	}
 
+	if arg.OrgName == "" {
+		scope.Log("ERROR:org_create: An Org name must be specified")
+		return vfilter.Null{}
+	}
+
 	org_manager, err := services.GetOrgManager()
 	if err != nil {
 		scope.Log("org_create: %s", err)


### PR DESCRIPTION
The sanity checker ensured the server is running in a sane state. It
also starts things like initial server artifacts etc.

This PR split sanity checks to run on the root org (i.e. once when the
server is started) and on each org. For example the initial server
artifacts are only run on the root org and not on other orgs.