### PR TITLE
Fixed Windows.Sys.Users artifact.

### DIFF
--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -81,13 +81,14 @@ sources:
         LET combined = SELECT * from chain(
            q1=local_users_with_mtime,
            q2=roaming_users)
-         ORDER BY Guid DESC
-
+         ORDER BY Gid DESC
 
         SELECT * FROM if(condition=OnlyRemote,
           then=roaming_users,
-          else=combined)
-         GROUP BY UUID, Name
+          else={
+            SELECT * FROM combined
+            GROUP BY UUID, Name
+          })
 
 reports:
   - type: HUNT

--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -34,7 +34,7 @@ sources:
                 then=timestamp(winfiletime=High * 4294967296 + Low))
 
         -- lookupSID() may not be available on deaddisk analysis
-        LET roaming_users <= SELECT
+        LET roaming_users = SELECT
            split(string=Key.OSPath.Basename, sep="-")[-1] as Uid,
            "" AS Gid,
            lookupSID(sid=Key.OSPath.Basename) || "" AS Name,
@@ -54,7 +54,7 @@ sources:
            ) AS Data
         FROM read_reg_key(globs=remoteRegKey, accessor="registry")
 
-        LET local_users <= select User_id as Uid,
+        LET local_users = select User_id as Uid,
            Primary_group_id as Gid, Name,
            Comment as Description, {
              SELECT *
@@ -64,6 +64,7 @@ sources:
            User_sid as UUID,
            "local" AS Type
         FROM users()
+        LIMIT 1000
 
         -- Populate the mtime from the user's home directory.
         LET local_users_with_mtime = SELECT Uid, Gid, Name, Description,
@@ -77,11 +78,8 @@ sources:
 
         LET combined = SELECT * from chain(
          q1=local_users_with_mtime,
-         q2={
-           -- Only show users not already shown in the local_users above.
-           SELECT * from roaming_users
-           WHERE NOT UUID IN local_users.UUID
-         })
+         q2=roaming_users)
+         GROUP BY UUID, Name
 
         SELECT * FROM if(condition=OnlyRemote,
           then=roaming_users,

--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -13,7 +13,9 @@ description: |
   of the entire ActiveDirectory as a list of 'local' users, however
   this does not mean that the users have logged into the DC
   locally. To check the users which have logged in, select the
-  `OnlyRemote` parameter.
+  `OnlyRemote` parameter. In this artifact we limit the number of
+  users to 1000. If you need to obtain the full list from the AD,
+  customize this artifact.
 
   By selecting the `OnlyRemote` parameter we only return a list of
   users with profiles cached in the registry (i.e. that were logged in
@@ -77,14 +79,15 @@ sources:
         FROM local_users
 
         LET combined = SELECT * from chain(
-         q1=local_users_with_mtime,
-         q2=roaming_users)
-         GROUP BY UUID, Name
+           q1=local_users_with_mtime,
+           q2=roaming_users)
+         ORDER BY Guid DESC
+
 
         SELECT * FROM if(condition=OnlyRemote,
           then=roaming_users,
           else=combined)
-
+         GROUP BY UUID, Name
 
 reports:
   - type: HUNT

--- a/gui/velociraptor/src/components/artifacts/artifacts.js
+++ b/gui/velociraptor/src/components/artifacts/artifacts.js
@@ -259,13 +259,17 @@ class ArtifactInspector extends React.Component {
               }
               <Navbar className="artifact-toolbar justify-content-between">
                 <ButtonGroup>
-                  <Button title={T("Add an Artifact")}
+                  <Button data-tooltip={T("Add an Artifact")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({showNewArtifactDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="plus"/>
                   </Button>
 
-                  <Button title={T("Edit an Artifact")}
+                  <Button data-tooltip={T("Edit an Artifact")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => {
                               this.setState({showEditedArtifactDialog: true});
                           }}
@@ -274,28 +278,36 @@ class ArtifactInspector extends React.Component {
                     <FontAwesomeIcon icon="pencil-alt"/>
                   </Button>
 
-                  <Button title={T("Delete Artifact")}
+                  <Button data-tooltip={T("Delete Artifact")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({showDeleteArtifactDialog: true})}
                           disabled={!deletable}
                           variant="default">
                     <FontAwesomeIcon icon="trash"/>
                   </Button>
 
-                  <Button title={T("Hunt Artifact")}
+                  <Button data-tooltip={T("Hunt Artifact")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.huntArtifact}
                           disabled={!this.huntArtifactEnabled()}
                           variant="default">
                     <FontAwesomeIcon icon="crosshairs"/>
                   </Button>
 
-                  <Button title={T("Collect Artifact")}
+                  <Button data-tooltip={T("Collect Artifact")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.collectArtifact}
                           disabled={!this.collectArtifactEnabled()}
                           variant="default">
                     <FontAwesomeIcon icon="cloud-download-alt"/>
                   </Button>
 
-                  <Button title={T("Upload Artifact Pack")}
+                  <Button data-tooltip={T("Upload Artifact Pack")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={()=>this.setState({showArtifactsUploadDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="upload"/>

--- a/gui/velociraptor/src/components/clients/host-info.js
+++ b/gui/velociraptor/src/components/clients/host-info.js
@@ -515,6 +515,7 @@ class VeloHostInfo extends Component {
                 <div className="client-info">
                   <div className="btn-group float-left toolbar" data-toggle="buttons">
                     <Button variant="default"
+                            as="a"
                             onClick={this.startInterrogate}
                             disabled={this.state.interrogateOperationId}>
                       { this.state.interrogateOperationId ?
@@ -534,12 +535,16 @@ class VeloHostInfo extends Component {
                     </Link>
                     { is_quarantined ?
                       <Button variant="default"
-                              title={T("Unquarantine Host")}
+                              data-tooltip={T("Unquarantine Host")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={this.unquarantineHost}>
                         <FontAwesomeIcon icon="virus-slash" />
                       </Button> :
                       <Button variant="default"
-                              title={T("Quarantine Host")}
+                              data-tooltip={T("Quarantine Host")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={()=>this.setState({
                                   showQuarantineDialog: true,
                               })}>
@@ -556,7 +561,9 @@ class VeloHostInfo extends Component {
                             this.updateClientInfo();
                         }}/>}
                     <Button variant="default"
-                            title={T("Add Label")}
+                            data-tooltip={T("Add Label")}
+                            data-position="right"
+                            className="btn-tooltip"
                             onClick={()=>this.setState({
                                 showLabelDialog: true,
                             })}>

--- a/gui/velociraptor/src/components/clients/search.js
+++ b/gui/velociraptor/src/components/clients/search.js
@@ -108,7 +108,6 @@ class VeloClientSearch extends Component {
                         <span className="button-label">{T("Show All")}</span>
                       </Dropdown.Item>
                       <Dropdown.Item
-                        title="Recent"
                         onClick={(e) => this.setQuery(
                             "recent:" + this.context.traits.username)}
                         variant="default" type="button">

--- a/gui/velociraptor/src/components/clients/shell-viewer.js
+++ b/gui/velociraptor/src/components/clients/shell-viewer.js
@@ -129,16 +129,18 @@ class _VeloShellCell extends Component {
         // expanded. These buttons can switch between the two modes.
         if (this.state.collapsed) {
             buttons.push(
-                <button className="btn btn-default" key={1}
-                        title={T("Expand")}
+                <button className="btn-tooltip btn btn-default" key={1}
+                        data-tooltip={T("Expand")}
+                        data-position="right"
                         onClick={() => this.setState({collapsed: false})} >
                   <i><FontAwesomeIcon icon="expand"/></i>
                 </button>
             );
         } else {
             buttons.push(
-                <button className="btn btn-default" key={2}
-                        title={T("Collapse")}
+                <button className="btn-tooltip btn btn-default" key={2}
+                        data-tooltip={T("Collapse")}
+                        data-position="right"
                         onClick={() => this.setState({collapsed: true})} >
                   <i><FontAwesomeIcon icon="compress"/></i>
                 </button>
@@ -149,16 +151,18 @@ class _VeloShellCell extends Component {
         // large so we dont fetch it until the user asks)
         if (this.state.loaded) {
             buttons.push(
-                <button className="btn btn-default" key={3}
-                        title={T("Hide Output")}
+                <button className="btn-tooltip btn btn-default" key={3}
+                        data-tooltip={T("Hide Output")}
+                        data-position="right"
                         onClick={() => this.setState({"loaded": false})} >
                   <i><FontAwesomeIcon icon="eye-slash"/></i>
                 </button>
             );
         } else {
             buttons.push(
-                <button className="btn btn-default" key={4}
-                        title={T("Load Output")}
+                <button className="btn-tooltip btn btn-default" key={4}
+                        data-tooltip={T("Load Output")}
+                        data-position="right"
                         onClick={this.loadData}>
                   <i><FontAwesomeIcon icon="eye"/></i>
                 </button>
@@ -166,7 +170,7 @@ class _VeloShellCell extends Component {
         }
 
         let flow_status = [
-            <button className="btn btn-outline-info"
+            <button className="btn btn-outline-info" key="1"
               onClick={e=>{this.viewFlow("overview");}}
             >
               <i><FontAwesomeIcon icon="external-link-alt"/></i>
@@ -175,8 +179,9 @@ class _VeloShellCell extends Component {
         // If the flow is currently running we may be able to stop it.
         if (this.props.flow.state  === 'RUNNING') {
             buttons.push(
-                <button className="btn btn-default" key={5}
-                        title={T("Stop")}
+                <button className="btn-tooltip btn btn-default" key={5}
+                        data-tooltip={T("Stop")}
+                        data-position="right"
                         onClick={this.cancelFlow}>
                   <i><FontAwesomeIcon icon="stop"/></i>
                 </button>
@@ -212,8 +217,9 @@ class _VeloShellCell extends Component {
         }
 
         flow_status.push(
-            <button className="btn btn-default" key={9}
-                    title={T("Delete")}
+            <button className="btn-tooltip btn btn-default" key={9}
+                    data-tooltip={T("Delete")}
+                    data-position="right"
                     onClick={()=>this.setState({showDeleteWizard: true})}>
               <i><FontAwesomeIcon icon="trash"/></i>
             </button>
@@ -229,14 +235,14 @@ class _VeloShellCell extends Component {
             })];
 
             if (this.props.flow.state  === 'ERROR') {
-                output.push(<Button variant="danger"
-                                    onClick={e=>{this.viewFlow("logs")}}
+                output.push(<Button variant="danger" key="errors"
+                                    onClick={e=>{this.viewFlow("logs");}}
                                     size="lg" block>
                               {T('Error')}
                             </Button>);
             } else {
-                output.push(<Button variant="link"
-                                    onClick={e=>{this.viewFlow("logs")}}
+                output.push(<Button variant="link" key="logs"
+                                    onClick={e=>{this.viewFlow("logs");}}
                                     size="lg" block>
                               {T('Logs')}
                             </Button>);
@@ -355,16 +361,18 @@ class _VeloVQLCell extends Component {
         // expanded. These buttons can switch between the two modes.
         if (this.state.collapsed) {
             buttons.push(
-                <button className="btn btn-default" key={1}
-                        title={T("Expand")}
+                <button className="btn-tooltip btn btn-default" key={1}
+                        data-tooltip={T("Expand")}
+                        data-position="right"
                         onClick={() => this.setState({collapsed: false})} >
                   <i><FontAwesomeIcon icon="expand"/></i>
                 </button>
             );
         } else {
             buttons.push(
-                <button className="btn btn-default" key={2}
-                        title={T("Collapse")}
+                <button className="btn-tooltip btn btn-default" key={2}
+                        data-tooltip={T("Collapse")}
+                        data-position="right"
                         onClick={() => this.setState({collapsed: true})} >
                   <i><FontAwesomeIcon icon="compress"/></i>
                 </button>
@@ -375,16 +383,18 @@ class _VeloVQLCell extends Component {
         // large so we dont fetch it until the user asks)
         if (this.state.loaded) {
             buttons.push(
-                <button className="btn btn-default" key={3}
-                        title={T("Hide Output")}
+                <button className="btn-tooltip btn btn-default" key={3}
+                        data-tooltip={T("Hide Output")}
+                        data-position="right"
                         onClick={() => this.setState({"loaded": false})} >
                   <i><FontAwesomeIcon icon="eye-slash"/></i>
                 </button>
             );
         } else {
             buttons.push(
-                <button className="btn btn-default" key={4}
-                        title={T("Load Output")}
+                <button className="btn-tooltip btn btn-default" key={4}
+                        data-tooltip={T("Load Output")}
+                        data-position="right"
                         onClick={() => this.setState({"loaded": true})}>
                   <i><FontAwesomeIcon icon="eye"/></i>
                 </button>
@@ -401,8 +411,9 @@ class _VeloVQLCell extends Component {
         // If the flow is currently running we may be able to stop it.
         if (this.props.flow.state  === 'RUNNING') {
             buttons.push(
-                <button className="btn btn-default" key={5}
-                        title={T("Stop")}
+                <button className="btn-tooltip btn btn-default" key={5}
+                        data-tooltip={T("Stop")}
+                        data-position="right"
                         onClick={this.cancelFlow}>
                   <i><FontAwesomeIcon icon="stop"/></i>
                 </button>
@@ -438,8 +449,9 @@ class _VeloVQLCell extends Component {
         }
 
         flow_status.push(
-            <button className="btn btn-default" key={5}
-                    title={T("Delete")}
+            <button className="btn-tooltip btn btn-default" key={5}
+                    data-tooltip={T("Delete")}
+                    data-position="right"
                     onClick={()=>this.setState({showDeleteWizard: true})}>
               <i><FontAwesomeIcon icon="trash"/></i>
             </button>

--- a/gui/velociraptor/src/components/core/paged-table.js
+++ b/gui/velociraptor/src/components/core/paged-table.js
@@ -223,8 +223,10 @@ class VeloPagedTable extends Component {
         if (transform.filter_column) {
             result.push(
                 <Button key="1"
-                  title={T("Transformed")}  disabled={true}
-                  variant="outline-dark">
+                        data-tooltip={T("Transformed")}  disabled={true}
+                        data-position="right"
+                        className="btn-tooltip"
+                        variant="outline-dark">
                   { transform.filter_column } ( {transform.filter_regex} )
                   <span className="transform-button">
                     <FontAwesomeIcon icon="filter"/>
@@ -236,7 +238,9 @@ class VeloPagedTable extends Component {
         if (transform.sort_column) {
             result.push(
                 <Button key="2"
-                  title={T("Transformed")}  disabled={true}
+                        data-tooltip={T("Transformed")}  disabled={true}
+                        data-position="right"
+                        className="btn-tooltip"
                   variant="outline-dark">
                   {transform.sort_column}
                   <span className="transform-button">
@@ -465,7 +469,9 @@ class VeloPagedTable extends Component {
                           <InspectRawJson rows={this.state.rows} />
                           <Button variant="default"
                                   target="_blank" rel="noopener noreferrer"
-                                  title={T("Download JSON")}
+                                  data-tooltip={T("Download JSON")}
+                                  data-position="right"
+                                  className="btn-tooltip"
                                   href={api.href("/api/v1/DownloadTable",
                                                  Object.assign(downloads, {
                                                      timezone: timezone,
@@ -475,7 +481,9 @@ class VeloPagedTable extends Component {
                           </Button>
                           <Button variant="default"
                                   target="_blank" rel="noopener noreferrer"
-                                  title={T("Download CSV")}
+                                  data-tooltip={T("Download CSV")}
+                                  data-position="right"
+                                  className="btn-tooltip"
                                   href={api.href("/api/v1/DownloadTable",
                                                  Object.assign(downloads, {
                                                      timezone: timezone,
@@ -488,7 +496,9 @@ class VeloPagedTable extends Component {
                                    onClick={()=>this.setState({
                                        show_transform_dialog: true,
                                    })}
-                                   title={T("Transform Table")}>
+                                   data-position="right"
+                                   className="btn-tooltip"
+                                   data-tooltip={T("Transform Table")}>
                              <FontAwesomeIcon icon="filter"/>
                            </Button>}
                         </ButtonGroup>

--- a/gui/velociraptor/src/components/core/table.js
+++ b/gui/velociraptor/src/components/core/table.js
@@ -77,7 +77,9 @@ export class InspectRawJson extends Component {
         return (
             <>
               <Button variant="default"
-                      title={T("Inspect Raw JSON")}
+                      data-tooltip={T("Inspect Raw JSON")}
+                      data-position="right"
+                      className="btn-tooltip"
                       onClick={() => this.setState({show: true})} >
                 <FontAwesomeIcon icon="binoculars"/>
               </Button>
@@ -144,7 +146,9 @@ export const ColumnToggleList = (e) => {
                  eventKey={column.dataField}
                  active={!hidden}
                  onSelect={c=>onColumnToggle(c)}
-                 title={T("Show/Hide Columns")}
+                 data-position="right"
+                 className="btn-tooltip"
+                 data-tooltip={T("Show/Hide Columns")}
                >
                  { column.text }
                </Dropdown.Item>;
@@ -152,7 +156,11 @@ export const ColumnToggleList = (e) => {
 
     return (
         <>
-          <Dropdown show={open} onToggle={onToggle}>
+          <Dropdown show={open}
+                    data-position="right"
+                    data-tooltip={T("Show/Hide Columns")}
+                    className="btn-tooltip"
+                    onToggle={onToggle}>
             <Dropdown.Toggle variant="default" id="dropdown-basic">
               <FontAwesomeIcon icon="columns"/>
             </Dropdown.Toggle>

--- a/gui/velociraptor/src/components/events/events.js
+++ b/gui/velociraptor/src/components/events/events.js
@@ -303,12 +303,16 @@ class EventMonitoring extends React.Component {
                 <ButtonGroup>
                   { client_id === "server" || client_id === "" ?
                     <>
-                      <Button title={T("Update server monitoring table")}
+                      <Button data-tooltip={T("Update server monitoring table")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={() => this.setState({showServerEventTableWizard: true})}
                               variant="default">
                         <FontAwesomeIcon icon="edit"/>
                       </Button>
-                      <Button title={T("Show server monitoring tables")}
+                      <Button data-tooltip={T("Show server monitoring tables")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={() => this.setState({showEventMonitoringPopup: true})}
                               variant="default">
                         <FontAwesomeIcon icon="binoculars"/>
@@ -316,12 +320,16 @@ class EventMonitoring extends React.Component {
 
                     </>:
                     <>
-                      <Button title={T("Update client monitoring table")}
+                      <Button data-tooltip={T("Update client monitoring table")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={() => this.setState({showEventTableWizard: true})}
                               variant="default">
                         <FontAwesomeIcon icon="edit"/>
                       </Button>
-                      <Button title={T("Show client monitoring tables")}
+                      <Button data-tooltip={T("Show client monitoring tables")}
+                              data-position="right"
+                              className="btn-tooltip"
                               onClick={() => this.setState({showEventMonitoringPopup: true})}
                               variant="default">
                         <FontAwesomeIcon icon="binoculars"/>
@@ -329,8 +337,11 @@ class EventMonitoring extends React.Component {
                     </>
                   }
                   { this.state.buttonsRenderer() }
-                  <Dropdown title={this.state.artifact.artifact ||
-                                   T("Select artifact")} variant="default">
+                  <Dropdown data-tooltip={this.state.artifact.artifact ||
+                                   T("Select artifact")}
+                            data-position="right"
+                            className="btn-tooltip"
+                            variant="default">
                     <Dropdown.Toggle variant="default">
                       <FontAwesomeIcon icon="book"/>
                       <span className="button-label">
@@ -357,7 +368,9 @@ class EventMonitoring extends React.Component {
 
                 <ButtonGroup className="float-right">
                   { this.state.mode === mode_notebook &&
-                    <Button title={T("Delete Notebook")}
+                    <Button data-tooltip={T("Delete Notebook")}
+                            data-position="right"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showDeleteNotebook: true})}
                             variant="default">
                       <FontAwesomeIcon icon="trash"/>

--- a/gui/velociraptor/src/components/events/timeline-viewer.js
+++ b/gui/velociraptor/src/components/events/timeline-viewer.js
@@ -397,25 +397,33 @@ export default class EventTimelineViewer extends React.Component {
                    </Dropdown.Menu>
                  </Dropdown>
 
-                 <Button title="Delete"
+                 <Button data-tooltip="Delete"
+                         data-position="right"
+                         className="btn-tooltip"
                          onClick={() => this.setState({showDeleteDialog: true})}
                          variant="default">
                    <FontAwesomeIcon icon="trash"/>
                  </Button>
 
-                 <Button title="Previous"
+                 <Button data-tooltip="Previous"
+                         data-position="right"
+                         className="btn-tooltip"
                          onClick={() => this.prevPage()}
                          variant="default">
                    <FontAwesomeIcon icon="backward"/>
                  </Button>
 
-                 <Button title="Center"
+                 <Button data-tooltip="Center"
+                         data-position="right"
+                         className="btn-tooltip"
                          onClick={() => this.centerPage()}
                          variant="default">
                    <FontAwesomeIcon icon="crosshairs"/>
                  </Button>
 
-                 <Button title="Next"
+                 <Button data-tooltip="Next"
+                         data-position="right"
+                         className="btn-tooltip"
                          onClick={() => this.nextPage()}
                          variant="default">
                    <FontAwesomeIcon icon="forward"/>

--- a/gui/velociraptor/src/components/flows/flows-list.js
+++ b/gui/velociraptor/src/components/flows/flows-list.js
@@ -459,38 +459,50 @@ class FlowsList extends React.Component {
 
               <Navbar className="flow-toolbar">
                 <ButtonGroup>
-                  <Button title={T("New Collection")}
+                  <Button data-tooltip={T("New Collection")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({showWizard: true})}
                           variant="default">
                     <FontAwesomeIcon icon="plus"/>
                   </Button>
 
                   { client_id !== "server" &&
-                    <Button title={T("Add to hunt")}
+                    <Button data-tooltip={T("Add to hunt")}
+                            data-position="right"
+                            className="btn-tooltip"
                             onClick={()=>this.setState({showAddToHunt: true})}
                             variant="default">
                       <FontAwesomeIcon icon="crosshairs"/>
                     </Button>
                   }
-                  <Button title={T("Delete Artifact Collection")}
+                  <Button data-tooltip={T("Delete Artifact Collection")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={()=>this.setState({showDeleteWizard: true}) }
                           variant="default">
                     <FontAwesomeIcon icon="trash-alt"/>
                   </Button>
 
                   { this.props.selected_flow.state !== "FINISHED" &&
-                    <Button title={T("Cancel Artifact Collection")}
+                    <Button data-tooltip={T("Cancel Artifact Collection")}
+                            data-position="right"
+                            className="btn-tooltip"
                             onClick={this.cancelButtonClicked}
                             variant="default">
                     <FontAwesomeIcon icon="stop"/>
                     </Button>
                   }
-                  <Button title={T("Copy Collection")}
+                  <Button data-tooltip={T("Copy Collection")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({showCopyWizard: true})}
                           variant="default">
                     <FontAwesomeIcon icon="copy"/>
                   </Button>
-                  <Button title={T("Save Collection")}
+                  <Button data-tooltip={T("Save Collection")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({
                               showSaveCollectionDialog: true
                           })}
@@ -499,7 +511,9 @@ class FlowsList extends React.Component {
                   </Button>
 
                   { isServer &&
-                    <Button title={T("Build offline collector")}
+                    <Button data-tooltip={T("Build offline collector")}
+                            data-position="right"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showOfflineWizard: true})}
                             variant="default">
                       <FontAwesomeIcon icon="paper-plane"/>
@@ -509,31 +523,41 @@ class FlowsList extends React.Component {
                 </ButtonGroup>
                 { tab === "notebook" &&
                   <ButtonGroup className="float-right">
-                    <Button title={T("Notebooks")}
+                    <Button data-tooltip={T("Notebooks")}
+                            data-position="left"
+                            className="btn-tooltip"
                             disabled={true}
                             variant="outline-dark">
                       <FontAwesomeIcon icon="book"/>
                     </Button>
 
-                    <Button title={T("Full Screen")}
+                    <Button data-tooltip={T("Full Screen")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={this.setFullScreen}
                             variant="default">
                       <FontAwesomeIcon icon="expand"/>
                     </Button>
 
-                    <Button title={T("Delete Notebook")}
+                    <Button data-tooltip={T("Delete Notebook")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showDeleteNotebook: true})}
                             variant="default">
                       <FontAwesomeIcon icon="trash"/>
                     </Button>
 
-                    <Button title={T("Notebook Uploads")}
+                    <Button data-tooltip={T("Notebook Uploads")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showNotebookUploadsDialog: true})}
                             variant="default">
                       <FontAwesomeIcon icon="fa-file-download"/>
                     </Button>
 
-                    <Button title={T("Export Notebook")}
+                    <Button data-tooltip={T("Export Notebook")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showExportNotebook: true})}
                             variant="default">
                       <FontAwesomeIcon icon="download"/>

--- a/gui/velociraptor/src/components/hunts/hunt-list.js
+++ b/gui/velociraptor/src/components/hunts/hunt-list.js
@@ -320,30 +320,40 @@ class HuntList extends React.Component {
 
               <Navbar className="hunt-toolbar">
                 <ButtonGroup>
-                  <Button title={T("New Hunt")}
+                  <Button data-tooltip={T("New Hunt")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={() => this.setState({showWizard: true})}
                           variant="default">
                     <FontAwesomeIcon icon="plus"/>
                   </Button>
-                  <Button title={T("Run Hunt")}
+                  <Button data-tooltip={T("Run Hunt")}
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={state !== 'PAUSED' && state !== 'STOPPED'}
                           onClick={() => this.setState({showRunHuntDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="play"/>
                   </Button>
-                  <Button title={T("Stop Hunt")}
+                  <Button data-tooltip={T("Stop Hunt")}
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={state !== 'RUNNING'}
                           onClick={this.stopHunt}
                           variant="default">
                     <FontAwesomeIcon icon="stop"/>
                   </Button>
-                  <Button title={T("Delete Hunt")}
+                  <Button data-tooltip={T("Delete Hunt")}
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={state === 'RUNNING' || !selected_hunt}
                           onClick={() => this.setState({showDeleteHuntDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="trash-alt"/>
                   </Button>
-                  <Button title={T("Copy Hunt")}
+                  <Button data-tooltip={T("Copy Hunt")}
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={!selected_hunt}
                           onClick={this.copyHunt}
                           variant="default">
@@ -352,31 +362,42 @@ class HuntList extends React.Component {
                 </ButtonGroup>
                 { tab === "notebook" &&
                   <ButtonGroup className="float-right">
-                  <Button title={T("Notebooks")}
+                    <Button data-tooltip={T("Notebooks")}
+                            data-position="right"
+                            className="btn-tooltip"
                             disabled={true}
                             variant="outline-dark">
                       <FontAwesomeIcon icon="book"/>
                     </Button>
 
-                  <Button title={T("Full Screen")}
+                    <Button data-tooltip={T("Full Screen")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={this.setFullScreen}
                             variant="default">
                       <FontAwesomeIcon icon="expand"/>
                     </Button>
 
-                    <Button title={T("Delete Notebook")}
+                    <Button data-tooltip={T("Delete Notebook")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showDeleteNotebook: true})}
                             variant="default">
                       <FontAwesomeIcon icon="trash"/>
                     </Button>
 
-                    <Button title={T("Notebook Uploads")}
+                    <Button data-tooltip={T("Notebook Uploads")}
+                            data-position="left"
+                            className="btn-tooltip"
                             onClick={() => this.setState({showNotebookUploadsDialog: true})}
                             variant="default">
                       <FontAwesomeIcon icon="fa-file-download"/>
                     </Button>
 
-                    <Button title={T("Export Notebook")}
+                    <Button data-tooltip={T("Export Notebook")}
+                            data-position="left"
+                            className="btn-tooltip"
+
                             onClick={() => this.setState({showExportNotebook: true})}
                             variant="default">
                       <FontAwesomeIcon icon="download"/>

--- a/gui/velociraptor/src/components/notebooks/full_notebook.js
+++ b/gui/velociraptor/src/components/notebooks/full_notebook.js
@@ -78,7 +78,9 @@ class FullScreenNotebook extends React.Component {
               <Spinner loading={this.state.loading} />
               <Navbar className="toolbar">
                 <ButtonGroup className="float-right floating-button">
-                  <Button title={T("Exit Fullscreen")}
+                  <Button data-tooltip={T("Exit Fullscreen")}
+                          data-position="left"
+                          className="btn-tooltip"
                           onClick={this.setSelectedNotebook}
                           variant="default">
                     <FontAwesomeIcon icon="compress"/>

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.js
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.js
@@ -453,47 +453,61 @@ export default class NotebookCellRenderer extends React.Component {
         let non_editing_toolbar = (
             <>
             <ButtonGroup>
-              <Button title={T("Cancel")}
+              <Button data-tooltip={T("Cancel")}
+                      data-position="right"
+                      className="btn-tooltip"
                       onClick={() => {this.props.setSelectedCellId("");}}
                       variant="default">
                 <FontAwesomeIcon icon="window-close"/>
               </Button>
 
-              <Button title={T("Recalculate")}
+              <Button data-tooltip={T("Recalculate")}
+                      data-position="right"
+                      className="btn-tooltip"
                       disabled={this.state.cell.calculating}
                       onClick={this.recalculate}
                       variant="default">
                 <FontAwesomeIcon icon="sync"/>
               </Button>
 
-              <Button title={T("Stop Calculating")}
+              <Button data-tooltip={T("Stop Calculating")}
+                      data-position="right"
+                      className="btn-tooltip"
                       disabled={!this.state.cell.calculating}
                       onClick={this.stopCalculating}
                       variant="default">
                 <FontAwesomeIcon icon="stop"/>
               </Button>
               { !this.state.collapsed &&
-                <Button title={T("Collapse")}
+                <Button data-tooltip={T("Collapse")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={() => this.setState({collapsed: true})}
                         variant="default">
                   <FontAwesomeIcon icon="compress"/>
                 </Button>
               }
               { this.state.collapsed &&
-                <Button title={T("Expand")}
+                <Button data-tooltip={T("Expand")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={() => this.setState({collapsed: false})}
                         variant="default">
                   <FontAwesomeIcon icon="expand"/>
                 </Button>
               }
-              <Button title={T("Edit Cell")}
+              <Button data-tooltip={T("Edit Cell")}
+                      data-position="right"
+                      className="btn-tooltip"
                       disabled={this.state.cell.calculating}
                       onClick={() => { this.setEditing(true); }}
                       variant="default">
                 <FontAwesomeIcon icon="pencil-alt"/>
               </Button>
 
-              <Button title={T("Up Cell")}
+              <Button data-tooltip={T("Up Cell")}
+                      data-position="right"
+                      className="btn-tooltip"
                       onClick={() => {
                           this.props.upCell(this.state.cell.cell_id);
                       }}
@@ -501,7 +515,9 @@ export default class NotebookCellRenderer extends React.Component {
                 <FontAwesomeIcon icon="arrow-up"/>
               </Button>
 
-              <Button title={T("Down Cell")}
+              <Button data-tooltip={T("Down Cell")}
+                      data-position="right"
+                      className="btn-tooltip"
                       onClick={() => {
                           this.props.downCell(this.state.cell.cell_id);
                       }}
@@ -510,7 +526,9 @@ export default class NotebookCellRenderer extends React.Component {
               </Button>
 
               {this.state.cell && this.state.cell.type === "vql" &&
-               <Button title={T("Add Timeline")}
+               <Button data-tooltip={T("Add Timeline")}
+                       data-position="right"
+                       className="btn-tooltip"
                        onClick={()=>this.setState({showAddCellToTimeline: true})}
                        variant="default">
                  <FontAwesomeIcon icon="calendar-alt"/>
@@ -582,6 +600,8 @@ export default class NotebookCellRenderer extends React.Component {
             </ButtonGroup>
             <ButtonGroup className="float-right">
               <Button title={T("Rendered")} disabled
+                        data-position="right"
+                        className="btn-tooltip"
                       variant="outline-info">
                 <VeloTimestamp usec={this.state.cell.timestamp * 1000} />
                 { this.state.cell.duration &&
@@ -595,6 +615,8 @@ export default class NotebookCellRenderer extends React.Component {
             <>
               <ButtonGroup>
                 <Button title={T("Undo")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={() => {this.setEditing(false); }}
                         variant="default">
                   <FontAwesomeIcon icon="window-close"/>
@@ -603,17 +625,23 @@ export default class NotebookCellRenderer extends React.Component {
                 <SettingsButton ace={this.state.ace}/>
 
                 <Button title={T("Stop Calculating")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={this.stopCalculating}
                         variant="default">
                   <FontAwesomeIcon icon="stop"/>
                 </Button>
 
                 <Button title={T("Format")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={this.formatCell}
                         variant="default">
                   <FontAwesomeIcon icon="indent"/>
                 </Button>
                 <Button title={T("Save")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={this.saveCell}
                         variant="default">
                   <FontAwesomeIcon icon="save"/>
@@ -623,6 +651,8 @@ export default class NotebookCellRenderer extends React.Component {
 
               <ButtonGroup className="float-right">
                 <Button title={T("Delete Cell")}
+                        data-position="right"
+                        className="btn-tooltip"
                         onClick={this.deleteCell}
                         variant="default">
                   <FontAwesomeIcon icon="trash"/>

--- a/gui/velociraptor/src/components/notebooks/notebooks-list.css
+++ b/gui/velociraptor/src/components/notebooks/notebooks-list.css
@@ -18,5 +18,5 @@ div.error-message {
 
 
 .notebook-output {
-    overflow-x: auto;
+    overflow-x: visible;
 }

--- a/gui/velociraptor/src/components/notebooks/notebooks-list.js
+++ b/gui/velociraptor/src/components/notebooks/notebooks-list.js
@@ -320,7 +320,9 @@ class NotebooksList extends React.Component {
 
               <Navbar className="toolbar">
                 <ButtonGroup>
-                  <Button title="Full Screen"
+                  <Button data-tooltip="Full Screen"
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={!this.props.selected_notebook ||
                                     !this.props.selected_notebook.notebook_id}
                           onClick={this.setFullScreen}
@@ -328,32 +330,42 @@ class NotebooksList extends React.Component {
                     <FontAwesomeIcon icon="expand"/>
                   </Button>
 
-                  <Button title="NewNotebook"
+                  <Button data-tooltip="NewNotebook"
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={()=>this.setState({showNewNotebookDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="plus"/>
                   </Button>
 
-                  <Button title="Delete Notebook"
+                  <Button data-tooltip="Delete Notebook"
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={_.isEmpty(this.props.selected_notebook)}
                           onClick={()=>this.setState({showDeleteNotebookDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="trash"/>
                   </Button>
 
-                  <Button title="Edit Notebook"
+                  <Button data-tooltip="Edit Notebook"
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={_.isEmpty(this.props.selected_notebook)}
                           onClick={()=>this.setState({showEditNotebookDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="wrench"/>
                   </Button>
-                  <Button title="NotebookUploads"
+                  <Button data-tooltip="NotebookUploads"
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={_.isEmpty(this.props.selected_notebook)}
                           onClick={()=>this.setState({showNotebookUploadsDialog: true})}
                           variant="default">
                     <FontAwesomeIcon icon="fa-file-download"/>
                   </Button>
-                  <Button title="ExportNotebook"
+                  <Button data-tooltip="ExportNotebook"
+                          data-position="right"
+                          className="btn-tooltip"
                           disabled={_.isEmpty(this.props.selected_notebook)}
                           onClick={()=>this.setState({showExportNotebookDialog: true})}
                           variant="default">

--- a/gui/velociraptor/src/components/sidebar/user-dashboard.js
+++ b/gui/velociraptor/src/components/sidebar/user-dashboard.js
@@ -9,6 +9,7 @@ import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import VeloReportViewer from "../artifacts/reporting.js";
+import T from '../i8n/i8n.js';
 
 import { withRouter }  from "react-router-dom";
 
@@ -64,13 +65,21 @@ class UserDashboard extends React.Component {
             <>
               <Navbar className="toolbar">
                 <ButtonGroup>
-                  <Button variant="default" onClick={() => this.setState({
+                  <Button variant="default"
+                          data-position="right"
+                          className="btn-tooltip"
+                          data-tooltip={T("Redraw dashboard")}
+                          onClick={() => this.setState({
                       version: this.state.version + 1,
                   })} >
                     <FontAwesomeIcon icon="sync"/>
                   </Button>
 
-                  <Button variant="default" onClick={() => {
+                  <Button variant="default"
+                          data-position="right"
+                          className="btn-tooltip"
+                          data-tooltip={T("Edit the dashboard")}
+                          onClick={() => {
                       this.props.history.push("/artifacts/Server.Monitor.Health");
                   }} >
                     <FontAwesomeIcon icon="pencil-alt"/>

--- a/gui/velociraptor/src/components/users/user-inspector.js
+++ b/gui/velociraptor/src/components/users/user-inspector.js
@@ -377,7 +377,8 @@ class UsersOverview extends Component {
                             { !this.context.traits.password_less &&
                               <Button
                                 disabled={!this.state.user_name}
-                                data-title={T("Update User Password")}
+                                data-tooltip={T("Update User Password")}
+                                data-position="top"
                                 onClick={()=>this.setState({
                                     showEditUserDialog: true
                                 })}
@@ -388,7 +389,8 @@ class UsersOverview extends Component {
                               </Button>
                             }
                             <Button
-                              data-title={T("Add a new user")}
+                              data-tooltip={T("Add a new user")}
+                              data-position="top"
                               onClick={()=>this.setState({
                                   showAddUserDialog: true
                               })}
@@ -427,7 +429,8 @@ class UsersOverview extends Component {
                             {T("Orgs")}
                             <Button
                               disabled={!this.state.user_name}
-                              data-title={T("Assign user to Orgs")}
+                              data-tooltip={T("Assign user to Orgs")}
+                              data-position="top"
                               onClick={()=>this.setState({
                                   showAddOrgDialog: true
                               })}

--- a/gui/velociraptor/src/components/utils/hex.js
+++ b/gui/velociraptor/src/components/utils/hex.js
@@ -220,7 +220,10 @@ export default class HexView extends React.Component {
                     { more && (this.state.expanded ?
                                <tr>
                                  <td colspan="16">
-                                   <Button variant="default-outline" title="Collapse"
+                                   <Button variant="default-outline"
+                                           data-tooltip="Collapse"
+                                           data-position="right"
+                                           className="btn-tooltip"
                                            onClick={()=>this.setState({expanded: false})} >
                                      <i><FontAwesomeIcon icon="arrow-up"/></i>
                                    </Button>
@@ -228,7 +231,10 @@ export default class HexView extends React.Component {
                                </tr>
                                : <tr>
             <td colspan="16">
-              <Button variant="default-outline"  title="Expand"
+              <Button variant="default-outline"
+                      data-tooltip="Expand"
+                      data-position="right"
+                      className="btn-tooltip"
                       onClick={()=>this.setState({expanded: true})} >
                 <i><FontAwesomeIcon icon="arrow-down"/></i>
               </Button>

--- a/gui/velociraptor/src/components/vfs/file-list.js
+++ b/gui/velociraptor/src/components/vfs/file-list.js
@@ -304,20 +304,26 @@ class VeloFileList extends Component {
             <Navbar className="toolbar">
               <ButtonGroup>
                 { this.state.lastRefreshOperationId ?
-                  <Button title={T("Currently refreshing")}
+                  <Button data-tooltip={T("Currently refreshing")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.startVfsRefreshOperation}
                           variant="default">
                     <FontAwesomeIcon icon="spinner" spin/>
                   </Button>
                   :
-                  <Button title={T("Refresh this directory (sync its listing with the client)")}
+                  <Button data-tooltip={T("Refresh this directory (sync its listing with the client)")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.startVfsRefreshOperation}
                           variant="default">
                     <FontAwesomeIcon icon="folder-open"/>
                   </Button>
                 }
                 { this.state.lastRecursiveRefreshOperationId ?
-                  <Button title={T("Currently refreshing from the client")}
+                  <Button data-tooltip={T("Currently refreshing from the client")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.cancelRecursiveRefresh}
                           variant="default">
                     <FontAwesomeIcon icon="spinner" spin/>
@@ -326,7 +332,9 @@ class VeloFileList extends Component {
                     </span>
                     <span className="button-label"><FontAwesomeIcon icon="stop"/></span>
                   </Button> :
-                  <Button title={T("Recursively refresh this directory (sync its listing with the client)")}
+                  <Button data-tooltip={T("Recursively refresh this directory (sync its listing with the client)")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.startRecursiveVfsRefreshOperation}
                           variant="default">
                     <FontAwesomeIcon icon="folder-open"/>
@@ -335,7 +343,9 @@ class VeloFileList extends Component {
                 }
 
                 { this.state.lastRecursiveDownloadOperationId ?
-                  <Button title={T("Currently fetching files from the client")}
+                  <Button data-tooltip={T("Currently fetching files from the client")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={this.cancelRecursiveDownload}
                           variant="default">
                     <FontAwesomeIcon icon="spinner" spin/>
@@ -346,7 +356,9 @@ class VeloFileList extends Component {
                     </span>
                     <span className="button-label"><FontAwesomeIcon icon="stop"/></span>
                   </Button> :
-                  <Button title={T("Recursively download this directory from the client")}
+                  <Button data-tooltip={T("Recursively download this directory from the client")}
+                          data-position="right"
+                          className="btn-tooltip"
                           onClick={()=>this.setState({showDownloadAllDialog: true})}
                           disabled={_.isEmpty(this.props.node && this.props.node.path)}
                           variant="default">
@@ -358,10 +370,12 @@ class VeloFileList extends Component {
 
                 <Link to={"/collected/" +this.props.client.client_id +
                           "/" + this.props.node.flow_id + "/overview"}
-                      title={T("View Collection")}
+                      data-tooltip={T("View Collection")}
+                      data-position="right"
                       role="button"
                       className={classNames({
                           "btn": true,
+                          "btn-tooltip": true,
                           "btn-default": true,
                           "disabled":  !this.props.node.flow_id,
                       })}>

--- a/gui/velociraptor/src/components/vfs/file-stats.js
+++ b/gui/velociraptor/src/components/vfs/file-stats.js
@@ -162,7 +162,10 @@ class VeloFileStats extends Component {
                           </dt>
                           <dd className="col-8">
                             <VeloTimestamp usec={ selectedRow.Download.mtime / 1000 } />
-                            <Button variant="outline-default" title={T("Download")}
+                            <Button variant="outline-default"
+                                    data-tooltip={T("Download")}
+                                    data-position="right"
+                                    className="btn-tooltip"
                                     href={api.href("/api/v1/DownloadVFSFile", {
                                         client_id: client_id,
                                         fs_components: selectedRow.Download.components,
@@ -179,7 +182,9 @@ class VeloFileStats extends Component {
                           <dt className="col-4">{T("Fetch from Client")}</dt>
                           <dd className="col-8">
                         { this.state.updateOperationFlowId ?
-                          <Button title={T("Currently refreshing from the client")}
+                          <Button data-tooltip={T("Currently refreshing from the client")}
+                                  data-position="right"
+                                  className="btn-tooltip"
                                   onClick={this.cancelDownload}
                                   variant="default">
                             <FontAwesomeIcon icon="sync" spin/>

--- a/gui/velociraptor/src/css/index.css
+++ b/gui/velociraptor/src/css/index.css
@@ -87,32 +87,66 @@ code {
   color: var(--color-foreground);
 }
 
-
-/* https://stackoverflow.com/questions/52706615/styling-button-tooltip */
-.btn-tooltip {
-   position: relative;
+.list-group-item {
+    background-color: var(--color-canvas-background);
+    color: var(--color-foreground);
 }
 
-.btn-tooltip::before {
-   background-color: var(--color-canvas-background);
-   border: 1px solid var(--accent-color);
-   border-radius: 8px;
-   color: var(--color-foreground);
-   content: attr(data-title);
-   display: none;
-   font-family: var(--font-family-sans-serif);
-   font-size: 14px;
-   padding: 4px 8px;
-   position: absolute;
-   top: -32px;
-   left: 0px;
-   z-index: 1;
-   white-space: nowrap;
-   opacity: 1;
+.btn-tooltip[data-tooltip] {
+  position: relative;
 }
 
-.btn-tooltip:hover::before {
-   display: block;
+.btn-tooltip[data-tooltip]:hover::before {
+  visibility: visible;
+  opacity: 1;
+}
+
+.btn-tooltip[data-tooltip]::before {
+  text-align:center;
+  content: attr(data-tooltip);
+  visibility: hidden;
+  opacity: 0;
+  min-width: 100%;
+  width: max-content;
+  height: max-content;
+  position: absolute;
+  box-sizing: border-box;
+  display: block;
+  margin: 0 auto;
+  padding: 4px 8px;
+  background-color: var(--color-canvas-background);
+  border: 1px solid var(--accent-color);
+  border-radius: 8px;
+  color: var(--color-foreground);
+  font-family: var(--font-family-sans-serif);
+  font-size: 14px;
+  padding: 4px 8px;
+  white-space: nowrap;
+  transition: opacity ease-out 150ms, bottom ease-out 150ms;
+  transition-property: opacity;
+  transition-delay: 400ms;
+  z-index: 10;
+}
+
+.btn-tooltip[data-position='top']::before {
+  bottom: 100%;
+}
+.btn-tooltip[data-position='right']::before {
+  left: 100%;
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
+}
+
+.btn-tooltip[data-position='bottom']::before {
+  top: 100%;
+}
+
+.btn-tooltip[data-position='left']::before {
+  right: 100%;
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
 }
 
 .btn-tooltip:disabled:hover::before {

--- a/gui/velociraptor/src/themes/coolgray-dark.css
+++ b/gui/velociraptor/src/themes/coolgray-dark.css
@@ -309,7 +309,6 @@ body.coolgray-dark {
 .coolgray-dark .btn-default {
   font-family: var(--font-family-sans-serif);
   font-size: var(--font-size-base);
-  font-size: inherit;
   color: var(--color-foreground);
   border-color: var(--color-btn-default-border);
   background: var(--color-btn-default-background);

--- a/gui/velociraptor/src/themes/veloci-dark.css
+++ b/gui/velociraptor/src/themes/veloci-dark.css
@@ -80,7 +80,7 @@
   --color-btn-default-border: #3f4754;
   --color-btn-default-background: #5cd00a80;
   --color-btn-default-background-hover: #0c900a80;
-  --color-btn-outline-link: var(--color-accent-25);
+  --color-btn-outline-link: var(--color-accent-50);
   --color-btn-outline-link-hover: var(--color-accent-75);
 
   --color-tab: var(--color-table-heading-background);


### PR DESCRIPTION
On domain controllers the users() VQL plugin will dump the entire AD but this is rarely what we want! We usually just want to find local users only.

Previously the artifact materialized the entire AD and filtered using an O(n^2) algorithm which means it often timed out on domain controllers.

The VQL is now:
- Limited to 1000 users on a DC
- Use group by to deduplicate the results from the registry scan

** Also updated title attributes to use the tooltip CSS so they are
   rendered more clearly.