### PR TITLE
Deduplicate glob hits

### DIFF
--- a/artifacts/testdata/manual/Sleep.yaml
+++ b/artifacts/testdata/manual/Sleep.yaml
@@ -1,10 +1,12 @@
 name: Test.Sleep
 description: |
   Used to test cancellation and artifact timeout on client
-  collections.
+  collections. Change to SERVER to test server cancellation.
 
 type: CLIENT
 
 sources:
   - query: |
-      SELECT sleep(time=60) FROM scope()
+      SELECT sleep(time=10)
+      FROM range(end=100)
+      WHERE log(message=format(format="Sent data %v", args=now()))

--- a/glob/fixtures/TestGlobWithContext.golden
+++ b/glob/fixtures/TestGlobWithContext.golden
@@ -62,5 +62,8 @@
  "011 Match masked by two matches /usr/bin , /usr/*/diff": [
   "/usr/bin",
   "/usr/bin/diff"
+ ],
+ "012 Multiple globs matching same file /bin/bash , /bin/ba*": [
+  "/bin/bash"
  ]
 }

--- a/glob/glob.go
+++ b/glob/glob.go
@@ -265,9 +265,13 @@ func (self *Globber) ExpandWithContext(
 
 		result := []accessors.FileInfo{}
 
+		seen := make(map[string]bool)
+
 		// For each file that matched, we check which component
 		// would match it.
 		for _, f := range files {
+			basename := f.Name()
+
 			for filterer, next := range self.filters {
 				if !filterer.Match(f) {
 					continue
@@ -277,18 +281,21 @@ func (self *Globber) ExpandWithContext(
 				}
 				_, next_has_sentinal := next.filters[sentinal_filter]
 				if next_has_sentinal {
-					result = append(result, f)
+					_, pres := seen[basename]
+					if !pres {
+						result = append(result, f)
+						seen[basename] = true
+					}
 				}
 
 				// Only recurse into directories.
 				if self.is_dir_or_link(f, accessor, 0) {
-					name := f.Name()
 					item := []*Globber{next}
-					prev_item, pres := children[name]
+					prev_item, pres := children[basename]
 					if pres {
 						item = append(prev_item, next)
 					}
-					children[name] = item
+					children[basename] = item
 				}
 			}
 		}

--- a/glob/glob.go
+++ b/glob/glob.go
@@ -265,8 +265,6 @@ func (self *Globber) ExpandWithContext(
 
 		result := []accessors.FileInfo{}
 
-		seen := make(map[string]bool)
-
 		// For each file that matched, we check which component
 		// would match it.
 		for _, f := range files {
@@ -281,11 +279,7 @@ func (self *Globber) ExpandWithContext(
 				}
 				_, next_has_sentinal := next.filters[sentinal_filter]
 				if next_has_sentinal {
-					_, pres := seen[basename]
-					if !pres {
-						result = append(result, f)
-						seen[basename] = true
-					}
+					result = append(result, f)
 				}
 
 				// Only recurse into directories.
@@ -306,12 +300,19 @@ func (self *Globber) ExpandWithContext(
 				result[i].OSPath().Basename(),
 				result[j].OSPath().Basename())
 		})
+		var last string
 		for _, f := range result {
+			basename := f.OSPath().Basename()
+			if last == basename {
+				continue
+			}
+
 			select {
 			case <-ctx.Done():
 				return
 
 			case output_chan <- f:
+				last = basename
 			}
 		}
 

--- a/glob/glob_test.go
+++ b/glob/glob_test.go
@@ -119,6 +119,7 @@ var _GlobFixture = []struct {
 	{"Recursive matches zero or more", []string{"/usr/bin/X11/**/diff"}},
 	{"Recursive matches none at end", []string{"/bin/bash/**"}},
 	{"Match masked by two matches", []string{"/usr/bin", "/usr/*/diff"}},
+	{"Multiple globs matching same file", []string{"/bin/bash", "/bin/ba*"}},
 }
 
 func GetMockFileSystemAccessor() accessors.FileSystemAccessor {

--- a/reporting/container.go
+++ b/reporting/container.go
@@ -346,7 +346,8 @@ func (self *Container) Upload(
 		store_as_name = filename
 	}
 
-	cached, pres := uploads.DeduplicateUploads(scope, store_as_name)
+	cached, pres, closer := uploads.DeduplicateUploads(scope, store_as_name)
+	defer closer()
 	if pres {
 		return cached, nil
 	}

--- a/services/launcher/flows.go
+++ b/services/launcher/flows.go
@@ -235,6 +235,21 @@ func (self *Launcher) CancelFlow(
 		return &api_proto.StartFlowResponse{}, nil
 	}
 
+	// Handle server collections especially via the server artifact
+	// runner.
+	if client_id == "server" {
+		server_artifacts_service, err := services.GetServerArtifactRunner(
+			config_obj)
+		if err != nil {
+			return nil, err
+		}
+
+		server_artifacts_service.Cancel(ctx, flow_id, username)
+		return &api_proto.StartFlowResponse{
+			FlowId: flow_id,
+		}, nil
+	}
+
 	collection_context, err := LoadCollectionContext(
 		config_obj, client_id, flow_id)
 	if err == nil {

--- a/services/notifications/notifications.go
+++ b/services/notifications/notifications.go
@@ -294,6 +294,9 @@ func (self *Notifier) NotifyListenerAsync(
 }
 
 func (self *Notifier) IsClientDirectlyConnected(client_id string) bool {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	if self.notification_pool == nil {
 		return false
 	}

--- a/services/orgs.go
+++ b/services/orgs.go
@@ -57,6 +57,7 @@ type ServiceContainer interface {
 	NotebookManager() (NotebookManager, error)
 	ClientEventManager() (ClientEventTable, error)
 	ServerEventManager() (ServerEventManager, error)
+	ServerArtifactRunner() (ServerArtifactRunner, error)
 	Notifier() (Notifier, error)
 	ACLManager() (ACLManager, error)
 }

--- a/services/server_artifacts.go
+++ b/services/server_artifacts.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"context"
+
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
+	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+)
+
+func GetServerArtifactRunner(config_obj *config_proto.Config) (ServerArtifactRunner, error) {
+	org_manager, err := GetOrgManager()
+	if err != nil {
+		return nil, err
+	}
+
+	return org_manager.Services(config_obj.OrgId).ServerArtifactRunner()
+}
+
+type ServerArtifactRunner interface {
+	// Start a new collection in the current process.
+	LaunchServerArtifact(
+		config_obj *config_proto.Config,
+		session_id string,
+		req *crypto_proto.FlowRequest,
+		collection_context *flows_proto.ArtifactCollectorContext) error
+
+	// Cancel the current running collection if possible.
+	Cancel(ctx context.Context, session_id, principal string)
+}

--- a/services/server_artifacts/collection_context.go
+++ b/services/server_artifacts/collection_context.go
@@ -56,15 +56,11 @@ func NewCollectionContextManager(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config,
-	msg *crypto_proto.VeloMessage,
+	req *crypto_proto.FlowRequest,
 	collection_context *flows_proto.ArtifactCollectorContext) (
 	CollectionContextManager, error) {
 
 	flow_id := collection_context.SessionId
-	if msg.FlowRequest == nil {
-		return nil, errors.New("Invalid request")
-	}
-
 	sub_ctx, cancel := context.WithCancel(ctx)
 	log_writer, err := NewServerLogWriter(sub_ctx, config_obj, flow_id)
 	if err != nil {
@@ -72,13 +68,13 @@ func NewCollectionContextManager(
 	}
 
 	row_limit := int64(1000000)
-	if msg.FlowRequest.MaxRows > 0 {
-		row_limit = int64(msg.FlowRequest.MaxRows)
+	if req.MaxRows > 0 {
+		row_limit = int64(req.MaxRows)
 	}
 
 	byte_limit := int64(1000000000)
-	if msg.FlowRequest.MaxUploadBytes > 0 {
-		byte_limit = int64(msg.FlowRequest.MaxUploadBytes)
+	if req.MaxUploadBytes > 0 {
+		byte_limit = int64(req.MaxUploadBytes)
 	}
 
 	self := &contextManager{

--- a/services/server_artifacts/server_uploader.go
+++ b/services/server_artifacts/server_uploader.go
@@ -49,7 +49,8 @@ func (self *ServerUploader) Upload(
 		store_as_name = filename
 	}
 
-	cached, pres := uploads.DeduplicateUploads(scope, store_as_name)
+	cached, pres, closer := uploads.DeduplicateUploads(scope, store_as_name)
+	defer closer()
 	if pres {
 		return cached, nil
 	}

--- a/uploads/client_uploader.go
+++ b/uploads/client_uploader.go
@@ -46,7 +46,8 @@ func (self *VelociraptorUploader) Upload(
 		store_as_name = filename
 	}
 
-	cached, pres := DeduplicateUploads(scope, store_as_name)
+	cached, pres, closer := DeduplicateUploads(scope, store_as_name)
+	defer closer()
 	if pres {
 		return cached, nil
 	}

--- a/uploads/deduplication.go
+++ b/uploads/deduplication.go
@@ -1,0 +1,94 @@
+package uploads
+
+import (
+	"sync"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/utils"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+)
+
+var (
+	dedup_mu sync.Mutex
+)
+
+type cachedUploadResponse struct {
+	mu sync.Mutex
+
+	response *UploadResponse
+}
+
+// Manage the uploader cache - this is used to deduplicate files that
+// are uploaded multiple time so they only upload one file.
+func DeduplicateUploads(scope vfilter.Scope,
+	store_as_name *accessors.OSPath) (*UploadResponse, bool, func()) {
+
+	dedup_mu.Lock()
+	defer dedup_mu.Unlock()
+
+	root_scope := vql_subsystem.GetRootScope(scope)
+	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
+	if utils.IsNil(cache_any) {
+		cache_any = ordereddict.NewDict()
+	}
+
+	cache, ok := cache_any.(*ordereddict.Dict)
+	if !ok {
+		cache = ordereddict.NewDict()
+	}
+	defer vql_subsystem.CacheSet(root_scope, UPLOAD_CTX, cache)
+
+	// Search for the cached upload response.
+	key := store_as_name.String()
+	cached_response_any, pres := cache.Get(key)
+	if pres {
+		cached_response, ok := cached_response_any.(*cachedUploadResponse)
+		if ok {
+			cached_response.mu.Lock()
+			return cached_response.response, true, cached_response.mu.Unlock
+		}
+	}
+
+	// If there is no cached item, we need to add a placeholder, so
+	// other uploaders will wait for us to complete.
+	placeholder := &cachedUploadResponse{}
+	placeholder.mu.Lock()
+	cache.Set(key, placeholder)
+	return nil, false, placeholder.mu.Unlock
+}
+
+// Add the result into the cache
+func CacheUploadResult(scope vfilter.Scope,
+	store_as_name *accessors.OSPath,
+	response *UploadResponse) {
+	root_scope := vql_subsystem.GetRootScope(scope)
+	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
+	if utils.IsNil(cache_any) {
+		return
+	}
+
+	cache, ok := cache_any.(*ordereddict.Dict)
+	if ok {
+		key := store_as_name.String()
+		cached_response_any, pres := cache.Get(key)
+		if !pres {
+			cached_response_any = &cachedUploadResponse{
+				response: response,
+			}
+		}
+
+		cached_response, ok := cached_response_any.(*cachedUploadResponse)
+		if ok {
+			cached_response.response = response
+		} else {
+			// Should not really happen but if it does, we just cache
+			// it anyway
+			cached_response = &cachedUploadResponse{
+				response: response,
+			}
+		}
+		cache.Set(key, cached_response)
+	}
+}

--- a/uploads/file_based.go
+++ b/uploads/file_based.go
@@ -92,7 +92,8 @@ func (self *FileBasedUploader) Upload(
 		store_as_name = filename
 	}
 
-	cached, pres := DeduplicateUploads(scope, store_as_name)
+	cached, pres, closer := DeduplicateUploads(scope, store_as_name)
+	defer closer()
 	if pres {
 		return cached, nil
 	}

--- a/uploads/utils.go
+++ b/uploads/utils.go
@@ -1,13 +1,8 @@
 package uploads
 
 import (
-	"github.com/Velocidex/ordereddict"
-	"www.velocidex.com/golang/velociraptor/accessors"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/utils"
-	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
-	"www.velocidex.com/golang/vfilter"
 )
 
 func ShouldPadFile(
@@ -46,47 +41,4 @@ func ShouldPadFile(
 	}
 
 	return false
-}
-
-// Manage the uploader cache - this is used to deduplicate files that
-// are uploaded multiple time so they only upload one file.
-func DeduplicateUploads(scope vfilter.Scope,
-	store_as_name *accessors.OSPath) (*UploadResponse, bool) {
-
-	root_scope := vql_subsystem.GetRootScope(scope)
-	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
-	if utils.IsNil(cache_any) {
-		cache_any = ordereddict.NewDict()
-		vql_subsystem.CacheSet(root_scope, UPLOAD_CTX, cache_any)
-	}
-
-	cache, ok := cache_any.(*ordereddict.Dict)
-	if ok {
-		key := store_as_name.String()
-		result_any, pres := cache.Get(key)
-		if pres {
-			result, ok := result_any.(*UploadResponse)
-			if ok {
-				return result, true
-			}
-		}
-	}
-	return nil, false
-}
-
-func CacheUploadResult(scope vfilter.Scope,
-	store_as_name *accessors.OSPath,
-	result *UploadResponse) {
-	root_scope := vql_subsystem.GetRootScope(scope)
-	cache_any := vql_subsystem.CacheGet(root_scope, UPLOAD_CTX)
-	if utils.IsNil(cache_any) {
-		cache_any = ordereddict.NewDict()
-		vql_subsystem.CacheSet(root_scope, UPLOAD_CTX, cache_any)
-	}
-
-	cache, ok := cache_any.(*ordereddict.Dict)
-	if ok {
-		key := store_as_name.String()
-		cache.Set(key, result)
-	}
 }


### PR DESCRIPTION
Where multiple glob expressions were used and the same file was found by multiple expressions the path was not properly deduplicated.

Also improved locking on the upload deduplication. When one thread is uploading, other threads should wait on it to complete.