### PR TITLE
Always write content to lock files

### DIFF
--- a/api/notebooks.go
+++ b/api/notebooks.go
@@ -431,6 +431,7 @@ func exportZipNotebook(
 	if err != nil {
 		return err
 	}
+	lock_file.Write([]byte("X"))
 	lock_file.Close()
 
 	// Allow 1 hour to export the notebook.
@@ -489,6 +490,7 @@ func exportHTMLNotebook(config_obj *config_proto.Config,
 	if err != nil {
 		return err
 	}
+	lock_file.Write([]byte("X"))
 	lock_file.Close()
 
 	writer, err := file_store_factory.WriteFile(filename)

--- a/vql/server/downloads/reporting.go
+++ b/vql/server/downloads/reporting.go
@@ -161,6 +161,7 @@ func CreateFlowReport(
 	if err != nil {
 		return nil, err
 	}
+	lock_file.Write([]byte("X"))
 	lock_file.Close()
 
 	manager, err := services.GetRepositoryManager(config_obj)


### PR DESCRIPTION
S3 will throw an XML metadata error when attempting to write empty files.