### PR TITLE
Update user delete VQL and grant

### DIFF
--- a/artifacts/definitions/Admin/Client/Uninstall.yaml
+++ b/artifacts/definitions/Admin/Client/Uninstall.yaml
@@ -30,14 +30,15 @@ sources:
       SELECT OS From info() where OS = 'windows'
 
     query:  |
-      LET packages = SELECT KeyName, DisplayName,UninstallString FROM Artifact.Windows.Sys.Programs()
+      LET packages = SELECT KeyName, DisplayName,UninstallString
+      FROM Artifact.Windows.Sys.Programs()
       WHERE DisplayName =~ DisplayNameRegex AND
         log(message="Will uninstall " + DisplayName)
 
       LET uninstall(UninstallString) = SELECT * FROM execve(
           argv=commandline_split(command=UninstallString) + "/quiet")
 
-      SELECT Name, DisplayName, UninstallString,
+      SELECT KeyName, DisplayName, UninstallString,
           if(condition=ReallyDoIt, then=uninstall(Name=UninstallString).Stdout) AS UninstallLog
       FROM packages
 
@@ -55,6 +56,7 @@ sources:
       then={
         SELECT * FROM execve(argv=["dpkg", "--remove", "velociraptor-client"])
       })
+
   - name: RPMBased
     precondition: |
       -- Only run if dpkg is installed.

--- a/artifacts/definitions/Server/Orgs/NewOrg.yaml
+++ b/artifacts/definitions/Server/Orgs/NewOrg.yaml
@@ -22,5 +22,6 @@ sources:
     LET org_record <= org_create(name=OrgName)
 
     SELECT org_record.name as Name, org_record.org_id AS OrgId,
-           user_create(orgs=org_record.org_id, roles="administrator", user=whoami()) AS AdminUser
+           user_create(orgs=org_record.org_id,
+                       roles="administrator", user=whoami()) AS AdminUser
     FROM scope()

--- a/artifacts/testdata/server/testcases/orgs.out.yaml
+++ b/artifacts/testdata/server/testcases/orgs.out.yaml
@@ -32,6 +32,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
   "effective_policy": {
    "all_query": true,
    "any_query": true,
@@ -61,6 +66,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
   "effective_policy": {
    "all_query": true,
    "any_query": true,
@@ -89,6 +99,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
+  "_policy": {
+   "roles": [
+    "reader"
+   ]
+  },
   "effective_policy": {
    "read_results": true
   }
@@ -102,6 +117,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
+  "_policy": {
+   "roles": [
+    "reader"
+   ]
+  },
   "effective_policy": {
    "read_results": true
   }
@@ -116,6 +136,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
   "effective_policy": {
    "all_query": true,
    "any_query": true,
@@ -145,6 +170,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
+  "_policy": {
+   "roles": [
+    "reader"
+   ]
+  },
   "effective_policy": {
    "read_results": true
   }
@@ -159,6 +189,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
   "effective_policy": {
    "all_query": true,
    "any_query": true,
@@ -187,6 +222,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
+  "_policy": {
+   "roles": [
+    "reader"
+   ]
+  },
   "effective_policy": {
    "read_results": true
   }
@@ -218,6 +258,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
   "effective_policy": {
    "all_query": true,
    "any_query": true,
@@ -246,6 +291,11 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
+  "_policy": {
+   "roles": [
+    "reader"
+   ]
+  },
   "effective_policy": {
    "read_results": true
   }

--- a/artifacts/testdata/server/testcases/users.in.yaml
+++ b/artifacts/testdata/server/testcases/users.in.yaml
@@ -13,12 +13,29 @@ Queries:
 
   # Grant replaces all roles (should lose investigator).
   - LET _ <= user_grant(user="TestUser", roles="reader")
-  - SELECT name, roles FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"
+  - SELECT user(user="TestUser") FROM scope()
 
-  # Now delete it
-  - SELECT user_delete(user="TestUser") FROM scope()
+  # Grant supports adding policy with specific permissions
+  - LET _ <= user_grant(user="TestUser", roles="reader", policy=dict(label_clients=TRUE))
+  - SELECT user(user="TestUser") FROM scope()
 
-  # Should be gone now.
+  # Create a new org
+  - LET _ <= org_create(name="MySecondOrg", org_id="ORGID2")
+  - LET _ <= user_grant(user="TestUser", roles="administrator", orgs="ORGID2")
+
+  # TestUser is an admin in ORGID2 and reader in root
+  - SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"
+
+  # Now delete it from the root org
+  - SELECT user_delete(user="TestUser", really_do_it=TRUE) FROM scope()
+
+  # Should be gone now but the user still exists in the ORGID2
+  - SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"
+
+  # Now delete it from the org
+  - SELECT user_delete(user="TestUser", really_do_it=TRUE, orgs="ORGID2") FROM scope()
+
+  # Should be gone now
   - SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"
 
   # Grant a non existant user a role

--- a/artifacts/testdata/server/testcases/users.out.yaml
+++ b/artifacts/testdata/server/testcases/users.out.yaml
@@ -14,16 +14,145 @@ SELECT whoami() FROM scope()[
    "investigator"
   ]
  }
-]LET _ <= user_grant(user="TestUser", roles="reader")[]SELECT name, roles FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"[
+]LET _ <= user_grant(user="TestUser", roles="reader")[]SELECT user(user="TestUser") FROM scope()[
+ {
+  "user(user=\"TestUser\")": {
+   "name": "TestUser",
+   "org_id": "",
+   "org_name": "",
+   "picture": "",
+   "email": false,
+   "roles": [
+    "reader"
+   ],
+   "_policy": {
+    "roles": [
+     "reader"
+    ]
+   },
+   "effective_policy": {
+    "read_results": true
+   }
+  }
+ }
+]LET _ <= user_grant(user="TestUser", roles="reader", policy=dict(label_clients=TRUE))[]SELECT user(user="TestUser") FROM scope()[
+ {
+  "user(user=\"TestUser\")": {
+   "name": "TestUser",
+   "org_id": "",
+   "org_name": "",
+   "picture": "",
+   "email": false,
+   "roles": [
+    "reader"
+   ],
+   "_policy": {
+    "label_clients": true,
+    "roles": [
+     "reader"
+    ]
+   },
+   "effective_policy": {
+    "read_results": true,
+    "label_clients": true
+   }
+  }
+ }
+]LET _ <= org_create(name="MySecondOrg", org_id="ORGID2")[]LET _ <= user_grant(user="TestUser", roles="administrator", orgs="ORGID2")[]SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"[
  {
   "name": "TestUser",
+  "org_id": "root",
+  "org_name": "\u003croot\u003e",
+  "picture": "",
+  "email": false,
   "roles": [
    "reader"
-  ]
- }
-]SELECT user_delete(user="TestUser") FROM scope()[
+  ],
+  "_policy": {
+   "label_clients": true,
+   "roles": [
+    "reader"
+   ]
+  },
+  "effective_policy": {
+   "read_results": true,
+   "label_clients": true
+  }
+ },
  {
-  "user_delete(user=\"TestUser\")": "TestUser"
+  "name": "TestUser",
+  "org_id": "ORGID2",
+  "org_name": "MySecondOrg",
+  "picture": "",
+  "email": false,
+  "roles": [
+   "administrator"
+  ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
+  "effective_policy": {
+   "all_query": true,
+   "any_query": true,
+   "read_results": true,
+   "label_clients": true,
+   "collect_client": true,
+   "collect_server": true,
+   "artifact_writer": true,
+   "server_artifact_writer": true,
+   "execve": true,
+   "notebook_editor": true,
+   "impersonation": true,
+   "server_admin": true,
+   "filesystem_read": true,
+   "filesystem_write": true,
+   "machine_state": true,
+   "prepare_results": true
+  }
+ }
+]SELECT user_delete(user="TestUser", really_do_it=TRUE) FROM scope()[
+ {
+  "user_delete(user=\"TestUser\", really_do_it=TRUE)": "TestUser"
+ }
+]SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"[
+ {
+  "name": "TestUser",
+  "org_id": "ORGID2",
+  "org_name": "MySecondOrg",
+  "picture": "",
+  "email": false,
+  "roles": [
+   "administrator"
+  ],
+  "_policy": {
+   "roles": [
+    "administrator"
+   ]
+  },
+  "effective_policy": {
+   "all_query": true,
+   "any_query": true,
+   "read_results": true,
+   "label_clients": true,
+   "collect_client": true,
+   "collect_server": true,
+   "artifact_writer": true,
+   "server_artifact_writer": true,
+   "execve": true,
+   "notebook_editor": true,
+   "impersonation": true,
+   "server_admin": true,
+   "filesystem_read": true,
+   "filesystem_write": true,
+   "machine_state": true,
+   "prepare_results": true
+  }
+ }
+]SELECT user_delete(user="TestUser", really_do_it=TRUE, orgs="ORGID2") FROM scope()[
+ {
+  "user_delete(user=\"TestUser\", really_do_it=TRUE, orgs=\"ORGID2\")": "TestUser"
  }
 ]SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUser"[]SELECT user_grant(user="TestUserNotThere", roles="reader") FROM scope()[
  {

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -449,6 +449,9 @@
   - name: client_id
     type: string
     required: true
+  - name: metadata
+    type: ordereddict.Dict
+    description: A dict containing metadata. If not specified we use kwargs.
   category: server
 - name: clients
   description: Retrieve the list of clients.
@@ -2068,7 +2071,7 @@
     description: A dict of headers to send.
   - name: method
     type: string
-    description: HTTP method to use (GET, POST)
+    description: HTTP method to use (GET, POST, PUT, PATCH, DELETE)
   - name: data
     type: string
     description: If specified we write this raw data into a POST request instead of
@@ -3454,6 +3457,9 @@
   - name: accessor
     type: string
     description: The accessor to use.
+  - name: prefix
+    type: accessors.OSPath
+    description: If specified we prefix all paths with this path.
   category: parsers
 - name: parse_ntfs
   description: |
@@ -4796,6 +4802,15 @@
   - name: wait_time
     type: int64
     description: Batch splunk upload this long (2 sec).
+  - name: hostname
+    type: string
+    description: Hostname for Splunk Events. Defaults to server hostname.
+  - name: timestamp_field
+    type: string
+    description: Field to use as event timestamp.
+  - name: hostname_field
+    type: string
+    description: Field to use as event hostname. Overrides hostname param.
   category: server
 - name: sql
   description: Run queries against sqlite, mysql, and postgres databases
@@ -4922,6 +4937,9 @@
   - name: prefix
     type: string
     description: The prefix to strip
+  - name: suffix
+    type: string
+    description: The suffix to strip
   category: basic
 - name: substr
   description: Create a substring from a string
@@ -5476,6 +5494,17 @@
     type: string
     description: A url to parse
   category: basic
+- name: user
+  description: Retrieves information about the Velociraptor user.
+  type: Function
+  args:
+  - name: user
+    type: string
+    description: The user to create or update.
+    required: true
+  - name: org
+    type: string
+    description: The org under which we query the user's ACL.
 - name: user_create
   description: Creates a new user from the server, or updates their permissions or
     reset their password.
@@ -5495,7 +5524,8 @@
     description: A password to set for the user (If not using SSO this might be needed).
   - name: orgs
     type: string
-    description: One or more org IDs to grant access to.
+    description: One or more org IDs to grant access to. If empty we use the current
+      org.
     repeated: true
   category: server
 - name: user_delete
@@ -5506,6 +5536,14 @@
     type: string
     description: The user to delete.
     required: true
+  - name: orgs
+    type: string
+    description: If set we only delete from these orgs, otherwise we delete from the
+      current org.
+    repeated: true
+  - name: really_do_it
+    type: bool
+    description: If not specified, just show what user will be removed
   category: server
 - name: user_grant
   description: Grants the user the specified roles.
@@ -5519,11 +5557,15 @@
     type: string
     description: List of roles to give the user.
     repeated: true
-    required: true
   - name: orgs
     type: string
-    description: One or more org IDs to grant access to.
+    description: One or more org IDs to grant access to. If not specified we use current
+      org
     repeated: true
+  - name: policy
+    type: ordereddict.Dict
+    description: A dict of permissions to set (e.g. as obtained from the gui_users()
+      function).
 - name: users
   description: Display information about workstation local users. This is obtained
     through the NetUserEnum() API.

--- a/vql/server/users/get.go
+++ b/vql/server/users/get.go
@@ -1,0 +1,66 @@
+package users
+
+import (
+	"context"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/users"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+)
+
+type UserFunctionArgs struct {
+	Username string `vfilter:"required,field=user,doc=The user to create or update."`
+	OrgId    string `vfilter:"optional,field=org,doc=The org under which we query the user's ACL."`
+}
+
+type UserFunction struct{}
+
+func (self UserFunction) Call(
+	ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+
+	// ACLs are checked by the users module
+	arg := &UserFunctionArgs{}
+	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+	if err != nil {
+		scope.Log("user: %s", err)
+		return vfilter.Null{}
+	}
+
+	org_config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		scope.Log("user: Command can only run on the server")
+		return vfilter.Null{}
+	}
+
+	principal := vql_subsystem.GetPrincipal(scope)
+	user_details, err := users.GetUser(ctx, principal, arg.Username)
+	if err != nil {
+		scope.Log("user: %s", err)
+		return vfilter.Null{}
+	}
+
+	details, err := getUserRecord(ctx, scope,
+		org_config_obj.OrgId, org_config_obj.OrgName, user_details)
+	if err != nil {
+		scope.Log("user: %v", err)
+		return vfilter.Null{}
+	}
+
+	return details
+}
+
+func (self UserFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:    "user",
+		Doc:     "Retrieves information about the Velociraptor user.",
+		ArgType: type_map.AddType(scope, &UserFunctionArgs{}),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&UserFunction{})
+}

--- a/vql/server/users/grant.go
+++ b/vql/server/users/grant.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	acl_proto "www.velocidex.com/golang/velociraptor/acls/proto"
+	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/users"
+	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
 
 type GrantFunctionArgs struct {
-	Username string   `vfilter:"required,field=user,doc=The user to create or update."`
-	Roles    []string `vfilter:"required,field=roles,doc=List of roles to give the user."`
-	OrgIds   []string `vfilter:"optional,field=orgs,doc=One or more org IDs to grant access to."`
+	Username string            `vfilter:"required,field=user,doc=The user to create or update."`
+	Roles    []string          `vfilter:"optional,field=roles,doc=List of roles to give the user."`
+	OrgIds   []string          `vfilter:"optional,field=orgs,doc=One or more org IDs to grant access to. If not specified we use current org"`
+	Policy   *ordereddict.Dict `vfilter:"optional,field=policy,doc=A dict of permissions to set (e.g. as obtained from the gui_users() function)."`
 }
 
 type GrantFunction struct{}
@@ -38,18 +41,32 @@ func (self GrantFunction) Call(
 		return vfilter.Null{}
 	}
 
-	orgs := users.LIST_ALL_ORGS
+	// If org ids not specified we use the current org id
+	orgs := arg.OrgIds
 	if len(arg.OrgIds) == 0 {
 		orgs = []string{org_config_obj.OrgId}
 	}
 
-	policy := &acl_proto.ApiClientACL{
-		Roles: arg.Roles,
+	policy := &acl_proto.ApiClientACL{}
+	if !utils.IsNil(arg.Policy) {
+		serialized, err := arg.Policy.MarshalJSON()
+		if err != nil {
+			scope.Log("user_grant: %s", err)
+			return vfilter.Null{}
+		}
+		err = json.Unmarshal(serialized, policy)
+		if err != nil {
+			scope.Log("user_grant: %s", err)
+			return vfilter.Null{}
+		}
+	} else if len(arg.Roles) == 0 {
+		scope.Log("user_grant: You must provide either roles or a policy object")
+		return vfilter.Null{}
 	}
+	policy.Roles = arg.Roles
 
 	principal := vql_subsystem.GetPrincipal(scope)
-	err = users.AddUserToOrg(ctx, users.UseExistingUser,
-		principal, arg.Username, orgs, policy)
+	err = users.GrantUserToOrg(ctx, principal, arg.Username, orgs, policy)
 	if err != nil {
 		scope.Log("user_grant: %s", err)
 		return vfilter.Null{}


### PR DESCRIPTION
Previously user_delete() would delete from all orgs but this can lead to an accident when the orgs pramaeter is omitted. The new behavior is to delete from the current org when no orgs are specified.