### PR TITLE
Implement filter for large artifact forms

### DIFF
--- a/gui/velociraptor/src/components/events/event-table.js
+++ b/gui/velociraptor/src/components/events/event-table.js
@@ -18,9 +18,9 @@ import axios from 'axios';
 
 import "react-bootstrap-typeahead/css/Typeahead.css";
 
+import NewCollectionConfigParameters from '../flows/new-collections-parameters.js';
 import {
     NewCollectionSelectArtifacts,
-    NewCollectionConfigParameters,
     NewCollectionRequest,
     NewCollectionLaunch,
     PaginationBuilder

--- a/gui/velociraptor/src/components/flows/new-collection.css
+++ b/gui/velociraptor/src/components/flows/new-collection.css
@@ -44,3 +44,21 @@
 .favorite-button {
     height: 42px;
 }
+
+table.param-form-table {
+    width: 100%;
+}
+
+.param-form-autosuggest .react-autosuggest__input {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
+.param-form-autosuggest .react-autosuggest__suggestions-container {
+    width: 130%;
+    margin: 0px;
+}
+
+.param-form-autosuggest div.react-autosuggest__suggestions-container--open {
+    margin-left: 0px;
+}

--- a/gui/velociraptor/src/components/flows/new-collection.js
+++ b/gui/velociraptor/src/components/flows/new-collection.js
@@ -15,6 +15,7 @@ import Row from 'react-bootstrap/Row';
 import VeloReportViewer from "../artifacts/reporting.js";
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Select from 'react-select';
+import NewCollectionConfigParameters from './new-collections-parameters.js';
 
 import Spinner from '../utils/spinner.js';
 import Col from 'react-bootstrap/Col';
@@ -361,106 +362,6 @@ class NewCollectionSelectArtifacts extends React.Component {
         );
     }
 };
-
-class NewCollectionConfigParameters extends React.Component {
-    static propTypes = {
-        request: PropTypes.object,
-        artifacts: PropTypes.array,
-        setArtifacts: PropTypes.func.isRequired,
-        parameters: PropTypes.object,
-        setParameters: PropTypes.func.isRequired,
-        paginator: PropTypes.object,
-    };
-
-    setValue = (artifact, name, value) => {
-        let parameters = this.props.parameters;
-        let artifact_parameters = parameters[artifact] || {};
-        artifact_parameters[name] = value;
-        parameters[artifact] = artifact_parameters;
-        this.props.setParameters(parameters);
-    }
-
-    removeArtifact = (name) => {
-        this.props.setArtifacts(remove_artifact(this.props.artifacts, name));
-    }
-
-    render() {
-        const expandRow = {
-            expandHeaderColumnRenderer: ({ isAnyExpands }) => {
-                if (isAnyExpands) {
-                    return <b>-</b>;
-                }
-                return <b>+</b>;
-            },
-            expandColumnRenderer: ({ expanded, rowKey }) => {
-                if (expanded) {
-                    return (
-                        <b key={rowKey}>-</b>
-                    );
-                }
-                return (<ButtonGroup>
-                          <Button variant="outline-default"><FontAwesomeIcon icon="wrench"/></Button>
-                          <Button variant="outline-default" onClick={
-                              () => this.props.setArtifacts(remove_artifact(
-                                  this.props.artifacts, rowKey))} >
-                            <FontAwesomeIcon icon="trash"/>
-                          </Button>
-                        </ButtonGroup>
-                );
-            },
-            showExpandColumn: true,
-            renderer: artifact => {
-                return _.map(artifact.parameters || [], (param, idx) => {
-                    let artifact_parameters = (
-                        this.props.parameters &&
-                            this.props.parameters[artifact.name]) || {};
-                    let value = artifact_parameters[param.name];
-                    // Only set default value if the parameter is not
-                    // defined. If it is an empty string then so be
-                    // it.
-                    if (_.isUndefined(value)) {
-                        value = param.default || "";
-                    }
-
-                    return (
-                        <VeloForm param={param} key={idx}
-                                  value={value}
-                                  setValue={(value) => this.setValue(
-                                      artifact.name,
-                                      param.name,
-                                      value)}/>
-                    );
-                });
-            }
-        };
-        return (
-            <>
-              <Modal.Header closeButton>
-                <Modal.Title>{ T(this.props.paginator.title) }</Modal.Title>
-              </Modal.Header>
-
-              <Modal.Body className="new-collection-parameter-page selectable">
-                { !_.isEmpty(this.props.artifacts) ?
-                  <BootstrapTable
-                    keyField="name"
-                    expandRow={ expandRow }
-                    columns={[{dataField: "name", text: T("Artifact")},
-                              {dataField: "parameter", text: "", hidden: true}]}
-                    data={this.props.artifacts} /> :
-                 <div className="no-content">
-                   {T("No artifacts configured. Please add some artifacts to collect")}
-                 </div>
-                }
-              </Modal.Body>
-              <Modal.Footer>
-                { this.props.paginator.makePaginator({
-                    props: this.props,
-                }) }
-              </Modal.Footer>
-            </>
-        );
-    };
-}
 
 class NewCollectionResources extends React.Component {
     static propTypes = {
@@ -1105,7 +1006,6 @@ class NewCollectionWizard extends React.Component {
 export {
     NewCollectionWizard as default,
     NewCollectionSelectArtifacts,
-    NewCollectionConfigParameters,
     NewCollectionResources,
     NewCollectionRequest,
     NewCollectionLaunch,

--- a/gui/velociraptor/src/components/flows/new-collections-parameters.js
+++ b/gui/velociraptor/src/components/flows/new-collections-parameters.js
@@ -1,0 +1,241 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import Autosuggest from 'react-autosuggest';
+
+import VeloForm from '../forms/form.js';
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import Modal from 'react-bootstrap/Modal';
+import T from '../i8n/i8n.js';
+import BootstrapTable from 'react-bootstrap-table-next';
+
+
+class ParameterSuggestion extends React.Component {
+    static propTypes = {
+        parameters: PropTypes.array,
+        setFilter: PropTypes.func.isRequired,
+    }
+
+    state = {
+        suggestions: [],
+        value: "",
+    }
+
+    componentDidMount = () => {
+        this.props.setFilter("");
+    }
+
+    onChange = (event, { newValue }) => {
+        this.props.setFilter(newValue.toLowerCase());
+        this.setState({
+            value: newValue
+        });
+    };
+
+    getSuggestionValue = suggestion => suggestion.name;
+
+    getSuggestions = value => {
+        const inputValue = value.trim().toLowerCase();
+        const inputLength = inputValue.length;
+
+        return inputLength === 0 ? [] : this.props.parameters.filter(x =>{
+            try {
+                return x.name.toLowerCase().search(inputValue) >= 0;
+            } catch(e) {
+                return value;
+            };
+        });
+    };
+
+    onSuggestionsFetchRequested = ({ value }) => {
+        this.setState({
+            suggestions: this.getSuggestions(value)
+        });
+    };
+
+    onSuggestionsClearRequested = () => {
+        this.setState({
+            suggestions: []
+        });
+    };
+
+    renderSuggestion = suggestion => (
+        <div key={suggestion.name}>
+          {suggestion.name}
+        </div>
+    );
+
+    render() {
+        const inputProps = {
+            placeholder: 'Filter artifact parameter name',
+            value: this.state.value,
+            onChange: this.onChange,
+        };
+
+        return (
+            <Row key="Autosuggest" name="AutoSuggest" className="param-form-autosuggest">
+              <Col sm="3">
+                <Autosuggest
+                  suggestions={this.state.suggestions}
+                  onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+                  onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+                  getSuggestionValue={this.getSuggestionValue}
+                  renderSuggestion={this.renderSuggestion}
+                  inputProps={inputProps}
+                />
+              </Col>
+              <Col sm="8">
+              </Col>
+            </Row>
+
+        );
+    }
+}
+
+
+
+// Remove the named artifact from the list of artifacts
+const remove_artifact = (artifacts, name) => {
+    return _.filter(artifacts, (x) => x.name !== name);
+};
+
+export default class NewCollectionConfigParameters extends React.Component {
+    static propTypes = {
+        request: PropTypes.object,
+        artifacts: PropTypes.array,
+        setArtifacts: PropTypes.func.isRequired,
+        parameters: PropTypes.object,
+        setParameters: PropTypes.func.isRequired,
+        paginator: PropTypes.object,
+    };
+
+    setValue = (artifact, name, value) => {
+        let parameters = this.props.parameters;
+        let artifact_parameters = parameters[artifact] || {};
+        artifact_parameters[name] = value;
+        parameters[artifact] = artifact_parameters;
+        this.props.setParameters(parameters);
+    }
+
+   removeArtifact = (name) => {
+        this.props.setArtifacts(remove_artifact(this.props.artifacts, name));
+    }
+
+    state = {
+        filters: {},
+    }
+
+    artifactParameterRenderer = artifact => {
+        let artifact_parameters = (
+            this.props.parameters &&
+                this.props.parameters[artifact.name]) || {};
+
+        let suggestions = [];
+        let form_parameters = _.map(artifact.parameters, (param, idx) => {
+            suggestions.push({name: param.name, key: idx});
+
+            let filter = this.state.filters[artifact.name] || "";
+
+            try {
+
+                if (filter && param.name.toLowerCase().search(filter) < 0 ) {
+                    return <></>;
+                }
+            } catch(e) {};
+
+            let value = artifact_parameters[param.name];
+            // Only set default value if the parameter is not
+            // defined. If it is an empty string then so be
+            // it.
+            if (_.isUndefined(value)) {
+                value = param.default || "";
+            }
+
+            return (
+                <VeloForm param={param} key={idx} name={idx}
+                          value={value}
+                          setValue={(value) => this.setValue(
+                              artifact.name,
+                              param.name,
+                              value)}/>
+               );
+        });
+
+        let results = [];
+        if(suggestions.length > 6) {
+            results.push(
+                <ParameterSuggestion key="Autosuggest" name="Autosuggest"
+                        parameters={suggestions}
+                        setFilter={x=>{
+                            let filters = this.state.filters;
+                            filters[artifact.name] = x;
+                            this.setState({filters: filters});
+                        }} />
+            );
+        }
+
+        return results.concat(form_parameters);
+    }
+
+    render() {
+        const expandRow = {
+            expandHeaderColumnRenderer: ({ isAnyExpands }) => {
+                if (isAnyExpands) {
+                    return <b>-</b>;
+                }
+                return <b>+</b>;
+            },
+            expandColumnRenderer: ({ expanded, rowKey }) => {
+                if (expanded) {
+                    return (
+                        <b key={rowKey}>-</b>
+                    );
+                }
+                return (<ButtonGroup>
+                          <Button variant="outline-default"><FontAwesomeIcon icon="wrench"/></Button>
+                          <Button variant="outline-default" onClick={
+                              () => this.props.setArtifacts(remove_artifact(
+                                  this.props.artifacts, rowKey))} >
+                            <FontAwesomeIcon icon="trash"/>
+                          </Button>
+                        </ButtonGroup>
+                );
+            },
+            showExpandColumn: true,
+            renderer: this.artifactParameterRenderer,
+        };
+        return (
+            <>
+              <Modal.Header closeButton>
+                <Modal.Title>{ T(this.props.paginator.title) }</Modal.Title>
+              </Modal.Header>
+
+              <Modal.Body className="new-collection-parameter-page selectable">
+                { !_.isEmpty(this.props.artifacts) ?
+                  <BootstrapTable
+                    keyField="name"
+                    expandRow={ expandRow }
+                    columns={[{dataField: "name", text: T("Artifact")},
+                              {dataField: "parameter", text: "", hidden: true}]}
+                    data={this.props.artifacts} /> :
+                 <div className="no-content">
+                   {T("No artifacts configured. Please add some artifacts to collect")}
+                 </div>
+                }
+              </Modal.Body>
+              <Modal.Footer>
+                { this.props.paginator.makePaginator({
+                    props: this.props,
+                }) }
+              </Modal.Footer>
+            </>
+        );
+    };
+}

--- a/gui/velociraptor/src/components/flows/offline-collector.js
+++ b/gui/velociraptor/src/components/flows/offline-collector.js
@@ -12,10 +12,10 @@ import ValidatedInteger from '../forms/validated_int.js';
 import api from '../core/api-service.js';
 import axios from 'axios';
 import T from '../i8n/i8n.js';
+import NewCollectionConfigParameters from './new-collections-parameters.js';
 
 import {
     NewCollectionSelectArtifacts,
-    NewCollectionConfigParameters,
     NewCollectionRequest,
     NewCollectionLaunch,
     PaginationBuilder

--- a/gui/velociraptor/src/components/hunts/new-hunt.js
+++ b/gui/velociraptor/src/components/hunts/new-hunt.js
@@ -15,10 +15,10 @@ import DateTimePicker from 'react-datetime-picker';
 import EstimateHunt from './estimate.js';
 import LabelForm from '../utils/labels.js';
 import api from '../core/api-service.js';
+import NewCollectionConfigParameters from '../flows/new-collections-parameters.js';
 
 import {
     NewCollectionSelectArtifacts,
-    NewCollectionConfigParameters,
     NewCollectionResources,
     NewCollectionRequest,
     NewCollectionLaunch,

--- a/vql/tools/process/tracker_test.go
+++ b/vql/tools/process/tracker_test.go
@@ -218,8 +218,6 @@ func (self *ProcessTrackerTestSuite) TestProcessTracker() {
 		assert.NoError(self.T(), err)
 
 		scope := manager.BuildScope(builder)
-		defer scope.Close()
-
 		rows := make([]*ordereddict.Dict, 0)
 		mvql, err := vfilter.MultiParse(test_case.Query)
 		for _, vql := range mvql {
@@ -227,6 +225,7 @@ func (self *ProcessTrackerTestSuite) TestProcessTracker() {
 				rows = append(rows, vfilter.RowToDict(ctx, scope, row))
 			}
 		}
+		scope.Close()
 
 		results.Set(test_case.Name, rows)
 	}


### PR DESCRIPTION
Some artifacts like the KapeTarget one have many parameters and searching through them was a pain. This PR adds a search box for these larger forms where the user can filter the parameters they need.