### PR TITLE
Allow collect_client() etc to accept ArtifactSpec protobuf

### DIFF
--- a/vql/server/hunts/hunts.go
+++ b/vql/server/hunts/hunts.go
@@ -330,10 +330,17 @@ func (self HuntFlowsPlugin) Call(
 		for flow_details := range hunt_dispatcher.GetFlows(
 			ctx, config_obj, scope, arg.HuntId, int(arg.StartRow)) {
 
+			client_id := ""
+			flow_id := ""
+			if flow_details.Context != nil {
+				client_id = flow_details.Context.ClientId
+				flow_id = flow_details.Context.SessionId
+			}
+
 			result := ordereddict.NewDict().
 				Set("HuntId", arg.HuntId).
-				Set("ClientId", flow_details.Context.ClientId).
-				Set("FlowId", flow_details.Context.SessionId).
+				Set("ClientId", client_id).
+				Set("FlowId", flow_id).
 				Set("Flow", json.ConvertProtoToOrderedDict(
 					flow_details.Context))
 


### PR DESCRIPTION
When inspecting Flow objects we often get an ArtifactContext protobug with contains an ArtifactSpec. This is different from the dict() based spec we use in VQL so it is difficult to feed the output of e.g. hunt_flows() into collect_client()

This PR makes it so collect_client() can handle the ArtifactSpec type transparently by converting it to a dict based spec.