### PR TITLE
Fixed incorrect usage of HTTP transport that broke in go1.19.6 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '1.19'
 
     - run: go version
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '^1.20'
 
     - run: go version
 

--- a/.github/workflows/musl.yaml
+++ b/.github/workflows/musl.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '^1.20'
 
     - run: go version
 

--- a/.github/workflows/musl.yaml
+++ b/.github/workflows/musl.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '1.19'
 
     - run: go version
 

--- a/http_comms/comms.go
+++ b/http_comms/comms.go
@@ -252,6 +252,8 @@ func NewHTTPConnector(
 				ExpectContinueTimeout: time.Duration(timeout) * time.Second,
 				ResponseHeaderTimeout: time.Duration(timeout) * time.Second,
 				TLSClientConfig:       tls_config,
+				TLSNextProto: make(map[string]func(
+					authority string, c *tls.Conn) http.RoundTripper),
 			},
 		},
 	}

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -89,7 +89,7 @@ type _HttpPluginResponse struct {
 	Url      string
 	Content  string
 	Response int
-	Headers vfilter.Any
+	Headers  vfilter.Any
 }
 
 type _HttpPlugin struct{}
@@ -145,6 +145,8 @@ func (self *HTTPClientCache) GetHttpClient(
 					net.Conn, error) {
 					return net.Dial("unix", components[0])
 				},
+				TLSNextProto: make(map[string]func(
+					authority string, c *tls.Conn) http.RoundTripper),
 			},
 		}
 		self.cache[key] = result
@@ -164,6 +166,8 @@ func (self *HTTPClientCache) GetHttpClient(
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},
+				TLSNextProto: make(map[string]func(
+					authority string, c *tls.Conn) http.RoundTripper),
 			},
 		}
 		self.cache[key] = result
@@ -295,6 +299,8 @@ func GetDefaultHTTPClient(
 				InsecureSkipVerify: true,
 				VerifyConnection:   customVerifyConnection(CA_Pool, config_obj),
 			},
+			TLSNextProto: make(map[string]func(
+				authority string, c *tls.Conn) http.RoundTripper),
 		},
 	}, nil
 }
@@ -456,7 +462,7 @@ func (self *_HttpPlugin) Call(
 		response := &_HttpPluginResponse{
 			Url:      arg.Url,
 			Response: http_resp.StatusCode,
-			Headers: http_resp.Header,
+			Headers:  http_resp.Header,
 		}
 
 		if arg.TempfileExtension != "" {

--- a/vql/tools/s3_upload.go
+++ b/vql/tools/s3_upload.go
@@ -135,6 +135,8 @@ func upload_S3(ctx context.Context, scope vfilter.Scope,
 			tr := &http.Transport{
 				Proxy:           networking.GetProxy(),
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSNextProto: make(map[string]func(
+					authority string, c *tls.Conn) http.RoundTripper),
 			}
 
 			client := &http.Client{Transport: tr}

--- a/vql/tools/webdav_upload.go
+++ b/vql/tools/webdav_upload.go
@@ -125,6 +125,8 @@ func upload_webdav(ctx context.Context, scope vfilter.Scope,
 		}).DialContext,
 		TLSHandshakeTimeout: 30 * time.Second,
 		TLSClientConfig:     tlsConfig,
+		TLSNextProto: make(map[string]func(
+			authority string, c *tls.Conn) http.RoundTripper),
 	}
 	client := &http.Client{
 		Transport: netTransport,


### PR DESCRIPTION
Go 1.19.6 introduced a behaviour change to break usage that worked in Go
1.19.2