### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,5 +84,5 @@ jobs:
     - name: StoreBinaries
       uses: actions/upload-artifact@v1
       with:
-        name: Binaries.zip
+        name: Binaries
         path: output


### PR DESCRIPTION
Binaries is uploaded as Binaries.zip.zip currently removing the redundant .zip will output a correctly built binaries folder that should be Binaries.zip