### PR TITLE
Add rate limits for client connections.

### DIFF
--- a/actions/query_log.go
+++ b/actions/query_log.go
@@ -1,3 +1,10 @@
+/*
+
+Keeps an in memory log of recent queries that can be used for
+debugging the client.
+
+*/
+
 package actions
 
 import (

--- a/http_comms/sender.go
+++ b/http_comms/sender.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/crypto"
@@ -255,6 +256,7 @@ func NewSender(
 	enroller *Enroller,
 	logger *logging.LogContext,
 	name string,
+	limiter *rate.Limiter,
 	handler string,
 	on_exit func(),
 	clock utils.Clock) (*Sender, error) {
@@ -264,8 +266,10 @@ func NewSender(
 	}
 
 	result := &Sender{
-		NotificationReader: NewNotificationReader(config_obj, connector, manager,
-			executor, enroller, logger, name, handler, on_exit, clock),
+		NotificationReader: NewNotificationReader(
+			config_obj, connector, manager,
+			executor, enroller, logger, name,
+			limiter, handler, on_exit, clock),
 		ring_buffer: ring_buffer,
 
 		// Urgent buffer is an in memory ring buffer to handle

--- a/http_comms/sender_test.go
+++ b/http_comms/sender_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
@@ -150,7 +151,8 @@ func testRingBuffer(
 
 	sender, err := NewSender(
 		config_obj, connector, manager, exe, rb, nil, /* enroller */
-		logger, "Sender", "control", nil, &utils.RealClock{})
+		logger, "Sender", rate.NewLimiter(rate.Inf, 0),
+		"control", nil, &utils.RealClock{})
 	assert.NoError(t, err)
 
 	sender.Start(subctx, wg)

--- a/responder/flow_manager.go
+++ b/responder/flow_manager.go
@@ -185,7 +185,12 @@ func (self *FlowManager) NewQueryContext(flow_id string) (
 		flow_context = &FlowContext{}
 	}
 	flow_context.AddQuery(result)
-	self.in_flight[flow_id] = flow_context
+
+	// All Monitoring queries share the same session id, so we create
+	// a different flow context cache for each query.
+	if flow_id != constants.MONITORING_WELL_KNOWN_FLOW {
+		self.in_flight[flow_id] = flow_context
+	}
 
 	return ctx, func() { self.closeContext(result) }
 }

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -253,6 +253,7 @@ func (self *Responder) flushLogMessages(ctx context.Context) {
 			NumberOfRows: count,
 			Jsonl:        string(buf),
 			ErrorMessage: error_message,
+			Artifact:     self.Artifact,
 		}})
 }
 

--- a/server/comms.go
+++ b/server/comms.go
@@ -133,8 +133,17 @@ func PrepareFrontendMux(
 	base := config_obj.Frontend.BasePath
 	router.Handle(base+"/healthz", healthz(server_obj))
 	router.Handle(base+"/server.pem", server_pem(config_obj))
+
+	// DEPRECATED: These are the old handler names - not great
+	// but here for backwards compatibility.
 	router.Handle(base+"/control", RecordHTTPStats(control(config_obj, server_obj)))
 	router.Handle(base+"/reader", RecordHTTPStats(reader(server_obj)))
+
+	// Send a message to the server.
+	router.Handle(base+"/send_messages", RecordHTTPStats(control(config_obj, server_obj)))
+
+	// Receive new messages from the server.
+	router.Handle(base+"/receive_messages", RecordHTTPStats(reader(server_obj)))
 
 	// Publicly accessible part of the filestore. NOTE: this
 	// does not have to be a physical directory - it is served


### PR DESCRIPTION
This rate limited is a fallback to avoid situations where a connection loop might occur without limits. The limiter ensures the clients do not connect more frequently than the max poll interval, even if they were just disconnected.