### PR TITLE
Allow for dynamic base_path

### DIFF
--- a/gui/velociraptor/src/components/core/api-service.jsx
+++ b/gui/velociraptor/src/components/core/api-service.jsx
@@ -95,6 +95,10 @@ axiosRetry(axios, {
 });
 
 let base_path = window.base_path || "";
+if (base_path === "") {
+  let pname = window.location.pathname;
+  base_path = pname.replace(/\/app.*$/, "");
+}
 
 // In development we only support running from /
 if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
If running the velociraptor gui behind a proxy that is modifying the url dynamically, using a static `base_path` value won't work. Added a check for not having a `base_path` explicitly set and instead building it from the current location path.