### PR TITLE
Bugfix: missing rows in VFS ListDirectory

### DIFF
--- a/actions/vql.go
+++ b/actions/vql.go
@@ -145,7 +145,9 @@ func (self VQLClientAction) StartQuery(
 		ClientConfig: config_obj.Client,
 		// Disable ACLs on the client.
 		ACLManager: acl_managers.NullACLManager{},
-		Env:        ordereddict.NewDict(),
+		Env: ordereddict.NewDict().
+			// Make the session id available in the query.
+			Set("_SessionId", responder.FlowContext().SessionId()),
 		Uploader:   uploader,
 		Repository: repository,
 		Logger:     log.New(&LogWriter{config_obj, responder, ctx}, "", 0),

--- a/artifacts/definitions/System/VFS/DownloadFile.yaml
+++ b/artifacts/definitions/System/VFS/DownloadFile.yaml
@@ -43,7 +43,8 @@ sources:
          then= {
            SELECT OSPath AS Path, Accessor,
               Size, upload(file=OSPath, accessor=Accessor) AS Upload
-           FROM glob(globs="**", root=Components, accessor=Accessor)
+           FROM glob(globs="**", root=Components,
+                     accessor=Accessor, nosymlink=TRUE)
            WHERE Mode.IsRegular
         },
         else={
@@ -57,7 +58,8 @@ sources:
              Upload.Size AS Size,
              Upload.StoredSize AS StoredSize,
              Upload.Sha256 AS Sha256,
-             Upload.Md5 AS Md5
+             Upload.Md5 AS Md5,
+             Path.Components AS _Components
       FROM if(condition=Recursively,
         then={ SELECT * FROM download_recursive},
         else={ SELECT * FROM download_one_file})

--- a/artifacts/definitions/System/VFS/ListDirectory.yaml
+++ b/artifacts/definitions/System/VFS/ListDirectory.yaml
@@ -22,7 +22,9 @@ parameters:
     default: 0
 
 export: |
-      LET VFSGenerator = generate(name="vfs", query={
+      -- Make the generator unique with the session id - so it can
+      -- only be shared by the two sources in this collection.
+      LET VFSGenerator = generate(name="vfs-" + _SessionId, query={
          SELECT * FROM vfs_ls(
             path="/", components=Components,
             accessor=Accessor, depth=Depth)
@@ -41,7 +43,8 @@ sources:
              Mtime as mtime,
              Atime as atime,
              Ctime as ctime,
-             Btime as btime
+             Btime as btime,
+             Idx AS _Idx
       FROM VFSGenerator
       WHERE Stats = NULL
 

--- a/json/csv.go
+++ b/json/csv.go
@@ -47,12 +47,20 @@ func ConvertJSONL(
 	arena := &fastjson.Arena{}
 
 	for serialized := range json_in {
+		if len(serialized) == 0 {
+			continue
+		}
+
+		// Line feed if needed.
+		if serialized[len(serialized)-1] != '\n' {
+			serialized = append(serialized, '\n')
+		}
+
 		// In the special case where we do not need to modify the json
 		// or convert it to csv then we can skip parsing it
 		// alltogether.
 		if extra_data == nil && jsonl_out != nil && csv_out == nil {
 			jsonl_out.Write(serialized)
-			jsonl_out.Write([]byte{'\n'})
 			continue
 		}
 
@@ -71,7 +79,6 @@ func ConvertJSONL(
 			// original JSONL without needing to encode it.
 			if extra_data == nil {
 				jsonl_out.Write(serialized)
-				jsonl_out.Write([]byte{'\n'})
 			} else {
 				jsonl_out.Write(
 					writeJsonObject(arena, obj, extra_keys, extra_value))

--- a/responder/api.go
+++ b/responder/api.go
@@ -34,5 +34,6 @@ type Responder interface {
 	Return(ctx context.Context)
 	Log(ctx context.Context, level string, msg string)
 	NextUploadId() int64
+	FlowContext() *FlowContext
 	Close()
 }

--- a/responder/monitoring.go
+++ b/responder/monitoring.go
@@ -178,6 +178,12 @@ func NewMonitoringResponder(
 	}
 }
 
+func (self *MonitoringResponder) FlowContext() *FlowContext {
+	return &FlowContext{
+		flow_id: "F.Monitoring",
+	}
+}
+
 func (self *MonitoringResponder) AddResponse(message *crypto_proto.VeloMessage) {
 	message.SessionId = "F.Monitoring"
 

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -83,7 +83,10 @@ func (self *FlowResponder) Close() {
 	self.wg.Done()
 }
 
-func (self *FlowResponder) GetFlowContext() *FlowContext {
+func (self *FlowResponder) FlowContext() *FlowContext {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	return self.flow_context
 }
 

--- a/services/vfs_service.go
+++ b/services/vfs_service.go
@@ -31,6 +31,7 @@ type VFSListRow struct {
 	Atime      time.Time         `json:"atime"`
 	Ctime      time.Time         `json:"ctime"`
 	Btime      time.Time         `json:"btime"`
+	Idx        uint64            `json:"idx"`
 }
 
 func GetVFSService(config_obj *config_proto.Config) (VFSService, error) {

--- a/vql/filesystem/vfs.go
+++ b/vql/filesystem/vfs.go
@@ -114,7 +114,7 @@ func listDir(
 
 		case output_chan <- &services.VFSListRow{
 			FullPath:   f.FullPath(),
-			Components: append([]string{}, f.OSPath().Components...),
+			Components: f.OSPath().Components,
 			Accessor:   accessor_name,
 			Data:       f.Data(),
 			Stats:      nil,
@@ -125,6 +125,7 @@ func listDir(
 			Atime:      f.Atime(),
 			Ctime:      f.Ctime(),
 			Btime:      f.Btime(),
+			Idx:        stats.EndIdx,
 		}:
 			stats.EndIdx++
 		}
@@ -132,7 +133,7 @@ func listDir(
 
 	// Send a stats message
 	output_chan <- &services.VFSListRow{
-		Components: append([]string{}, path.Components...),
+		Components: path.Components,
 		Accessor:   accessor_name,
 		Stats: &services.VFSPartition{
 			StartIdx: stats.StartIdx,


### PR DESCRIPTION
When two VFS ListDirectory artifacts were running rows would get mixed up because the generator was named the same and they all used the same one. This can cause rows to be missing in each collection.