### PR TITLE
Attempt to decompress client messages if errors occur.

### DIFF
--- a/crypto/messages.go
+++ b/crypto/messages.go
@@ -38,7 +38,30 @@ func (self *MessageInfo) IterateJobs(
 		message_list := &crypto_proto.MessageList{}
 		err := proto.Unmarshal(raw, message_list)
 		if err != nil {
-			return errors.WithStack(err)
+			// TODO: Issue #2069 suggests that maybe the message is
+			// compressed but it is not indicated as such under as yet
+			// unknown conditions. We retry to decompress the data
+			// anyway just in case to see if the data is actually
+			// maybe compressed twice or just marked as uncompressed
+			// incorrectly. The proto unmarshal error should never
+			// really occur so the performance hit on this is not
+			// expected to be large.
+			decompressed, err2 := utils.Uncompress(ctx, raw)
+			if err2 != nil {
+				// Zlib decompression does have a checksum so if we
+				// hit an error here just pass the original protobuf
+				// errr on.
+				return err
+			}
+
+			// Try to parse it with the decompressed data just in
+			// case.
+			err := proto.Unmarshal(decompressed, message_list)
+			if err != nil {
+				// No it really is corrupted :-( no idea how this
+				// happens...
+				return errors.WithStack(err)
+			}
 		}
 
 		for _, job := range message_list.Job {

--- a/gui/velociraptor/src/components/welcome/logoff.js
+++ b/gui/velociraptor/src/components/welcome/logoff.js
@@ -10,7 +10,7 @@ import "./login.css";
 export default class LogoffPage extends Component {
     render() {
         let username = window.ErrorState && window.ErrorState.Username;
-        let base_path = window.ErrorState && window.ErrorState.BasePath || "/";
+        let base_path = (window.ErrorState && window.ErrorState.BasePath) || "/";
 
         return (
             <Modal className="full-height"


### PR DESCRIPTION
This is a test for #2069 to see if we are able to workaround incorrectly compressed client messages.