### PR TITLE
Use a more compact flow_id for hunts.

### DIFF
--- a/artifacts/testdata/manual/TestLog.yaml
+++ b/artifacts/testdata/manual/TestLog.yaml
@@ -1,0 +1,9 @@
+name: Test.TestLog
+description: |
+  Stream logs slowly - test that GUI updates logs
+
+sources:
+  - query: |
+      SELECT sleep(time=1),
+         log(message="Message %v", args=_value, dedup=-1) AS Log
+      FROM range(end=100)

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -551,7 +551,7 @@ func (self *HuntDispatcher) CreateHunt(
 
 	// Set the collection ID already on the hunt request - all flows
 	// from this hunt will have the same flow id.
-	hunt.StartRequest.FlowId = "F.Hunt." + hunt.HuntId
+	hunt.StartRequest.FlowId = utils.CreateFlowIdFromHuntId(hunt.HuntId)
 	hunt.StartRequest.CompiledCollectorArgs = append(
 		hunt.StartRequest.CompiledCollectorArgs, compiled...)
 	hunt.StartRequest.Creator = hunt.Creator

--- a/services/hunt_manager/hunt_manager.go
+++ b/services/hunt_manager/hunt_manager.go
@@ -50,7 +50,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -366,12 +365,10 @@ func (self *HuntManager) ProcessFlowCompletion(
 		return errors.New("FlowId not found")
 	}
 
-	parts := strings.Split(flow_id, ".H.")
-	if len(parts) != 2 {
+	hunt_id, ok := utils.ExtractHuntId(flow_id)
+	if !ok {
 		return nil
 	}
-
-	hunt_id := "H." + parts[1]
 
 	// Flow is complete so add it to the hunt stats. We send a
 	// mutation to the hunt dispatcher to mediate internal hunt state

--- a/services/hunt_manager/hunt_manager_test.go
+++ b/services/hunt_manager/hunt_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/hunt_manager"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/velociraptor/vtesting"
 
@@ -44,7 +45,7 @@ func (self *HuntTestSuite) SetupTest() {
 
 	self.hunt_id += "A"
 	self.expected.Creator = self.hunt_id
-	self.expected.FlowId = "F.Hunt." + self.hunt_id
+	self.expected.FlowId = utils.CreateFlowIdFromHuntId(self.hunt_id)
 
 	// Write a client record.
 	client_info_obj := &actions_proto.ClientInfo{

--- a/utils/hunts.go
+++ b/utils/hunts.go
@@ -1,0 +1,21 @@
+package utils
+
+import "strings"
+
+func ExtractHuntId(flow_id string) (string, bool) {
+	parts := strings.Split(flow_id, ".")
+	if len(parts) < 3 || parts[2] != "H" {
+		return "", false
+	}
+
+	return "H." + parts[1], true
+}
+
+func CreateFlowIdFromHuntId(hunt_id string) string {
+	parts := strings.SplitN(hunt_id, ".", 2)
+	if len(parts) != 2 {
+		return "F." + hunt_id
+	}
+	return "F." + parts[1] + ".H"
+
+}

--- a/utils/hunts_test.go
+++ b/utils/hunts_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"testing"
+
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+)
+
+func TestExtractHuntId(t *testing.T) {
+	hunt_id := "H.123"
+	flow_id := CreateFlowIdFromHuntId(hunt_id)
+	assert.Equal(t, "F.123.H", flow_id)
+
+	extracted_hunt_id, ok := ExtractHuntId(flow_id)
+	assert.True(t, ok)
+	assert.Equal(t, extracted_hunt_id, hunt_id)
+
+	// Regular flow
+	extracted_hunt_id, ok = ExtractHuntId("F.1234")
+	assert.True(t, !ok)
+}


### PR DESCRIPTION
Flow IDs have the requirements that they are sortable with creation time. We can reuse the hunt id in this context.