### PR TITLE
Store client path components in the uploads metadata

### DIFF
--- a/flows/client_flow_runner.go
+++ b/flows/client_flow_runner.go
@@ -267,6 +267,11 @@ func (self *ClientFlowRunner) FileBuffer(
 			Set("vfs_path", file_path_manager.VisibleVFSPath()).
 			Set("_Components", file_path_manager.Path().Components()).
 			Set("file_size", file_buffer.Size).
+
+			// The client's components and accessor that were used to
+			// upload the file.
+			Set("_accessor", file_buffer.Pathspec.Accessor).
+			Set("_client_components", file_buffer.Pathspec.Components).
 			Set("uploaded_size", file_buffer.StoredSize))
 
 		// Additional row for sparse files
@@ -276,6 +281,8 @@ func (self *ClientFlowRunner) FileBuffer(
 				Set("started", time.Now().UTC().String()).
 				Set("vfs_path", file_path_manager.VisibleVFSPath()+".idx").
 				Set("_Components", file_path_manager.Path().Components()).
+				Set("_accessor", file_buffer.Pathspec.Accessor).
+				Set("_client_components", file_buffer.Pathspec.Components).
 				Set("file_size", file_buffer.Size).
 				Set("uploaded_size", file_buffer.StoredSize))
 		}


### PR DESCRIPTION
This makes it a lot easier to use them later when creating the downloads export. Previously the download code had to derive the client's original components from the filestore components but this is not always possible to do reliably. Carrying the original client's path components through makes it more reliable and easier.