### PR TITLE
Bugfix: Store client specific dashboard in client space.

### DIFF
--- a/actions/events.go
+++ b/actions/events.go
@@ -127,6 +127,11 @@ func (self *EventTable) close() {
 
 	// Wait until the queries have completed.
 	self.wg.Wait()
+
+	// Clear the list of events we are tracking - we are an empty
+	// event table right now - so further updates will restart the
+	// queries again.
+	self.Events = nil
 }
 
 func (self *EventTable) Version() uint64 {

--- a/api/csv.go
+++ b/api/csv.go
@@ -198,6 +198,15 @@ func getPathSpec(
 		return paths.NewNotebookPathManager(in.NotebookId).Cell(
 			in.CellId).Logs(), nil
 
+		// Handle dashboards specially. Dashboards are kind of
+		// non-interactive notebook stored in a special notebook ID
+		// called "Dashboards". Cells within the dashboard correspond
+		// to different artifacts. Dashboard cells are recalculated
+		// each time they are viewed.
+	} else if in.NotebookId == "Dashboards" && in.CellId != "" {
+		return paths.NewDashboardPathManager(in.Type, in.CellId, in.ClientId).
+			QueryStorage(in.TableId).Path(), nil
+
 	} else if in.NotebookId != "" && in.CellId != "" {
 		return paths.NewNotebookPathManager(in.NotebookId).Cell(
 			in.CellId).QueryStorage(in.TableId).Path(), nil

--- a/api/reports.go
+++ b/api/reports.go
@@ -20,9 +20,9 @@ import (
 // notebook (but historically predate it).
 // TODO: Think about consolidating reports and notebooks
 // Currently this is used from:
-// 1. Home screen (dashboard)
-// 2. Client's VQL Drilldown screen
-// 3. View Artifacts screen
+// 1. Home screen (dashboard)  (type: "SERVER_EVENT")
+// 2. Client's VQL Drilldown screen (type: "CLIENT")
+// 3. View Artifacts screen (type: "ARTIFACT_DESCRIPTION")
 func getReport(ctx context.Context,
 	config_obj *config_proto.Config,
 	acl_manager vql_subsystem.ACLManager,
@@ -35,8 +35,8 @@ func getReport(ctx context.Context,
 	bare_artifact_name := strings.TrimPrefix(in.Artifact,
 		constants.ARTIFACT_CUSTOM_NAME_PREFIX)
 
-	notebook_cell_path_manager := paths.NewNotebookPathManager(
-		"Dashboard." + bare_artifact_name).Cell(bare_artifact_name)
+	notebook_cell_path_manager := paths.NewDashboardPathManager(
+		in.Type, bare_artifact_name, in.ClientId)
 
 	template_engine, err := reporting.NewGuiTemplateEngine(
 		config_obj, ctx, nil, /* default scope */

--- a/artifacts/definitions/Server/Monitor/Health.yaml
+++ b/artifacts/definitions/Server/Monitor/Health.yaml
@@ -69,7 +69,7 @@ reports:
 
       {{ Query "LET ColumnTypes <= dict(ClientConfig='url') \
                 SELECT Name, OrgId, \
-                       format(format='[%s](/notebooks/Dashboards/Dashboard.%s/uploads/client.%s.config.yaml)', \
+                       format(format='[%s](/notebooks/Dashboards/%s/uploads/client.%s.config.yaml)', \
                        args=[OrgId, ArtifactName, OrgId]) AS ClientConfig, \
                        upload(accessor='data', file=_client_config, \
                               name='client.'+OrgId+'.config.yaml') AS _Upload \

--- a/gui/velociraptor/src/components/utils/url.js
+++ b/gui/velociraptor/src/components/utils/url.js
@@ -8,6 +8,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Modal from 'react-bootstrap/Modal';
 import Navbar from 'react-bootstrap/Navbar';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import api from '../core/api-service.js';
+
 
 export default class URLViewer extends Component {
     static propTypes = {
@@ -41,7 +43,7 @@ export default class URLViewer extends Component {
                    className="url-link"
                    size="sm"
                    variant="outline-info"
-                   href={url} target="_blank">
+                   href={api.href(url)} target="_blank">
                    <FontAwesomeIcon icon="external-link-alt"/>
                    <span className="button-label">{desc}</span>
                </Button>;

--- a/paths/dashboard.go
+++ b/paths/dashboard.go
@@ -1,0 +1,38 @@
+package paths
+
+import "www.velocidex.com/golang/velociraptor/file_store/api"
+
+// Dashboards may live in a global place or a client specific place
+func NewDashboardPathManager(dashboard_type, artifact,
+	client_id string) *NotebookCellPathManager {
+
+	if dashboard_type == "ARTIFACT_DESCRIPTION" {
+		return &NotebookCellPathManager{
+			notebook_id: "Dashboards",
+			cell_id:     artifact,
+			root: NOTEBOOK_ROOT.
+				SetType(api.PATH_TYPE_DATASTORE_JSON),
+		}
+	}
+
+	// The Dashboard name is based on the root of the artifact name
+	artifact, _ = SplitFullSourceName(artifact)
+
+	if client_id == "" {
+		return &NotebookCellPathManager{
+			notebook_id: "Dashboards",
+			cell_id:     artifact,
+			client_id:   client_id,
+			root: NOTEBOOK_ROOT.
+				SetType(api.PATH_TYPE_DATASTORE_JSON),
+		}
+	}
+
+	return &NotebookCellPathManager{
+		client_id:   client_id,
+		cell_id:     artifact,
+		notebook_id: "Dashboards",
+		root: CLIENTS_ROOT.AddUnsafeChild(client_id).
+			SetType(api.PATH_TYPE_DATASTORE_JSON),
+	}
+}

--- a/paths/notebooks.go
+++ b/paths/notebooks.go
@@ -183,7 +183,8 @@ func (self *NotebookCellPathManager) QueryStorage(id int64) *NotebookCellQuery {
 
 func (self *NotebookCellPathManager) GetUploadsFile(filename string) api.FSPathSpec {
 	return self.root.AsFilestorePath().
-		AddUnsafeChild(self.notebook_id, "uploads", filename).
+		AddUnsafeChild(self.notebook_id,
+			self.cell_id, "uploads", filename).
 		SetType(api.PATH_TYPE_FILESTORE_ANY)
 }
 

--- a/reporting/gui.go
+++ b/reporting/gui.go
@@ -496,10 +496,9 @@ func (self *GuiTemplateEngine) Query(queries ...string) interface{} {
 			result = append(result, path)
 
 			file_store_factory := file_store.GetFileStore(self.config_obj)
-
 			rs_writer, err := result_sets.NewResultSetWriter(
 				file_store_factory, path.Path(),
-				opts, utils.BackgroundWriter,
+				opts, utils.SyncCompleter,
 				result_sets.TruncateMode)
 			if err != nil {
 				self.Error("Error: %v\n", err)


### PR DESCRIPTION
The old Reports are migrated to the notebook renderer which needs to write the result to the datastore. This requires choosing an appropriate location for the notebook on disk. Previously all notebooks were put in the global notebooks directory but some reports are specific for each client.

This PR refactores the paths of where reports will be stored.

Currently reports are used for:

1. Home screen (dashboard)  (type: "SERVER_EVENT")
2. Client's VQL Drilldown screen (type: "CLIENT")
3. View Artifacts screen (type: "ARTIFACT_DESCRIPTION")
4. Client Monitoring report (to be deprecated - same as monitoring notebook).