### PR TITLE
Correct uninstall args for RPM based agents

### DIFF
--- a/artifacts/definitions/Admin/Client/Uninstall.yaml
+++ b/artifacts/definitions/Admin/Client/Uninstall.yaml
@@ -69,7 +69,7 @@ sources:
     query:  |
       SELECT * FROM if(condition=ReallyDoIt,
       then={
-        SELECT * FROM execve(argv=["rpm", "--remove", "velociraptor-client"])
+        SELECT * FROM execve(argv=["rpm", "--erase", "velociraptor-client"])
       })
 
   - name: MacOS


### PR DESCRIPTION
RPM `--remove` argument does not exist; the argument `--erase` should be used instead.