### PR TITLE
Bugfix: Process address space lockup under some conditions

### DIFF
--- a/accessors/process/process_address_space_windows.go
+++ b/accessors/process/process_address_space_windows.go
@@ -62,7 +62,8 @@ func (self *ProcessReader) getRange(offset uint64) *process.VMemInfo {
 func (self *ProcessReader) readDistinctPages(buf []byte) (int, error) {
 	page_count := len(buf) / PAGE_SIZE
 	if page_count <= 1 {
-		return page_count * PAGE_SIZE, nil
+		// Buffer is smaller than pagesize, just return a null buffer
+		return len(buf), nil
 	}
 
 	// Read as many pages as possible into the buffer ignoring errors.
@@ -112,7 +113,8 @@ func (self *ProcessReader) Read(buf []byte) (int, error) {
 	// no data, we never return an error - just zero pad those
 	// regions.
 	if err != nil {
-		return self.readDistinctPages(buf)
+		res, err := self.readDistinctPages(buf)
+		return res, err
 	}
 
 	// Advance the read pointer.

--- a/file_store/memory/memory.go
+++ b/file_store/memory/memory.go
@@ -43,7 +43,8 @@ func NewMemoryFileStore(config_obj *config_proto.Config) *MemoryFileStore {
 	}
 
 	// Sanitize the FilestoreDirectory
-	if config_obj.Datastore.FilestoreDirectory != "" {
+	if config_obj.Datastore.FilestoreDirectory != "" &&
+		strings.HasSuffix(config_obj.Datastore.FilestoreDirectory, "/") {
 		config_obj.Datastore.FilestoreDirectory = strings.TrimSuffix(
 			config_obj.Datastore.FilestoreDirectory, "/")
 	}

--- a/vql/common/yara.go
+++ b/vql/common/yara.go
@@ -374,6 +374,7 @@ func (self *scanReporter) RuleMatching(rule *yara.Rule) (bool, error) {
 			File:     self.file_info,
 			FileName: self.filename,
 		}
+
 		select {
 		case <-self.ctx.Done():
 			return false, nil


### PR DESCRIPTION
When reading invalid ranges smaller than a page size, the process address space attempts to break the range into smaller page size reads. However when there was less than a page worth of data to read it returned a zero length read which causes an infinite loop.