### PR TITLE
Hex column types did not required hex encoding

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -97,12 +97,12 @@ parameters:
       Windows.Events.ServiceCreation
 
 column_types:
-  - name: Hex
+  - name: Base64Hex
     type: base64hex
 
 sources:
   - query: |
-      SELECT base64encode(string="This should popup in a hex editor") AS Hex,
+      SELECT base64encode(string="This should popup in a hex editor") AS Base64Hex,
              ChoiceSelector, Flag, Flag2, Flag3,
              OffFlag, StartDate, StartDate2, StartDate3,
              CSVData, CSVData2, JSONData, JSONData2,
@@ -184,7 +184,7 @@ sources:
 
                  FlowId, ClientId, URL, URL AS SafeURL, Base64Data,
 
-                 "Hello" AS Data
+                 format(format="%02x", args="Hello") AS Data
           FROM scope()
 
       - type: Markdown
@@ -335,7 +335,8 @@ sources:
 
           */
 
-          LET ColumnTypes = dict(`StartDate`='timestamp')
+          LET ColumnTypes = dict(`StartDate`='timestamp', Hex='hex')
+          LET Hex = "B0 EC 48 5F 18 77"
 
           SELECT Hex, StartDate, hash(accessor="data", path="Hello") AS Hash
           FROM source()

--- a/artifacts/definitions/Windows/System/VAD.yaml
+++ b/artifacts/definitions/Windows/System/VAD.yaml
@@ -97,7 +97,7 @@ sources:
                          Tags=Tags,
                          Offset=String.Offset,
                          Name=String.Name) as YaraHit,
-                    String.Data AS YaraContext,
+                    base64encode(string=String.Data) AS YaraContext,
                     _PathSpec, _Address
                 FROM yara(
                             accessor='offset',
@@ -136,4 +136,4 @@ sources:
 
 column_types:
   - name: YaraContext
-    type: hex
+    type: base64hex

--- a/gui/velociraptor/src/components/core/table.jsx
+++ b/gui/velociraptor/src/components/core/table.jsx
@@ -561,7 +561,18 @@ export function formatColumns(columns, env) {
 
         case "hex":
             x.formatter = (cell, row) => {
-                return <HexViewPopup data={cell}/>;
+                let bytearray = [];
+                for (let c = 0; c < cell.length; c += 2) {
+                    let term = cell.substr(c, 2);
+                    if (term.match(/[0-9a-fA-F]{2}/)) {
+                        bytearray.push(parseInt(term, 16));
+                    } else {
+                        c--;
+                    }
+                }
+                return <ContextMenu value={cell}>
+                         <HexViewPopup byte_array={bytearray}/>
+                       </ContextMenu>;
             };
             x.type = null;
             break;
@@ -570,11 +581,18 @@ export function formatColumns(columns, env) {
         case "base64":
             x.formatter = (cell, row) => {
                 try {
-                    cell = atob(cell);
-                } catch(e) {};
-                return <ContextMenu value={cell}>
-                         <HexViewPopup data={cell}/>
-                       </ContextMenu>;
+                    let binary_string = atob(cell);
+                    var len = binary_string.length;
+                    var bytes = new Uint8Array(len);
+                    for (var i = 0; i < len; i++) {
+                        bytes[i] = binary_string.charCodeAt(i);
+                    }
+                    return <ContextMenu value={cell}>
+                             <HexViewPopup byte_array={bytes}/>
+                           </ContextMenu>;
+                } catch(e) {
+                    return <></>;
+                };
             };
             x.type = null;
             break;

--- a/gui/velociraptor/src/components/utils/hex.css
+++ b/gui/velociraptor/src/components/utils/hex.css
@@ -35,3 +35,7 @@ th.offset {
 .hex-dialog-body table.offset-area {
     margin-left: 30px;
 }
+
+td.hex-container {
+    display: inline-block;
+}

--- a/gui/velociraptor/src/components/utils/hex.jsx
+++ b/gui/velociraptor/src/components/utils/hex.jsx
@@ -58,6 +58,16 @@ export class HexViewPopup extends React.Component {
         }
 
         let string_data = _.toString(this.props.data);
+        if (!string_data && this.props.byte_array) {
+            for(let i=0;i<10 && i<this.props.byte_array.length;i++) {
+                let c = this.props.byte_array[i];
+                if (c>0x20 && c<0x7e) {
+                    string_data += String.fromCharCode(c);
+                } else {
+                    string_data += ".";
+                }
+            }
+        }
         if (string_data.length > 10) {
             string_data = string_data.substring(0, 10) + "...";
         }
@@ -143,6 +153,13 @@ export default class HexView extends React.Component {
                 };
                 data_row.push(('0' + char).substr(-2)); // add leading zero if necessary
             };
+
+            // Pad with extra spaces to maintain alignment
+            let pad = this.state.rows - data.length % this.state.columns;
+            for (var j = 0; j < pad; j++) {
+                safe_data += " ";
+                data_row.push("   ");
+            }
 
             hexDataRows.push({
                 offset: rowOffset,
@@ -249,7 +266,7 @@ export default class HexView extends React.Component {
                   </thead>
                   <tbody>
                     <tr>
-                      <td>
+                      <td >
                         <table className="offset-area">
                           <tbody>
                             { _.map(this.state.hexDataRows, (row, idx)=>{
@@ -264,10 +281,10 @@ export default class HexView extends React.Component {
                           </tbody>
                         </table>
                       </td>
-                      <td>
+                      <td className="hex-container">
                         { hexArea }
                       </td>
-                      <td>
+                      <td className="hex-container">
                         { contextArea }
                       </td>
                     </tr>


### PR DESCRIPTION
Hex columns were encoding the string value in the column. Generally this is incorrect as the string valu comes from JSON and if the VQL query emits raw binary data into the JSON then it will be corrupted while contecting to UTF8.

This PR requires a column declared as "hex" to be actually hex encoded similarly to the base64 columns. This helps to correct the VQL because non-encoded data will simply not show up. This is preferable to almost correct data which has UTF8 errors in it.