### PR TITLE
Ensure reserved user names can not be used

### DIFF
--- a/artifacts/testdata/server/testcases/users.in.yaml
+++ b/artifacts/testdata/server/testcases/users.in.yaml
@@ -42,3 +42,10 @@ Queries:
   - SELECT user_grant(user="TestUserNotThere", roles="reader") FROM scope()
   - SELECT * FROM test_read_logs() WHERE Log =~ "User not found" AND NOT Log =~ "SELECT"
   - SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUserNotThere"
+
+  # Should refuse to add a user with a reserved name
+  - SELECT user_create(
+       user="VelociraptorServer", password="hunter2",
+       roles=["investigator"]) FROM scope()
+
+  - SELECT * FROM test_read_logs() WHERE Log =~ "Username is reserved" AND NOT Log =~ "SELECT"

--- a/artifacts/testdata/server/testcases/users.out.yaml
+++ b/artifacts/testdata/server/testcases/users.out.yaml
@@ -162,4 +162,12 @@ SELECT whoami() FROM scope()[
  {
   "Log": "Velociraptor: user_grant: User not found\n"
  }
-]SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUserNotThere"[]
+]SELECT * FROM gui_users(all_orgs=TRUE) WHERE name =~ "TestUserNotThere"[]SELECT user_create( user="VelociraptorServer", password="hunter2", roles=["investigator"]) FROM scope()[
+ {
+  "user_create(user=\"VelociraptorServer\", password=\"hunter2\", roles=[\"investigator\"])": null
+ }
+]SELECT * FROM test_read_logs() WHERE Log =~ "Username is reserved" AND NOT Log =~ "SELECT"[
+ {
+  "Log": "Velociraptor: user_create: Username is reserved\n"
+ }
+]

--- a/bin/config_interactive.go
+++ b/bin/config_interactive.go
@@ -517,7 +517,7 @@ func addUser(config_obj *config_proto.Config) error {
 			return nil
 		}
 
-		user_record, err := users.NewUserRecord(username)
+		user_record, err := users.NewUserRecord(config_obj, username)
 		if err != nil {
 			fmt.Printf("%v", err)
 			continue

--- a/bin/gui.go
+++ b/bin/gui.go
@@ -128,7 +128,7 @@ func doGUI() error {
 		}
 
 		// Create a user with default password
-		user_record, err := users.NewUserRecord("admin")
+		user_record, err := users.NewUserRecord(config_obj, "admin")
 		if err != nil {
 			return fmt.Errorf("Unable to create admin user: %w", err)
 		}

--- a/bin/users.go
+++ b/bin/users.go
@@ -82,7 +82,7 @@ func doAddUser() error {
 		return err
 	}
 
-	user_record, err := users.NewUserRecord(*user_add_name)
+	user_record, err := users.NewUserRecord(config_obj, *user_add_name)
 	if err != nil {
 		return fmt.Errorf("add user: %s", err)
 	}

--- a/services/sanity/users.go
+++ b/services/sanity/users.go
@@ -39,7 +39,7 @@ func createInitialUsers(
 		user_record, err := users_manager.GetUser(ctx, user.Name)
 		if err != nil || user_record.Name != user.Name {
 			logger.Info("Initial user %v not present, creating", user.Name)
-			new_user, err := users.NewUserRecord(user.Name)
+			new_user, err := users.NewUserRecord(config_obj, user.Name)
 			if err != nil {
 				return err
 			}

--- a/services/users/delete.go
+++ b/services/users/delete.go
@@ -13,6 +13,11 @@ func (self *UserManager) DeleteUser(
 	ctx context.Context,
 	org_config_obj *config_proto.Config, username string) error {
 
+	err := validateUsername(org_config_obj, username)
+	if err != nil {
+		return err
+	}
+
 	org_manager, err := services.GetOrgManager()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously reserved user names like VelociraptorServer were blocked from being added in VQL but it was still possible to use the command line to add these reserved user names.

This PR adds additional contraints and a test to confirm these reserved user names are not added.