### PR TITLE
Uploads are now deduplicated on store_as_name.

### DIFF
--- a/reporting/container.go
+++ b/reporting/container.go
@@ -340,6 +340,11 @@ func (self *Container) Upload(
 		store_as_name = filename
 	}
 
+	cached, pres := uploads.DeduplicateUploads(scope, store_as_name)
+	if pres {
+		return cached, nil
+	}
+
 	store_path, err := accessors.NewZipFilePath("uploads")
 	if err != nil {
 		return nil, err
@@ -362,6 +367,7 @@ func (self *Container) Upload(
 		self.uploads = append(self.uploads, result)
 		self.mu.Unlock()
 
+		uploads.CacheUploadResult(scope, store_as_name, result)
 		return result, nil
 	}
 
@@ -393,6 +399,7 @@ func (self *Container) Upload(
 	self.stats.TotalUploadedBytes += result.Size
 	self.stats_mu.Unlock()
 
+	uploads.CacheUploadResult(scope, store_as_name, result)
 	return result, nil
 }
 

--- a/services/server_artifacts/fixtures/TestMultiSource.golden
+++ b/services/server_artifacts/fixtures/TestMultiSource.golden
@@ -16,8 +16,8 @@
  "state": 3,
  "status": "Oops\n",
  "artifacts_with_results": [
-  "TestMultiSource/Source2",
-  "TestMultiSource/Source1"
+  "TestMultiSource/Source1",
+  "TestMultiSource/Source2"
  ],
  "query_stats": [
   {

--- a/services/server_artifacts/server_uploader.go
+++ b/services/server_artifacts/server_uploader.go
@@ -49,6 +49,11 @@ func (self *ServerUploader) Upload(
 		store_as_name = filename
 	}
 
+	cached, pres := uploads.DeduplicateUploads(scope, store_as_name)
+	if pres {
+		return cached, nil
+	}
+
 	result, err := self.FileStoreUploader.Upload(ctx, scope, filename,
 		accessor, store_as_name, expected_size,
 		mtime, atime, ctime, btime, reader)
@@ -99,6 +104,8 @@ func (self *ServerUploader) Upload(
 		"System.Upload.Completion",
 		"server", self.session_id,
 	)
+
+	uploads.CacheUploadResult(scope, store_as_name, result)
 	return result, err
 }
 

--- a/uploads/client_uploader.go
+++ b/uploads/client_uploader.go
@@ -18,7 +18,8 @@ import (
 )
 
 var (
-	BUFF_SIZE = int64(1024 * 1024)
+	BUFF_SIZE  = int64(1024 * 1024)
+	UPLOAD_CTX = "__uploads"
 )
 
 // An uploader delivering files from client to server.
@@ -41,6 +42,15 @@ func (self *VelociraptorUploader) Upload(
 	reader io.Reader) (
 	*UploadResponse, error) {
 
+	if store_as_name == nil {
+		store_as_name = filename
+	}
+
+	cached, pres := DeduplicateUploads(scope, store_as_name)
+	if pres {
+		return cached, nil
+	}
+
 	upload_id := self.Responder.NextUploadId()
 
 	// Try to collect sparse files if possible
@@ -48,11 +58,8 @@ func (self *VelociraptorUploader) Upload(
 		ctx, scope, filename, accessor, store_as_name,
 		expected_size, mtime, upload_id, reader)
 	if err == nil {
+		CacheUploadResult(scope, store_as_name, result)
 		return result, nil
-	}
-
-	if store_as_name == nil {
-		store_as_name = filename
 	}
 
 	result = &UploadResponse{
@@ -131,6 +138,8 @@ func (self *VelociraptorUploader) Upload(
 			result.StoredSize = offset
 			result.Sha256 = hex.EncodeToString(sha_sum.Sum(nil))
 			result.Md5 = hex.EncodeToString(md5_sum.Sum(nil))
+
+			CacheUploadResult(scope, store_as_name, result)
 			return result, nil
 		}
 	}

--- a/uploads/fixtures/TestClientUploaderDeduplicateStoreAsName.golden
+++ b/uploads/fixtures/TestClientUploaderDeduplicateStoreAsName.golden
@@ -1,0 +1,31 @@
+{
+ "responses": [
+  {
+   "session_id": "Test23",
+   "request_id": 5,
+   "FileBuffer": {
+    "pathspec": {
+     "path": "TestFile.txt",
+     "accessor": "data"
+    },
+    "size": 11,
+    "stored_size": 11,
+    "data": "SGVsbG8gd29ybGQ="
+   }
+  },
+  {
+   "session_id": "Test23",
+   "request_id": 5,
+   "FileBuffer": {
+    "pathspec": {
+     "path": "TestFile.txt",
+     "accessor": "data"
+    },
+    "offset": 11,
+    "size": 11,
+    "stored_size": 11,
+    "eof": true
+   }
+  }
+ ]
+}

--- a/vql/scope.go
+++ b/vql/scope.go
@@ -21,6 +21,7 @@ package vql
 import (
 	"sync"
 
+	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -44,7 +45,11 @@ func (self *ScopeCache) Set(key string, value interface{}) {
 }
 
 func CacheGet(scope vfilter.Scope, key string) interface{} {
-	any_obj, _ := scope.Resolve(CACHE_VAR)
+	any_obj, pres := scope.Resolve(CACHE_VAR)
+	if !pres {
+		scope.AppendVars(ordereddict.NewDict().
+			Set(CACHE_VAR, NewScopeCache()))
+	}
 	cache, ok := any_obj.(*ScopeCache)
 	if ok {
 		cache.mu.Lock()
@@ -56,7 +61,12 @@ func CacheGet(scope vfilter.Scope, key string) interface{} {
 }
 
 func CacheSet(scope vfilter.Scope, key string, value interface{}) {
-	any_obj, _ := scope.Resolve(CACHE_VAR)
+	any_obj, pres := scope.Resolve(CACHE_VAR)
+	if !pres {
+		scope.AppendVars(ordereddict.NewDict().
+			Set(CACHE_VAR, NewScopeCache()))
+	}
+
 	cache, ok := any_obj.(*ScopeCache)
 	if ok {
 		cache.mu.Lock()


### PR DESCRIPTION
It is often convenient in VQL to repeat the same finding from the same file on multiple rows. But previously each invocation of the upload() function would cause the file to be uploaded again

Although it is possible to work around this using the cache() function it is more useful to only upload the same file once but provide a reference to the upload on each row.

This PR deduplicates the uploads by store_as_name.