### PR TITLE
Fixed backwards compatible bug

### DIFF
--- a/flows/artifacts.go
+++ b/flows/artifacts.go
@@ -211,7 +211,7 @@ func closeContext(
 		int64(len(collection_context.QueryStats)) >= collection_context.TotalRequests &&
 		!collection_context.UserNotified {
 
-		// Record the message was sent - so we never resent the
+		// Record the message was sent - so we never resend the
 		// message, even with new data.
 		collection_context.UserNotified = true
 

--- a/flows/collection_context.go
+++ b/flows/collection_context.go
@@ -37,6 +37,13 @@ func updateQueryStats(
 				stat.NamesWithResponse = status.NamesWithResponse
 			}
 
+			// On older versions of the client QueryId is not
+			// propagated properly so we end up with all statuses with
+			// a query id of 0. In this case we should keep all the
+			// statuses even if they are already received so we can
+			// terminate the flow.
+			status.Duration = 0
+			collection_context.QueryStats = append(collection_context.QueryStats, status)
 			return
 		}
 	}


### PR DESCRIPTION
0.6.6 relies on accurate query id being reported by the client in status messages. This did not happen in older clients. This PR works around this issue by retaining all status messages anyway.