### PR TITLE
Removing unused CSS for GUI

### DIFF
--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -17,7 +17,7 @@
                 "@fortawesome/react-fontawesome": "0.2.0",
                 "@popperjs/core": "^2.11.6",
                 "ace-builds": "1.15.0",
-                "axios": "^1.2.6",
+                "axios": ">=1.2.6",
                 "axios-retry": "3.4.0",
                 "bootstrap": "^4.6.2",
                 "classnames": "^2.3.2",
@@ -71,11 +71,13 @@
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.19.1",
+                "@fullhuman/postcss-purgecss": "^5.0.0",
                 "@testing-library/react": "12",
                 "@vitejs/plugin-react": "^3.0.0",
                 "eslint": "^8.29.0",
                 "eslint-config-react-app": "^7.0.1",
                 "eslint-plugin-flowtype": "^8.0.3",
+                "postcss": "^8.4.21",
                 "vite": "^4.0.1",
                 "vite-plugin-compression": "^0.5.1"
             }
@@ -2483,6 +2485,18 @@
             "peerDependencies": {
                 "@fortawesome/fontawesome-svg-core": "~1 || ~6",
                 "react": ">=16.3"
+            }
+        },
+        "node_modules/@fullhuman/postcss-purgecss": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-5.0.0.tgz",
+            "integrity": "sha512-onDS/b/2pMRzqSoj4qOs2tYFmOpaspjTAgvACIHMPiicu1ptajiBruTrjBzTKdxWdX0ldaBb7wj8nEaTLyFkJw==",
+            "dev": true,
+            "dependencies": {
+                "purgecss": "^5.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -4942,6 +4956,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/csso": {
@@ -9308,9 +9334,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.20",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-            "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+            "version": "8.4.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+            "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
             "dev": true,
             "funding": [
                 {
@@ -9329,6 +9355,19 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "dev": true,
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/postcss-value-parser": {
@@ -9508,6 +9547,70 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
             "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
+        },
+        "node_modules/purgecss": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-5.0.0.tgz",
+            "integrity": "sha512-RAnuxrGuVyLLTr8uMbKaxDRGWMgK5CCYDfRyUNNcaz5P3kGgD2b7ymQGYEyo2ST7Tl/ScwFgf5l3slKMxHSbrw==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^9.0.0",
+                "glob": "^8.0.3",
+                "postcss": "^8.4.4",
+                "postcss-selector-parser": "^6.0.7"
+            },
+            "bin": {
+                "purgecss": "bin/purgecss.js"
+            }
+        },
+        "node_modules/purgecss/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/purgecss/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/purgecss/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/purgecss/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/qs": {
             "version": "6.11.0",
@@ -14721,6 +14824,15 @@
                 "prop-types": "^15.8.1"
             }
         },
+        "@fullhuman/postcss-purgecss": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-5.0.0.tgz",
+            "integrity": "sha512-onDS/b/2pMRzqSoj4qOs2tYFmOpaspjTAgvACIHMPiicu1ptajiBruTrjBzTKdxWdX0ldaBb7wj8nEaTLyFkJw==",
+            "dev": true,
+            "requires": {
+                "purgecss": "^5.0.0"
+            }
+        },
         "@humanwhocodes/config-array": {
             "version": "0.11.8",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -16705,6 +16817,12 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+        },
+        "cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true
         },
         "csso": {
             "version": "4.2.0",
@@ -20143,14 +20261,24 @@
             "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
         },
         "postcss": {
-            "version": "8.4.20",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-            "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+            "version": "8.4.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+            "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "dev": true,
+            "requires": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
             }
         },
         "postcss-value-parser": {
@@ -20319,6 +20447,57 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
             "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
+        },
+        "purgecss": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-5.0.0.tgz",
+            "integrity": "sha512-RAnuxrGuVyLLTr8uMbKaxDRGWMgK5CCYDfRyUNNcaz5P3kGgD2b7ymQGYEyo2ST7Tl/ScwFgf5l3slKMxHSbrw==",
+            "dev": true,
+            "requires": {
+                "commander": "^9.0.0",
+                "glob": "^8.0.3",
+                "postcss": "^8.4.4",
+                "postcss-selector-parser": "^6.0.7"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "9.5.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+                    "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+                    "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^5.0.1",
+                        "once": "^1.3.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
         },
         "qs": {
             "version": "6.11.0",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -12,8 +12,8 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "0.2.0",
         "@popperjs/core": "^2.11.6",
-        "axios": ">=1.2.6",
         "ace-builds": "1.15.0",
+        "axios": ">=1.2.6",
         "axios-retry": "3.4.0",
         "bootstrap": "^4.6.2",
         "classnames": "^2.3.2",
@@ -96,11 +96,13 @@
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
+        "@fullhuman/postcss-purgecss": "^5.0.0",
         "@testing-library/react": "12",
         "@vitejs/plugin-react": "^3.0.0",
         "eslint": "^8.29.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-flowtype": "^8.0.3",
+        "postcss": "^8.4.21",
         "vite": "^4.0.1",
         "vite-plugin-compression": "^0.5.1"
     }

--- a/gui/velociraptor/postcss.config.cjs
+++ b/gui/velociraptor/postcss.config.cjs
@@ -1,0 +1,9 @@
+const purgecss = require("@fullhuman/postcss-purgecss");
+
+module.exports = {
+  plugins: [
+    purgecss({
+      content: ["./src/index.html", "./src/**/*.jsx", "./src/**/*.css"],
+    }),
+  ],
+};


### PR DESCRIPTION
Adding support to use [postcss](https://postcss.org/), a neat little build tool that can enable some useful things like removing unused css via [purgecss](https://purgecss.com/).

Purgecss removes all unused css prior to building with vite.

Using a `.cjs` extension to play nice with javascript declarations and vite. Hopefully since this is just part of the GUI build chain it won't be an issue.

| before purgecss  | after purgecss | difference |
| ------------- | ------------- | ------------- |
| 397.97 kB (unzipped) | 236.91 kB (unzipped)  | 161.06 kB (40.47%)|
| 58.37 kB (gzip)  | 35.91 kB (gzip)  | 22.46 kB (38.47%) |

Pre purgecss:
<img width="1683" alt="pre-purgecss" src="https://user-images.githubusercontent.com/3946895/220236351-aa433e3e-5753-4736-bd4f-d7cdc60cb69f.png">

Post purgecss:
<img width="1689" alt="post-purgecss" src="https://user-images.githubusercontent.com/3946895/220236372-e825f968-ef66-4933-86da-feb3d3fba4b6.png">

---

Also nice talking to you @scudette the other day, this is a delightful project! (especially now that I figured how to build for arm64 :D )

