### PR TITLE
Refactoring side panel navigation as "main menu" navigation, tweaked the hamburger button

### DIFF
--- a/gui/velociraptor/src/components/i8n/de.jsx
+++ b/gui/velociraptor/src/components/i8n/de.jsx
@@ -96,6 +96,9 @@ const Deutsch = {
     "Create a new artifact": "Erstellen eines neuen Artefakt",
     "Save": "Speichern",
     "Search": "Suchen",
+    "Toggle Main Menu": "Hauptmenü umschalten",
+    "Main Menu": "Hauptmenü",
+    "Welcome": "Willkommen",
 
     // Keyboard navigation.
     "Global hotkeys": "Globale Hotkeys",

--- a/gui/velociraptor/src/components/i8n/en.jsx
+++ b/gui/velociraptor/src/components/i8n/en.jsx
@@ -46,6 +46,9 @@ const English = {
     "Shell": "Shell",
     "Close": "Close",
     "Search": "Search",
+    "Main Menu": "Main Menu",
+    "Toggle Main Menu": "Toggle Main Menu",
+    "Welcome": "Welcome",
     "Connected": "Connected",
     "time_ago": (value, unit) => {
         return value + ' ' + unit + ' ago';

--- a/gui/velociraptor/src/components/i8n/es.jsx
+++ b/gui/velociraptor/src/components/i8n/es.jsx
@@ -97,6 +97,9 @@ const Spanish = {
     "Create a new artifact": "Crear un nuevo artefacto",
     "Save": "Guardar",
     "Search": "Buscar",
+    "Toggle Main Menu": "Alternar menú principal",
+    "Main Menu": "Menú principal",
+    "Welcome": "Bienvenido",
 
     // Keyboard navigation.
     "Global hotkeys": "Teclas de acceso directo globales",

--- a/gui/velociraptor/src/components/i8n/fr.jsx
+++ b/gui/velociraptor/src/components/i8n/fr.jsx
@@ -98,6 +98,9 @@ const French = {
     "Create a new artifact": "Créer un nouvel artefact",
     "Save": "Enregistrer",
     "Search": "Recherche",
+    "Toggle Main Menu": "Basculer le menu principal",
+    "Main Menu": "Menu principal",
+    "Welcome": "Bienvenu",
 
     // Navigation au clavier.
     "Global hotkeys": "Raccourcis globaux",

--- a/gui/velociraptor/src/components/i8n/jp.jsx
+++ b/gui/velociraptor/src/components/i8n/jp.jsx
@@ -95,6 +95,9 @@ const Japanese = {
     "Create a new artifact": "新規アーティファクトを作成する",
     "Save": "保存",
     "Search": "検索",
+    "Toggle Main Menu": "メインメニューの切り替え",
+    "Main Menu": "メインメニュー",
+    "Welcome": "いらっしゃいませ",
 
     // Keyboard navigation.
     "Global hotkeys": "グローバルホットキー",

--- a/gui/velociraptor/src/components/i8n/por.jsx
+++ b/gui/velociraptor/src/components/i8n/por.jsx
@@ -98,6 +98,9 @@ const Portuguese = {
     "Create a new artifact": "Criar um novo artefato",
     "Save": "Salvar",
     "Search": "Procurar",
+    "Toggle Main Menu": "Alternar menu principal",
+    "Main Menu": "Menu principal",
+    "Welcome": "Bem-vindo",
 
     // Navegação do teclado.
     "Global hotkeys": "Teclas de atalho globais",

--- a/gui/velociraptor/src/components/sidebar/navigator.css
+++ b/gui/velociraptor/src/components/sidebar/navigator.css
@@ -29,9 +29,15 @@ img.velo-logo {
 
 /* Sidebar navbar */
 
-section.navigator a {
+nav.navigator a {
+  display: block;
+  padding: 0.5rem 1rem;
   text-decoration: none;
   color: var(--color-sidebar-foreground);
+}
+
+nav.navigator li.nav-link {
+  padding: 0;
 }
 
 .navigator.nav-pills.nav li {
@@ -43,7 +49,7 @@ section.navigator a {
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.navigator.nav-pills.nav .nav-link.disabled {
+nav.navigator ul.navigator.nav-pills.nav .nav-link.disabled {
   opacity: 30%;
   pointer-events: none;
 }
@@ -53,7 +59,7 @@ section.navigator a {
   width: 260px;
 }
 
-a.active .nav.nav-pills.navigator .nav-link {
+.nav.nav-pills.navigator .nav-link:has(a.active) {
   background-color: var(--color-sidebar-active-background);
   color: var(--color-sidebar-active-foreground);
 }
@@ -66,10 +72,6 @@ a.active .nav.nav-pills.navigator .nav-link {
 button a.nav-link {
   padding: 0px;
   color: black;
-}
-
-.nav-link {
-  padding: 0.5rem 1rem;
 }
 
 .navicon {
@@ -109,10 +111,12 @@ div#navigator.collapsed {
   width: 260px;
 }
 
-span.hamburger {
+button.hamburger {
   float: left;
   font-size: 30px;
   cursor: pointer;
+  border: none;
+  background-color: var(--color-header-background);
 }
 
 a.disabled {

--- a/gui/velociraptor/src/components/sidebar/navigator.jsx
+++ b/gui/velociraptor/src/components/sidebar/navigator.jsx
@@ -71,248 +71,237 @@ class VeloNavigator extends Component {
         return (
             <>
               <div className="float-left navigator">
-                <span className="hamburger toolbar-buttons"
-                      onClick={this.toggle}>&#9776;</span>
-                <a href="#welcome">
-                  <img src={logo} className="velo-logo" alt="velo logo"/>
-                </a>
-                <div className={classNames({
-                    'collapsed': this.state.collapsed,
-                    'uncollapsed': !this.state.collapsed})}
-                     id="navigator"
-                     onClick={this.collapse}>
-                  <div>
-                    <section className="navigator">
-                      <NavLink exact={true} to="/dashboard">
-                        <ul className="nav nav-pills navigator">
-                          <li className="nav-link" state="userDashboard">
-                            <span>
-                              <i className="navicon">
-                                <FontAwesomeIcon icon="home"/></i>
-                            </span>
-                            {T("Home")}
-                          </li>
-                        </ul>
-                      </NavLink>
-
-                      <NavLink to="/hunts">
-                        <ul className="nav nav-pills navigator">
-                          <li className="nav-link" state="hunts" >
-                            <span>
-                              <i className="navicon">
-                                <FontAwesomeIcon icon="crosshairs"/></i>
-                            </span>
-                            {T("Hunt Manager")}
-                          </li>
-                        </ul>
-                      </NavLink>
-
-                      <NavLink to="/artifacts">
-                        <ul className="nav nav-pills navigator">
-                          <li className="nav-link" state="view_artifacts" >
-                            <span>
-                              <i className="navicon">
-                                <FontAwesomeIcon icon="wrench"/></i>
-                            </span>
-                            {T("View Artifacts")}
-                          </li>
-                        </ul>
-                      </NavLink>
-
-                      { !customization.disable_server_events &&
-                        <NavLink to="/events/server">
-                          <ul className="nav nav-pills  navigator">
-                            <li className="nav-link" state="server_events" >
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="eye"/></i>
-                              </span>
-                              {T("Server Events")}
-                            </li>
-                          </ul>
+                <button
+                  className="hamburger toolbar-buttons"
+                  onClick={this.toggle}
+                  aria-expanded={!this.state.collapsed}
+                >
+                  <span aria-hidden="true">&#9776;</span>
+                  <span className="sr-only">{T("Toggle Main Menu")}</span>
+              </button>
+              <a href="#welcome">
+                <img src={logo} className="velo-logo" alt={T("Welcome")} />
+              </a>
+              <div
+                className={classNames({
+                  collapsed: this.state.collapsed,
+                  uncollapsed: !this.state.collapsed,
+                })}
+                id="navigator"
+                onClick={this.collapse}
+              >
+                <div>
+                  <nav className="navigator" aria-labelledby="mainmenu">
+                    <h2 id="mainmenu" className="sr-only">
+                      {T("Main Menu")}
+                    </h2>
+                    <ul className="nav nav-pills navigator">
+                      <li className="nav-link" state="userDashboard">
+                        <NavLink exact={true} to="/dashboard">
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="home" />
+                            </i>
+                          </span>
+                          {T("Home")}
                         </NavLink>
-                      }
+                      </li>
 
-                      <NavLink to="/collected/server">
-                        <ul className="nav nav-pills  navigator">
-                          <li className="nav-link" state="server_artifacts" >
-                            <span>
-                              <i className="navicon">
-                                <FontAwesomeIcon icon="server"/></i>
-                            </span>
-                            {T("Server Artifacts")}
-                          </li>
-                        </ul>
-                      </NavLink>
-
-                      <NavLink to="/notebooks">
-                        <ul className="nav nav-pills navigator">
-                          <li className="nav-link" state="notebook" >
-                            <span>
-                              <i className="navicon">
-                                <FontAwesomeIcon icon="book"/></i>
-                            </span>
-                            {T("Notebooks")}
-                          </li>
-                        </ul>
-                      </NavLink>
-
-                      { user_is_admin && !customization.disable_user_management &&
-                        <NavLink to="/users">
-                          <ul className="nav nav-pills navigator">
-                            <li className="nav-link" state="users" >
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="user"/></i>
-                              </span>
-                              {T("Users")}
-                            </li>
-                          </ul>
+                      <li className="nav-link" state="hunts">
+                        <NavLink to="/hunts">
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="crosshairs" />
+                            </i>
+                          </span>
+                          {T("Hunt Manager")}
                         </NavLink>
-                      }
+                      </li>
 
-                      { disabled ?
-                        <>
-                          <ul className="nav nav-pills navigator">
-                            <li className={classNames({
-                                "nav-link": true,
-                                disabled: disabled})}>
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="laptop"/> </i>
-                              </span>
-                              {T("Host Information")}
-                            </li>
-                          </ul>
+                      <li className="nav-link" state="view_artifacts">
+                        <NavLink to="/artifacts">
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="wrench" />
+                            </i>
+                          </span>
+                          {T("View Artifacts")}
+                        </NavLink>
+                      </li>
 
-                          <ul className="nav nav-pills navigator">
-                            <li className={classNames({
-                                "nav-link": true,
-                                disabled: disabled})}>
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="folder-open"/> </i>
-                              </span>
-                              {T("Virtual Filesystem")}
-                            </li>
-                          </ul>
-                          <ul className="nav nav-pills navigator">
-                            <li className={classNames({
-                                "nav-link": true,
-                                disabled: disabled})}>
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="history"/></i>
-                              </span>
-                              {T("Collected Artifacts")}
-                            </li>
-                          </ul>
-                          <ul className="nav nav-pills navigator">
-                            <li className={classNames({
-                                "nav-link": true,
-                                disabled: disabled})}>
-                              <span>
-                                <i className="navicon">
-                                  <FontAwesomeIcon icon="binoculars"/></i>
-                              </span>
-                              {T("Client Events")}
-                            </li>
-                          </ul>
-                        </>
-                        :
-                        <>
-                          <NavLink className={disabled}
-                                   to={"/host/" + this.props.client.client_id}>
-                            <ul className="nav nav-pills navigator">
-                              <li className={classNames({
-                                  "nav-link": true,
-                                  disabled: disabled})}>
-                                <span>
-                                  <i className="navicon">
-                                    <FontAwesomeIcon icon="laptop"/> </i>
-                                </span>
-                                {T("Host Information")}
-                              </li>
-                            </ul>
+                      {!customization.disable_server_events && (
+                        <li className="nav-link" state="server_events">
+                          <NavLink to="/events/server">
+                            <span>
+                              <i className="navicon">
+                                <FontAwesomeIcon icon="eye" />
+                              </i>
+                            </span>
+                            {T("Server Events")}
                           </NavLink>
+                        </li>
+                      )}
 
-                          <NavLink className={disabled}
-                                   disabled={disabled}
-                                   to={"/vfs/" + this.props.client.client_id + EncodePathInURL(vfs_path) }>
-                            <ul className="nav nav-pills navigator">
-                              <li className={classNames({
-                                  "nav-link": true,
-                                  disabled: disabled})}>
-                                <span>
-                                  <i className="navicon">
-                                    <FontAwesomeIcon icon="folder-open"/> </i>
-                                </span>
-                                {T("Virtual Filesystem")}
-                              </li>
-                            </ul>
+                      <li className="nav-link" state="server_artifacts">
+                        <NavLink to="/collected/server">
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="server" />
+                            </i>
+                          </span>
+                          {T("Server Artifacts")}
+                        </NavLink>
+                      </li>
+
+                      <li className="nav-link" state="notebook">
+                        <NavLink to="/notebooks">
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="book" />
+                            </i>
+                          </span>
+                          {T("Notebooks")}
+                        </NavLink>
+                      </li>
+
+                      {user_is_admin && !customization.disable_user_management && (
+                        <li className="nav-link" state="users">
+                          <NavLink to="/users">
+                            <span>
+                              <i className="navicon">
+                                <FontAwesomeIcon icon="user" />
+                              </i>
+                            </span>
+                            {T("Users")}
                           </NavLink>
+                        </li>
+                      )}
 
-                          <NavLink className={disabled}
-                                   disabled={disabled}
-                                   to={"/collected/" + this.props.client.client_id}>
-                            <ul className="nav nav-pills navigator">
-                              <li className={classNames({
-                                  "nav-link": true,
-                                  disabled: disabled})}>
-                                <span>
-                                  <i className="navicon">
-                                    <FontAwesomeIcon icon="history"/></i>
-                                </span>
-                                {T("Collected Artifacts")}
-                              </li>
-                            </ul>
-                          </NavLink>
+                      <li
+                        className={classNames({
+                          "nav-link": true,
+                          disabled: disabled,
+                        })}
+                      >
+                        <NavLink
+                          className={disabled}
+                          disabled={disabled}
+                          aria-hidden={disabled ? "true" : "false"}
+                          tabIndex={disabled ? "-1" : "0"}
+                          to={"/host/" + this.props.client.client_id}
+                        >
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="laptop" />{" "}
+                            </i>
+                          </span>
+                          {T("Host Information")}
+                        </NavLink>
+                      </li>
 
-                          <NavLink className={disabled}
-                                   disabled={disabled}
-                                   to={"/events/" + this.props.client.client_id}>
-                            <ul className="nav nav-pills navigator">
-                              <li className={classNames({
-                                  "nav-link": true,
-                                  disabled: disabled})}>
-                                <span>
-                                  <i className="navicon">
-                                    <FontAwesomeIcon icon="binoculars"/></i>
-                                </span>
-                                {T("Client Events")}
-                              </li>
-                            </ul>
-                          </NavLink>
-                        </>
-                      }
+                      <li
+                        className={classNames({
+                          "nav-link": true,
+                          disabled: disabled,
+                        })}
+                      >
+                        <NavLink
+                          className={disabled}
+                          disabled={disabled}
+                          aria-hidden={disabled !== null ? "true" : "false"}
+                          tabIndex={disabled !== null ? "-1" : "0"}
+                          to={
+                            "/vfs/" +
+                            this.props.client.client_id +
+                            EncodePathInURL(vfs_path)
+                          }
+                        >
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="folder-open" />{" "}
+                            </i>
+                          </span>
+                          {T("Virtual Filesystem")}
+                        </NavLink>
+                      </li>
 
-                      { _.map(sidebar_links, x=>{
-                          return  (
-                           <ul key={x.text}
-                               className="nav nav-pills navigator">
-                             <li className={classNames({
-                                 "nav-link": true})}>
-                               <a href={x.url} rel="noreferrer"
-                                  target={x.new_tab ? "_blank" : ""}>
-                                 <span>
-                                   <img className="sidebar-icon"
-                                        alt={x.text}
-                                        src={x.icon_url}/>
-                                 </span>
-                                 {T(x.text)}
-                               </a>
-                              </li>
-                            </ul>
-                          );
-                          })
-                      }
-                    </section>
-                  </div>
+                      <li
+                        className={classNames({
+                          "nav-link": true,
+                          disabled: disabled,
+                        })}
+                      >
+                        <NavLink
+                          className={disabled}
+                          disabled={disabled}
+                          aria-hidden={disabled !== null ? "true" : "false"}
+                          tabIndex={disabled !== null ? "-1" : "0"}
+                          to={"/collected/" + this.props.client.client_id}
+                        >
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="history" />
+                            </i>
+                          </span>
+                          {T("Collected Artifacts")}
+                        </NavLink>
+                      </li>
+
+                      <li
+                        className={classNames({
+                          "nav-link": true,
+                          disabled: disabled,
+                        })}
+                      >
+                        <NavLink
+                          className={disabled}
+                          disabled={disabled}
+                          aria-hidden={disabled !== null ? "true" : "false"}
+                          tabIndex={disabled !== null ? "-1" : "0"}
+                          to={"/events/" + this.props.client.client_id}
+                        >
+                          <span>
+                            <i className="navicon">
+                              <FontAwesomeIcon icon="binoculars" />
+                            </i>
+                          </span>
+                          {T("Client Events")}
+                        </NavLink>
+                      </li>
+
+                      {_.map(sidebar_links, (x) => {
+                        return (
+                          <li
+                            key={x.text}
+                            className={classNames({
+                              "nav-link": true,
+                            })}
+                          >
+                            <a
+                              href={x.url}
+                              rel="noreferrer"
+                              target={x.new_tab ? "_blank" : ""}
+                            >
+                              <span>
+                                <img
+                                  className="sidebar-icon"
+                                  alt=""
+                                  src={x.icon_url}
+                                />
+                              </span>
+                              {T(x.text)}
+                            </a>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </nav>
                 </div>
               </div>
-            </>
-        );
-    }
+            </div>
+          </>
+      );
+  }
 }
 
 export default VeloNavigator;

--- a/gui/velociraptor/src/themes/coolgray-dark.css
+++ b/gui/velociraptor/src/themes/coolgray-dark.css
@@ -272,14 +272,21 @@ body.coolgray-dark {
   padding-bottom: 1em;
 }
 
-.coolgray-dark .navigator.nav-pills.nav li:hover {
+.coolgray-dark nav.navigator .nav-pills .nav-link {
+  padding: 0;
+}
+
+.coolgray-dark .navigator.nav-pills.nav li:hover > a:not(.active) {
   color: var(--color-sidebar-inactive-foreground-hover);
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.coolgray-dark a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.coolgray-dark .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.coolgray-dark .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
 }
 
 .coolgray-dark .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/github-dimmed-dark.css
+++ b/gui/velociraptor/src/themes/github-dimmed-dark.css
@@ -246,9 +246,12 @@ body.github-dimmed-dark {
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.github-dimmed-dark a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.github-dimmed-dark .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.github-dimmed-dark .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
 }
 
 .github-dimmed-dark .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/midnight.css
+++ b/gui/velociraptor/src/themes/midnight.css
@@ -283,14 +283,21 @@ body.midnight {
   padding-bottom: 1em;
 }
 
-.midnight .navigator.nav-pills.nav li:hover {
+.midnight nav.navigator .nav-pills .nav-link {
+  padding: 0;
+}
+
+.midnight .navigator.nav-pills.nav li:hover > a:not(.active) {
   color: var(--color-sidebar-inactive-foreground-hover);
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.midnight a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.midnight .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.midnight .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
 }
 
 .midnight .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/ncurses.css
+++ b/gui/velociraptor/src/themes/ncurses.css
@@ -366,9 +366,12 @@ body.ncurses {
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.ncurses a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.ncurses .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.ncurses .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
 }
 
 .ncurses .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/no-theme.css
+++ b/gui/velociraptor/src/themes/no-theme.css
@@ -83,6 +83,22 @@ body.no-theme {
     border-color: #e5e5e5;
 }
 
+/*
+ Main menu navigation
+ */
+.no-theme .navigator.nav-pills.nav li:hover > a:not(.active) {
+    color: var(--color-sidebar-inactive-foreground-hover);
+    background: var(--color-sidebar-inactive-background-hover);
+}
+
+.no-theme .navigator.nav-pills.nav li:has(a.active) {
+    background: var(--color-sidebar-active-background);
+}
+
+.no-theme .navigator.nav-pills.nav li a.active {
+    color: var(--color-sidebar-active-foreground);
+}
+
 .no-theme .btn-outline-info {
     border-color: #17a2b8;
     color: #17a2b8;

--- a/gui/velociraptor/src/themes/pink-light.css
+++ b/gui/velociraptor/src/themes/pink-light.css
@@ -172,7 +172,8 @@ body.pink-light {
   border-color: whitesmoke;
 }
 
-.pink-light .hamburger {
+.pink-light button.hamburger {
+  background-color: #fff0f5;
   color: var(--color-sidebar-foreground);
 }
 
@@ -254,9 +255,18 @@ body.pink-light {
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.pink-light a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.pink-light .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.pink-light .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
+}
+
+.pink-light .navigator.nav-pills.nav .nav-link.disabled {
+  color: var(--color-sidebar-disabled-foreground);
+  background: var(--color-sidebar-background);
+  pointer-events: none;
 }
 
 .pink-light .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/veloci-dark.css
+++ b/gui/velociraptor/src/themes/veloci-dark.css
@@ -257,9 +257,12 @@ body.veloci-dark {
   background: var(--color-sidebar-inactive-background-hover);
 }
 
-.veloci-dark a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
+.veloci-dark .navigator.nav-pills.nav li:has(a.active) {
   background: var(--color-sidebar-active-background);
+}
+
+.veloci-dark .navigator.nav-pills.nav li a.active {
+  color: var(--color-sidebar-active-foreground);
 }
 
 .veloci-dark .navigator.nav-pills.nav .nav-link.disabled {

--- a/gui/velociraptor/src/themes/veloci-light.css
+++ b/gui/velociraptor/src/themes/veloci-light.css
@@ -154,7 +154,8 @@ body.veloci-light {
   border-color: var(--color-sidebar-background);
 }
 
-.veloci-light .hamburger {
+.veloci-light button.hamburger {
+  background-color: var(--color-sidebar-background);
   color: var(--color-sidebar-foreground);
 }
 
@@ -224,22 +225,25 @@ body.veloci-light {
 /* Sidebar navbar */
 
 .veloci-light div#navigator {
-  font-size: var(--font-size-base);
-  font-family: var(--font-family-sans-serif);
-  color: var(--color-sidebar-foreground);
-  box-shadow: none;
-  border-right: none;
-  background: var(--color-sidebar-background);
+    font-size: var(--font-size-base);
+    font-family: var(--font-family-sans-serif);
+    color: var(--color-sidebar-foreground);
+    box-shadow: none;
+    border-right: none;
+    background: var(--color-sidebar-background);
 }
 
-.veloci-light .navigator.nav-pills.nav li:hover {
-  color: var(--color-sidebar-inactive-foreground-hover);
-  background: var(--color-sidebar-inactive-background-hover);
+.veloci-light .navigator.nav-pills.nav li:hover > a:not(.active) {
+    color: var(--color-sidebar-inactive-foreground-hover);
+    background: var(--color-sidebar-inactive-background-hover);
 }
 
-.veloci-light a.active .navigator.nav-pills.nav li {
-  color: var(--color-sidebar-active-foreground);
-  background: var(--color-sidebar-active-background);
+.veloci-light .navigator.nav-pills.nav li:has(a.active) {
+    background: var(--color-sidebar-active-background);
+}
+
+.veloci-light .navigator.nav-pills.nav li a.active {
+    color: var(--color-sidebar-active-foreground);
 }
 
 .veloci-light .navigator.nav-pills.nav .nav-link.disabled {


### PR DESCRIPTION
Hello!

I did a few tweaks to improve the accessibility of the sidebar.

I created a new landmark "main menu" navigation (see screenshots to see the difference).

In the `<VeloNavigator />` I opted to remove the ternary that renders the "disabled" links as spans or elements and opted to just render links then hide it from assistive tech using `aria-hidden`. There was a slight challenge in ensuring the links don't get keyboard focus which is why I have the `tabIndex` as well.

My only question with this is what are the possible values of `disabled` in the `<VeloNavigator />` component? I'm seeing null and disabled, but couldn't find all possible values. Hopefully the null check is sufficient enough?

There is another approach in utilizing the `aria-disabled` but it requires tweaking the `hrefs` appropriately to prevent a user from accidentally going to a page that is disabled, once this happens all the main menu navigation links become enabled. This would seem more useful for disabling form controls like `<input />`, `<button />`, or `<textarea />`.

Added a few more phrases to the i18n dictionaries, then used where appropriate.

If you notice in the screenshots it says "list 8 items" but reads the enabled links as "3 out of 12," this is fine in my experience. As users get familiar with using the application consistency is useful. When a user learns how to enable the "Host Information," "Virtual Filesystem," "Collected Artifacts," and "Client Events" links, navigation to the main menu and jumping to the relevant link becomes easier.

The hamburger span is now a hamburger button, if you take a peak at the screenshots you'll see another aria attribute `expanded` lets users know what is happening as they are activating the button.

Other minor tweaks was removing the duplicate `alt` text in the `sidebar_links`, the `T(x.text)` is already sufficient otherwise it repeats the information twice in a screenreader for example.

<details><summary>voiceover screenshots before/after</summary>

Previous iteration:

![previous-main-menu-naviation](https://user-images.githubusercontent.com/3946895/222980673-b73e1012-2d0b-4b4b-94a5-d71f344ec2cc.png)

![previous-main-menu-link](https://user-images.githubusercontent.com/3946895/222980702-1eb24d5e-784f-40d0-a908-d2d4de0b7d13.png)

New Iteration:

![button-toggle-collapsed](https://user-images.githubusercontent.com/3946895/222980720-988058d9-1eaa-4b33-a88b-bfe040f2eaf5.png)

![button-toggle-expanded](https://user-images.githubusercontent.com/3946895/222980724-175b147a-d922-427f-82a6-4110ada3d78b.png)

![main-menu-navigation-landmark](https://user-images.githubusercontent.com/3946895/222980776-5a807085-8351-4590-a579-605ce5e6e2b2.png)

![main-menu-list-active-link-number](https://user-images.githubusercontent.com/3946895/222980778-f767e093-7793-4ba3-a3d0-75fc70164c4f.png)

![main-menu-list-link-out-of-total](https://user-images.githubusercontent.com/3946895/222980783-a4134e38-7c12-40d7-8a73-dabf0d6b6695.png)

![main-menu-list-current-link](https://user-images.githubusercontent.com/3946895/222980806-6e343439-3d9c-43c5-9201-3ad021b86535.png)

Hardcoded a disabled link as enabled for reference:

![main-menu-list-virtual-filesystem](https://user-images.githubusercontent.com/3946895/222980827-30360998-a9ef-498e-bd8c-667f3a0ef0c8.png)
</details>