### PR TITLE
Bugfix: Server artifact running should use parent context for save

### DIFF
--- a/responder/responder.go
+++ b/responder/responder.go
@@ -150,7 +150,7 @@ func (self *FlowResponder) AddResponse(message *crypto_proto.VeloMessage) {
 
 	// Check flow limits. Must be done without a lock on the responder.
 	if message.FileBuffer != nil {
-		self.flow_context.ChargeBytes(uint64(len(message.FileBuffer.Data)))
+		self.flow_context.ChargeBytes(uint64(message.FileBuffer.DataLength))
 	}
 	if message.VQLResponse != nil {
 		self.flow_context.ChargeRows(message.VQLResponse.TotalRows)


### PR DESCRIPTION
Previously used the cancellable sub ctx which means that sometimes when cancelling a server artifact the final status could not be written becuase the context was already cancelled.