### PR TITLE
When creating a new org pass the new org id to the acl function

### DIFF
--- a/services/orgs/ids.go
+++ b/services/orgs/ids.go
@@ -8,6 +8,13 @@ import (
 	"www.velocidex.com/golang/velociraptor/constants"
 )
 
+func (self *OrgManager) SetOrgIdForTesting(a string) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.NextOrgIdForTesting = &a
+}
+
 // Make sure the new ID is unique (There are only 64k possibilities so
 // chance of a clash are high)
 func (self *OrgManager) NewOrgId() string {
@@ -17,6 +24,13 @@ func (self *OrgManager) NewOrgId() string {
 
 		org_id := constants.ORG_PREFIX + base32.HexEncoding.EncodeToString(buf)[:4]
 		self.mu.Lock()
+		if self.NextOrgIdForTesting != nil {
+			org_id = *self.NextOrgIdForTesting
+			self.mu.Unlock()
+
+			return org_id
+		}
+
 		_, pres := self.orgs[org_id]
 		self.mu.Unlock()
 

--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -47,6 +47,8 @@ type OrgManager struct {
 	// Each org has a separate config object.
 	orgs            map[string]*OrgContext
 	org_id_by_nonce map[string]string
+
+	NextOrgIdForTesting *string
 }
 
 func (self *OrgManager) ListOrgs() []*api_proto.OrgRecord {

--- a/services/orgs/tests.go
+++ b/services/orgs/tests.go
@@ -15,6 +15,10 @@ type TestOrgManager struct {
 	services *ServiceContainer
 }
 
+func (self *TestOrgManager) SetOrgIdForTesting(a string) {
+	self.OrgManager.SetOrgIdForTesting(a)
+}
+
 func (self *TestOrgManager) Start(
 	ctx context.Context,
 	org_config *config_proto.Config,

--- a/services/sanity/fixtures/TestCreateUserInOrgs.golden
+++ b/services/sanity/fixtures/TestCreateUserInOrgs.golden
@@ -1,4 +1,23 @@
 {
+ "/users/User1": {
+  "name": "User1",
+  "orgs": [
+   {
+    "id": "root",
+    "name": "\u003croot\u003e"
+   },
+   {
+    "id": "O01",
+    "name": "Org1"
+   },
+   {
+    "id": "OT02",
+    "name": "Org2"
+   }
+  ],
+  "password_hash": "DX3EdpodhRYoAnA6GFW3bjtlK9o+BYKrMkM/Y9xqBzY=",
+  "password_salt": "D2GtD9Y5FRMCEkLvuax4AkXMIVJ/o/nF5VLUciPjg6I="
+ },
  "O01/acl/User1.json": {
   "roles": [
    "administrator"
@@ -9,53 +28,15 @@
   "nonce": "Nonce Of O01",
   "org_id": "O01"
  },
- "O01/users/User1": {
-  "name": "User1",
-  "orgs": [
-   {
-    "id": "root",
-    "name": "\u003croot\u003e"
-   },
-   {
-    "id": "O01",
-    "name": "Org1"
-   },
-   {
-    "id": "O02",
-    "name": "Org2"
-   }
-  ],
-  "password_hash": "DX3EdpodhRYoAnA6GFW3bjtlK9o+BYKrMkM/Y9xqBzY=",
-  "password_salt": "D2GtD9Y5FRMCEkLvuax4AkXMIVJ/o/nF5VLUciPjg6I="
- },
- "O02/acl/User1.json": {
+ "OT02/acl/User1.json": {
   "roles": [
    "administrator"
   ]
  },
- "O02/org": {
+ "OT02/org": {
   "name": "Org2",
-  "nonce": "Nonce Of O02",
-  "org_id": "O02"
- },
- "O02/users/User1": {
-  "name": "User1",
-  "orgs": [
-   {
-    "id": "root",
-    "name": "\u003croot\u003e"
-   },
-   {
-    "id": "O01",
-    "name": "Org1"
-   },
-   {
-    "id": "O02",
-    "name": "Org2"
-   }
-  ],
-  "password_hash": "DX3EdpodhRYoAnA6GFW3bjtlK9o+BYKrMkM/Y9xqBzY=",
-  "password_salt": "D2GtD9Y5FRMCEkLvuax4AkXMIVJ/o/nF5VLUciPjg6I="
+  "nonce": "Nonce Of OT02",
+  "org_id": "OT02"
  },
  "root/acl/User1.json": {
   "roles": [
@@ -66,24 +47,5 @@
   "name": "\u003croot\u003e",
   "nonce": "Nonce Of root",
   "org_id": "root"
- },
- "root/users/User1": {
-  "name": "User1",
-  "orgs": [
-   {
-    "id": "root",
-    "name": "\u003croot\u003e"
-   },
-   {
-    "id": "O01",
-    "name": "Org1"
-   },
-   {
-    "id": "O02",
-    "name": "Org2"
-   }
-  ],
-  "password_hash": "DX3EdpodhRYoAnA6GFW3bjtlK9o+BYKrMkM/Y9xqBzY=",
-  "password_salt": "D2GtD9Y5FRMCEkLvuax4AkXMIVJ/o/nF5VLUciPjg6I="
  }
 }

--- a/services/sanity/orgs.go
+++ b/services/sanity/orgs.go
@@ -22,10 +22,14 @@ func createInitialOrgs(config_obj *config_proto.Config) error {
 	for _, org := range config_obj.GUI.InitialOrgs {
 		logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 		logger.Info("<green>Creating initial org for</> %v", org.Name)
-		_, err := org_manager.CreateNewOrg(org.Name, org.OrgId)
+		org_record, err := org_manager.CreateNewOrg(org.Name, org.OrgId)
 		if err != nil {
 			return err
 		}
+
+		// Receive the newly created orgid and update the config file
+		// with it
+		org.OrgId = org_record.OrgId
 	}
 
 	return nil


### PR DESCRIPTION
When specifying an empty orgid in CreateNewOrg() a new org id is created. We need to update this in order to place the ACLs in the correct org.