### PR TITLE
Authentication configuration error reporting/validation

### DIFF
--- a/api/authenticators/auth.go
+++ b/api/authenticators/auth.go
@@ -2,6 +2,7 @@ package authenticators
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -58,9 +59,22 @@ func getAuthenticatorByType(
 	return nil, errors.New("No valid authenticator found")
 }
 
+func configRequirePublicUrl(config_obj *config_proto.Config) error {
+	if config_obj.GUI.PublicUrl == "" {
+		return fmt.Errorf("Authentication type `%s' requires valid public_url parameter",
+				  config_obj.GUI.Authenticator.Type)
+	}
+	return nil
+
+}
+
 func init() {
 	RegisterAuthenticator("azure", func(config_obj *config_proto.Config,
 		auth_config *config_proto.Authenticator) (Authenticator, error) {
+		err := configRequirePublicUrl(config_obj)
+		if err != nil {
+			return nil, err
+		}
 		return &AzureAuthenticator{
 			config_obj:    config_obj,
 			authenticator: auth_config,
@@ -71,6 +85,10 @@ func init() {
 
 	RegisterAuthenticator("github", func(config_obj *config_proto.Config,
 		auth_config *config_proto.Authenticator) (Authenticator, error) {
+		err := configRequirePublicUrl(config_obj)
+		if err != nil {
+			return nil, err
+		}
 		return &GitHubAuthenticator{
 			config_obj:    config_obj,
 			authenticator: auth_config,
@@ -81,6 +99,10 @@ func init() {
 
 	RegisterAuthenticator("google", func(config_obj *config_proto.Config,
 		auth_config *config_proto.Authenticator) (Authenticator, error) {
+		err := configRequirePublicUrl(config_obj)
+		if err != nil {
+			return nil, err
+		}
 		return &GoogleAuthenticator{
 			config_obj:    config_obj,
 			authenticator: auth_config,
@@ -105,6 +127,10 @@ func init() {
 
 	RegisterAuthenticator("oidc", func(config_obj *config_proto.Config,
 		auth_config *config_proto.Authenticator) (Authenticator, error) {
+		err := configRequirePublicUrl(config_obj)
+		if err != nil {
+			return nil, err
+		}
 		return &OidcAuthenticator{
 			config_obj:    config_obj,
 			authenticator: auth_config,

--- a/api/authenticators/github.go
+++ b/api/authenticators/github.go
@@ -113,6 +113,20 @@ func (self *GitHubAuthenticator) oauthGithubCallback() http.Handler {
 			return
 		}
 
+		formError := r.FormValue("error")
+		if formError != "" {
+			desc := r.FormValue("error_description")
+			if desc != "" {
+				formError = desc
+			}
+			logging.GetLogger(self.config_obj, &logging.GUIComponent).
+				WithFields(logrus.Fields{
+					"err": formError,
+				}).Error("getUserDataFromGithub")
+			http.Redirect(w, r, self.base, http.StatusTemporaryRedirect)
+			return
+		}
+
 		data, err := self.getUserDataFromGithub(r.Context(), r.FormValue("code"))
 		if err != nil {
 			logging.GetLogger(self.config_obj, &logging.GUIComponent).


### PR DESCRIPTION
This PR contains two commits to improve the validation and error reporting of the configuration of SSO authenticators. For now it just scratches the itch I found: a missing public_url parameter caused a silent loop back to the login page without anything helpful to diagnose it in the log. GitHub reports errors back to the caller in the querystring and I expect others do as well. Also since we now required the public_url parameter to be set for the callback URLs to work, we should require it and fail if it is not configured properly. There are probably more opportunities here to catch these kinds of problems earlier.