### PR TITLE
Pass collection_context to server artifact runner directly.

### DIFF
--- a/gui/velociraptor/src/components/clients/client-summary.jsx
+++ b/gui/velociraptor/src/components/clients/client-summary.jsx
@@ -49,6 +49,10 @@ export default class VeloClientSummary extends Component {
             api.get("v1/GetClient/" + client_id, params,
                     this.source.token).then(
                 response=>{
+                    if (response.cancel) return;
+                    if (!response.data || response.data.client_id !== client_id) {
+                        return;
+                    }
                     this.props.setClient(response.data);
                 }).catch(err=>{
                     // The client is not valid - navigate away from

--- a/gui/velociraptor/src/components/clients/client_info.jsx
+++ b/gui/velociraptor/src/components/clients/client_info.jsx
@@ -53,7 +53,8 @@ class ClientSetterFromRoute extends Component {
 
             api.get('v1/GetClient/' + client_id, {},
                     this.source.token).then(resp => {
-                        if (resp.data && resp.data.items) {
+                        if (resp.cancel) return;
+                        if (resp.data && resp.data.client_id === client_id) {
                             window.globals.client = resp.data;
                             this.props.setClient(resp.data);
                         }

--- a/gui/velociraptor/src/components/clients/shell-viewer.jsx
+++ b/gui/velociraptor/src/components/clients/shell-viewer.jsx
@@ -584,19 +584,20 @@ class ShellViewer extends Component {
             return;
         }
 
-        api.get('v1/GetClientFlows/'+ this.props.client.client_id, {
+        let client_id = this.props.client.client_id;
+        api.get('v1/GetClientFlows/'+ client_id, {
             count: 100, offset: 0,
             artifact: "(Windows.System.PowerShell|Windows.System.CmdShell|Linux.Sys.BashShell|Generic.Client.VQL)"
         },
                 this.source.token // CancelToken
                ).then(function(response) {
                    if (response.cancel) return;
+                    if (!response.data || response.data.client_id !== client_id) {
+                        return;
+                    }
+
                    let new_state  = Object.assign({}, this.state);
                    new_state.flows = [];
-                   if (!response.data) {
-                       return;
-                   }
-
                    let items = response.data.items || [];
 
                    for(var i=0; i<items.length; i++) {

--- a/services/server_artifacts/api.go
+++ b/services/server_artifacts/api.go
@@ -3,6 +3,7 @@ package server_artifacts
 import (
 	"context"
 	"io"
+	"sync"
 
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
@@ -29,6 +30,12 @@ type CollectionContextManager interface {
 	Logger() LogWriter
 
 	GetContext() *flows_proto.ArtifactCollectorContext
+
+	// Loads the context from storage.
+	Load() error
+
+	// Start writing the collection context to storage.
+	StartRefresh(wg *sync.WaitGroup)
 
 	// A Query context track a single query in the collection.
 	GetQueryContext(query *actions_proto.VQLCollectorArgs) QueryContext

--- a/uploads/utils.go
+++ b/uploads/utils.go
@@ -52,10 +52,12 @@ func ShouldPadFile(
 // are uploaded multiple time so they only upload one file.
 func DeduplicateUploads(scope vfilter.Scope,
 	store_as_name *accessors.OSPath) (*UploadResponse, bool) {
-	cache_any := vql_subsystem.CacheGet(scope, UPLOAD_CTX)
+
+	root_scope := vql_subsystem.GetRootScope(scope)
+	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
 	if utils.IsNil(cache_any) {
 		cache_any = ordereddict.NewDict()
-		vql_subsystem.CacheSet(scope, UPLOAD_CTX, cache_any)
+		vql_subsystem.CacheSet(root_scope, UPLOAD_CTX, cache_any)
 	}
 
 	cache, ok := cache_any.(*ordereddict.Dict)
@@ -75,10 +77,11 @@ func DeduplicateUploads(scope vfilter.Scope,
 func CacheUploadResult(scope vfilter.Scope,
 	store_as_name *accessors.OSPath,
 	result *UploadResponse) {
-	cache_any := vql_subsystem.CacheGet(scope, UPLOAD_CTX)
+	root_scope := vql_subsystem.GetRootScope(scope)
+	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
 	if utils.IsNil(cache_any) {
 		cache_any = ordereddict.NewDict()
-		vql_subsystem.CacheSet(scope, UPLOAD_CTX, cache_any)
+		vql_subsystem.CacheSet(root_scope, UPLOAD_CTX, cache_any)
 	}
 
 	cache, ok := cache_any.(*ordereddict.Dict)


### PR DESCRIPTION
Previously the launcher stored it and the server artifact runner loaded it immediately. This causes problems with distributed storage where writes may not be immediately visible to readers.