### PR TITLE
Bugfix: Do not expand sparse files when importing

### DIFF
--- a/api/datastore.go
+++ b/api/datastore.go
@@ -34,8 +34,7 @@ func (self *ApiServer) GetSubject(
 		return nil, Status(self.verbose, err)
 	}
 
-	perm, err := services.CheckAccessWithToken(
-		org_config_obj, token, acls.DATASTORE_ACCESS)
+	perm, err := services.CheckAccessWithToken(token, acls.DATASTORE_ACCESS)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied,
 			"User is not allowed to access datastore.")
@@ -87,8 +86,7 @@ func (self *ApiServer) SetSubject(
 		return nil, Status(self.verbose, err)
 	}
 
-	perm, err := services.CheckAccessWithToken(
-		org_config_obj, token, acls.DATASTORE_ACCESS)
+	perm, err := services.CheckAccessWithToken(token, acls.DATASTORE_ACCESS)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied,
 			"User is not allowed to access datastore.")
@@ -152,8 +150,7 @@ func (self *ApiServer) ListChildren(
 		return nil, Status(self.verbose, err)
 	}
 
-	perm, err := services.CheckAccessWithToken(
-		org_config_obj, token, acls.DATASTORE_ACCESS)
+	perm, err := services.CheckAccessWithToken(token, acls.DATASTORE_ACCESS)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied,
 			"User is not allowed to access datastore.")
@@ -212,8 +209,7 @@ func (self *ApiServer) DeleteSubject(
 		return nil, Status(self.verbose, err)
 	}
 
-	perm, err := services.CheckAccessWithToken(
-		org_config_obj, token, acls.DATASTORE_ACCESS)
+	perm, err := services.CheckAccessWithToken(token, acls.DATASTORE_ACCESS)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied,
 			"User is not allowed to access datastore.")

--- a/api/events.go
+++ b/api/events.go
@@ -31,8 +31,7 @@ func (self *ApiServer) PushEvents(
 	}
 
 	// Check that the principal is allowed to push to the queue.
-	ok, err := services.CheckAccessWithToken(
-		org_config_obj, token, acls.PUBLISH, in.Artifact)
+	ok, err := services.CheckAccessWithToken(token, acls.PUBLISH, in.Artifact)
 	if err != nil {
 		return nil, Status(self.verbose, err)
 	}
@@ -94,8 +93,7 @@ func (self *ApiServer) WriteEvent(
 	}
 
 	// Check that the principal is allowed to push to the queue.
-	ok, err := services.CheckAccessWithToken(
-		config_obj, token, acls.MACHINE_STATE, in.Query.Name)
+	ok, err := services.CheckAccessWithToken(token, acls.MACHINE_STATE, in.Query.Name)
 	if err != nil {
 		return nil, Status(self.verbose, err)
 	}

--- a/file_store/uploader/uploader.go
+++ b/file_store/uploader/uploader.go
@@ -26,7 +26,7 @@ func (self *FileStoreUploader) Upload(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	expected_size int64,
 	mtime time.Time,
 	atime time.Time,
@@ -35,21 +35,23 @@ func (self *FileStoreUploader) Upload(
 	reader io.Reader) (
 	*uploads.UploadResponse, error) {
 
-	if store_as_name == "" {
-		store_as_name = filename.String()
+	if store_as_name == nil {
+		store_as_name = filename
 	}
 
-	output_path := self.root_path.AddUnsafeChild(store_as_name)
+	output_path := self.root_path.AddUnsafeChild(store_as_name.Components...)
 	out_fd, err := self.file_store.WriteFile(output_path)
 	if err != nil {
-		scope.Log("Unable to open file %s: %v", store_as_name, err)
+		scope.Log("Unable to open file %s: %v",
+			store_as_name.String(), err)
 		return nil, err
 	}
 	defer out_fd.Close()
 
 	err = out_fd.Truncate()
 	if err != nil {
-		scope.Log("Unable to truncate file %s: %v", store_as_name, err)
+		scope.Log("Unable to truncate file %s: %v",
+			store_as_name.String(), err)
 		return nil, err
 	}
 

--- a/flows/artifacts_test.go
+++ b/flows/artifacts_test.go
@@ -361,7 +361,7 @@ func (self *TestSuite) TestClientUploaderStoreFile() {
 	scope := vql_subsystem.MakeScope().AppendVars(ordereddict.NewDict().
 		Set(vql_subsystem.ACL_MANAGER_VAR, acl_managers.NullACLManager{}))
 	uploader.Upload(context.Background(), scope,
-		filename, "ntfs", "", 1000,
+		filename, "ntfs", nil, 1000,
 		nilTime, nilTime, nilTime, nilTime, reader)
 
 	// Get a new collection context.
@@ -818,7 +818,7 @@ func (self *TestSuite) TestClientUploaderStoreSparseFile() {
 	scope := vql_subsystem.MakeScope().AppendVars(ordereddict.NewDict().
 		Set(vql_subsystem.ACL_MANAGER_VAR, acl_managers.NullACLManager{}))
 	uploader.Upload(context.Background(), scope,
-		sparse_filename, "ntfs", "", 1000,
+		sparse_filename, "ntfs", nil, 1000,
 		nilTime, nilTime, nilTime, nilTime, reader)
 
 	// Get a new collection context.
@@ -950,7 +950,7 @@ func (self *TestSuite) TestClientUploaderStoreSparseFileNTFS() {
 
 	// Upload the file to the responder.
 	uploader.Upload(context.Background(), scope,
-		sparse_filename, "ntfs", "", 1000,
+		sparse_filename, "ntfs", nil, 1000,
 		nilTime, nilTime, nilTime, nilTime, fd)
 
 	// Get a new collection context.

--- a/reporting/container.go
+++ b/reporting/container.go
@@ -253,6 +253,7 @@ func (self *Container) WriteJSON(name string, data interface{}) error {
 // Parse the path according to the accessor to return the components
 func (self *Container) getPathComponents(
 	scope vfilter.Scope, accessor string, path string) ([]string, error) {
+
 	file_store_factory, err := accessors.GetAccessor(accessor, scope)
 	if err != nil {
 		return nil, err
@@ -266,6 +267,20 @@ func (self *Container) getPathComponents(
 	return os_path.Components, nil
 }
 
+func formatFilename(filename *accessors.OSPath, accessor string) string {
+	result := filename.String()
+
+	// These paths can be very large so we elide them.
+	switch accessor {
+	case "data", "sparse":
+		if len(result) > 50 {
+			result = result[:50] + "..."
+		}
+	}
+
+	return result
+}
+
 // Upload the file into the zip file.  We treat the zip file as our
 // filestore here - this means that file paths will be very
 // conservatively escaped to ensure maximum compatibility with zip
@@ -276,7 +291,7 @@ func (self *Container) Upload(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	expected_size int64,
 	mtime time.Time,
 	atime time.Time,
@@ -285,7 +300,7 @@ func (self *Container) Upload(
 	reader io.Reader) (*uploads.UploadResponse, error) {
 
 	result := &uploads.UploadResponse{
-		Path: filename.String(),
+		Path: formatFilename(filename, accessor),
 		Size: uint64(expected_size),
 	}
 
@@ -297,28 +312,19 @@ func (self *Container) Upload(
 	// The filename to store the file inside the zip - due to escaping
 	// issues this may not be exactly the same as the file name we
 	// receive.
-	var store_path *accessors.OSPath
-
-	if store_as_name == "" {
-		// Write to the zip file with the generic OSPath
-		store_path = accessors.NewZipFilePath("uploads").Append(accessor).
-			Append(filename.Components...)
-	} else {
-		// Try to figure out the OSPath for the store as name
-		components, err := self.getPathComponents(scope, accessor, store_as_name)
-		if err != nil {
-			components = []string{store_as_name}
-		}
-		store_path = accessors.NewZipFilePath("uploads").Append(accessor).
-			Append(components...)
+	if store_as_name == nil {
+		store_as_name = filename
 	}
+
+	store_path := accessors.NewZipFilePath("uploads").Append(accessor).
+		Append(store_as_name.Components...)
 
 	// Where to store the file inside the Zip file.
 	result.StoredName = store_path.String()
 	result.Components = store_path.Components
 
 	scope.Log("Collecting file %s into %s (%v bytes)",
-		filename.String(), result.StoredName, expected_size)
+		formatFilename(filename, accessor), result.StoredName, expected_size)
 
 	// Try to collect sparse files if possible
 	err := self.maybeCollectSparseFile(ctx, scope, reader, result, mtime)
@@ -437,6 +443,7 @@ func (self *Container) maybeCollectSparseFile(
 			StoredName: result.StoredName + ".idx",
 			Path:       result.Path + ".idx",
 			Reference:  result.Reference,
+			Type:       "idx",
 		}
 		writer, err := self.Create(idx_upload.StoredName, time.Time{})
 		if err != nil {
@@ -497,7 +504,8 @@ func (self *Container) Close() error {
 					Set("vfs_path", record.Path).
 					Set("_Components", record.Components).
 					Set("file_size", record.Size).
-					Set("uploaded_size", record.StoredSize))
+					Set("uploaded_size", record.StoredSize).
+					Set("Type", record.Type))
 				if err != nil {
 					break
 				}

--- a/reporting/container.go
+++ b/reporting/container.go
@@ -432,7 +432,13 @@ func (self *Container) maybeCollectSparseFile(
 
 	// If there were any sparse runs, create an index.
 	if is_sparse {
-		writer, err := self.Create(result.StoredName+".idx", time.Time{})
+		idx_upload := &uploads.UploadResponse{
+			Components: utils.CopySlice(result.Components),
+			StoredName: result.StoredName + ".idx",
+			Path:       result.Path + ".idx",
+			Reference:  result.Reference,
+		}
+		writer, err := self.Create(idx_upload.StoredName, time.Time{})
 		if err != nil {
 			return err
 		}
@@ -447,6 +453,14 @@ func (self *Container) maybeCollectSparseFile(
 		if err != nil {
 			return err
 		}
+
+		idx_upload.Size = uint64(len(serialized))
+		idx_upload.StoredSize = uint64(len(serialized))
+
+		// Add it to the uploads list.
+		self.mu.Lock()
+		self.uploads = append(self.uploads, idx_upload)
+		self.mu.Unlock()
 	}
 
 	result.StoredSize = uint64(count)

--- a/reporting/uploader.go
+++ b/reporting/uploader.go
@@ -27,7 +27,7 @@ func (self *NotebookUploader) Upload(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	expected_size int64,
 	mtime time.Time,
 	atime time.Time,
@@ -36,10 +36,10 @@ func (self *NotebookUploader) Upload(
 	reader io.Reader) (
 	*uploads.UploadResponse, error) {
 
-	if store_as_name == "" {
-		store_as_name = filename.String()
+	if store_as_name == nil {
+		store_as_name = filename
 	}
-	dest_path_spec := self.PathManager.GetUploadsFile(store_as_name)
+	dest_path_spec := self.PathManager.GetUploadsFile(store_as_name.String())
 
 	file_store_factory := file_store.GetFileStore(self.config_obj)
 	writer, err := file_store_factory.WriteFile(dest_path_spec)
@@ -59,7 +59,7 @@ func (self *NotebookUploader) Upload(
 	n, err := utils.Copy(ctx, writer, io.TeeReader(
 		io.TeeReader(reader, sha_sum), md5_sum))
 	return &uploads.UploadResponse{
-		Path:   store_as_name,
+		Path:   store_as_name.String(),
 		Size:   uint64(n),
 		Sha256: hex.EncodeToString(sha_sum.Sum(nil)),
 		Md5:    hex.EncodeToString(md5_sum.Sum(nil)),

--- a/services/acl_manager/acl_manager.go
+++ b/services/acl_manager/acl_manager.go
@@ -12,6 +12,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/paths"
+	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
@@ -141,93 +142,13 @@ func (self ACLManager) CheckAccess(
 	}
 
 	for _, permission := range permissions {
-		ok, err := self.CheckAccessWithToken(acl_obj, permission)
+		ok, err := services.CheckAccessWithToken(acl_obj, permission)
 		if !ok || err != nil {
 			return ok, err
 		}
 	}
 
 	return true, nil
-}
-
-func (self ACLManager) CheckAccessWithToken(
-	token *acl_proto.ApiClientACL,
-	permission acls.ACL_PERMISSION, args ...string) (bool, error) {
-
-	// The super user can do everything.
-	if token.SuperUser {
-		return true, nil
-	}
-
-	// Requested permission
-	switch permission {
-	case acls.ALL_QUERY:
-		return token.AllQuery, nil
-
-	case acls.ANY_QUERY:
-		return token.AnyQuery, nil
-
-	case acls.PUBLISH:
-		if len(args) == 1 {
-			for _, allowed_queue := range token.PublishQueues {
-				if allowed_queue == args[0] {
-					return true, nil
-				}
-
-			}
-		}
-
-	case acls.READ_RESULTS:
-		return token.ReadResults, nil
-
-	case acls.LABEL_CLIENT:
-		return token.LabelClients, nil
-
-	case acls.COLLECT_CLIENT:
-		return token.CollectClient, nil
-
-	case acls.COLLECT_SERVER:
-		return token.CollectServer, nil
-
-	case acls.ARTIFACT_WRITER:
-		return token.ArtifactWriter, nil
-
-	case acls.SERVER_ARTIFACT_WRITER:
-		return token.ServerArtifactWriter, nil
-
-	case acls.EXECVE:
-		return token.Execve, nil
-
-	case acls.NOTEBOOK_EDITOR:
-		return token.NotebookEditor, nil
-
-	case acls.SERVER_ADMIN:
-		return token.ServerAdmin, nil
-
-	case acls.ORG_ADMIN:
-		return token.OrgAdmin, nil
-
-	case acls.IMPERSONATION:
-		return token.Impersonation, nil
-
-	case acls.FILESYSTEM_READ:
-		return token.FilesystemRead, nil
-
-	case acls.FILESYSTEM_WRITE:
-		return token.FilesystemWrite, nil
-
-	case acls.MACHINE_STATE:
-		return token.MachineState, nil
-
-	case acls.PREPARE_RESULTS:
-		return token.PrepareResults, nil
-
-	case acls.DATASTORE_ACCESS:
-		return token.DatastoreAccess, nil
-
-	}
-
-	return false, nil
 }
 
 func (self ACLManager) GrantRoles(

--- a/services/server_artifacts/server_uploader.go
+++ b/services/server_artifacts/server_uploader.go
@@ -29,7 +29,7 @@ func (self *ServerUploader) Upload(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	expected_size int64,
 	mtime time.Time,
 	atime time.Time,
@@ -70,7 +70,7 @@ func (self *ServerUploader) Upload(
 			Set("Timestamp", timestamp).
 			Set("ClientId", "server").
 			Set("VFSPath", result.Path).
-			Set("UploadName", store_as_name).
+			Set("UploadName", store_as_name.String()).
 			Set("Accessor", "fs").
 			Set("Size", result.Size).
 			Set("UploadedSize", result.Size)

--- a/uploads/api.go
+++ b/uploads/api.go
@@ -21,6 +21,9 @@ type UploadResponse struct {
 	StoredName string   `json:"StoredName,omitempty"`
 	Reference  string   `json:"Reference,omitempty"`
 	Components []string `json:"Components,omitempty"`
+
+	// The type of upload this is (Currently "idx" is an index file)
+	Type string `json:"Type,omitempty"`
 }
 
 // Provide an uploader capable of uploading any reader object.
@@ -29,7 +32,7 @@ type Uploader interface {
 		scope vfilter.Scope,
 		filename *accessors.OSPath,
 		accessor string,
-		store_as_name string,
+		store_as_name *accessors.OSPath,
 		expected_size int64,
 		mtime time.Time,
 		atime time.Time,

--- a/uploads/client_uploader.go
+++ b/uploads/client_uploader.go
@@ -32,7 +32,7 @@ func (self *VelociraptorUploader) Upload(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	expected_size int64,
 	mtime time.Time,
 	atime time.Time,
@@ -49,13 +49,13 @@ func (self *VelociraptorUploader) Upload(
 		return result, nil
 	}
 
-	if store_as_name == "" {
-		store_as_name = filename.String()
+	if store_as_name == nil {
+		store_as_name = filename
 	}
 
 	result = &UploadResponse{
 		Path:       filename.String(),
-		StoredName: store_as_name,
+		StoredName: store_as_name.String(),
 	}
 
 	offset := uint64(0)
@@ -86,7 +86,7 @@ func (self *VelociraptorUploader) Upload(
 
 		packet := &actions_proto.FileBuffer{
 			Pathspec: &actions_proto.PathSpec{
-				Path:     store_as_name,
+				Path:     store_as_name.String(),
 				Accessor: accessor,
 			},
 			Offset:     offset,
@@ -130,7 +130,7 @@ func (self *VelociraptorUploader) maybeUploadSparse(
 	scope vfilter.Scope,
 	filename *accessors.OSPath,
 	accessor string,
-	store_as_name string,
+	store_as_name *accessors.OSPath,
 	ignored_expected_size int64,
 	mtime time.Time,
 	reader io.Reader) (
@@ -150,8 +150,8 @@ func (self *VelociraptorUploader) maybeUploadSparse(
 		Path: filename.String(),
 	}
 
-	if store_as_name == "" {
-		store_as_name = filename.String()
+	if store_as_name == nil {
+		store_as_name = filename
 	}
 
 	self.Count += 1
@@ -211,7 +211,7 @@ func (self *VelociraptorUploader) maybeUploadSparse(
 			RequestId: constants.TransferWellKnownFlowId,
 			FileBuffer: &actions_proto.FileBuffer{
 				Pathspec: &actions_proto.PathSpec{
-					Path:     store_as_name,
+					Path:     store_as_name.String(),
 					Accessor: accessor,
 				},
 				Size:       uint64(real_size),
@@ -279,7 +279,7 @@ func (self *VelociraptorUploader) maybeUploadSparse(
 
 			packet := &actions_proto.FileBuffer{
 				Pathspec: &actions_proto.PathSpec{
-					Path:     store_as_name,
+					Path:     store_as_name.String(),
 					Accessor: accessor,
 				},
 				Offset:     uint64(write_offset),
@@ -319,7 +319,7 @@ func (self *VelociraptorUploader) maybeUploadSparse(
 		RequestId: constants.TransferWellKnownFlowId,
 		FileBuffer: &actions_proto.FileBuffer{
 			Pathspec: &actions_proto.PathSpec{
-				Path:     store_as_name,
+				Path:     store_as_name.String(),
 				Accessor: accessor,
 			},
 			Size:       uint64(real_size),

--- a/uploads/client_uploader_test.go
+++ b/uploads/client_uploader_test.go
@@ -72,7 +72,7 @@ func TestClientUploaderSparse(t *testing.T) {
 	ctx := context.Background()
 	scope := vql_subsystem.MakeScope()
 	uploader.maybeUploadSparse(ctx, scope,
-		filename, "ntfs", "", 1000, nilTime, range_reader)
+		filename, "ntfs", nil, 1000, nilTime, range_reader)
 	responses := responder.GetTestResponses(resp)
 
 	// Expected size is the combined sum of all ranges with data
@@ -112,7 +112,7 @@ func TestClientUploaderSparseWithEOF(t *testing.T) {
 	ctx := context.Background()
 	scope := vql_subsystem.MakeScope()
 	uploader.maybeUploadSparse(ctx, scope,
-		filename, "ntfs", "", 1000, nilTime, range_reader)
+		filename, "ntfs", nil, 1000, nilTime, range_reader)
 	responses := responder.GetTestResponses(resp)
 
 	// Expected size is the combined sum of all ranges with data
@@ -148,7 +148,7 @@ func TestClientUploader(t *testing.T) {
 
 	resp, err := uploader.Upload(
 		ctx, scope, getOSPath(name),
-		"file", "", 1000,
+		"file", nil, 1000,
 		nilTime, nilTime, nilTime, nilTime, fd)
 	assert.NoError(t, err)
 	assert.Equal(t, resp.Path, name)
@@ -179,7 +179,7 @@ func TestClientUploaderCompletelySparse(t *testing.T) {
 	scope := vql_subsystem.MakeScope()
 
 	uploader.maybeUploadSparse(ctx, scope,
-		filename, "ntfs", "", 1000, nilTime, range_reader)
+		filename, "ntfs", nil, 1000, nilTime, range_reader)
 	responses := responder.GetTestResponses(resp)
 
 	// Expected size is the combined sum of all ranges with data
@@ -210,7 +210,7 @@ func TestClientUploaderSparseMultiBuffer(t *testing.T) {
 	ctx := context.Background()
 	scope := vql_subsystem.MakeScope()
 	uploader.maybeUploadSparse(ctx, scope,
-		filename, "ntfs", "", 1000, nilTime, range_reader)
+		filename, "ntfs", nil, 1000, nilTime, range_reader)
 	responses := responder.GetTestResponses(resp)
 	assert.Equal(t, CombineOutput("/foo", responses), "Hello hello ")
 	for _, response := range responses {
@@ -242,7 +242,7 @@ func TestClientUploaderNoIndexIfNotSparse(t *testing.T) {
 	ctx := context.Background()
 	scope := vql_subsystem.MakeScope()
 	uploader.maybeUploadSparse(ctx, scope,
-		filename, "ntfs", "", 1000, nilTime, range_reader)
+		filename, "ntfs", nil, 1000, nilTime, range_reader)
 	responses := responder.GetTestResponses(resp)
 	assert.Equal(t, CombineOutput("/foo", responses), "Hello hello ")
 

--- a/vql/acl_managers/role.go
+++ b/vql/acl_managers/role.go
@@ -20,9 +20,9 @@ type RoleACLManager struct {
 
 func (self *RoleACLManager) CheckAccess(
 	permissions ...acls.ACL_PERMISSION) (bool, error) {
+
 	for _, permission := range permissions {
-		ok, err := services.CheckAccessWithToken(
-			self.config_obj, self.Token, permission)
+		ok, err := services.CheckAccessWithToken(self.Token, permission)
 		if !ok || err != nil {
 			return ok, err
 		}
@@ -47,7 +47,7 @@ func (self *RoleACLManager) CheckAccessInOrg(
 func (self *RoleACLManager) CheckAccessWithArgs(
 	permission acls.ACL_PERMISSION, args ...string) (bool, error) {
 
-	return services.CheckAccessWithToken(self.config_obj, self.Token, permission, args...)
+	return services.CheckAccessWithToken(self.Token, permission, args...)
 }
 
 // NewRoleACLManager creates an ACL manager with only the assigned

--- a/vql/acl_managers/server.go
+++ b/vql/acl_managers/server.go
@@ -35,7 +35,7 @@ func (self *ServerACLManager) CheckAccess(
 	}
 
 	for _, permission := range permissions {
-		ok, err := services.CheckAccessWithToken(self.config_obj, policy, permission)
+		ok, err := services.CheckAccessWithToken(policy, permission)
 		if !ok || err != nil {
 			return ok, err
 		}
@@ -81,7 +81,7 @@ func (self *ServerACLManager) CheckAccessInOrg(
 		return false, err
 	}
 	for _, permission := range permissions {
-		ok, err := services.CheckAccessWithToken(self.config_obj, policy, permission)
+		ok, err := services.CheckAccessWithToken(policy, permission)
 		if !ok || err != nil {
 			return ok, err
 		}
@@ -97,7 +97,7 @@ func (self *ServerACLManager) CheckAccessWithArgs(
 		return false, err
 	}
 
-	return services.CheckAccessWithToken(self.config_obj, policy, permission, args...)
+	return services.CheckAccessWithToken(policy, permission, args...)
 }
 
 func NewServerACLManager(

--- a/vql/networking/upload.go
+++ b/vql/networking/upload.go
@@ -36,7 +36,7 @@ import (
 
 type UploadFunctionArgs struct {
 	File     *accessors.OSPath `vfilter:"required,field=file,doc=The file to upload"`
-	Name     string            `vfilter:"optional,field=name,doc=The name of the file that should be stored on the server"`
+	Name     *accessors.OSPath `vfilter:"optional,field=name,doc=The name of the file that should be stored on the server"`
 	Accessor string            `vfilter:"optional,field=accessor,doc=The accessor to use"`
 	Mtime    vfilter.Any       `vfilter:"optional,field=mtime,doc=Modified time to record"`
 	Atime    vfilter.Any       `vfilter:"optional,field=atime,doc=Access time to record"`
@@ -134,7 +134,7 @@ func (self UploadFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) 
 
 type UploadDirectoryFunctionArgs struct {
 	File       *accessors.OSPath `vfilter:"required,field=file,doc=The file to upload"`
-	Name       string            `vfilter:"optional,field=name,doc=Filename to be stored within the output directory"`
+	Name       *accessors.OSPath `vfilter:"optional,field=name,doc=Filename to be stored within the output directory"`
 	Accessor   string            `vfilter:"optional,field=accessor,doc=The accessor to use"`
 	OutputPath string            `vfilter:"required,field=output,doc=An output directory to store files in."`
 

--- a/vql/tools/collector/fixtures/TestCollectionWithUpload.golden
+++ b/vql/tools/collector/fixtures/TestCollectionWithUpload.golden
@@ -1,6 +1,28 @@
 {
  "zip_contents": {
   "uploads/data/file.txt": "hello world",
+  "uploads/sparse/C%3A/file.sparse.txt.idx": [
+   {
+    "ranges": [
+     {
+      "file_length": 5,
+      "length": 5
+     },
+     {
+      "file_offset": 5,
+      "original_offset": 5,
+      "length": 5
+     },
+     {
+      "file_offset": 5,
+      "original_offset": 10,
+      "file_length": 3,
+      "length": 3
+     }
+    ]
+   }
+  ],
+  "uploads/sparse/C%3A/file.sparse.txt": "This bit",
   "results/Custom.TestArtifactUpload.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000",
   "results/Custom.TestArtifactUpload.json": [
    {
@@ -16,10 +38,24 @@
       "data",
       "file.txt"
      ]
+    },
+    "SparseUpload": {
+     "Path": "{\"DelegateAccessor\":\"data\",\"DelegatePath\":\"This is...",
+     "Size": 21,
+     "StoredSize": 8,
+     "sha256": "d2bc3dd9279837fd268d82ea397b6980dee5ae462464493c80f495786b4025c2",
+     "md5": "f55a5cc260e3fc562d841a2f6d2b7d22",
+     "StoredName": "/uploads/sparse/C%3A/file.sparse.txt",
+     "Components": [
+      "uploads",
+      "sparse",
+      "C:",
+      "file.sparse.txt"
+     ]
     }
    }
   ],
-  "log.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000}\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u000c\u0001\u0000\u0000\u0000\u0001\u0000\u0000\ufffd\u0001\u0000\u0000\u0000\u0001\u0000\u0000",
+  "log.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000}\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u000c\u0001\u0000\u0000\u0000\u0001\u0000\u0000\ufffd\u0001\u0000\u0000\u0000\u0001\u0000\u0000U\u0002\u0000\u0000\u0000\u0001\u0000\u0000",
   "log.json": [
    {
     "_ts": 1602103388,
@@ -37,18 +73,24 @@
     "_ts": 1602103388,
     "client_time": 1602103388,
     "level": "DEFAULT",
+    "message": "Collecting file {\"DelegateAccessor\":\"data\",\"DelegatePath\":\"This is... into /uploads/sparse/C%3A/file.sparse.txt (21 bytes)\n"
+   },
+   {
+    "_ts": 1602103388,
+    "client_time": 1602103388,
+    "level": "DEFAULT",
     "message": "Collected 1 rows for Custom.TestArtifactUpload\n"
    },
    {
     "_ts": 1602103388,
     "client_time": 1602103388,
     "level": "DEBUG",
-    "message": "Query Stats: {\"RowsScanned\":2,\"PluginsCalled\":1,\"FunctionsCalled\":1,\"ProtocolSearch\":0,\"ScopeCopy\":6}\n"
+    "message": "Query Stats: {\"RowsScanned\":2,\"PluginsCalled\":1,\"FunctionsCalled\":4,\"ProtocolSearch\":0,\"ScopeCopy\":6}\n"
    }
   ],
-  "collection_context.json": "{\n \"session_id\": \"F.1234\",\n \"request\": {\n  \"artifacts\": [\n   \"Custom.TestArtifactUpload\"\n  ]\n },\n \"create_time\": 1602103388000000000,\n \"start_time\": 1602103388000000000,\n \"total_uploaded_files\": 1,\n \"total_expected_uploaded_bytes\": 11,\n \"total_uploaded_bytes\": 11,\n \"total_collected_rows\": 1,\n \"total_requests\": 2,\n \"state\": 2,\n \"artifacts_with_results\": [\n  \"Custom.TestArtifactUpload\"\n ],\n \"query_stats\": [\n  {},\n  {\n   \"names_with_response\": [\n    \"Custom.TestArtifactUpload\"\n   ],\n   \"log_rows\": 2,\n   \"result_rows\": 1\n  }\n ]\n}",
-  "requests.json": "{\n \"items\": [\n  {\n   \"session_id\": \"F.1234\",\n   \"request_id\": 1,\n   \"VQLClientAction\": {\n    \"query_id\": 1,\n    \"total_queries\": 1,\n    \"Query\": [\n     {\n      \"VQL\": \"LET Custom_TestArtifactUpload_0_0 = SELECT upload(file=\\\"hello world\\\", accessor=\\\"data\\\", name=\\\"file.txt\\\") AS Upload FROM scope()\"\n     },\n     {\n      \"Name\": \"Custom.TestArtifactUpload\",\n      \"VQL\": \"SELECT * FROM Custom_TestArtifactUpload_0_0\"\n     }\n    ],\n    \"max_row\": 1000\n   }\n  }\n ]\n}",
-  "uploads.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000",
+  "collection_context.json": "{\n \"session_id\": \"F.1234\",\n \"request\": {\n  \"artifacts\": [\n   \"Custom.TestArtifactUpload\"\n  ]\n },\n \"create_time\": 1602103388000000000,\n \"start_time\": 1602103388000000000,\n \"total_uploaded_files\": 3,\n \"total_expected_uploaded_bytes\": 11,\n \"total_uploaded_bytes\": 11,\n \"total_collected_rows\": 1,\n \"total_requests\": 2,\n \"state\": 2,\n \"artifacts_with_results\": [\n  \"Custom.TestArtifactUpload\"\n ],\n \"query_stats\": [\n  {},\n  {\n   \"names_with_response\": [\n    \"Custom.TestArtifactUpload\"\n   ],\n   \"log_rows\": 3,\n   \"result_rows\": 1\n  }\n ]\n}",
+  "requests.json": "{\n \"items\": [\n  {\n   \"session_id\": \"F.1234\",\n   \"request_id\": 1,\n   \"VQLClientAction\": {\n    \"query_id\": 1,\n    \"total_queries\": 1,\n    \"Query\": [\n     {\n      \"VQL\": \"LET Custom_TestArtifactUpload_0_0 = SELECT upload(file=\\\"hello world\\\", accessor=\\\"data\\\", name=\\\"file.txt\\\") AS Upload, upload(file=pathspec(Path='[{\\\"length\\\":5,\\\"offset\\\":0},{\\\"length\\\":3,\\\"offset\\\":10}]', DelegateAccessor=\\\"data\\\", DelegatePath=\\\"This is a bit of text\\\"), accessor=\\\"sparse\\\", name=pathspec(Path=\\\"C:/file.sparse.txt\\\", path_type=\\\"windows\\\")) AS SparseUpload FROM scope()\"\n     },\n     {\n      \"Name\": \"Custom.TestArtifactUpload\",\n      \"VQL\": \"SELECT * FROM Custom_TestArtifactUpload_0_0\"\n     }\n    ],\n    \"max_row\": 1000\n   }\n  }\n ]\n}",
+  "uploads.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000\ufffd\u0000\u0000\u0000\u0000\u0001\u0000\u0000\ufffd\u0001\u0000\u0000\u0000\u0001\u0000\u0000",
   "uploads.json": [
    {
     "Timestamp": "2020-10-07T20:43:08Z",
@@ -60,8 +102,42 @@
      "file.txt"
     ],
     "file_size": 11,
-    "uploaded_size": 11
+    "uploaded_size": 11,
+    "Type": ""
+   },
+   {
+    "Timestamp": "2020-10-07T20:43:08Z",
+    "started": "2020-10-07 20:43:08 +0000 UTC",
+    "vfs_path": "{\"DelegateAccessor\":\"data\",\"DelegatePath\":\"This is....idx",
+    "_Components": [
+     "uploads",
+     "sparse",
+     "C:",
+     "file.sparse.txt"
+    ],
+    "file_size": 156,
+    "uploaded_size": 156,
+    "Type": "idx"
+   },
+   {
+    "Timestamp": "2020-10-07T20:43:08Z",
+    "started": "2020-10-07 20:43:08 +0000 UTC",
+    "vfs_path": "{\"DelegateAccessor\":\"data\",\"DelegatePath\":\"This is...",
+    "_Components": [
+     "uploads",
+     "sparse",
+     "C:",
+     "file.sparse.txt"
+    ],
+    "file_size": 21,
+    "uploaded_size": 8,
+    "Type": ""
    }
   ]
- }
+ },
+ "artifacts_with_results": [
+  "Custom.TestArtifactUpload"
+ ],
+ "total_uploaded_files": 3,
+ "Imported upload.json": "{\"Timestamp\":\"2020-10-07T20:43:08Z\",\"started\":\"2020-10-07 20:43:08 +0000 UTC\",\"vfs_path\":\"data\",\"_Components\":[\"uploads\",\"data\",\"file.txt\"],\"file_size\":11,\"uploaded_size\":11,\"Type\":\"\"}\n{\"Timestamp\":\"2020-10-07T20:43:08Z\",\"started\":\"2020-10-07 20:43:08 +0000 UTC\",\"vfs_path\":\"{\\\"DelegateAccessor\\\":\\\"data\\\",\\\"DelegatePath\\\":\\\"This is....idx\",\"_Components\":[\"uploads\",\"sparse\",\"C:\",\"file.sparse.txt\"],\"file_size\":156,\"uploaded_size\":156,\"Type\":\"idx\"}\n{\"Timestamp\":\"2020-10-07T20:43:08Z\",\"started\":\"2020-10-07 20:43:08 +0000 UTC\",\"vfs_path\":\"{\\\"DelegateAccessor\\\":\\\"data\\\",\\\"DelegatePath\\\":\\\"This is...\",\"_Components\":[\"uploads\",\"sparse\",\"C:\",\"file.sparse.txt\"],\"file_size\":21,\"uploaded_size\":8,\"Type\":\"\"}\n"
 }

--- a/vql/tools/collector/import_test.go
+++ b/vql/tools/collector/import_test.go
@@ -43,7 +43,7 @@ func (self *TestSuite) TestImportCollection() {
 	context, ok := result.(*proto.ArtifactCollectorContext)
 	assert.True(self.T(), ok)
 
-	// Check the improt was successful.
+	// Check the import was successful.
 	assert.Equal(self.T(), []string{"Linux.Search.FileFinder"},
 		context.ArtifactsWithResults)
 	assert.Equal(self.T(), uint64(1), context.TotalCollectedRows)


### PR DESCRIPTION
The offline collection zip may contain very sparse files (e.g. $J) so we do not want to automatically expand those files when importing as a collection.

This PR introduces a new accessor "collector_sparse" which does not automatically expand sparse files, instead the importer copies the index file as it is.