### PR TITLE
Refactored event monitoring to not use globals

### DIFF
--- a/actions/events_test.go
+++ b/actions/events_test.go
@@ -174,6 +174,8 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 	label_manager := services.GetLabeler(self.ConfigObj)
 	label_manager.(*labels.Labeler).Clock = self.Clock
 
+	actions.QueryLog.Clear()
+
 	require.NoError(self.T(),
 		label_manager.SetClientLabel(
 			context.Background(), self.ConfigObj, self.client_id, "Foobar"))
@@ -196,7 +198,7 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 
 	// Wait until all the queries are done.
 	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
-		return len(actions.QueryLog.Get()) == 2
+		return len(actions.QueryLog.Get()) > 0
 	})
 
 	// Now check that no updates are performed.

--- a/actions/events_test.go
+++ b/actions/events_test.go
@@ -159,6 +159,7 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
 		return len(actions.QueryLog.Get()) > 0
 	})
+	actions.QueryLog.Clear()
 
 	// We no longer need to update the event table - it is up to date.
 	assert.False(self.T(),
@@ -173,8 +174,6 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 	// advanced.
 	label_manager := services.GetLabeler(self.ConfigObj)
 	label_manager.(*labels.Labeler).Clock = self.Clock
-
-	actions.QueryLog.Clear()
 
 	require.NoError(self.T(),
 		label_manager.SetClientLabel(
@@ -195,11 +194,6 @@ func (self *EventsTestSuite) TestEventTableUpdate() {
 
 	// The new table has 1 queries still since it has not really changed.
 	assert.Equal(self.T(), len(new_message.UpdateEventTable.Event), 1)
-
-	// Wait until all the queries are done.
-	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
-		return len(actions.QueryLog.Get()) > 0
-	})
 
 	// Now check that no updates are performed.
 	actions.QueryLog.Clear()

--- a/api/api.go
+++ b/api/api.go
@@ -891,7 +891,9 @@ func (self *ApiServer) SetServerMonitoringState(
 	}
 	principal := user_record.Name
 
-	permissions := acls.SERVER_ADMIN
+	// Monitoring queries needs same permissions as regular artifact
+	// collections.
+	permissions := acls.COLLECT_SERVER
 	perm, err := services.CheckAccess(org_config_obj, principal, permissions)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf(
@@ -915,7 +917,7 @@ func (self *ApiServer) GetClientMonitoringState(
 	}
 	principal := user_record.Name
 
-	permissions := acls.SERVER_ADMIN
+	permissions := acls.READ_RESULTS
 	perm, err := services.CheckAccess(org_config_obj, principal, permissions)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf(
@@ -950,7 +952,7 @@ func (self *ApiServer) SetClientMonitoringState(
 		return nil, Status(self.verbose, err)
 	}
 	principal := user_record.Name
-	permissions := acls.SERVER_ADMIN
+	permissions := acls.COLLECT_CLIENT
 	perm, err := services.CheckAccess(org_config_obj, principal, permissions)
 	if !perm || err != nil {
 		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf(

--- a/artifacts/testdata/windows/test.config.yaml
+++ b/artifacts/testdata/windows/test.config.yaml
@@ -1,6 +1,6 @@
 Client:
   server_urls:
-    - https://127.0.0.1:8000/
+    - https://127.0.0.1:8/
   ca_certificate:
     -----BEGIN CERTIFICATE-----
     MIIDKjCCAhKgAwIBAgIQF6ez0Fecf/sHLEfqHttIqTANBgkqhkiG9w0BAQsFADAa

--- a/bin/gui.go
+++ b/bin/gui.go
@@ -84,6 +84,7 @@ func doGUI() error {
 		// Frontend only suitable for local client
 		config_obj.Frontend.BindAddress = "127.0.0.1"
 		config_obj.Frontend.BindPort = 8000
+		config_obj.Frontend.DoNotCompressArtifacts = true
 
 		// Client configuration.
 		config_obj.Client.ServerUrls = []string{"https://localhost:8000/"}

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,6 @@ func GetDefaultConfig() *config_proto.Config {
 			GRPCPoolMaxSize: 100,
 			GRPCPoolMaxWait: 60,
 		},
-		Services: &config_proto.ServerServicesConfig{},
 		Datastore: &config_proto.DatastoreConfig{
 			Implementation: "FileBaseDataStore",
 

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2985,6 +2985,25 @@
     type: bool
     description: This call will clear previous mocks for this plugin
   category: utils
+- name: mock_clear
+  description: Resets all mocks.
+  type: Function
+- name: mock_replay
+  description: Replay recorded calls on a mock.
+  type: Function
+  args:
+  - name: plugin
+    type: string
+    description: The plugin to mock
+  - name: function
+    type: string
+    description: The function to mock
+  - name: expected_calls
+    type: int
+    description: How many times plugin should be called
+  - name: clear
+    type: bool
+    description: This call will clear previous mocks for this plugin
 - name: modules
   description: Enumerate Loaded DLLs.
   type: Plugin
@@ -3899,6 +3918,9 @@
   - name: path_type
     type: string
     description: Type of path this is (windows,linux,registry,ntfs).
+  - name: accessor
+    type: string
+    description: The accessor to use to parse the path with
   category: plugin
 - name: pipe
   description: |
@@ -4788,8 +4810,7 @@
     description: The accessor to use
   - name: regex
     type: string
-    description: The split regular expression (e.g. a comma)
-    required: true
+    description: The split regular expression (e.g. a comma, default whitespace)
   - name: columns
     type: string
     description: If the first row is not the headers, this arg must provide a list
@@ -4801,6 +4822,12 @@
   - name: count
     type: int
     description: Only split into this many columns if possible.
+  - name: record_regex
+    type: string
+    description: 'A regex to split data into records (default '
+  - name: buffer_size
+    type: int
+    description: Maximum size of line buffer (default 64kb).
   category: parsers
 - name: splunk_upload
   description: Upload rows to splunk.
@@ -5219,6 +5246,10 @@
     description: The PID to get the token for.
     required: true
   category: windows
+- name: trace
+  description: Upload a trace file.
+  type: Function
+  version: 1
 - name: unhex
   description: |
     Apply hex decoding to the string.
@@ -5492,6 +5523,9 @@
   - name: flow_id
     type: string
     description: A flow ID (client or server artifacts)
+  - name: hunt_id
+    type: string
+    description: A hunt ID
   category: server
 - name: url
   description: |

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -14,7 +14,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/config"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
-	"www.velocidex.com/golang/velociraptor/responder"
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vtesting"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
@@ -24,16 +23,6 @@ import (
 
 type ExecutorTestSuite struct {
 	test_utils.TestSuite
-}
-
-func (self *ExecutorTestSuite) SetupTest() {
-	self.TestSuite.SetupTest()
-
-	err := self.Sm.Start(responder.StartFlowManager)
-	assert.NoError(self.T(), err)
-
-	flow_manager := responder.GetFlowManager(self.Ctx, self.ConfigObj)
-	flow_manager.ResetForTests()
 }
 
 // Cancelling the flow multiple times will cause a single

--- a/executor/flows.go
+++ b/executor/flows.go
@@ -17,8 +17,7 @@ func (self *ClientExecutor) ProcessFlowRequest(
 	ctx context.Context,
 	config_obj *config_proto.Config, req *crypto_proto.VeloMessage) {
 
-	flow_manager := responder.GetFlowManager(ctx, config_obj)
-	flow_context := flow_manager.FlowContext(self.Outbound, req)
+	flow_context := self.flow_manager.FlowContext(self.Outbound, req)
 	defer flow_context.Close()
 
 	// Control concurrency for the entire collection at once. If a

--- a/executor/services.go
+++ b/executor/services.go
@@ -1,20 +1,11 @@
 package executor
 
-import (
-	"context"
-	"sync"
-
-	"www.velocidex.com/golang/velociraptor/actions"
-	"www.velocidex.com/golang/velociraptor/config"
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
-	"www.velocidex.com/golang/velociraptor/logging"
-)
-
+/*
 func StartEventTableService(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config,
+	exe *ClientExecutor,
 	output_chan chan *crypto_proto.VeloMessage) error {
 
 	logger := logging.GetLogger(config_obj, &logging.ClientComponent)
@@ -26,7 +17,7 @@ func StartEventTableService(
 	writeback, _ := config.GetWriteback(config_obj.Client)
 	if writeback != nil && writeback.EventQueries != nil {
 		actions.UpdateEventTable{}.Run(config_obj, ctx,
-			output_chan, writeback.EventQueries)
+			exe.MonitoringManager(), output_chan, writeback.EventQueries)
 	}
 
 	logger.Info("<green>Starting</> event query service with version %v.",
@@ -34,3 +25,4 @@ func StartEventTableService(
 
 	return nil
 }
+*/

--- a/executor/testutils.go
+++ b/executor/testutils.go
@@ -3,23 +3,49 @@ package executor
 import (
 	"context"
 
+	"www.velocidex.com/golang/velociraptor/actions"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
+	"www.velocidex.com/golang/velociraptor/responder"
 )
 
-type TestExecutor struct{}
+type _TestExecutor struct {
+	flow_manager  *responder.FlowManager
+	event_manager *actions.EventTable
+}
 
-func (self *TestExecutor) ClientId() string {
+func NewTestExecutor() *_TestExecutor {
+	return &_TestExecutor{
+		event_manager: &actions.EventTable{},
+	}
+}
+
+func NewClientExecutorForTests() *ClientExecutor {
+	return &ClientExecutor{
+		Outbound:      make(chan *crypto_proto.VeloMessage),
+		Inbound:       make(chan *crypto_proto.VeloMessage),
+		event_manager: &actions.EventTable{},
+	}
+}
+
+func (self *_TestExecutor) FlowManager() *responder.FlowManager {
+	return nil
+}
+
+func (self *_TestExecutor) EventManager() *actions.EventTable {
+	return nil
+}
+
+func (self *_TestExecutor) ClientId() string {
 	return ""
 }
 
-func (self *TestExecutor) ReadFromServer() *crypto_proto.VeloMessage {
+func (self *_TestExecutor) ReadFromServer() *crypto_proto.VeloMessage {
 	return nil
 }
-func (self *TestExecutor) SendToServer(message *crypto_proto.VeloMessage) {}
-func (self *TestExecutor) ProcessRequest(
-	ctx context.Context,
+func (self *_TestExecutor) SendToServer(message *crypto_proto.VeloMessage) {}
+func (self *_TestExecutor) ProcessRequest(ctx context.Context,
 	message *crypto_proto.VeloMessage) {
 }
-func (self *TestExecutor) ReadResponse() <-chan *crypto_proto.VeloMessage {
+func (self *_TestExecutor) ReadResponse() <-chan *crypto_proto.VeloMessage {
 	return nil
 }

--- a/http_comms/comms_test.go
+++ b/http_comms/comms_test.go
@@ -186,10 +186,7 @@ func (self *CommsTestSuite) TestAbort() {
 	urls := []string{self.frontend1.URL}
 
 	// Not a real executor but we can emulate closing channels.
-	exec := &executor.ClientExecutor{
-		Outbound: make(chan *crypto_proto.VeloMessage),
-		Inbound:  make(chan *crypto_proto.VeloMessage),
-	}
+	exec := executor.NewClientExecutorForTests()
 
 	wg := &sync.WaitGroup{}
 	defer wg.Wait()
@@ -236,7 +233,7 @@ func (self *CommsTestSuite) TestEnrollment() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	self.frontend1.responses = []*Response{
@@ -273,7 +270,7 @@ func (self *CommsTestSuite) TestServerError() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	self.frontend1.responses = []*Response{
@@ -321,7 +318,7 @@ func (self *CommsTestSuite) TestMultiFrontends() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	// Frontend1 will return 500 all the time.
@@ -382,7 +379,7 @@ func (self *CommsTestSuite) TestMultiFrontendsAllIsBorked() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	// Frontend1 will return 500 all the time.
@@ -456,7 +453,7 @@ func (self *CommsTestSuite) TestMultiFrontendsIntermittantFailure() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	// FE1 is not completely off just loaded - so initial
@@ -516,7 +513,7 @@ func (self *CommsTestSuite) TestMultiFrontendsHeavyFailure() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	// FE1 is not completely off just loaded - so initial
@@ -590,7 +587,7 @@ func (self *CommsTestSuite) TestMultiFrontendRedirect() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	// FE1 is not completely off just loaded - so initial
@@ -657,7 +654,7 @@ func (self *CommsTestSuite) TestMultiFrontendRedirectWithErrors() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	self.frontend1.responses = []*Response{
@@ -751,7 +748,7 @@ func (self *CommsTestSuite) TestMultiRedirects() {
 
 	crypto_manager := &crypto_test.NullCryptoManager{}
 	communicator, err := NewHTTPCommunicator(ctx, self.config_obj, crypto_manager,
-		&executor.TestExecutor{}, urls, nil, clock)
+		executor.NewTestExecutor(), urls, nil, clock)
 	assert.NoError(self.T(), err)
 
 	self.frontend1.responses = []*Response{

--- a/http_comms/sender.go
+++ b/http_comms/sender.go
@@ -250,7 +250,7 @@ func (self *Sender) Start(
 func NewSender(
 	config_obj *config_proto.Config,
 	connector IConnector,
-	manager crypto.ICryptoManager,
+	crypto_manager crypto.ICryptoManager,
 	executor executor.Executor,
 	ring_buffer IRingBuffer,
 	enroller *Enroller,
@@ -267,7 +267,7 @@ func NewSender(
 
 	result := &Sender{
 		NotificationReader: NewNotificationReader(
-			config_obj, connector, manager,
+			config_obj, connector, crypto_manager,
 			executor, enroller, logger, name,
 			limiter, handler, on_exit, clock),
 		ring_buffer: ring_buffer,
@@ -275,9 +275,10 @@ func NewSender(
 		// Urgent buffer is an in memory ring buffer to handle
 		// urgent queries. This ensures urgent queries can
 		// skip the buffer ahead of normal queries.
-		urgent_buffer: NewRingBuffer(config_obj, 2*config_obj.Client.MaxUploadSize),
-		release:       make(chan bool),
-		clock:         clock,
+		urgent_buffer: NewRingBuffer(config_obj, executor.FlowManager(),
+			2*config_obj.Client.MaxUploadSize),
+		release: make(chan bool),
+		clock:   clock,
 	}
 
 	return result, nil

--- a/http_comms/sender_test.go
+++ b/http_comms/sender_test.go
@@ -36,6 +36,7 @@ import (
 	crypto_test "www.velocidex.com/golang/velociraptor/crypto/testing"
 	"www.velocidex.com/golang/velociraptor/executor"
 	"www.velocidex.com/golang/velociraptor/logging"
+	"www.velocidex.com/golang/velociraptor/responder"
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vtesting"
 )
@@ -216,7 +217,8 @@ func TestSender(t *testing.T) {
 
 	// Make the ring buffer 10 bytes - this is enough for one
 	// message but no more.
-	rb := NewRingBuffer(config_obj, 10)
+	flow_manager := responder.NewFlowManager(ctx, config_obj)
+	rb := NewRingBuffer(config_obj, flow_manager, 10)
 	testRingBuffer(ctx, rb, config_obj, "0123456789", t)
 }
 
@@ -242,7 +244,8 @@ func TestSenderWithFileBuffer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rb, err := NewFileBasedRingBuffer(ctx, config_obj, logger)
+	flow_manager := responder.NewFlowManager(ctx, config_obj)
+	rb, err := NewFileBasedRingBuffer(ctx, config_obj, flow_manager, logger)
 	require.NoError(t, err)
 
 	testRingBuffer(ctx, rb, config_obj, "0123456789", t)

--- a/http_comms/service.go
+++ b/http_comms/service.go
@@ -29,7 +29,7 @@ func StartHttpCommunicatorService(
 		return nil, err
 	}
 
-	manager, err := crypto_client.NewClientCryptoManager(
+	crypto_manager, err := crypto_client.NewClientCryptoManager(
 		config_obj, []byte(writeback.PrivateKey))
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func StartHttpCommunicatorService(
 	comm, err := NewHTTPCommunicator(
 		ctx,
 		config_obj,
-		manager,
+		crypto_manager,
 		exe,
 		config_obj.Client.ServerUrls,
 		func() { on_error(ctx, config_obj) },

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
@@ -60,6 +61,16 @@ func (self *NotificationPool) IsClientConnected(client_id string) bool {
 	self.mu.Unlock()
 
 	return pres
+}
+
+func (self *NotificationPool) DebugPrint() {
+	self.mu.Lock()
+	fmt.Printf("Clients connected: ")
+	for k := range self.clients {
+		fmt.Printf("%v ", k)
+	}
+	fmt.Printf("\n")
+	self.mu.Unlock()
 }
 
 func (self *NotificationPool) Listen(client_id string) (chan bool, func()) {

--- a/responder/flow_manager.go
+++ b/responder/flow_manager.go
@@ -26,13 +26,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	constants "www.velocidex.com/golang/velociraptor/constants"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
-	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/utils"
-)
-
-var (
-	mu                  sync.Mutex
-	_FlowManagerService *FlowManager
 )
 
 // A Flow Manager runs on the client and keeps track of all flows that
@@ -65,13 +59,6 @@ func NewFlowManager(ctx context.Context,
 		cancelled:  make(map[string]bool),
 	}
 	return result
-}
-
-func (self *FlowManager) ResetForTests() {
-	mu.Lock()
-	defer mu.Unlock()
-
-	_FlowManagerService.in_flight = make(map[string]*FlowContext)
 }
 
 func (self *FlowManager) removeFlowContext(flow_id string) {
@@ -128,30 +115,4 @@ func (self *FlowManager) FlowContext(
 		return flow_context
 	}
 	return flow_context
-}
-
-func GetFlowManager(
-	ctx context.Context, config_obj *config_proto.Config) *FlowManager {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if _FlowManagerService == nil {
-		_FlowManagerService = NewFlowManager(ctx, config_obj)
-	}
-
-	return _FlowManagerService
-}
-
-// Initialize the flow manager service.
-func StartFlowManager(ctx context.Context, wg *sync.WaitGroup,
-	config_obj *config_proto.Config) error {
-	mu.Lock()
-	defer mu.Unlock()
-
-	logger := logging.GetLogger(config_obj, &logging.ClientComponent)
-	logger.Info("<green>Starting</> client flow manager.")
-
-	_FlowManagerService = NewFlowManager(ctx, config_obj)
-
-	return nil
 }

--- a/responder/pool.go
+++ b/responder/pool.go
@@ -26,6 +26,7 @@ import (
 // pool client immediately.
 
 var (
+	mu                       sync.Mutex
 	GlobalPoolEventResponder *PoolEventResponder
 )
 

--- a/responder/testutils.go
+++ b/responder/testutils.go
@@ -22,13 +22,17 @@ func (self *TestResponderType) Close() {
 	self.flow_context.Close()
 }
 
+func (self *TestResponderType) Output() chan *crypto_proto.VeloMessage {
+	return self.output
+}
+
 func TestResponderWithFlowId(
 	config_obj *config_proto.Config, flow_id string) *TestResponderType {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	output_chan, drain := NewMessageDrain(ctx)
 
-	flow_manager := GetFlowManager(ctx, config_obj)
+	flow_manager := NewFlowManager(ctx, config_obj)
 	result := &TestResponderType{
 		FlowResponder: &FlowResponder{
 			ctx:    ctx,

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -271,11 +271,14 @@ func (self *ClientEventTable) setClientMonitoringState(
 		return err
 	}
 
-	notifier, err := services.GetNotifier(config_obj)
-	if err != nil {
-		return err
-	}
+	// This does not happen usually - on when running in GUI mode
+	// because we need low latency there.
 	if config_obj.Defaults.EventChangeNotifyAllClients {
+		notifier, err := services.GetNotifier(config_obj)
+		if err != nil {
+			return err
+		}
+
 		for _, c := range notifier.ListClients() {
 			notifier.NotifyDirectListener(c)
 		}

--- a/startup/client.go
+++ b/startup/client.go
@@ -5,8 +5,6 @@ import (
 
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/executor"
-	"www.velocidex.com/golang/velociraptor/http_comms"
-	"www.velocidex.com/golang/velociraptor/responder"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/orgs"
 )
@@ -16,7 +14,6 @@ import (
 func StartClientServices(
 	ctx context.Context,
 	config_obj *config_proto.Config,
-	exe *executor.ClientExecutor,
 	on_error func(ctx context.Context,
 		config_obj *config_proto.Config)) (*services.Service, error) {
 
@@ -35,24 +32,10 @@ func StartClientServices(
 		return sm, err
 	}
 
-	err = sm.Start(responder.StartFlowManager)
-	if err != nil {
-		return sm, err
-	}
-
 	_, err = orgs.NewOrgManager(sm.Ctx, sm.Wg, sm.Config)
 	if err != nil {
 		return sm, err
 	}
-
-	_, err = http_comms.StartHttpCommunicatorService(
-		ctx, sm.Wg, config_obj, exe, on_error)
-	if err != nil {
-		return sm, err
-	}
-
-	err = executor.StartEventTableService(
-		ctx, sm.Wg, config_obj, exe.Outbound)
 
 	return sm, err
 }

--- a/startup/pool.go
+++ b/startup/pool.go
@@ -37,8 +37,10 @@ func StartPoolClientServices(
 		return err
 	}
 
-	err = executor.StartEventTableService(
-		sm.Ctx, sm.Wg, config_obj, exe.Outbound)
+	/*
+		err = executor.StartEventTableService(
+			sm.Ctx, sm.Wg, config_obj, exe.Outbound)
+	*/
 
 	return nil
 }

--- a/vql/server/downloads/downloads.go
+++ b/vql/server/downloads/downloads.go
@@ -4,7 +4,6 @@ package downloads
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -802,8 +801,6 @@ func generateCombinedResults(
 
 			reader.Close()
 		}
-
-		fmt.Printf("Exported All for Artifact %v\n", artifact_source)
 	}
 
 	return nil

--- a/vql/server/monitoring/add_monitoring.go
+++ b/vql/server/monitoring/add_monitoring.go
@@ -26,7 +26,7 @@ func (self AddClientMonitoringFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_CLIENT)
 	if err != nil {
 		scope.Log("add_client_monitoring: %s", err)
 		return vfilter.Null{}
@@ -189,7 +189,7 @@ func (self AddServerMonitoringFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 	if err != nil {
 		scope.Log("add_server_monitoring: %s", err)
 		return vfilter.Null{}

--- a/vql/server/monitoring/event_monitoring.go
+++ b/vql/server/monitoring/event_monitoring.go
@@ -24,7 +24,7 @@ func (self GetClientMonitoring) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 	if err != nil {
 		scope.Log("get_client_monitoring: %s", err)
 		return vfilter.Null{}
@@ -71,7 +71,7 @@ func (self SetClientMonitoring) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_CLIENT)
 	if err != nil {
 		scope.Log("set_client_monitoring: %s", err)
 		return vfilter.Null{}
@@ -147,7 +147,7 @@ func (self GetServerMonitoring) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 	if err != nil {
 		scope.Log("get_server_monitoring: %s", err)
 		return vfilter.Null{}
@@ -204,7 +204,7 @@ func (self SetServerMonitoring) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 	if err != nil {
 		scope.Log("set_server_monitoring: %s", err)
 		return vfilter.Null{}

--- a/vql/server/monitoring/rm_monitoring.go
+++ b/vql/server/monitoring/rm_monitoring.go
@@ -23,7 +23,7 @@ func (self RemoveClientMonitoringFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_CLIENT)
 	if err != nil {
 		scope.Log("rm_client_monitoring: %s", err)
 		return vfilter.Null{}
@@ -85,7 +85,7 @@ func (self RemoveServerMonitoringFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 	if err != nil {
 		scope.Log("rm_server_monitoring: %s", err)
 		return vfilter.Null{}


### PR DESCRIPTION
Event monitoing and client side flow manager were globals for the client which caused problems when running multiple clients in the same process (e.g. `velociraptor gui` command)

The refactor creates separate instaces that live within the executor allowing multiple different instances to exist simultaneously.

* Also reduced premission requirements for manipulating client event tables to COLLECT_CLIENT (normally given to the investigator role).