### PR TITLE
http_comms: create ring buffer temporary file in the same directory

### DIFF
--- a/http_comms/ring_buffer.go
+++ b/http_comms/ring_buffer.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -384,7 +384,7 @@ func NewFileBasedRingBuffer(
 	// (`C:\Program Files\Velociraptor\Tools`) so symlink attacks are
 	// mitigated but in case Velociraptor is misconfigured we are
 	// extra careful.
-	fd, err := ioutil.TempFile(".", "")
+	fd, err := os.CreateTemp(filepath.Dir(filename), "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Commit 591a883674c (Several security related bugfixes.  (#1962)) included a fix for a symlink race.  It uses the CWD to create a temporary file and then moves it into place.  When Velociraptor is started from systemd, the CWD will be /.  This is safe, but some newer varieties of Linux systems have a read-only root.  Moreover, even if /tmp were used, it's possible that /tmp and the target file are on different file systems.

This commit uses the directory of the target filename to create the temp file instead.