### PR TITLE
auth: don't return a base path with two leading slashes

### DIFF
--- a/api/authenticators/auth.go
+++ b/api/authenticators/auth.go
@@ -123,6 +123,9 @@ func init() {
 func getBasePath(config_obj *config_proto.Config) string {
 	bare := strings.TrimSuffix(config_obj.GUI.BasePath, "/")
 	bare = strings.TrimPrefix(bare, "/")
+	if bare == "" {
+		return "/"
+	}
 	return "/" + bare + "/"
 }
 


### PR DESCRIPTION
When the base path is empty, getBasePath will return "//" which results in incorrect redirects and links being generated.  The // is interpreted as a request to use the same protocol that was used to initiate the request, so e.g. //auth/github/login gets treated as https://auth/github/login by browsers.