### PR TITLE
authenticode is a function and not a plug

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -173,9 +173,9 @@
   category: linux
 - name: authenticode
   description: |
-    This plugin parses authenticode information from PE files.
+    Parses authenticode information from PE files.
 
-    On windows, the plugin will also use the windows API to determine
+    On windows, the function will also use the windows API to determine
     if the binary is trusted by the system.
   type: Function
   args:


### PR DESCRIPTION
Prevent confusion for users who read the documentation and try to use `authenticode` as a plugin, e.g. in the right side of a select statement.