### PR TITLE
Bugfix: Minions should not start the ServerMonitoringService

### DIFF
--- a/bin/config_interactive.go
+++ b/bin/config_interactive.go
@@ -456,10 +456,13 @@ func configSelfSigned(config_obj *config_proto.Config) error {
 			Prompt:   gui_port_question,
 		},
 	}, config_obj.GUI)
-
 	if err != nil {
 		return err
 	}
+
+	config_obj.GUI.PublicUrl = fmt.Sprintf(
+		"https://%s:%s/", config_obj.Frontend.Hostname,
+		config_obj.GUI.BindPort)
 
 	config_obj.Client.UseSelfSignedSsl = true
 	config_obj.Client.ServerUrls = append(

--- a/bin/config_interactive.go
+++ b/bin/config_interactive.go
@@ -461,7 +461,7 @@ func configSelfSigned(config_obj *config_proto.Config) error {
 	}
 
 	config_obj.GUI.PublicUrl = fmt.Sprintf(
-		"https://%s:%s/", config_obj.Frontend.Hostname,
+		"https://%s:%d/", config_obj.Frontend.Hostname,
 		config_obj.GUI.BindPort)
 
 	config_obj.Client.UseSelfSignedSsl = true

--- a/services/orgs/services.go
+++ b/services/orgs/services.go
@@ -620,7 +620,9 @@ func maybeFlushFilesOnClose(
 		go func() {
 			defer wg.Done()
 			<-ctx.Done()
-			flusher.Flush()
+			if flusher != nil {
+				flusher.Flush()
+			}
 		}()
 	}
 
@@ -635,7 +637,9 @@ func maybeFlushFilesOnClose(
 		go func() {
 			defer wg.Done()
 			<-ctx.Done()
-			flusher.Flush()
+			if flusher != nil {
+				flusher.Flush()
+			}
 		}()
 	}
 

--- a/services/spec.go
+++ b/services/spec.go
@@ -47,7 +47,6 @@ func MinionServicesSpec() *config_proto.ServerServicesConfig {
 		Launcher:            true,
 		RepositoryManager:   true,
 		FrontendServer:      true,
-		MonitoringService:   true,
 		JournalService:      true,
 		DynDns:              true,
 	}


### PR DESCRIPTION
There should be only a single server monitoring service running on the master node.