### PR TITLE
Add shaded container around artifact description content

### DIFF
--- a/artifacts/definitions/Server/Internal/ArtifactDescription.yaml
+++ b/artifacts/definitions/Server/Internal/ArtifactDescription.yaml
@@ -20,6 +20,8 @@ reports:
       ##### Author: {{ $artifact.Author }}
       {{end}}
 
+      <div class="description-content">
+
       {{ $artifact.Description }}
 
       {{ if $artifact.Reference }}
@@ -30,6 +32,7 @@ reports:
       {{- end -}}
       </ul>
       {{ end }}
+      </div>
 
       {{ if $artifact.Tools }}
       ### Tools

--- a/gui/velociraptor/src/themes/coolgray-dark.css
+++ b/gui/velociraptor/src/themes/coolgray-dark.css
@@ -136,15 +136,6 @@ body.coolgray-dark {
   letter-spacing: 0.4px;
 }
 
-.coolgray-dark .report-viewer p,
-.coolgray-dark .report-viewer ol,
-.coolgray-dark .report-viewer ul,
-.coolgray-dark .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: var(--font-size-base);
-  letter-spacing: 0.4px;
-}
-
 .coolgray-dark code {
   font-family: var(--font-family-monospace);
   color: var(--color-accent-100);
@@ -727,6 +718,14 @@ body.coolgray-dark {
 
 /* Artifact viewer screen */
 
+.coolgray-dark .report-viewer .description-content {
+  font-family: var(--font-family-paragraph);
+  font-size: var(--font-size-base);
+  letter-spacing: 0.4px;
+  background: var(--color-table-row-hover);
+  padding: 12px;
+}
+
 .coolgray-dark .report-viewer h1 {
   color: var(--color-foreground);
 }
@@ -739,11 +738,6 @@ body.coolgray-dark {
   margin-top: 2rem;
   font-size: 18px;
   color: #dead87;
-}
-
-.coolgray-dark .modal-title {
-    font-size: 1.2rem;
-    height: 50px;
 }
 
 .coolgray-dark .report-viewer h4 {

--- a/gui/velociraptor/src/themes/github-dimmed-dark.css
+++ b/gui/velociraptor/src/themes/github-dimmed-dark.css
@@ -129,14 +129,6 @@ body.github-dimmed-dark {
   letter-spacing: 0.4px;
 }
 
-.github-dimmed-dark .report-viewer p,
-.github-dimmed-dark .report-viewer ol,
-.github-dimmed-dark .report-viewer ul
-.github-dimmed-dark .report-viewer li {
-  font-family: var(--font-family-sans-serif);
-  font-size: var(--font-size-large);
-}
-
 .github-dimmed-dark dl {
   font-family: var(--font-family-sans-serif);
   font-size: var(--font-size-base);
@@ -620,6 +612,14 @@ body.github-dimmed-dark {
 }
 
 /* Artifact viewer screen */
+
+.github-dimmed-dark .report-viewer .description-content {
+  font-family: var(--font-family-sans-serif);
+  font-size: var(--font-size-large);
+  border-radius: 5px;
+  border: 1px solid var(--color-btn-default-border);
+  padding: 12px;
+}
 
 .github-dimmed-dark .report-viewer h1 {
   color: var(--color-accent-100);

--- a/gui/velociraptor/src/themes/midnight.css
+++ b/gui/velociraptor/src/themes/midnight.css
@@ -145,16 +145,6 @@ body.midnight {
   color: darkorange;
 }
 
-.midnight .report-viewer p,
-.midnight .report-viewer ol,
-.midnight .report-viewer ul,
-.midnight .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: var(--font-size-base);
-  letter-spacing: 0.4px;
-  color: darkorange;
-}
-
 .midnight code {
   font-family: var(--font-family-monospace);
   color: var(--color-accent-100);
@@ -761,6 +751,14 @@ body.midnight {
 
 /* Artifact viewer screen */
 
+.midnight .report-viewer .description-content {
+  font-family: var(--font-family-paragraph);
+  font-size: var(--font-size-base);
+  letter-spacing: 0.4px;
+  color: darkorange;
+  padding: 12px;
+}
+
 .midnight .report-viewer h1 {
   color: darkorange;
 }
@@ -773,12 +771,6 @@ body.midnight {
   margin-top: 2rem;
   font-size: 18px;
   color: var(--color-foreground);
-}
-
-.midnight .modal-title {
-    font-size: 1.2rem;
-    height: 50px;
-    color: darkorange;
 }
 
 .midnight .report-viewer h4 {
@@ -828,6 +820,8 @@ body.midnight {
   background: var(--color-canvas-background);
   color: var(--color-foreground);
   font-family: var(--font-family-sans-serif);
+  border: 1px solid var(--color-btn-default-border);
+  border-radius: 0;
 }
 
 .midnight .modal-content dt {
@@ -836,10 +830,11 @@ body.midnight {
 
 .midnight .modal-header {
   border-bottom: 2px solid var(--color-btn-default-border);
+  background: var(--color-header-background);
 }
 
 .midnight .modal-header .close {
-  color: var(--color-foreground-dimmed);
+  color: var(--color-foreground);
   opacity: 1;
   text-shadow: none;
   outline: none;
@@ -855,6 +850,7 @@ body.midnight {
 
 .midnight .modal-footer {
   border-top: 2px solid var(--color-btn-default-border);
+  background: var(--color-footer-background);
 }
 
 .midnight .modal-content pre {

--- a/gui/velociraptor/src/themes/ncurses.css
+++ b/gui/velociraptor/src/themes/ncurses.css
@@ -930,6 +930,11 @@ body.ncurses {
   background: lightgrey;
 }
 
+.ncurses .report-viewer .description-content {
+  background: white;
+  padding: 12px;
+}
+
 .ncurses .report-viewer h1,
 .ncurses .report-viewer h2 {
   margin-top: 2rem;

--- a/gui/velociraptor/src/themes/no-theme.css
+++ b/gui/velociraptor/src/themes/no-theme.css
@@ -31,12 +31,12 @@ body.no-theme {
   color: var(--color-code);
 }
 
-.no-theme .report-viewer p,
-.no-theme .report-viewer ol,
-.no-theme .report-viewer ul,
-.no-theme .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: 16px;
+.no-theme .report-viewer .description-content {
+    font-family: var(--font-family-paragraph);
+    font-size: 16px;
+    background: #F7F7F7;
+    border-radius: 5px;
+    padding: 12px;
 }
 
 .no-theme .btn.btn-default {

--- a/gui/velociraptor/src/themes/pink-light.css
+++ b/gui/velociraptor/src/themes/pink-light.css
@@ -141,14 +141,6 @@ body.pink-light {
   color: var(--color-code);
 }
 
-.pink-light .report-viewer p,
-.pink-light .report-viewer ol,
-.pink-light .report-viewer ul,
-.pink-light .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: var(--font-size-large);
-}
-
 .pink-light dl {
   font-family: var(--font-family-sans-serif);
 }
@@ -587,6 +579,14 @@ body.pink-light {
 }
 
 /* Artifact viewer screen */
+
+.pink-light .report-viewer .description-content {
+  font-family: var(--font-family-paragraph);
+  font-size: var(--font-size-large);
+  background: #F7F7F7;
+  border-radius: 5px;
+  padding: 12px;
+}
 
 .pink-light .report-viewer h3 {
   margin-top: 2rem;

--- a/gui/velociraptor/src/themes/veloci-dark.css
+++ b/gui/velociraptor/src/themes/veloci-dark.css
@@ -95,7 +95,7 @@
   /* --color-page-link-background: #121212;
   --color-page-link-active-background: #444444; */
   --color-form-background: #121212;
-  --color-card-heading-background: #303030;
+  --color-card-heading-background: #2E2E2E;
   --color-monospace-color: #eeeeee;
 
   --color-page-link-active-background: #0c900a;
@@ -105,7 +105,7 @@
   --color-table-row-stripe: rgba(255, 255, 255, 0.03);
   --color-table-row-selected: rgba(255, 255, 255, 0.05);
   --color-table-row-selected-text: var(--color-foreground);
-  --color-table-heading-background: #303030;
+  --color-table-heading-background: rgba(255, 255, 255, 0.05);
   --color-table-row-hover: rgba(255, 255, 255, 0.01);
 
   --color-code: var(--color-accent-100);
@@ -147,18 +147,9 @@ body.veloci-dark {
   color: var(--color-code);
 }
 
-.veloci-dark .report-viewer p,
-.veloci-dark .report-viewer ol,
-.veloci-dark .report-viewer ul,
-.veloci-dark .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: var(--font-size-large);
-}
-
 .veloci-dark dl {
   font-family: var(--font-family-sans-serif);
 }
-
 
 .veloci-dark h1,
 .veloci-dark h2,
@@ -600,6 +591,14 @@ body.veloci-dark {
 
 /* Artifact viewer screen */
 
+.veloci-dark .report-viewer .description-content {
+  font-family: var(--font-family-paragraph);
+  font-size: var(--font-size-large);
+  background: #2E2E2E;
+  border-radius: 5px;
+  padding: 12px;
+}
+
 .veloci-dark .report-viewer h3 {
   margin-top: 2rem;
   color: #3b84d9;
@@ -654,7 +653,7 @@ body.veloci-dark {
 /* modal dialogs */
 
 .veloci-dark .modal-content {
-  background: var(--color-card-heading-background);
+  background: #3D3D3D;
   color: var(--color-foreground);
 }
 

--- a/gui/velociraptor/src/themes/veloci-light.css
+++ b/gui/velociraptor/src/themes/veloci-light.css
@@ -137,14 +137,6 @@ body.veloci-light {
   color: var(--color-code);
 }
 
-.veloci-light .report-viewer p,
-.veloci-light .report-viewer ol,
-.veloci-light .report-viewer ul,
-.veloci-light .report-viewer li {
-  font-family: var(--font-family-paragraph);
-  font-size: var(--font-size-large);
-}
-
 .veloci-light dl {
   font-family: var(--font-family-sans-serif);
 }
@@ -568,6 +560,14 @@ body.veloci-light {
 }
 
 /* Artifact viewer screen */
+
+.veloci-light .report-viewer .description-content {
+  font-family: var(--font-family-paragraph);
+  font-size: var(--font-size-large);
+  background: #F7F7F7;
+  border-radius: 5px;
+  padding: 12px;
+}
 
 .veloci-light .report-viewer h3 {
   margin-top: 2rem;


### PR DESCRIPTION
Improved legibility of the artifact viewer content.

Examples:

![Screenshot from 2022-11-30 08-15-24](https://user-images.githubusercontent.com/9843422/204734562-9b9d23ab-88a3-4b40-ab86-c51c432d286c.png)

![Screenshot from 2022-11-30 08-16-16](https://user-images.githubusercontent.com/9843422/204734587-8f5972e5-70cc-4f31-b7c2-89456b9cc240.png)
