### PR TITLE
utils/time.jsx: fix handling of nanosecond-resolution timestamps

### DIFF
--- a/gui/velociraptor/src/components/utils/time.jsx
+++ b/gui/velociraptor/src/components/utils/time.jsx
@@ -18,6 +18,10 @@ const renderToolTip = (props, ts) => {
 };
 
 const digitsRegex = /^[0-9.]+$/;
+//
+// The log contains timestamps like: '2022-08-19 23:34:53.165297306 +0000 UTC'
+// Date() can only handle '2022-08-19 23:34:53.165+00:00'
+const timestampWithNanoRegex = /(\d{4}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2}\.\d{3})\d+ ([-+]\d{2})(\d{2})/;
 
 // Try hard to convert the value into a proper timestamp.
 export const ToStandardTime = value => {
@@ -27,7 +31,6 @@ export const ToStandardTime = value => {
         // (can happen with 64 bit ints which JSON does not support).
         if (digitsRegex.test(value)) {
             value = parseFloat(value);
-
         } else {
             // Maybe an iso string
             let parsed = new Date(value);
@@ -36,6 +39,16 @@ export const ToStandardTime = value => {
                 // Ok this is fine.
                 return parsed;
             };
+
+	    const m = value.match(timestampWithNanoRegex);
+	    if (m) {
+		let newDate = m[1] + m[2] + ":" + m[3];
+
+		parsed = new Date(newDate);
+		if (!_.isNaN(parsed.getTime())) {
+		    return parsed;
+		}
+	    }
         }
     }
 


### PR DESCRIPTION
The logging infrastructure produces timestamps with nanosecond resolution but the javascript spec for the Date() API only handles up to millisecond resolution (as well as a different format for timezones).

This results in the log table showing "Invalid date" under Timestamp and causes an uncaught exception in the tooltip that shows relative time.

This commit strips out the additional digits and reformats the time zone to the expected format:
2022-08-19 19:56:29.261590674 +0000 UTC becomes 2022-08-19 19:56:29.261+00:00