### PR TITLE
Added an --msi flag to the config repack command

### DIFF
--- a/docs/wix/README.md
+++ b/docs/wix/README.md
@@ -1,18 +1,19 @@
 # Customizing Velociraptor deployments.
 
-This directory contains the WiX XML configuration file that can be used to tailor
-your Velociraptor deployment. The configuration file can be used to
-build a Windows installer package (MSI) which automatically installs
-the service.  This directory also contains a batch file used to build
-the MSI based on the custom XML configuration file.
+This directory contains the WiX XML configuration file that can be
+used to tailor your Velociraptor deployment. The configuration file
+can be used to build a Windows installer package (MSI) which
+automatically installs the service.  This directory also contains a
+batch file used to build the MSI based on the custom XML configuration
+file.
 
 The advantage of building your own MSI is that your config file will
 be bundled inside the MSI so you do not need to push it to endpoints -
 simply assign the MSI to your endpoints via SCCM or GPO. You can also
 adjust the binary name, service name, etc.
 
-To build MSI packages you will need to download and install the WIX distribution
-from the github page (it requires .NET 3.5):
+To build MSI packages you will need to download and install the WIX
+distribution from the github page (it requires .NET 3.5):
 
 http://wixtoolset.org/releases/
 
@@ -55,6 +56,34 @@ You can now push the MSI using group policy everywhere in your domain.
 Note: When upgrading, keep the UpgradeCode the same to ensure the old
 package is uninstalled and the new one is installed.
 
+# Experimental - repacking the custom MSI
+
+An experimental feature is to repack the custom MSI with an
+deployment's client configuration without rebuilding the MSI. This is
+much easier than having to have Wix installed and can be done on any
+operating system.
+
+In order to use this, copy the provided `custom.config.yaml` which is
+a special placeholder for a config file, into the output directory as
+`client.config.yaml` and build the custom MSI as described above.
+
+If you install this custom MSI, the placeholder config file will be
+installed in place of the `client.config.yaml`. Since the placeholder
+is **not** a valid configuration file, Velociraptor will wait before
+starting and attempt to reload the file every few seconds. This
+provides you the opportunity to manually replace the file at a later
+stage.
+
+However, it is now possible to repack a new client configuration file
+into the MSI using the following command:
+
+```
+velociraptor config repack client.config.yaml --msi velociraptor.msi repacked_velociraptor.msi -v
+```
+
+Repacking replaces the placeholder inside the MSI with the real config
+file. The new MSI will then automatically install the correct
+configuration file.
 
 # Standard MSI
 

--- a/docs/wix/custom.xml
+++ b/docs/wix/custom.xml
@@ -3,7 +3,7 @@
 <?define PackageDescription="Velociraptor Service Installer" ?>
 <?define Manufacturer="Velocidex" ?>
 <?define Name="Velociraptor" ?>
-<?define Version="0.59.0" ?>
+<?define Version="0.67.0" ?>
 <?define BinaryName="Velociraptor.exe" ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
@@ -19,6 +19,10 @@
              InstallerVersion='200' Languages='1033' Compressed='yes'
              SummaryCodepage='1252' />
     <Media Id='1' Cabinet='Sample.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1' />
+
+    <!-- Put the config file on an uncompressed cab file so we can repack it later -->
+    <Media Id='2' CompressionLevel="none" Cabinet='part2.cab' EmbedCab='yes' DiskPrompt='CD-ROM #2' />
+
     <Property Id='DiskPrompt' Value="Installation [1]" />
 
     <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
@@ -91,7 +95,7 @@
           </Component>
           <Component Id='Config' Guid='*'>
             <File Id='Config' Name='client.config.yaml'
-                  DiskId='1' Source='Output/client.config.yaml' KeyPath='yes'>
+                  DiskId='2' Source='Output/client.config.yaml' KeyPath='yes'>
             </File>
           </Component>
         </Directory>


### PR DESCRIPTION
This allows Velociraptor to repack a special MSI with the custom client configuration for a deployment.

Having the ability to prepare a deployment MSI without needing to have Wix installed allows for more server side automation.