### PR TITLE
Fixed incorrect usage of HTTP transport that broke in go1.19.6

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '^1.20'
 
     - run: go version
 

--- a/.github/workflows/musl.yaml
+++ b/.github/workflows/musl.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '^1.20'
 
     - run: go version
 


### PR DESCRIPTION
Go 1.19.6 introduced a behaviour change to break usage that worked in Go 1.19.2