### PR TITLE
Refactored repack functionality into a VQL function

### DIFF
--- a/artifacts/definitions/Server/Internal/ToolDependencies.yaml
+++ b/artifacts/definitions/Server/Internal/ToolDependencies.yaml
@@ -1,0 +1,35 @@
+name: Server.Internal.ToolDependencies
+description: |
+  An internal artifact that defines some tool
+  depenencies. Velociraptor releases for offline collector
+
+tools:
+  - name: VelociraptorWindows
+    github_project: Velocidex/velociraptor
+    github_asset_regex: windows-amd64.exe
+    serve_locally: true
+
+  - name: VelociraptorWindows_x86
+    github_project: Velocidex/velociraptor
+    github_asset_regex: windows-386.exe
+    serve_locally: true
+
+  - name: VelociraptorLinux
+    github_project: Velocidex/velociraptor
+    github_asset_regex: linux-amd64
+    serve_locally: true
+
+  - name: VelociraptorDarwin
+    github_project: Velocidex/velociraptor
+    github_asset_regex: darwin-amd64
+    serve_locally: true
+
+  - name: VelociraptorWindowsMSI
+    github_project: Velocidex/velociraptor
+    github_asset_regex: windows-amd64.msi
+    serve_locally: true
+
+  - name: VelociraptorWindows_x86MSI
+    github_project: Velocidex/velociraptor
+    github_asset_regex: windows-386.msi
+    serve_locally: true

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -8,27 +8,6 @@ description: |
 
 type: SERVER
 
-tools:
-  - name: VelociraptorWindows
-    github_project: Velocidex/velociraptor
-    github_asset_regex: windows-amd64.exe
-    serve_locally: true
-
-  - name: VelociraptorWindows_x86
-    github_project: Velocidex/velociraptor
-    github_asset_regex: windows-386.exe
-    serve_locally: true
-
-  - name: VelociraptorLinux
-    github_project: Velocidex/velociraptor
-    github_asset_regex: linux-amd64
-    serve_locally: true
-
-  - name: VelociraptorDarwin
-    github_project: Velocidex/velociraptor
-    github_asset_regex: darwin-amd64
-    serve_locally: true
-
 parameters:
   - name: OS
     default: Windows
@@ -287,39 +266,6 @@ parameters:
              message="Aborting collection: Failed to upload to cloud bucket!")
           FROM scope()})
 
-  - name: PackageToolsArtifact
-    description: Collects and uploads third party binaries.
-    type: hidden
-    default: |
-      name: PackageToolsArtifact
-      parameters:
-       - name: Binaries
-         type: json_array
-         default: '[]'
-      sources:
-       - query: |
-          LET temp <= tempfile()
-
-          LET uploader = SELECT ToolName,
-                                Upload.StoredName AS Filename,
-                                Upload.sha256 AS ExpectedHash,
-                                Upload.Size AS Size
-          FROM foreach(row=Binaries,
-            query={
-              SELECT _value AS ToolName, upload(file=FullPath, name=Name) AS Upload
-              FROM Artifact.Generic.Utils.FetchBinary(
-                   ToolName=_value, SleepDuration='0',
-                   ToolInfo=inventory_get(tool=_value))
-            })
-
-          // Flush the entire query into the inventory file.
-          LET _ <= SELECT * FROM write_csv(filename=temp, query=uploader)
-
-          // Now upload it.
-          SELECT upload(file=temp, name="inventory.csv") AS Inventory,
-                 read_file(filename=temp) AS Data
-          FROM scope()
-
   - name: FetchBinaryOverride
     type: hidden
     description: |
@@ -348,20 +294,15 @@ parameters:
 
 sources:
   - query: |
-      LET Payload <= tempfile(extension=".zip")
       LET Binaries <= SELECT * FROM foreach(
           row={
              SELECT tools FROM artifact_definitions(names=artifacts)
           }, query={
              SELECT * FROM foreach(row=tools,
              query={
-              SELECT name AS Binary FROM scope()
+                SELECT name AS Binary FROM scope()
              })
           }) GROUP BY Binary
-
-      // Get some tempfiles to work with.
-      LET Config <= tempfile()
-      LET Destination <= tempfile()
 
       // Choose the right target binary depending on the target OS
       LET tool_name = SELECT * FROM switch(
@@ -373,24 +314,12 @@ sources:
            WHERE NOT log(message="Unknown target type " + OS) }
       )
 
-      // Repack this binary.
-      LET _ <= log(message="Will get tool " + tool_name[0].Type)
-
-      LET target_binary <= SELECT FullPath, Name
-         FROM Artifact.Generic.Utils.FetchBinary(
-            ToolName=tool_name[0].Type, SleepDuration="0",
-            ToolInfo=inventory_get(tool=tool_name[0].Type))
-         WHERE log(message="Target binary " + Name + " is at " + FullPath)
+      LET Target <= tool_name[0].Type
 
       // This is what we will call it.
       LET CollectorName <= format(
           format='Collector_%v',
-          args=[target_binary[0].Name, ])
-
-      // Create a zip file with the binaries in it.
-      LET _ <= SELECT * FROM collect(artifacts="PackageToolsArtifact",
-         output=Payload, args=dict(PackageToolsArtifact=dict(Binaries=Binaries.Binary)),
-         artifact_definitions=PackageToolsArtifact)
+          args=inventory_get(tool=Target).Definition.filename)
 
       LET CollectionArtifact <= SELECT Value FROM switch(
         a = { SELECT CommonCollections + StandardCollection AS Value
@@ -423,6 +352,7 @@ sources:
          else=encryption_args
       )
 
+      -- Add custom definition if needed. Built in definitions are not added
       LET definitions <= SELECT * FROM chain(
       a = { SELECT name, description, tools, parameters, sources
             FROM artifact_definitions(names=artifacts)
@@ -489,26 +419,12 @@ sources:
           artifact_definitions=definitions)
       )
 
-      LET me <= SELECT Exe FROM info()
-                WHERE log(message="My binary is " + Exe)
-
-      // Copy the configuration to a temp file and shell out to our
-      // binary to repack it.
-      LET repack_step = SELECT upload(
-           file=Destination,
-           accessor="file",
-           name=CollectorName) AS Binary,
-           timestamp(epoch=now()) As CreationTime
-      FROM execve(argv=[
-        me[0].Exe, "config", "repack",
-        "--exe", target_binary[0].FullPath,
-        "--append", Payload,
-        copy(dest=Config,
-             accessor='data',
-             filename=serialize(format='json', item=autoexec)),
-        Destination ], length=1000000)
-      WHERE log(message="Creating config on " + Config) AND log(message=Stderr)
+      // Do the actual repacking.
+      LET repack_step = repack(
+           upload_name=CollectorName,
+           target=tool_name[0].Type,
+           binaries=Binaries.Binary,
+           config=serialize(format='json', item=autoexec))
 
       // Only actually run stuff if everything looks right.
-      SELECT * FROM if(condition=autoexec AND target_binary AND me[0].Exe,
-         then=repack_step)
+      SELECT repack_step FROM scope()

--- a/artifacts/definitions/Server/Utils/CreateMSI.yaml
+++ b/artifacts/definitions/Server/Utils/CreateMSI.yaml
@@ -1,0 +1,26 @@
+name: Server.Utils.CreateMSI
+description: |
+  Build an MSI ready for deployment in the current org.
+
+type: SERVER
+
+parameters:
+  - name: AlsoBuild_x86
+    description: Also build 32 bit MSI for deployment.
+    type: bool
+
+sources:
+- query: |
+    LET Build(Target) = repack(
+        upload_name=format(
+          format='Org_%v_%v',
+          args=[org().name, inventory_get(tool=Target).Definition.filename]),
+        target=Target,
+        config=serialize(format='yaml', item=org()._client_config))
+
+    SELECT * FROM chain(a={
+       SELECT Build(Target="VelociraptorWindowsMSI") FROM scope()
+    }, b={
+       SELECT Build(Target="VelociraptorWindows_x86MSI") FROM scope()
+       WHERE AlsoBuild_x86
+    })

--- a/artifacts/testdata/server/testcases/tools.out.yaml
+++ b/artifacts/testdata/server/testcases/tools.out.yaml
@@ -22,7 +22,23 @@ SELECT inventory_add(tool='Autorun_amd64', url='https://storage.googleapis.com/g
   "inventory_get(tool='Autorun_amd64')": {
    "Tool_Autorun_amd64_HASH": "083d7eee4ed40a3e5a35675503b0b6be0cb627b4cb1009d185a558a805f64153",
    "Tool_Autorun_amd64_FILENAME": "autorunsc_x64.exe",
-   "Tool_Autorun_amd64_URL": "https://storage.googleapis.com/go.velocidex.com/autorunsc.exe"
+   "Tool_Autorun_amd64_URL": "https://storage.googleapis.com/go.velocidex.com/autorunsc.exe",
+   "Definition": {
+    "name": "Autorun_amd64",
+    "url": "https://storage.googleapis.com/go.velocidex.com/autorunsc.exe",
+    "admin_override": true,
+    "filestore_path": "affbb298885d99a7569ef9ec463bbfbf9db112a11cec65cf78ec8657ab78950a",
+    "filename": "autorunsc_x64.exe",
+    "hash": "083d7eee4ed40a3e5a35675503b0b6be0cb627b4cb1009d185a558a805f64153",
+    "versions": [
+     {
+      "name": "Autorun_amd64",
+      "url": "https://live.sysinternals.com/tools/autorunsc64.exe",
+      "serve_locally": true,
+      "artifact": "Windows.Sysinternals.Autoruns"
+     }
+    ]
+   }
   }
  }
 ]SELECT inventory_add(tool='Autorun_amd64', serve_locally=TRUE, url='https://storage.googleapis.com/go.velocidex.com/autorunsc.exe', hash='083d7eee4ed40a3e5a35675503b0b6be0cb627b4cb1009d185a558a805f64153', filename='autorunsc_x64.exe') FROM scope()[
@@ -49,7 +65,25 @@ SELECT inventory_add(tool='Autorun_amd64', url='https://storage.googleapis.com/g
   "inventory_get(tool='Autorun_amd64')": {
    "Tool_Autorun_amd64_HASH": "083d7eee4ed40a3e5a35675503b0b6be0cb627b4cb1009d185a558a805f64153",
    "Tool_Autorun_amd64_FILENAME": "autorunsc_x64.exe",
-   "Tool_Autorun_amd64_URL": "https://127.0.0.1:8/public/affbb298885d99a7569ef9ec463bbfbf9db112a11cec65cf78ec8657ab78950a"
+   "Tool_Autorun_amd64_URL": "https://127.0.0.1:8/public/affbb298885d99a7569ef9ec463bbfbf9db112a11cec65cf78ec8657ab78950a",
+   "Definition": {
+    "name": "Autorun_amd64",
+    "url": "https://storage.googleapis.com/go.velocidex.com/autorunsc.exe",
+    "serve_locally": true,
+    "admin_override": true,
+    "serve_url": "https://127.0.0.1:8/public/affbb298885d99a7569ef9ec463bbfbf9db112a11cec65cf78ec8657ab78950a",
+    "filestore_path": "affbb298885d99a7569ef9ec463bbfbf9db112a11cec65cf78ec8657ab78950a",
+    "filename": "autorunsc_x64.exe",
+    "hash": "083d7eee4ed40a3e5a35675503b0b6be0cb627b4cb1009d185a558a805f64153",
+    "versions": [
+     {
+      "name": "Autorun_amd64",
+      "url": "https://live.sysinternals.com/tools/autorunsc64.exe",
+      "serve_locally": true,
+      "artifact": "Windows.Sysinternals.Autoruns"
+     }
+    ]
+   }
   }
  }
 ]SELECT inventory_add(tool="FooBar", file=srcDir+"/artifacts/testdata/files/yara_test.txt") FROM scope()[
@@ -76,7 +110,16 @@ SELECT inventory_add(tool='Autorun_amd64', url='https://storage.googleapis.com/g
   "inventory_get(tool=\"FooBar\")": {
    "Tool_FooBar_HASH": "f03278c10a41adcc97f24a612a680e7aa43efb461b337fef3d2a3d47b51e77bb",
    "Tool_FooBar_FILENAME": "yara_test.txt",
-   "Tool_FooBar_URL": "https://127.0.0.1:8/public/1c21ee4d8609f81482dc0a78c641e4586488a9fd562ee28eec25e448a9d0b2e1"
+   "Tool_FooBar_URL": "https://127.0.0.1:8/public/1c21ee4d8609f81482dc0a78c641e4586488a9fd562ee28eec25e448a9d0b2e1",
+   "Definition": {
+    "name": "FooBar",
+    "serve_locally": true,
+    "admin_override": true,
+    "serve_url": "https://127.0.0.1:8/public/1c21ee4d8609f81482dc0a78c641e4586488a9fd562ee28eec25e448a9d0b2e1",
+    "filestore_path": "1c21ee4d8609f81482dc0a78c641e4586488a9fd562ee28eec25e448a9d0b2e1",
+    "filename": "yara_test.txt",
+    "hash": "f03278c10a41adcc97f24a612a680e7aa43efb461b337fef3d2a3d47b51e77bb"
+   }
   }
  }
 ]

--- a/bin/allowlist.go
+++ b/bin/allowlist.go
@@ -148,6 +148,7 @@ var (
 		"rate",
 		"read_file",
 		"relpath",
+		"repack",
 		"remap",
 		"rm_client_monitoring",
 		"rot13",

--- a/bin/binary_test.go
+++ b/bin/binary_test.go
@@ -114,6 +114,8 @@ func TestAutoexec(t *testing.T) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
+	os.Chmod(exe.Name(), 0755)
+
 	// Run the repacked binary with no args - it should run the
 	// `artifacts list` command.
 	cmd = exec.Command(exe.Name())
@@ -380,6 +382,8 @@ func TestGenerateConfigWithMerge(t *testing.T) {
 	cmd = exec.Command(binary, "config", "repack", config_file.Name(), exe.Name())
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err)
+
+	os.Chmod(exe.Name(), 0755)
 
 	// Run the repacked binary with invalid environ - config
 	// should come from embedded.

--- a/bin/collector_test.go
+++ b/bin/collector_test.go
@@ -244,7 +244,7 @@ func (self *CollectorTestSuite) TearDownSuite() {
 	self.test_server.Close()
 }
 
-func (self *CollectorTestSuite) TestCollector() {
+func (self *CollectorTestSuite) TestCollectorPlain() {
 	t := self.T()
 
 	// Change into the tmpdir
@@ -306,7 +306,7 @@ func (self *CollectorTestSuite) TestCollector() {
 	for _, f := range r.File {
 		fmt.Printf("Contents of collector:  %s (%v bytes)\n",
 			f.Name, f.UncompressedSize)
-		if strings.HasPrefix(f.Name, "uploads/file/Collector") {
+		if strings.HasPrefix(f.Name, "uploads/scope/Collector") {
 			fmt.Printf("Extracting %v to %v\n", f.Name, output_executable)
 
 			rc, err := f.Open()
@@ -432,7 +432,7 @@ func (self *CollectorTestSuite) TestCollectorEncrypted() {
 	for _, f := range r.File {
 		fmt.Printf("Contents of collector:  %s (%v bytes)\n",
 			f.Name, f.UncompressedSize)
-		if strings.HasPrefix(f.Name, "uploads/file/Collector") {
+		if strings.HasPrefix(f.Name, "uploads/scope/Collector") {
 			fmt.Printf("Extracting %v to %v\n", f.Name, output_executable)
 
 			rc, err := f.Open()

--- a/bin/repack.go
+++ b/bin/repack.go
@@ -20,18 +20,18 @@
 package main
 
 import (
-	"bytes"
-	"compress/zlib"
-	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
-	"regexp"
+	"path/filepath"
 
-	errors "github.com/go-errors/errors"
-	"www.velocidex.com/golang/velociraptor/config"
-	logging "www.velocidex.com/golang/velociraptor/logging"
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
+	"www.velocidex.com/golang/velociraptor/uploads"
+	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
+	"www.velocidex.com/golang/vfilter"
 )
 
 var (
@@ -46,7 +46,7 @@ var (
 
 	repack_command_config = repack_command.Arg(
 		"config_file", "The filename to write into the binary.").
-		Required().String()
+		Required().File()
 
 	repack_command_append = repack_command.Flag(
 		"append", "If provided we append the file to the output binary.").
@@ -55,16 +55,21 @@ var (
 	repack_command_output = repack_command.Arg(
 		"output", "The filename to write the repacked binary.").
 		Required().String()
-
-	embedded_re = regexp.MustCompile(`#{3}<Begin Embedded Config>\r?\n`)
-
-	embedded_msi_re = regexp.MustCompile(`## Velociraptor client configuration`)
 )
 
 func doRepack() error {
-	config_obj, err := new(config.Loader).
-		WithFileLoader(*repack_command_config).
-		WithVerbose(true).
+	if *repack_command_exe == "" {
+		*repack_command_exe, _ = os.Executable()
+	}
+
+	// Read the config file
+	config_data, err := ioutil.ReadAll(*repack_command_config)
+	if err != nil {
+		return err
+	}
+
+	config_obj, err := makeDefaultConfigLoader().
+		WithFileLoader(*config_path).
 		LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
@@ -80,204 +85,50 @@ func doRepack() error {
 		return err
 	}
 
-	logger := logging.GetLogger(config_obj, &logging.ToolComponent)
-
-	config_fd, err := os.Open(*repack_command_config)
+	output_path, err := filepath.Abs(*repack_command_output)
 	if err != nil {
-		return fmt.Errorf("Unable to open config file: %w", err)
+		return err
+	}
+	builder := services.ScopeBuilder{
+		Config:     sm.Config,
+		ACLManager: acl_managers.NewRoleACLManager(sm.Config, "administrator"),
+		Uploader: &uploads.FileBasedUploader{
+			UploadDir: filepath.Dir(output_path),
+		},
+		Logger: log.New(&LogWriter{sm.Config}, "", 0),
+		Env: ordereddict.NewDict().
+			Set("ConfigData", config_data).
+			Set("Exe", *repack_command_exe).
+			Set("UploadName", filepath.Base(output_path)),
 	}
 
-	config_data, err := ioutil.ReadAll(config_fd)
+	query := `
+       SELECT repack(exe=Exe, accessor="file",
+          config=ConfigData, upload_name=UploadName) AS RepackInfo
+       FROM scope()
+`
+
+	manager, err := services.GetRepositoryManager(config_obj)
 	if err != nil {
-		return fmt.Errorf("Unable to open config file: %w", err)
+		return err
 	}
+	scope := manager.BuildScope(builder)
+	defer scope.Close()
 
-	// Validate the config file.
-	os.Setenv("VELOCIRAPTOR_CONFIG", string(config_data))
-	_, err = new(config.Loader).
-		WithEnvLiteralLoader("VELOCIRAPTOR_CONFIG").
-		LoadAndValidate()
+	statements, err := vfilter.MultiParse(query)
 	if err != nil {
-		return fmt.Errorf("Provided config file not valid: %w", err)
+		return err
 	}
 
-	outfd, err := os.OpenFile(*repack_command_output,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		return fmt.Errorf("Unable to create output file: %w", err)
-	}
-
-	if *repack_command_msi != "" {
-		return repackMSI(
-			config_data, *repack_command_msi, outfd, logger)
-	}
-
-	// Compress the string.
-	var b bytes.Buffer
-	w := zlib.NewWriter(&b)
-	_, err = w.Write(config_data)
-	if err != nil {
-		return fmt.Errorf("Unable to write: %w", err)
-	}
-	w.Close()
-
-	if b.Len() > len(config.FileConfigDefaultYaml)-40 {
-		return fmt.Errorf("config file is too large to embed.")
-	}
-
-	config_data = b.Bytes()
-
-	// Now pad to the end of the config.
-	for i := 0; i < len(config.FileConfigDefaultYaml)-40-len(config_data); i++ {
-		config_data = append(config_data, '#')
-	}
-
-	input := *repack_command_exe
-	if input == "" {
-		input, err = os.Executable()
+	out_fd := os.Stdout
+	for _, vql := range statements {
+		err = outputJSON(ctx, scope, vql, out_fd)
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return err
 		}
 	}
 
-	fd, err := os.Open(input)
-	if err != nil {
-		return fmt.Errorf("Unable to open executable: %w", err)
-	}
-	defer fd.Close()
-
-	data, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return fmt.Errorf("Unable to read executable: %w", err)
-	}
-	logger.Info("Read complete binary at %v bytes\n", len(data))
-
-	if *repack_command_append != nil {
-		// A PE file - adjust the size of the .rsrc section to
-		// cover the entire binary.
-		if string(data[0:2]) == "MZ" {
-			stat, err := (*repack_command_append).Stat()
-			if err != nil {
-				return fmt.Errorf("Unable to read appended file: %w", err)
-			}
-
-			end_of_file := int64(len(data)) + stat.Size()
-
-			// This is the IMAGE_SECTION_HEADER.Name which
-			// is also the start of IMAGE_SECTION_HEADER.
-			offset_to_rsrc := bytes.Index(data, []byte(".rsrc"))
-
-			// Found it.
-			if offset_to_rsrc > 0 {
-				// IMAGE_SECTION_HEADER.PointerToRawData is a 32 bit int.
-				start_of_rsrc_section := binary.LittleEndian.Uint32(
-					data[offset_to_rsrc+20:])
-				size_of_raw_data := uint32(end_of_file) - start_of_rsrc_section
-				binary.LittleEndian.PutUint32(
-					data[offset_to_rsrc+16:], size_of_raw_data)
-			}
-		}
-
-		appended, err := ioutil.ReadAll(*repack_command_append)
-		if err != nil {
-			return fmt.Errorf("Unable to read appended file: %w", err)
-		}
-
-		data = append(data, appended...)
-	}
-
-	match := embedded_re.FindIndex(data)
-	if match == nil {
-		return fmt.Errorf("I can not seem to locate the embedded config????")
-	}
-
-	end := match[1]
-
-	logger.Info("Write %v\n", len(data[:end]))
-	_, err = outfd.Write(data[:end])
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Write %v\n", len(config_data))
-	_, err = outfd.Write(config_data)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Write %v\n", len(data[end+len(config_data):]))
-	_, err = outfd.Write(data[end+len(config_data):])
-	if err != nil {
-		return err
-	}
-
-	err = outfd.Close()
-	if err != nil {
-		return err
-	}
-
-	return os.Chmod(outfd.Name(), 0777)
-}
-
-func repackMSI(config_data []byte,
-	msi_path string, outfd *os.File, logger *logging.LogContext) error {
-	logger.Info("Will repack MSI from %v", msi_path)
-
-	fd, err := os.Open(msi_path)
-	if err != nil {
-		return err
-	}
-	defer fd.Close()
-
-	data, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return err
-	}
-
-	if string(data[0:4]) != "\xD0\xCF\x11\xE0" {
-		return errors.New("File does not look like an MSI")
-	}
-
-	match := embedded_msi_re.FindIndex(data)
-	if match == nil || match[1] < 10 {
-		return fmt.Errorf("I can not seem to locate the embedded config???? To repack an MSI, be sure to build from custom.xml with the custom.config.yaml file.")
-	}
-
-	end := match[0]
-
-	// null out the checksum because we are too lazy to calculate it.
-	data[end-8] = 0
-	data[end-7] = 0
-	data[end-6] = 0
-	data[end-5] = 0
-
-	// We must keep the same length as the embedded config file
-	// unfortunately. The default embedded config file conists of a
-	// lot of padding to accomodate.
-	logger.Info("Write %v bytes of preamble \n", len(data[:end]))
-	_, err = outfd.Write(data[:end])
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Write %v bytes of config_data\n", len(config_data))
-	_, err = outfd.Write(config_data)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Write %v bytes of post data\n", len(data[end+len(config_data):]))
-	_, err = outfd.Write(data[end+len(config_data):])
-	if err != nil {
-		return err
-	}
-
-	err = outfd.Close()
-	if err != nil {
-		return err
-	}
-
-	return os.Chmod(outfd.Name(), 0777)
+	return nil
 }
 
 func init() {

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2813,6 +2813,52 @@
   category: plugin
 - name: mail
   description: Send Email to a remote server.
+  type: Function
+  args:
+  - name: to
+    type: string
+    description: Recipient of the mail
+    repeated: true
+    required: true
+  - name: from
+    type: string
+    description: The from email address.
+  - name: cc
+    type: string
+    description: A cc for the mail
+    repeated: true
+  - name: subject
+    type: string
+    description: The subject.
+  - name: body
+    type: string
+    description: The body of the mail.
+    required: true
+  - name: period
+    type: int64
+    description: How long to wait before sending the next mail - help to throttle
+      mails.
+  - name: server_port
+    type: uint64
+    description: The SMTP server port to use (default 587).
+  - name: server
+    type: string
+    description: The SMTP server to use (if not specified we try the config file).
+  - name: auth_username
+    type: string
+    description: The SMTP username we authenticate to the server.
+  - name: auth_password
+    type: string
+    description: The SMTP username password we use to authenticate to the server.
+  - name: skip_verify
+    type: bool
+    description: 'Skip SSL verification(default: False).'
+  - name: root_ca
+    type: string
+    description: As a better alternative to disable_ssl_security, allows root ca certs
+      to be added here.
+- name: mail
+  description: Send Email to a remote server.
   type: Plugin
   args:
   - name: to
@@ -2838,7 +2884,6 @@
     type: int64
     description: How long to wait before sending the next mail - help to throttle
       mails.
-    required: true
   - name: server_port
     type: uint64
     description: The SMTP server port to use (default 587).
@@ -2851,6 +2896,13 @@
   - name: auth_password
     type: string
     description: The SMTP username password we use to authenticate to the server.
+  - name: skip_verify
+    type: bool
+    description: 'Skip SSL verification(default: False).'
+  - name: root_ca
+    type: string
+    description: As a better alternative to disable_ssl_security, allows root ca certs
+      to be added here.
   category: server
 - name: max
   description: |
@@ -4487,6 +4539,32 @@
   - name: clear
     type: bool
     description: If set we clear all accessors from the device manager
+- name: repack
+  description: Repack and upload a repacked binary or MSI to the server.
+  type: Function
+  args:
+  - name: target
+    type: string
+    description: The name of the target OS to repack (VelociraptorWindows, VelociraptorLinux,
+      VelociraptorDarwin)
+  - name: exe
+    type: accessors.OSPath
+    description: Alternative a path to the executable to repack
+  - name: accessor
+    type: string
+    description: The accessor to use to read the file.
+  - name: binaries
+    type: string
+    description: List of tool names that will be repacked into the target
+    repeated: true
+  - name: config
+    type: string
+    description: The config to be repacked in the form of a json or yaml string
+    required: true
+  - name: upload_name
+    type: string
+    description: The name of the upload to create
+    required: true
 - name: rm
   description: Remove a file from the filesystem using the API.
   type: Function

--- a/gui/velociraptor/src/components/flows/offline-collector.jsx
+++ b/gui/velociraptor/src/components/flows/offline-collector.jsx
@@ -28,6 +28,13 @@ class OfflinePaginator extends PaginationBuilder {
                        "Review", "Launch"];
 }
 
+const tool_name_lookup = {
+    Windows: "VelociraptorWindows",
+    Windows_x86: "VelociraptorWindows_x86",
+    Linux: "VelociraptorLinux",
+    MacOS: "VelociraptorDarwin",
+}
+
 
 class OfflineCollectorParameters  extends React.Component {
     static propTypes = {
@@ -350,14 +357,7 @@ class OfflineCollectorParameters  extends React.Component {
                   <Form.Group as={Row}>
                     <Form.Label column sm="3">{T("Velociraptor Binary")}</Form.Label>
                     <Col sm="8">
-                      {this.props.parameters.target_os === "Windows" &&
-                       <ToolViewer name="VelociraptorWindows"/>}
-                      {this.props.parameters.target_os === "Windows_x86" &&
-                       <ToolViewer name="VelociraptorWindows_x86"/>}
-                      {this.props.parameters.target_os === "Linux" &&
-                       <ToolViewer name="VelociraptorLinux"/>}
-                      {this.props.parameters.target_os === "MacOS" &&
-                       <ToolViewer name="VelociraptorDarwin"/>}
+                       <ToolViewer name={tool_name_lookup[this.props.parameters.target_os]}/>
                     </Col>
                   </Form.Group>
                   <Form.Group as={Row}>
@@ -672,12 +672,11 @@ export default class OfflineCollectorWizard extends React.Component {
             PREV_STEP: this.gotoPrevStep(),
         };
 
-        let extra_tools = [
-            "VelociraptorWindows",
-            "VelociraptorLinux",
-            "VelociraptorWindows_x86",
-            "VelociraptorDarwin",
-        ];
+        let extra_tools = [ ];
+        if ( this.state.collector_parameters &&
+             this.state.collector_parameters.target_os) {
+            extra_tools.push(tool_name_lookup[this.state.collector_parameters.target_os]);
+        }
 
         return (
             <Modal show={true}

--- a/services/inventory.go
+++ b/services/inventory.go
@@ -23,12 +23,18 @@ func GetInventory(config_obj *config_proto.Config) (Inventory, error) {
 	return org_manager.Services(config_obj.OrgId).Inventory()
 }
 
+// Options to the AddTool() API
 type ToolOptions struct {
 	// Tool is being upgraded.
 	Upgrade bool
 
 	// Admin is overriding tool in inventory.
 	AdminOverride bool
+
+	// Tool definition is from an artifact definition. Hold onto this
+	// as one of the prestine versions so the user can reset it back
+	// if needed.
+	ArtifactDefinition bool
 }
 
 type Inventory interface {

--- a/services/inventory/inventory_test.go
+++ b/services/inventory/inventory_test.go
@@ -67,7 +67,9 @@ func (self *ServicesTestSuite) TestGihubTools() {
 			Name:             tool_name,
 			GithubProject:    "Velocidex/velociraptor",
 			GithubAssetRegex: "windows-amd64.exe",
-		}, services.ToolOptions{})
+		}, services.ToolOptions{
+			ArtifactDefinition: true,
+		})
 	assert.NoError(self.T(), err)
 
 	// Adding the tool simply fetches the github url but not the

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -436,7 +436,8 @@ func (self *Launcher) EnsureToolsDeclared(
 			err = inventory.AddTool(ctx,
 				config_obj, tool,
 				services.ToolOptions{
-					Upgrade: true,
+					Upgrade:            true,
+					ArtifactDefinition: true,
 				})
 			if err != nil {
 				return err

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -584,7 +584,10 @@ func updateTools(
 		tool_request := proto.Clone(tool).(*artifacts_proto.Tool)
 		tool_request.Artifact = artifact.Name
 		err := inventory.AddTool(ctx, config_obj, tool_request,
-			services.ToolOptions{Upgrade: true})
+			services.ToolOptions{
+				Upgrade:            true,
+				ArtifactDefinition: true,
+			})
 		if err != nil {
 			return err
 		}

--- a/services/sanity/sanity.go
+++ b/services/sanity/sanity.go
@@ -288,7 +288,8 @@ func checkForServerUpgrade(
 					err = inventory.AddTool(ctx,
 						config_obj, tool_definition,
 						services.ToolOptions{
-							Upgrade: true,
+							Upgrade:            true,
+							ArtifactDefinition: true,
 						})
 					if err != nil {
 						// Errors are not fatal during upgrade.

--- a/utils/sanitize.go
+++ b/utils/sanitize.go
@@ -105,7 +105,8 @@ func SanitizeStringForZip(component string) string {
 
 	// Windows can not have a trailing "." instead swallowing it
 	// completely.
-	if component[length-1] == '.' {
+	if component[length-1] == '.' ||
+		component[length-1] == ' ' {
 		return component[:length-1] + "%2E"
 	}
 

--- a/vql/server/inventory.go
+++ b/vql/server/inventory.go
@@ -184,7 +184,8 @@ func (self *InventoryGetFunction) Call(ctx context.Context,
 	result := ordereddict.NewDict().
 		Set("Tool_"+arg.Tool+"_HASH", tool.Hash).
 		Set("Tool_"+arg.Tool+"_FILENAME", tool.Filename).
-		Set("Tool_"+arg.Tool+"_URL", url)
+		Set("Tool_"+arg.Tool+"_URL", url).
+		Set("Definition", tool)
 	return result
 }
 

--- a/vql/server/orgs/current.go
+++ b/vql/server/orgs/current.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Velocidex/ordereddict"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/services"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -33,7 +34,17 @@ func (self *CurrentOrgFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	return org_record
+	org_config_obj, _ := org_manager.GetOrgConfig(config_obj.OrgId)
+	client_config := &config_proto.Config{
+		Version: org_config_obj.Version,
+		Client:  org_config_obj.Client,
+	}
+
+	return ordereddict.NewDict().
+		Set("name", org_record.Name).
+		Set("nonce", org_record.Nonce).
+		Set("id", config_obj.OrgId).
+		Set("_client_config", client_config)
 }
 
 func (self CurrentOrgFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {

--- a/vql/tools/repack.go
+++ b/vql/tools/repack.go
@@ -1,0 +1,398 @@
+/*
+  Repacks a client with a provided configuration and upload to the
+  server.
+
+  Previously this functionality was completely implemented in VQL on
+  the server, but this approach requires enabling functionality such
+  as execve(), http_client() etc. On servers which restrict server
+  side functionality the pure VQL implementation is not functional, so
+  we have refactored this into a specific VQL function which we can
+  allow based on ACL permissions.
+*/
+
+package tools
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/config"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/csv"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/paths"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/third_party/zip"
+	"www.velocidex.com/golang/velociraptor/utils"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/networking"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+)
+
+var (
+	embedded_re     = regexp.MustCompile(`#{3}<Begin Embedded Config>\r?\n`)
+	embedded_msi_re = regexp.MustCompile(`## Velociraptor client configuration`)
+)
+
+const (
+	MAX_MEMORY = 200 * 1024 * 1024
+	MSI_MAGIC  = "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1"
+)
+
+type RepackFunctionArgs struct {
+	Target     string            `vfilter:"optional,field=target,doc=The name of the target OS to repack (VelociraptorWindows, VelociraptorLinux, VelociraptorDarwin)"`
+	Exe        *accessors.OSPath `vfilter:"optional,field=exe,doc=Alternative a path to the executable to repack"`
+	Accessor   string            `vfilter:"optional,field=accessor,doc=The accessor to use to read the file."`
+	Binaries   []string          `vfilter:"optional,field=binaries,doc=List of tool names that will be repacked into the target"`
+	Config     string            `vfilter:"required,field=config,doc=The config to be repacked in the form of a json or yaml string"`
+	UploadName string            `vfilter:"required,field=upload_name,doc=The name of the upload to create"`
+}
+
+type RepackFunction struct{}
+
+func (self RepackFunction) Call(ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+
+	arg := &RepackFunctionArgs{}
+	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
+	if err != nil {
+		scope.Log("ERROR:client_repack: %v", err)
+		return vfilter.Null{}
+	}
+
+	err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+	if err != nil {
+		scope.Log("ERROR:client_repack: %v", err)
+		return vfilter.Null{}
+	}
+
+	config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		scope.Log("ERROR:client_repack: Command can only run on the server")
+		return vfilter.Null{}
+	}
+
+	if arg.Config == "" {
+		scope.Log("ERROR:client_repack: Config not specified")
+		return vfilter.Null{}
+	}
+
+	// Validate the config file.
+	_, err = new(config.Loader).
+		WithLiteralLoader([]byte(arg.Config)).LoadAndValidate()
+	if err != nil {
+		scope.Log("ERROR:client_repack: Provided config file not valid: %v", err)
+		return vfilter.Null{}
+	}
+
+	exe_bytes, err := readExeFile(ctx, config_obj, scope,
+		arg.Exe, arg.Accessor, arg.Target)
+	if err != nil {
+		scope.Log("ERROR:client_repack: %v", err)
+		return vfilter.Null{}
+	}
+
+	// Are we repacking an MSI?
+	if len(exe_bytes) > 8 && string(exe_bytes[:8]) == MSI_MAGIC {
+		return RepackMSI(ctx, scope, arg.UploadName,
+			exe_bytes, []byte(arg.Config))
+	}
+
+	// Compress the string.
+	var b bytes.Buffer
+	w := zlib.NewWriter(&b)
+	_, err = w.Write([]byte(arg.Config))
+	if err != nil {
+		scope.Log("ERROR:client_repack: %v", err)
+		return vfilter.Null{}
+	}
+	w.Close()
+
+	if b.Len() > len(config.FileConfigDefaultYaml)-40 {
+		return fmt.Errorf("config file is too large to embed.")
+	}
+
+	compressed_config_data := b.Bytes()
+
+	// If binaries are specified, do them as well.
+	if len(arg.Binaries) > 0 {
+		exe_bytes, err = AppendBinaries(
+			ctx, config_obj, scope, exe_bytes, arg.Binaries)
+		if err != nil {
+			scope.Log("ERROR:client_repack: %v", err)
+			return vfilter.Null{}
+		}
+	}
+
+	match := embedded_re.FindIndex(exe_bytes)
+	if match == nil {
+		scope.Log("ERROR:client_repack: I can not seem to locate the embedded config????")
+		return vfilter.Null{}
+	}
+
+	end := match[1]
+
+	if len(exe_bytes) < end+len(compressed_config_data) {
+		scope.Log("ERROR:client_repack: I can not seem to locate the embedded config????")
+		return vfilter.Null{}
+	}
+
+	for i := 0; i < len(compressed_config_data); i++ {
+		exe_bytes[end+i] = compressed_config_data[i]
+	}
+
+	sub_scope := scope.Copy()
+	sub_scope.AppendVars(
+		ordereddict.NewDict().Set("PACKED_Binary", exe_bytes))
+
+	return (&networking.UploadFunction{}).Call(
+		ctx, sub_scope, ordereddict.NewDict().
+			Set("file", "PACKED_Binary").
+			Set("name", arg.UploadName).
+			Set("accessor", "scope"))
+}
+
+func readExeFile(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	scope vfilter.Scope,
+	exe *accessors.OSPath,
+	accessor_name string,
+	target_tool string) ([]byte, error) {
+
+	if exe != nil {
+		accessor, err := accessors.GetAccessor(accessor_name, scope)
+		if err != nil {
+			return nil, err
+		}
+
+		fd, err := accessor.OpenWithOSPath(exe)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		return ioutil.ReadAll(fd)
+	}
+
+	// Fetch the tool definition
+	inventory, err := services.GetInventory(config_obj)
+	if err != nil {
+		return nil, err
+	}
+
+	tool, err := inventory.GetToolInfo(ctx, config_obj, target_tool)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the actual tool from the filestore. NOTE: Tools are stored
+	// in a central location in the root org that gets served to all
+	// orgs.
+	org_manager, err := services.GetOrgManager()
+	if err != nil {
+		return nil, err
+	}
+
+	// The path is determined by the org specific inventory manager,
+	// but must be opened using the root orgs filestore.
+	path_manager := paths.NewInventoryPathManager(config_obj, tool)
+
+	root_config_obj, _ := org_manager.GetOrgConfig("root")
+	root_file_store_factory := file_store.GetFileStore(root_config_obj)
+	fd, err := root_file_store_factory.ReadFile(path_manager.Path())
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := fd.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if s.Size() > MAX_MEMORY {
+		return nil, errors.New("Total binary size exceeded")
+	}
+
+	// For now read the whole file into memory so we can repack
+	// it. TODO: Can we do this in a more efficient way?
+	exe_bytes := make([]byte, s.Size())
+	n, err := fd.Read(exe_bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return exe_bytes[:n], nil
+}
+
+func RepackMSI(
+	ctx context.Context,
+	scope vfilter.Scope, upload_name string,
+	data []byte, config_data []byte) vfilter.Any {
+	scope.Log("client_repack: Will Repack an MSI file with %v bytes", len(config_data))
+
+	// Make sure the config_data is at least big enough so we get to
+	// the comment section of the placeholder.
+	config_data_len := len(config_data)
+	for i := 0; i < 2000-config_data_len; i++ {
+		config_data = append(config_data, '\n')
+	}
+
+	match := embedded_msi_re.FindIndex(data)
+	if match == nil || match[1] < 10 {
+		scope.Log("client_repack: I can not seem to locate the embedded config???? To repack an MSI, be sure to build from custom.xml with the custom.config.yaml file.")
+		return vfilter.Null{}
+	}
+
+	end := match[0]
+
+	// null out the checksum because we are too lazy to calculate it.
+	data[end-8] = 0
+	data[end-7] = 0
+	data[end-6] = 0
+	data[end-5] = 0
+
+	// Copy the config data on top of the old one
+	for i := 0; i < len(config_data); i++ {
+		data[end+i] = config_data[i]
+	}
+
+	sub_scope := scope.Copy()
+	sub_scope.AppendVars(
+		ordereddict.NewDict().Set("PACKED_MSI", data))
+
+	return (&networking.UploadFunction{}).Call(
+		ctx, sub_scope, ordereddict.NewDict().
+			Set("file", "PACKED_MSI").
+			Set("name", upload_name).
+			Set("accessor", "scope"))
+}
+
+func AppendBinaries(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	scope vfilter.Scope,
+	exe_bytes []byte, binaries []string) ([]byte, error) {
+
+	org_manager, err := services.GetOrgManager()
+	if err != nil {
+		return nil, err
+	}
+
+	root_config_obj, _ := org_manager.GetOrgConfig("root")
+
+	// Build the zip file that contains all the binaries.
+	csv_file := &bytes.Buffer{}
+	csv_writer := csv.GetCSVAppender(
+		config_obj, scope, csv_file, true, json.DefaultEncOpts())
+
+	buf := &bytes.Buffer{}
+	zip := zip.NewWriter(buf)
+
+	inventory, err := services.GetInventory(config_obj)
+	if err != nil {
+		return nil, err
+	}
+
+	file_store_factory := file_store.GetFileStore(root_config_obj)
+	for _, name := range binaries {
+		tool, err := inventory.GetToolInfo(ctx, config_obj, name)
+		if err != nil {
+			return nil, err
+		}
+
+		// Try to open the tool directly from the filestore
+		path_manager := paths.NewInventoryPathManager(config_obj, tool)
+		fd, err := file_store_factory.ReadFile(path_manager.Path())
+		if err != nil {
+			return nil, err
+		}
+
+		outfd, err := zip.Create("uploads/" + tool.Filename)
+		if err != nil {
+			fd.Close()
+			return nil, err
+		}
+
+		n, err := utils.Copy(ctx, outfd, fd)
+		fd.Close()
+
+		csv_writer.Write(ordereddict.NewDict().
+			Set("ToolName", tool.Name).
+			Set("Filename", "uploads/"+tool.Filename).
+			Set("ExpectedHash", tool.Hash).
+			Set("Size", n))
+	}
+
+	csv_writer.Close()
+	outfd, err := zip.Create("uploads/inventory.csv")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = outfd.Write(csv_file.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	err = zip.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return appendPayload(exe_bytes, buf.Bytes()), nil
+}
+
+// Appends the payload to the exe adjusting resource headers if
+// needed.
+func appendPayload(exe_bytes []byte, payload []byte) []byte {
+	if payload != nil {
+		// A PE file - adjust the size of the .rsrc section to
+		// cover the entire binary.
+		if string(exe_bytes[0:2]) == "MZ" {
+			end_of_file := int64(len(exe_bytes) + len(payload))
+
+			// This is the IMAGE_SECTION_HEADER.Name which
+			// is also the start of IMAGE_SECTION_HEADER.
+			offset_to_rsrc := bytes.Index(exe_bytes, []byte(".rsrc"))
+
+			// Found it.
+			if offset_to_rsrc > 0 {
+				// IMAGE_SECTION_HEADER.PointerToRawData is a 32 bit int.
+				start_of_rsrc_section := binary.LittleEndian.Uint32(
+					exe_bytes[offset_to_rsrc+20:])
+				size_of_raw_data := uint32(end_of_file) - start_of_rsrc_section
+				binary.LittleEndian.PutUint32(
+					exe_bytes[offset_to_rsrc+16:], size_of_raw_data)
+			}
+		}
+
+		exe_bytes = append(exe_bytes, payload...)
+	}
+
+	return exe_bytes
+}
+
+func (self RepackFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:    "repack",
+		Doc:     "Repack and upload a repacked binary or MSI to the server.",
+		ArgType: type_map.AddType(scope, &RepackFunctionArgs{}),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&RepackFunction{})
+}

--- a/vql/tools/repack_test.go
+++ b/vql/tools/repack_test.go
@@ -24,13 +24,12 @@ import (
 )
 
 var (
-	/*
-		msi_src          = ""
-		binary_src       = ""
-		repacked_msi_dst = ""
-		repacked_dst     = ""
-	*/
+	msi_src          = ""
+	binary_src       = ""
+	repacked_msi_dst = ""
+	repacked_dst     = ""
 
+/*
 	// Set these to capture the repacked file for manual inspection.
 	repacked_msi_dst = "/tmp/m_repacked.msi"
 	repacked_dst     = "/tmp/m_repacked.exe"
@@ -39,6 +38,7 @@ var (
 	// inspect the produced data
 	binary_src = "../../output/velociraptor.exe"
 	msi_src    = "/tmp/velociraptor-v0.6.8-rc1-windows-amd64.msi"
+*/
 )
 
 type RepackTestSuite struct {

--- a/vql/tools/repack_test.go
+++ b/vql/tools/repack_test.go
@@ -1,0 +1,205 @@
+package tools
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Velocidex/ordereddict"
+	"github.com/stretchr/testify/suite"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/config"
+	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/uploads"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
+	"www.velocidex.com/golang/velociraptor/vql/server"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+
+	_ "www.velocidex.com/golang/velociraptor/accessors/data"
+	_ "www.velocidex.com/golang/velociraptor/accessors/file"
+)
+
+var (
+	/*
+		msi_src          = ""
+		binary_src       = ""
+		repacked_msi_dst = ""
+		repacked_dst     = ""
+	*/
+
+	// Set these to capture the repacked file for manual inspection.
+	repacked_msi_dst = "/tmp/m_repacked.msi"
+	repacked_dst     = "/tmp/m_repacked.exe"
+
+	// Provide the real binary and msi so they can be packed then
+	// inspect the produced data
+	binary_src = "../../output/velociraptor.exe"
+	msi_src    = "/tmp/velociraptor-v0.6.8-rc1-windows-amd64.msi"
+)
+
+type RepackTestSuite struct {
+	test_utils.TestSuite
+}
+
+func (self *RepackTestSuite) TestRepackBinary() {
+	ctx := self.Ctx
+
+	dir, err := ioutil.TempDir("", "tmp")
+	assert.NoError(self.T(), err)
+
+	defer os.RemoveAll(dir)
+
+	builder := services.ScopeBuilder{
+		Config:     self.ConfigObj,
+		ACLManager: acl_managers.NullACLManager{},
+		Uploader: &uploads.FileBasedUploader{
+			UploadDir: dir,
+		},
+	}
+
+	manager, err := services.GetRepositoryManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	scope := manager.BuildScope(builder)
+	scope.SetLogger(log.New(os.Stderr, "", 0))
+
+	defer scope.Close()
+
+	if binary_src == "" {
+		binary_src = filepath.Join(dir, "binary.exe")
+		fd, err := os.OpenFile(binary_src, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
+		assert.NoError(self.T(), err)
+
+		fd.Write(config.FileConfigDefaultYaml)
+		fd.Close()
+	} else {
+		binary_src, _ = filepath.Abs(binary_src)
+	}
+
+	accessor, err := accessors.GetAccessor("file", scope)
+	assert.NoError(self.T(), err)
+
+	tool_pathspec, err := accessor.ParsePath(binary_src)
+	assert.NoError(self.T(), err)
+
+	// Add the Windows Binary to the inventory
+	result := (&server.InventoryAddFunction{}).Call(
+		ctx, scope, ordereddict.NewDict().
+			Set("tool", "VelociraptorWindows").
+			Set("accessor", "file").
+			Set("file", tool_pathspec))
+
+	_, ok := result.(*ordereddict.Dict)
+	assert.True(self.T(), ok, "Result type is %T", result)
+
+	result = RepackFunction{}.Call(
+		ctx, scope,
+		ordereddict.NewDict().
+			// Set a fixed client id to keep it predictable
+			Set("target", "VelociraptorWindows").
+			Set("config", `
+autoexec:
+ argv:
+  - help
+`).
+			Set("binaries", []string{"VelociraptorWindows"}).
+			Set("upload_name", "test.zip"))
+
+	upload_response, ok := result.(*uploads.UploadResponse)
+	assert.True(self.T(), ok, "Result type is %T", result)
+
+	// Save a copy of the repacked data for inspection.
+	if repacked_dst != "" {
+		utils.CopyFile(ctx, upload_response.Path, repacked_dst, 0644)
+		scope.Log("Stored repacked binary in %v for manual inspection", repacked_dst)
+	}
+}
+
+func (self *RepackTestSuite) TestRepackMSI() {
+	ctx := self.Ctx
+
+	dir, err := ioutil.TempDir("", "tmp")
+	assert.NoError(self.T(), err)
+
+	defer os.RemoveAll(dir)
+
+	builder := services.ScopeBuilder{
+		Config:     self.ConfigObj,
+		ACLManager: acl_managers.NullACLManager{},
+		Uploader: &uploads.FileBasedUploader{
+			UploadDir: dir,
+		},
+	}
+
+	manager, err := services.GetRepositoryManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	scope := manager.BuildScope(builder)
+	scope.SetLogger(log.New(os.Stderr, "", 0))
+
+	defer scope.Close()
+
+	// Build a file that looks like an msi for testing.
+	if msi_src == "" {
+		msi_src = filepath.Join(dir, "binary.msi")
+		fd, err := os.OpenFile(msi_src, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
+		assert.NoError(self.T(), err)
+
+		fd.Write([]byte(MSI_MAGIC))
+		template, err := os.Open("../../docs/wix/output/client.config.yaml")
+		assert.NoError(self.T(), err)
+
+		data, err := ioutil.ReadAll(template)
+		assert.NoError(self.T(), err)
+
+		fd.Write(data)
+		fd.Close()
+	} else {
+		msi_src, _ = filepath.Abs(msi_src)
+	}
+
+	accessor, err := accessors.GetAccessor("file", scope)
+	assert.NoError(self.T(), err)
+
+	tool_pathspec, err := accessor.ParsePath(msi_src)
+	assert.NoError(self.T(), err)
+
+	// Add the Windows Binary to the inventory
+	result := (&server.InventoryAddFunction{}).Call(
+		ctx, scope, ordereddict.NewDict().
+			Set("tool", "VelociraptorWindows").
+			Set("accessor", "file").
+			Set("file", tool_pathspec))
+
+	_, ok := result.(*ordereddict.Dict)
+	assert.True(self.T(), ok, "Result type is %T", result)
+
+	result = RepackFunction{}.Call(
+		ctx, scope,
+		ordereddict.NewDict().
+			// Set a fixed client id to keep it predictable
+			Set("target", "VelociraptorWindows").
+			Set("config", `
+autoexec:
+ argv:
+  - help
+`).
+			Set("upload_name", "test.zip"))
+
+	upload_response, ok := result.(*uploads.UploadResponse)
+	assert.True(self.T(), ok, "Result type is %T", result)
+
+	// Save a copy of the repacked data for inspection.
+	if repacked_dst != "" {
+		utils.CopyFile(ctx, upload_response.Path, repacked_msi_dst, 0644)
+		scope.Log("Stored repacked msi in %v for manual inspection", repacked_msi_dst)
+	}
+}
+
+func TestRepackPlugin(t *testing.T) {
+	suite.Run(t, &RepackTestSuite{})
+}


### PR DESCRIPTION
Previously repacking (as used by the offline collector) was implemented in VQL by calling the main binary with the repack command. This is problematic on servers which remove the execve() functionality.

This PR implements the repack functionality in VQL and therefore makes it available for use in restricted environments. It also simplifies the CreateCollector artifact.

Also added a Server.Utils.CreateMSI artifact which automatically prepares an MSI for use within an org.