### PR TITLE
Bugfix: Parsing OSPath from list of components

### DIFF
--- a/accessors/fixtures/TestVQLParsing.golden
+++ b/accessors/fixtures/TestVQLParsing.golden
@@ -1,0 +1,117 @@
+{
+ "Simple Path": {
+  "Components": [
+   "Hello",
+   "World"
+  ],
+  "PathSpec": {
+   "Path": "/Hello/World"
+  }
+ },
+ "Path With {": {
+  "Components": [
+   "Hello",
+   "{this is a test}"
+  ],
+  "PathSpec": {
+   "Path": "/Hello/{this is a test}"
+  }
+ },
+ "FSPathSpec": {
+  "Components": [
+   "Hello",
+   "World.json"
+  ],
+  "PathSpec": {
+   "DelegateAccessor": "fs",
+   "DelegatePath": "fs:",
+   "Path": "Hello/World.json"
+  }
+ },
+ "FSPathSpec With type": {
+  "Components": [
+   "Hello",
+   "World.zip"
+  ],
+  "PathSpec": {
+   "DelegateAccessor": "fs",
+   "DelegatePath": "fs:",
+   "Path": "Hello/World.zip"
+  }
+ },
+ "DSPathSpec": {
+  "Components": [
+   "Hello",
+   "World.json.db"
+  ],
+  "PathSpec": {
+   "DelegateAccessor": "fs",
+   "DelegatePath": "ds:",
+   "Path": "Hello/World.json.db"
+  }
+ },
+ "DSPathSpec With Type": {
+  "Components": [
+   "Hello",
+   "World.db"
+  ],
+  "PathSpec": {
+   "DelegateAccessor": "fs",
+   "DelegatePath": "ds:",
+   "Path": "Hello/World.db"
+  }
+ },
+ "OSPath": {
+  "Components": [
+   "foo",
+   "bar"
+  ],
+  "PathSpec": {
+   "Path": "/foo/bar"
+  }
+ },
+ "PathSpec": {
+  "Components": [
+   "foo",
+   "bar"
+  ],
+  "PathSpec": {
+   "Path": "/foo/bar"
+  }
+ },
+ "Serialized PathSpec": {
+  "Components": [
+   "foo",
+   "bar.txt"
+  ],
+  "PathSpec": {
+   "DelegateAccessor": "file",
+   "DelegatePath": "/tmp/file.zip",
+   "Path": "/foo/bar.txt"
+  }
+ },
+ "Multiple parts of mixed type": {
+  "Components": [
+   "root",
+   "home",
+   "foo",
+   "bar",
+   "Hello.txt"
+  ],
+  "PathSpec": {
+   "Path": "/root/home/foo/bar/Hello.txt"
+  }
+ },
+ "Multiple parts of mixed type 2": {
+  "Components": [
+   "root",
+   "home",
+   "a",
+   "b",
+   "Hello.txt"
+  ],
+  "PathSpec": {
+   "Path": "/root/home/a/b/Hello.txt"
+  }
+ }
+}

--- a/accessors/vql_arg_parser.go
+++ b/accessors/vql_arg_parser.go
@@ -87,9 +87,13 @@ func parseOSPath(ctx context.Context,
 		a_value := reflect.Indirect(reflect.ValueOf(value))
 		if a_value.Type().Kind() == reflect.Slice {
 			for idx := 0; idx < a_value.Len(); idx++ {
-				item, err := parseOSPath(ctx, scope, args,
-					a_value.Index(int(idx)).Interface())
+				slice_item := a_value.Index(int(idx)).Interface()
+				item, err := parseOSPath(ctx, scope, args, slice_item)
 				if err != nil {
+					string_item, ok := slice_item.(string)
+					if ok {
+						result = result.Append(string_item)
+					}
 					continue
 				}
 				item_os_path, ok := item.(*OSPath)

--- a/accessors/vql_arg_parser_test.go
+++ b/accessors/vql_arg_parser_test.go
@@ -1,0 +1,90 @@
+package accessors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Velocidex/ordereddict"
+	"github.com/sebdah/goldie"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
+	"www.velocidex.com/golang/velociraptor/json"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+
+	_ "www.velocidex.com/golang/velociraptor/accessors/file"
+)
+
+type testStruct struct {
+	Path     *accessors.OSPath `vfilter:"required,field=path"`
+	Accessor string            `vfilter:"optional,field=accessor"`
+}
+
+type testCases struct {
+	name string
+	in   vfilter.Any
+}
+
+var testcases = []testCases{
+	{name: "Simple Path",
+		in: []string{
+			"Hello", "World",
+		}},
+	{name: "Path With {",
+		in: []string{
+			"Hello", "{this is a test}",
+		}},
+	{name: "FSPathSpec",
+		in: path_specs.NewUnsafeFilestorePath("Hello", "World")},
+	{name: "FSPathSpec With type",
+		in: path_specs.NewUnsafeFilestorePath("Hello", "World").
+			SetType(api.PATH_TYPE_FILESTORE_DOWNLOAD_ZIP)},
+	{name: "DSPathSpec",
+		in: path_specs.NewUnsafeDatastorePath("Hello", "World")},
+
+	{name: "DSPathSpec With Type",
+		in: path_specs.NewUnsafeDatastorePath("Hello", "World").
+			SetType(api.PATH_TYPE_DATASTORE_PROTO)},
+
+	{name: "OSPath",
+		in: accessors.MustNewGenericOSPath("/foo/bar")},
+
+	{name: "PathSpec",
+		in: accessors.MustNewGenericOSPath("/foo/bar").PathSpec()},
+
+	{name: "Serialized PathSpec",
+		in: `{"Path": "/foo/bar.txt", "Accessor": "zip", "DelegatePath": "/tmp/file.zip", "DelegateAccessor": "file"}`},
+
+	{name: "Multiple parts of mixed type",
+		in: []vfilter.Any{accessors.MustNewGenericOSPath("/foo/bar"), "Hello.txt"}},
+
+	// Just join all parts
+	{name: "Multiple parts of mixed type",
+		in: []vfilter.Any{"/root/home", accessors.MustNewGenericOSPath("/foo/bar"), "Hello.txt"}},
+
+	{name: "Multiple parts of mixed type 2",
+		in: []vfilter.Any{"/root/home", `{"Path": "/a/b"}`, "Hello.txt"}},
+}
+
+func TestVQLParsing(t *testing.T) {
+	ctx := context.Background()
+	scope := vql_subsystem.MakeScope()
+	result := ordereddict.NewDict()
+
+	for _, testcase := range testcases {
+		args := ordereddict.NewDict().
+			Set("accessor", "file").
+			Set("path", testcase.in)
+		arg := &testStruct{}
+		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+		assert.NoError(t, err)
+
+		result.Set(testcase.name, ordereddict.NewDict().
+			Set("Components", arg.Path.Components).
+			Set("PathSpec", arg.Path.PathSpec()))
+	}
+	goldie.Assert(t, "TestVQLParsing", json.MustMarshalIndent(result))
+}

--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -325,12 +325,12 @@ func reject_with_username(
 		logrus.Fields{
 			"remote": r.RemoteAddr,
 			"method": r.Method,
-			"url":    r.URL,
+			"url":    r.URL.String(),
 			"err":    err.Error(),
 		})
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(http.StatusUnauthorized)
+	w.WriteHeader(http.StatusOK)
 
 	renderRejectionMessage(config_obj,
 		w, username, []velociraptor.AuthenticatorInfo{

--- a/api/authenticators/template.go
+++ b/api/authenticators/template.go
@@ -30,6 +30,7 @@ func renderRejectionMessage(
 	}
 
 	err = tmpl.Execute(w, velociraptor.HTMLtemplateArgs{
+		BasePath: getBasePath(config_obj),
 		ErrState: json.MustMarshalString(velociraptor.ErrState{
 			Type:           "Login",
 			Username:       username,
@@ -61,6 +62,7 @@ func renderLogoffMessage(
 	}
 
 	err = tmpl.Execute(w, velociraptor.HTMLtemplateArgs{
+		BasePath: getBasePath(config_obj),
 		ErrState: json.MustMarshalString(velociraptor.ErrState{
 			Type:           "Logoff",
 			Username:       username,

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	errors "github.com/go-errors/errors"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -133,7 +134,7 @@ func PrepareGUIMux(
 		return nil, err
 	}
 
-	base := config_obj.GUI.BasePath
+	base := strings.TrimSuffix(config_obj.GUI.BasePath, "/")
 
 	mux.Handle(base+"/api/", csrfProtect(config_obj,
 		auther.AuthenticateUserHandler(h)))

--- a/artifacts/testdata/server/testcases/notebook.out.yaml
+++ b/artifacts/testdata/server/testcases/notebook.out.yaml
@@ -28,8 +28,8 @@ LET _ <= mock_time(now=1669861615)[]LET _ <= SELECT OSPath, file_store_delete(pa
   "Size": 8
  },
  {
-  "FullPath": "/N.CG74N2JSSV75S/NC.CG74N5GVJAA2E/uploads/test.txt",
-  "Size": 11
+  "FullPath": "/N.CG74N2JSSV75S/NC.CG74N5GVJAA2E/uploads",
+  "Size": 0
  },
  {
   "FullPath": "/N.CG74N2JSSV75S/files/NA.CG75NPHSURTDQimage.png",

--- a/artifacts/testdata/server/testcases/notebook.out.yaml
+++ b/artifacts/testdata/server/testcases/notebook.out.yaml
@@ -28,8 +28,8 @@ LET _ <= mock_time(now=1669861615)[]LET _ <= SELECT OSPath, file_store_delete(pa
   "Size": 8
  },
  {
-  "FullPath": "/N.CG74N2JSSV75S/NC.CG74N5GVJAA2E/uploads",
-  "Size": 0
+  "FullPath": "/N.CG74N2JSSV75S/NC.CG74N5GVJAA2E/uploads/test.txt",
+  "Size": 11
  },
  {
   "FullPath": "/N.CG74N2JSSV75S/files/NA.CG75NPHSURTDQimage.png",

--- a/gui/velociraptor/src/components/sidebar/navigator.jsx
+++ b/gui/velociraptor/src/components/sidebar/navigator.jsx
@@ -82,7 +82,7 @@ class VeloNavigator extends Component {
                   <span className="sr-only">{T("Toggle Main Menu")}</span>
               </button>
               <a href="#welcome">
-                <img src={logo} className="velo-logo" alt={T("Welcome")} />
+                <img src={window.base_path + logo} className="velo-logo" alt={T("Welcome")} />
               </a>
               <div
                 className={classNames({

--- a/gui/velociraptor/src/components/welcome/login.jsx
+++ b/gui/velociraptor/src/components/welcome/login.jsx
@@ -20,24 +20,25 @@ class Authenticator extends Component {
     }
 
     getIcon = ()=>{
+        let base_path = window.base_path || "";
         let provider_name = this.props.param.ProviderName;
         switch(provider_name) {
         case "Google":
             return <img className="logo" alt='google logo'
-                        src={google_logo}/>;
+                        src={base_path + google_logo}/>;
         case "Github":
             return <img className="logo" alt='github logo'
-                        src={github_logo}/>;
+                        src={base_path + github_logo}/>;
         case "Microsoft":
             return <img className="logo" alt='microsoft logo'
-                        src={azure_logo}/>;
+                        src={base_path + azure_logo}/>;
         default:
             if (this.props.param.ProviderAvatar) {
                 return <img className="logo" alt='oidc logo'
                             src={this.props.param.ProviderAvatar}/>;
             }
             return <img className="logo" alt='oidc logo'
-                        src={openid_logo}/>;
+                        src={base_path + openid_logo}/>;
         }
     }
 

--- a/gui/velociraptor/src/components/welcome/logoff.jsx
+++ b/gui/velociraptor/src/components/welcome/logoff.jsx
@@ -45,7 +45,7 @@ export default class LogoffPage extends Component {
                         <a href={base_path}>
                           <Row>
                             <Col sm="1">
-                              <img src={logo}
+                              <img src={window.base_path + -logo}
                                    className="velo-logo" alt="velo logo"/>
                             </Col>
                             <Col sm="9" className="provider">

--- a/gui/velociraptor/vite.config.js
+++ b/gui/velociraptor/vite.config.js
@@ -77,4 +77,4 @@ export default defineConfig({
         },
       },
     },
-})
+});

--- a/magefile.go
+++ b/magefile.go
@@ -42,6 +42,8 @@ var (
 		"crypto/b0x.yaml":           "crypto/ab0x.go",
 	}
 
+	index_template = "gui/velociraptor/build/index.html"
+
 	// apt-get install gcc-mingw-w64-x86-64
 	mingw_xcompiler = "x86_64-w64-mingw32-gcc"
 
@@ -453,6 +455,12 @@ func fileb0x(asset string) error {
 }
 
 func ensure_assets() error {
+	// Fixup the vite build - this is a hack but i cant figure vite
+	// now.
+	replace_string_in_file(
+		index_template, `="/app/assets/index`,
+		`="{{.BasePath}}/app/assets/index`)
+
 	for asset, target := range assets {
 		before := timestamp_of(target)
 		err := fileb0x(asset)


### PR DESCRIPTION
If a component fails to parse as a pathspec then include it as a raw string instead of dropping it.