### PR TITLE
More fixes for Windows.System.VAD (#2317)

### DIFF
--- a/accessors/process/doc.go
+++ b/accessors/process/doc.go
@@ -1,3 +1,25 @@
 package process
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
 // Accessor for processes.
+
+var (
+	processAccessorCurrentOpened = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "accessor_process_current_open",
+		Help: "Number of currently opened processes",
+	})
+
+	processAccessorTotalOpened = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "accessor_process_total_open",
+		Help: "Total Number of opened processes",
+	})
+
+	processAccessorTotalReadProcessMemory = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "accessor_process_total_read_process_memory",
+		Help: "Total Number of opened buffers read from process memory",
+	})
+)

--- a/artifacts/definitions/Windows/System/VAD.yaml
+++ b/artifacts/definitions/Windows/System/VAD.yaml
@@ -41,7 +41,7 @@ parameters:
     type: yara
   - name: ContextBytes
     description: Include this amount of bytes around yara hit as context.
-    default: 10000
+    default: 200
     type: int
 
 
@@ -83,17 +83,21 @@ sources:
 
       -- if suspicious yara added, search for it
       LET yara_sections = SELECT *
-        FROM foreach(row=sections,
-            query={
+        FROM foreach(row={
+                SELECT * FROM sections
+                WHERE NOT State =~ "RESERVE"
+            }, query={
                 SELECT
                     ProcessCreateTime, Pid, Name,MappingName,
-                    AddressRange,Protection,SectionSize,
-                    enumerate(items=dict(
-                        Rule=Rule,
-                        Meta=Meta,
-                      Tags=Tags,
-                      String=String))[0] as YaraHit,
-                    _PathSpec,_Address
+                    AddressRange,State,Type,ProtectionMsg,
+                    Protection,SectionSize,
+                    dict(Rule=Rule,
+                         Meta=Meta,
+                         Tags=Tags,
+                         Offset=String.Offset,
+                         Name=String.Name) as YaraHit,
+                    String.Data AS YaraContext,
+                    _PathSpec, _Address
                 FROM yara(
                             accessor='offset',
                             files=_PathSpec,
@@ -127,3 +131,7 @@ sources:
       SELECT * FROM if(condition= UploadSection,
                     then= upload_results,
                     else= results)
+
+column_types:
+  - name: YaraContext
+    type: hex

--- a/crypto/client/manager.go
+++ b/crypto/client/manager.go
@@ -55,7 +55,7 @@ type CryptoManager struct {
 func (self *CryptoManager) Clear() {
 	self.cipher_lru.Clear()
 	self.Resolver.Clear()
-	self.unauthenticated_lru.Purge()
+	self.unauthenticated_lru.Flush()
 }
 
 func (self *CryptoManager) ClientId() string {

--- a/datastore/memcache.go
+++ b/datastore/memcache.go
@@ -579,6 +579,7 @@ func (self *MemcacheDatastore) Close() {
 	self.dir_cache.Flush()
 }
 
+// Clear the cache and drop the data on the floor.
 func (self *MemcacheDatastore) Clear() {
 	self.data_cache.Purge()
 	self.dir_cache.Purge()

--- a/go.mod
+++ b/go.mod
@@ -214,6 +214,7 @@ require (
 // replace github.com/Velocidex/grpc-go-pool => /home/mic/projects/grpc-go-pool
 // replace www.velocidex.com/golang/oleparse => /home/matt/git/oleparse
 // replace github.com/go-errors/errors => /home/mic/projects/errors
+// replace github.com/Velocidex/ttlcache/v2 => /home/mic/projects/ttlcache
 
 // Remove search for html end block. This allows inserting unbalanced
 // HTML tags into the markdown

--- a/gui/velociraptor/src/components/flows/flows-list.js
+++ b/gui/velociraptor/src/components/flows/flows-list.js
@@ -140,8 +140,8 @@ export class SaveCollectionDialog extends React.PureComponent {
     }
 
     render() {
-        let collected_artifacts = this.props.flow.artifacts_with_results || [];
-        let artifacts = collected_artifacts.join(",");
+        let collected_artifacts = this.props.flow.request.artifacts || [];
+        let artifacts = collected_artifacts.join(", ");
         return (
             <Modal show={true} onHide={this.props.onClose}>
               <Modal.Header closeButton>

--- a/services/client_info/client_info.go
+++ b/services/client_info/client_info.go
@@ -301,7 +301,7 @@ func (self *ClientInfoManager) Start(
 			defer wg.Done()
 
 			// When we teardown write the data to storage if needed.
-			defer self.lru.Purge()
+			defer self.lru.Flush()
 
 			for {
 				select {
@@ -544,7 +544,7 @@ func (self *ClientInfoManager) FlushAll() {
 }
 
 func (self *ClientInfoManager) Clear() {
-	self.lru.Purge()
+	self.lru.Flush()
 }
 
 func (self *ClientInfoManager) Remove(ctx context.Context, client_id string) {

--- a/vql/common/yara.go
+++ b/vql/common/yara.go
@@ -108,7 +108,7 @@ func (self YaraScanPlugin) Call(
 		rules, err := getYaraRules(arg.Key, arg.Namespace, arg.Rules,
 			arg.YaraVariables, scope)
 		if err != nil {
-			scope.Log("proc_yara: %v", err)
+			scope.Log("yara: %v", err)
 			return
 		}
 


### PR DESCRIPTION
* More fixes for Windows.System.VAD

Caching of process accessor readers helps to alleviate extra work in opening each process.

* Close process handles when query ends.

* Added reference counting of process readers

Ensures we do not leak handles