### PR TITLE
Bugfix: uploads.json in the flow download refered to filestore paths

### DIFF
--- a/artifacts/definitions/Windows/KapeFiles/Extract.yaml
+++ b/artifacts/definitions/Windows/KapeFiles/Extract.yaml
@@ -28,6 +28,8 @@ description: |
   velociraptor-v0.6.7-linux-amd64 artifacts collect Windows.KapeFiles.Extract --args ContainerPath=Collection-DESKTOP-2OR51GL-2021-07-16_06_56_50_-0700_PDT.zip --args OutputDirectory=/tmp/MyOutput/
   ```
 
+type: SERVER
+
 parameters:
   - name: OutputDirectory
     description: Directory to write on (must be set).
@@ -58,7 +60,7 @@ sources:
           })
 
       LET ALLUploads = SELECT *, RootPathSpec + _Components AS FileUpload,
-                              OutputPathSpec + _Components[3:] AS Dest,
+                              OutputPathSpec + _Components[2:] AS Dest,
                               get(item=AllFileMetadata,
                                   field=vfs_path) AS Metadata
         FROM parse_jsonl(accessor="collector",

--- a/artifacts/testdata/server/testcases/export.out.yaml
+++ b/artifacts/testdata/server/testcases/export.out.yaml
@@ -1,27 +1,27 @@
 LET Download <= create_flow_download( client_id="C.4f5e52adf0a337a9", name="sparse", flow_id="F.BN2HJBD1R85EA", wait=TRUE, expand_sparse=FALSE)[]SELECT OSPath, Size FROM glob(globs="**", accessor="zip", root=pathspec(DelegateAccessor="fs", DelegatePath=Download)) WHERE OSPath =~ "uploads" AND NOT IsDir[
  {
   "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/sparse.zip\",\"Path\":\"/uploads.json\"}",
-  "Size": 477
+  "Size": 351
  },
  {
   "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/sparse.zip\",\"Path\":\"/uploads.json.index\"}",
   "Size": 16
  },
  {
-  "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/sparse.zip\",\"Path\":\"/uploads/X.txt\"}",
+  "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/sparse.zip\",\"Path\":\"/uploads/sparse/X.txt\"}",
   "Size": 10
  }
 ]LET Download <= create_flow_download( client_id="C.4f5e52adf0a337a9", name="not-sparse", flow_id="F.BN2HJBD1R85EA", wait=TRUE, expand_sparse=TRUE)[]SELECT OSPath, Size FROM glob(globs="**", accessor="zip", root=pathspec(DelegateAccessor="fs", DelegatePath=Download)) WHERE OSPath =~ "uploads" AND NOT IsDir[
  {
   "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/not-sparse.zip\",\"Path\":\"/uploads.json\"}",
-  "Size": 477
+  "Size": 351
  },
  {
   "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/not-sparse.zip\",\"Path\":\"/uploads.json.index\"}",
   "Size": 16
  },
  {
-  "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/not-sparse.zip\",\"Path\":\"/uploads/X.txt\"}",
+  "OSPath": "{\"DelegateAccessor\":\"fs\",\"DelegatePath\":\"fs:/downloads/C.4f5e52adf0a337a9/F.BN2HJBD1R85EA/not-sparse.zip\",\"Path\":\"/uploads/sparse/X.txt\"}",
   "Size": 15
  }
 ]

--- a/vql/server/downloads/downloads.go
+++ b/vql/server/downloads/downloads.go
@@ -346,62 +346,113 @@ func copyUploadFiles(
 	if err != nil {
 		return err
 	}
-	err = copyResultSetIntoContainer(ctx, config_obj, container, format,
-		flow_path_manager.UploadMetadata(), root_path.Append("uploads.json"))
-	if err != nil {
-		return err
-	}
 
-	// Read all the upload metadata
+	// Read all the upload metadata and copy the files to the container.
 	file_store_factory := file_store.GetFileStore(config_obj)
 	reader, err := result_sets.NewResultSetReader(file_store_factory,
 		flow_path_manager.UploadMetadata())
 	if err != nil {
 		return err
 	}
-	defer reader.Close()
 
-	for row := range reader.Rows(ctx) {
-		components, pres := row.GetStrings("_Components")
-		if !pres || len(components) < 1 {
-			continue
-		}
+	output_chan := make(chan vfilter.Row)
+	go func() {
+		defer close(output_chan)
+		defer reader.Close()
 
-		// Ensure we store index files into the correct place.
-		file_type, _ := row.GetString("Type")
-		if file_type == "idx" {
-			// If we expand the files we dont need any indexes
-			if expand_sparse {
+		for row := range reader.Rows(ctx) {
+			components, pres := row.GetStrings("_Components")
+			if !pres || len(components) < 1 {
 				continue
 			}
-			components[len(components)-1] += ".idx"
-		}
 
-		var src api.FSPathSpec
-		dest_root_path, err := accessors.NewZipFilePath(prefix)
-		if err != nil {
-			return err
-		}
+			// Ensure we store index files into the correct place.
+			file_type, _ := row.GetString("Type")
+			if file_type == "idx" {
+				// If we expand the files we dont need any indexes
+				if expand_sparse {
+					continue
+				}
+				components[len(components)-1] += ".idx"
+			}
 
-		dest := dest_root_path.Append("uploads")
-		if len(components) > 6 && components[0] == "clients" {
-			src = path_specs.NewUnsafeFilestorePath(components...).
-				SetType(api.PATH_TYPE_FILESTORE_ANY)
-			dest = dest.Append(components[6:]...)
-		} else {
-			src = flow_path_manager.UploadContainer().AddChild(components[1:]...).
-				SetType(api.PATH_TYPE_FILESTORE_ANY)
-			dest = dest.Append(components...)
-		}
+			var src api.FSPathSpec
+			dest_root_path, err := accessors.NewZipFilePath(prefix)
+			if err != nil {
+				continue
+			}
 
-		// Copy from the file store at these locations.
-		err = copyFile(ctx, scope, config_obj, container, src, dest, expand_sparse)
-		if err != nil {
-			return err
-		}
-	}
+			dest := dest_root_path.Append("uploads")
+			if len(components) > 6 && components[0] == "clients" {
+				//Remove the prefix in the file store where the files
+				//are stored. The uploads file in the file store
+				//refers to the location in the filestore where the
+				//file is actually stored, while the uploads.json in
+				//the container refers to the location in the
+				//container where the file is actually
+				//stored. Therefore we need to convert from one to the
+				//other.
 
-	return nil
+				// For example, in t he file store a file may be
+				// stored with these path components (root is the filestore):
+
+				//	components = [
+				//		"clients",
+				//		"C.1bfa6928675831f5-O123",
+				//		"collections",
+				//		"F.CE2PSBS6BQCSO",
+				//		"uploads",
+				//		"auto",
+				//		"C:",
+				//		"Windows",
+				//		"System32",
+				//		"winevt",
+				//		"Logs",
+				//		"System.evtx"
+				//	]
+
+				//	In the container, we store a shorter path (root at the zip root)
+				//	components = [
+				//		"uploads",
+				//		"auto",   <- accessor name
+				//		"C:",
+				//		"Windows",
+				//		"System32",
+				//		"winevt",
+				//		"Logs",
+				//		"System.evtx"
+				//	]
+
+				// Therefore we need to update the _Components field
+				// to refer to the components in the zip file.
+
+				row.Update("_Components", components[4:])
+				src = path_specs.NewUnsafeFilestorePath(components...).
+					SetType(api.PATH_TYPE_FILESTORE_ANY)
+				dest = dest_root_path.Append(components[4:]...)
+
+			} else {
+				src = flow_path_manager.UploadContainer().AddChild(components[1:]...).
+					SetType(api.PATH_TYPE_FILESTORE_ANY)
+				dest = dest_root_path.Append(components...)
+			}
+
+			// Copy from the file store at these locations.
+			err = copyFile(ctx, scope, config_obj, container, src, dest, expand_sparse)
+			if err != nil {
+				row.Set("Error", err.Error())
+			}
+
+			// Write the modified row into the uploads.json file.
+			output_chan <- row
+		}
+	}()
+
+	// Copy the modified rows into the uploads file.
+	_, err = container.WriteResultSet(ctx, config_obj, scope, format,
+		root_path.Append("uploads.json").String(), output_chan)
+
+	return err
 }
 
 func copyFile(
@@ -412,6 +463,9 @@ func copyFile(
 	src api.FSPathSpec,
 	dest *accessors.OSPath,
 	expand_sparse bool) (err error) {
+
+	scope.Log("DEBUG: downloadFlowToZip: Copy file from %v to %v\n",
+		src.AsClientPath(), dest.String())
 
 	file_store_factory := file_store.GetFileStore(config_obj)
 	fd, err := file_store_factory.ReadFile(src)

--- a/vql/server/downloads/fixtures/TestExportCollectionUploads.golden
+++ b/vql/server/downloads/fixtures/TestExportCollectionUploads.golden
@@ -1,0 +1,29 @@
+[
+ {
+  "Timestamp": "2020-10-07T20:43:08Z",
+  "started": "2020-10-07 20:43:08 +0000 UTC",
+  "vfs_path": "data",
+  "_Components": [
+   "uploads",
+   "data",
+   "file.txt"
+  ],
+  "file_size": 11,
+  "uploaded_size": 11,
+  "Type": ""
+ },
+ {
+  "Timestamp": "2020-10-07T20:43:08Z",
+  "started": "2020-10-07 20:43:08 +0000 UTC",
+  "vfs_path": "{\"DelegateAccessor\":\"data\",\"DelegatePath\":\"This is...",
+  "_Components": [
+   "uploads",
+   "sparse",
+   "C:",
+   "file.sparse.txt"
+  ],
+  "file_size": 21,
+  "uploaded_size": 8,
+  "Type": ""
+ }
+]

--- a/vql/tools/collector/import.go
+++ b/vql/tools/collector/import.go
@@ -197,6 +197,9 @@ func (self ImportCollectionFunction) Call(ctx context.Context,
 
 			// Copy from the archive to the file store at these locations.
 			src := root.Append(components...)
+
+			// First directory in zip file is "upload" we skip that
+			// and append the other components to the filestore path.
 			dest := flow_path_manager.UploadContainer().AddChild(components[1:]...)
 
 			err := self.copyFileWithIndex(ctx, config_obj, scope,


### PR DESCRIPTION
The _Components column of the uploads.json in the filestore refers to filestore
paths (e.g. clients/C.1bfa6928675831f5-O123/collections/F.CE2PSBS6BQCSO...) This makes it incompatible with the offline collector which uses this column to refer to paths within the zip file itself.

Previously this same file was just copied to the container but now it is being modified to support the different components list. This makes the upload.json format compatible with the offline collector so that VQL artifacts designed to work on the offline collector can also work on flow downloads.