### PR TITLE
users: AddUserToOrg needs GetUserWithHashes or it will remove passwor…

### DIFF
--- a/users/add_org.go
+++ b/users/add_org.go
@@ -65,7 +65,7 @@ func AddUserToOrg(
 	user_manager := services.GetUserManager()
 
 	// Hold on to the error until after ACL check
-	user_record, err := user_manager.GetUser(ctx, username)
+	user_record, err := user_manager.GetUserWithHashes(ctx, username)
 	if err != nil {
 		if err == services.UserNotFoundError &&
 			options == UseExistingUser {


### PR DESCRIPTION
…d (#2226)

When AddUserToOrg rewrites the user record and local authentication is in use, it clears the password fields.  We need to use GetUserWithHashes instead.