### PR TITLE
Verify client's key with or without the org id.

### DIFF
--- a/api/csv.go
+++ b/api/csv.go
@@ -60,19 +60,9 @@ func getTable(
 
 	file_store_factory := file_store.GetFileStore(config_obj)
 
-	options := result_sets.ResultSetOptions{}
-	if in.SortColumn != "" {
-		options.SortColumn = in.SortColumn
-		options.SortAsc = in.SortDirection
-	}
-
-	if in.FilterColumn != "" &&
-		in.FilterRegex != "" {
-		options.FilterColumn = in.FilterColumn
-		options.FilterRegex, err = regexp.Compile("(?i)" + in.FilterRegex)
-		if err != nil {
-			return nil, err
-		}
+	options, err := getTableOptions(in)
+	if err != nil {
+		return result, err
 	}
 
 	rs_reader, err := result_sets.NewResultSetReaderWithOptions(
@@ -344,4 +334,23 @@ func getTimeline(
 	}
 
 	return result, nil
+}
+
+func getTableOptions(in *api_proto.GetTableRequest) (
+	options result_sets.ResultSetOptions, err error) {
+	if in.SortColumn != "" {
+		options.SortColumn = in.SortColumn
+		options.SortAsc = in.SortDirection
+	}
+
+	if in.FilterColumn != "" &&
+		in.FilterRegex != "" {
+		options.FilterColumn = in.FilterColumn
+		options.FilterRegex, err = regexp.Compile("(?i)" + in.FilterRegex)
+		if err != nil {
+			return options, err
+		}
+	}
+
+	return options, nil
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	VERSION                    = "0.6.7-dev"
+	VERSION                    = "0.6.7-rc1"
 	ENROLLMENT_WELL_KNOWN_FLOW = "E:Enrol"
 	MONITORING_WELL_KNOWN_FLOW = FLOW_PREFIX + "Monitoring"
 

--- a/datastore/filebased.go
+++ b/datastore/filebased.go
@@ -59,6 +59,8 @@ import (
 
 var (
 	file_based_imp = &FileBaseDataStore{}
+
+	datastoreNotConfiguredError = errors.New("Datastore not configured")
 )
 
 const (
@@ -294,6 +296,10 @@ func (self *FileBaseDataStore) Close() {}
 func writeContentToFile(config_obj *config_proto.Config,
 	urn api.DSPathSpec, data []byte) error {
 
+	if config_obj.Datastore == nil {
+		return datastoreNotConfiguredError
+	}
+
 	filename := urn.AsDatastoreFilename(config_obj)
 	file, err := os.OpenFile(
 		filename, os.O_RDWR|os.O_CREATE, 0660)
@@ -331,6 +337,11 @@ func writeContentToFile(config_obj *config_proto.Config,
 func readContentFromFile(
 	config_obj *config_proto.Config, urn api.DSPathSpec,
 	must_exist bool) ([]byte, error) {
+
+	if config_obj.Datastore == nil {
+		return nil, datastoreNotConfiguredError
+	}
+
 	file, err := os.Open(urn.AsDatastoreFilename(config_obj))
 	if err == nil {
 		defer file.Close()

--- a/gui/velociraptor/src/components/core/paged-table.js
+++ b/gui/velociraptor/src/components/core/paged-table.js
@@ -110,6 +110,9 @@ class VeloPagedTable extends Component {
 
         translate_column_headers: PropTypes.bool,
 
+        // If set we remove the option to filter/sort the table.
+        no_transformations: PropTypes.bool,
+
         // An optional toolbar that can be passed to the table.
         toolbar: PropTypes.object,
 
@@ -472,13 +475,14 @@ class VeloPagedTable extends Component {
                                                  }))}>
                             <FontAwesomeIcon icon="file-csv"/>
                           </Button>
-                          <Button variant="default"
-                                  onClick={()=>this.setState({
-                                      show_transform_dialog: true,
-                                  })}
-                                  title={T("Transform Table")}>
-                            <FontAwesomeIcon icon="filter"/>
-                          </Button>
+                          {!this.props.no_transformations &&
+                           <Button variant="default"
+                                   onClick={()=>this.setState({
+                                       show_transform_dialog: true,
+                                   })}
+                                   title={T("Transform Table")}>
+                             <FontAwesomeIcon icon="filter"/>
+                           </Button>}
                         </ButtonGroup>
                         { transformed.length > 0 &&
                           <ButtonGroup className="float-right">

--- a/gui/velociraptor/src/components/hunts/hunt-clients.js
+++ b/gui/velociraptor/src/components/hunts/hunt-clients.js
@@ -53,6 +53,7 @@ export default class HuntClients extends React.Component {
               renderers={renderers}
               params={params}
               translate_column_headers={true}
+              no_transformations={true}
             />
         );
     }

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -286,7 +286,9 @@ LET ColumnTypes <= dict(
 /*
 # Flows with ERROR status
 */
-SELECT ClientId, FlowId, Flow.start_time As StartedTime,
+SELECT ClientId,
+       client_info(client_id=ClientId).os_info.hostname AS Hostname,
+       FlowId, Flow.start_time As StartedTime,
        Flow.state AS FlowState, Flow.status as FlowStatus,
        Flow.execution_duration as Duration,
        Flow.total_collected_bytes as TotalBytes,
@@ -297,7 +299,9 @@ WHERE FlowState =~ 'ERROR'
 /*
 ## Flows with RUNNING status
 */
-SELECT ClientId, FlowId, Flow.start_time As StartedTime,
+SELECT ClientId,
+       client_info(client_id=ClientId).os_info.hostname AS Hostname,
+       FlowId, Flow.start_time As StartedTime,
        Flow.state AS FlowState, Flow.status as FlowStatus,
        Flow.execution_duration as Duration,
        Flow.total_collected_bytes as TotalBytes,
@@ -308,13 +312,16 @@ WHERE FlowState =~ 'RUNNING'
 /*
 ## Flows with FINISHED status
 */
-SELECT ClientId, FlowId, Flow.start_time As StartedTime,
+SELECT ClientId,
+       client_info(client_id=ClientId).os_info.hostname AS Hostname,
+       FlowId, Flow.start_time As StartedTime,
        Flow.state AS FlowState, Flow.status as FlowStatus,
        Flow.execution_duration as Duration,
        Flow.total_collected_bytes as TotalBytes,
        Flow.total_collected_rows as TotalRows
 FROM hunt_flows(hunt_id=HuntId)
 WHERE FlowState =~ 'Finished'
+LIMIT 1000
 `})
 
 	return getDefaultCellsForSources(config_obj, sources, notebook_metadata)

--- a/utils/orgs.go
+++ b/utils/orgs.go
@@ -35,6 +35,11 @@ func OrgIdFromClientId(client_id string) string {
 	return ""
 }
 
+func ClientIdFromSource(client_id string) string {
+	parts := strings.Split(client_id, "-")
+	return parts[0]
+}
+
 func IsRootOrg(org_id string) bool {
 	return org_id == "" || org_id == "root"
 }


### PR DESCRIPTION
Fixed a bug in the `velociraptor gui` command that made the second org client unresponsive.

Also hide the table filtering in the Hunt Clients tab because it can not work (Users are supposed to use the hunt cell suggestion instead).