### PR TITLE
Add Windows.Registry.PuttyHostKeys

### DIFF
--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -3,7 +3,7 @@ author: Matt Green - @mgreen27
 description: |
    This artifact extracts PuTTY SSH host keys.
    
-   As a security meassure PuTTY and its companion utilities PSCP, PSFTP, and Plink 
+   As a security measure PuTTY and its companion utilities PSCP, PSFTP, and Plink 
    records the host key for each server connected to, in the Windows Registry.
    
    - Output KeyName: ssh-ed12345@22:27.27.27.27

--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -31,12 +31,10 @@ sources:
       SELECT 
         Mtime,
         Username,
-        OSPath.Basename as KeyName,
-        Data.value as KeyValue,
-        path_join(components=[
-            "HKEY_USERS", UUID, OSPath.Dirname.Path
-                ], path_type="registry") as Key,
-        OSPath.DelegatePath as SourcePath
+        OSPath.Basename AS KeyName,
+        Data.value AS KeyValue,
+        HKEY_USERS + UUID + OSPath.Dirname AS Key,
+        OSPath.DelegatePath AS SourcePath
       FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob,userRegex=TargetUser)
       WHERE KeyName =~ TargetKeyName
         AND KeyValue =~ TargetKeyValue

--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -1,0 +1,43 @@
+name: Windows.Registry.PuttyHostKeys
+author: Matt Green - @mgreen27
+description: |
+   This artifact extracts PuTTY SSH host keys.
+   
+   As a security messure PuTTY and its companion utilities PSCP, PSFTP, and Plink 
+   records the host key for each server connected to, in the Windows Registry.
+   
+   - Output KeyName: ssh-ed12345@22:27.27.27.27
+   - To search for a specific IP: TargetKeyName =~ ':\<IP\>$'
+   - To search for a specific PORT: TargetKeyName =~ '@\<PORT\>:.+$'
+   
+   
+type: CLIENT
+
+parameters:
+   - name: KeyGlob
+     default: Software\SimonTatham\Putty\SshHostKeys\**
+   - name: TargetUser
+     default: .
+   - name: TargetKeyValue
+     default: .
+   - name: TargetKeyValue
+     default: .
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows' 
+
+    query: |
+      SELECT 
+        Mtime,
+        Username,
+        OSPath.Basename as KeyName,
+        Data.value as KeyValue,
+        path_join(components=[
+            "HKEY_USERS", UUID, OSPath.Dirname.Path
+                ], path_type="registry") as Key,
+        OSPath.DelegatePath as SourcePath
+      FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob,userRegex=TargetUser)
+      WHERE KeyName =~ TargetKeyName
+        AND KeyValue =~ TargetKeyValue
+

--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -3,7 +3,7 @@ author: Matt Green - @mgreen27
 description: |
    This artifact extracts PuTTY SSH host keys.
    
-   As a security messure PuTTY and its companion utilities PSCP, PSFTP, and Plink 
+   As a security meassure PuTTY and its companion utilities PSCP, PSFTP, and Plink 
    records the host key for each server connected to, in the Windows Registry.
    
    - Output KeyName: ssh-ed12345@22:27.27.27.27

--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -28,6 +28,8 @@ sources:
       SELECT OS From info() where OS = 'windows' 
 
     query: |
+      LET HKEY_USERS <= pathspec(path_type="registry", Path="HKEY_USERS")
+
       SELECT 
         Mtime,
         Username,

--- a/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
+++ b/artifacts/definitions/Windows/Registry/PuttyHostKeys.yaml
@@ -18,7 +18,7 @@ parameters:
      default: Software\SimonTatham\Putty\SshHostKeys\**
    - name: TargetUser
      default: .
-   - name: TargetKeyValue
+   - name: TargetKeyName
      default: .
    - name: TargetKeyValue
      default: .


### PR DESCRIPTION
Simple artifact to cover putty windows host keys.

Useful in scoping plink abuse.