### PR TITLE
Suppress logging to files for admin commands

### DIFF
--- a/bin/artifacts.go
+++ b/bin/artifacts.go
@@ -146,6 +146,8 @@ func getRepository(config_obj *config_proto.Config) (services.Repository, error)
 }
 
 func doArtifactCollect() error {
+	logging.DisableLogging()
+
 	if *artificat_command_collect_admin_flag {
 		err := checkAdmin()
 		if err != nil {
@@ -276,6 +278,8 @@ func getFilterRegEx(pattern string) (*regexp.Regexp, error) {
 }
 
 func doArtifactShow() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithNullLoader().LoadAndValidate()
 	if err != nil {
@@ -313,6 +317,8 @@ func doArtifactShow() error {
 }
 
 func doArtifactList() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithNullLoader().LoadAndValidate()
 	if err != nil {

--- a/bin/config.go
+++ b/bin/config.go
@@ -126,6 +126,8 @@ func maybeGetOrgConfig(
 }
 
 func doShowConfig() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		LoadAndValidate()
 	if err != nil {
@@ -227,6 +229,8 @@ func generateNewKeys(config_obj *config_proto.Config) error {
 }
 
 func doGenerateConfigNonInteractive() error {
+	logging.DisableLogging()
+
 	// We have to suppress writing to stdout so users can redirect
 	// output to a file.
 	logging.SuppressLogging = true
@@ -257,6 +261,8 @@ func doGenerateConfigNonInteractive() error {
 }
 
 func doRotateKeyConfig() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {
@@ -293,6 +299,8 @@ func doRotateKeyConfig() error {
 }
 
 func doReissueServerKeys() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {
@@ -344,6 +352,8 @@ func getClientConfig(config_obj *config_proto.Config) *config_proto.Config {
 }
 
 func doDumpClientConfig() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()
 	if err != nil {
@@ -375,6 +385,8 @@ func doDumpClientConfig() error {
 }
 
 func doDumpApiClientConfig() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredCA().
 		WithRequiredUser().

--- a/bin/config_frontend.go
+++ b/bin/config_frontend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	errors "github.com/go-errors/errors"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
@@ -34,6 +35,8 @@ func reportCurrentSetup(config_obj *config_proto.Config) string {
 }
 
 func doConfigFrontend() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {

--- a/bin/config_interactive.go
+++ b/bin/config_interactive.go
@@ -218,6 +218,8 @@ func configureDeploymentType(config_obj *config_proto.Config) error {
 }
 
 func doGenerateConfigInteractive() error {
+	logging.DisableLogging()
+
 	config_obj := config.GetDefaultConfig()
 
 	// Figure out which type of server we have.

--- a/bin/csv.go
+++ b/bin/csv.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Velocidex/ordereddict"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -22,6 +23,8 @@ var (
 )
 
 func doCSV() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithNullLoader().LoadAndValidate()
 	if err != nil {

--- a/bin/deaddisk.go
+++ b/bin/deaddisk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Velocidex/yaml/v2"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -233,6 +234,8 @@ FROM Artifact.Windows.Forensics.PartitionTable(ImagePath=ImagePath)
 }
 
 func doDeadDisk() error {
+	logging.DisableLogging()
+
 	full_config_obj, err := APIConfigLoader.WithNullLoader().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)

--- a/bin/debian.go
+++ b/bin/debian.go
@@ -47,9 +47,9 @@ import (
 
 	"github.com/Velocidex/yaml/v2"
 	"github.com/xor-gate/debpkg"
-	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 )
 
@@ -162,7 +162,7 @@ WantedBy=multi-user.target
 func doServerDeb() error {
 	// Disable logging when creating a deb - we may not create the
 	// deb on the same system where the logs should go.
-	_ = config.ValidateClientConfig(&config_proto.Config{})
+	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
@@ -304,7 +304,7 @@ func doSingleServerDeb(
 func doClientDeb() error {
 	// Disable logging when creating a deb - we may not create the
 	// deb on the same system where the logs should go.
-	_ = config.ValidateClientConfig(&config_proto.Config{})
+	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()

--- a/bin/fs.go
+++ b/bin/fs.go
@@ -121,6 +121,8 @@ func eval_local_query(
 }
 
 func doLS(path, accessor string) error {
+	logging.DisableLogging()
+
 	config_obj, err := APIConfigLoader.WithNullLoader().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
@@ -181,6 +183,8 @@ func doLS(path, accessor string) error {
 }
 
 func doRM(path, accessor string) error {
+	logging.DisableLogging()
+
 	config_obj, err := APIConfigLoader.WithNullLoader().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
@@ -235,6 +239,8 @@ func doRM(path, accessor string) error {
 }
 
 func doCp(path, accessor string, dump_dir string) error {
+	logging.DisableLogging()
+
 	config_obj, err := APIConfigLoader.
 		WithNullLoader().LoadAndValidate()
 	if err != nil {
@@ -325,6 +331,8 @@ SELECT * from foreach(
 }
 
 func doCat(path, accessor_name string) error {
+	logging.DisableLogging()
+
 	_, err := APIConfigLoader.
 		WithNullLoader().LoadAndValidate()
 	if err != nil {

--- a/bin/golden.go
+++ b/bin/golden.go
@@ -260,6 +260,8 @@ func runTest(fixture *testFixture, sm *services.Service,
 }
 
 func doGolden() error {
+	logging.DisableLogging()
+
 	vql_subsystem.RegisterPlugin(&MemoryLogPlugin{})
 	vql_subsystem.RegisterFunction(&WriteFilestoreFunction{})
 	vql_subsystem.RegisterFunction(&MockTimeFunciton{})

--- a/bin/grant.go
+++ b/bin/grant.go
@@ -9,6 +9,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/acls"
 	acl_proto "www.velocidex.com/golang/velociraptor/acls/proto"
 	"www.velocidex.com/golang/velociraptor/json"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -52,6 +53,8 @@ var (
 )
 
 func doGrant() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
@@ -140,7 +143,10 @@ func doGrant() error {
 }
 
 func doShow() error {
-	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
+	logging.DisableLogging()
+
+	config_obj, err := makeDefaultConfigLoader().
+		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
 	}

--- a/bin/hunts.go
+++ b/bin/hunts.go
@@ -10,6 +10,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/json"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
@@ -25,6 +26,8 @@ var (
 )
 
 func doHuntReconstruct() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().

--- a/bin/index.go
+++ b/bin/index.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"www.velocidex.com/golang/velociraptor/datastore"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services/indexing"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -19,6 +20,8 @@ var (
 )
 
 func doRebuildIndex() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredUser().
 		WithRequiredFrontend().

--- a/bin/installer_darwin.go
+++ b/bin/installer_darwin.go
@@ -44,6 +44,8 @@ var (
 )
 
 func doRemove() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredClient().
 		WithWriteback().LoadAndValidate()
 	if err != nil {
@@ -65,6 +67,8 @@ func doRemove() error {
 }
 
 func doInstall() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredClient().
 		WithWriteback().LoadAndValidate()
 	if err != nil {

--- a/bin/installer_windows.go
+++ b/bin/installer_windows.go
@@ -78,6 +78,8 @@ var (
 )
 
 func doInstall(config_obj *config_proto.Config) (err error) {
+	logging.DisableLogging()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -321,6 +323,8 @@ func removeService(name string) error {
 }
 
 func doRemove() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)

--- a/bin/orgs.go
+++ b/bin/orgs.go
@@ -30,6 +30,8 @@ var (
 )
 
 func doOrgLs() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
@@ -62,6 +64,8 @@ func doOrgLs() error {
 }
 
 func doOrgUserAdd() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
@@ -107,6 +111,8 @@ func doOrgUserAdd() error {
 }
 
 func doOrgCreate() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
@@ -143,6 +149,8 @@ func doOrgCreate() error {
 }
 
 func doOrgDelete() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().

--- a/bin/pool.go
+++ b/bin/pool.go
@@ -29,6 +29,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/executor"
 	"www.velocidex.com/golang/velociraptor/http_comms"
 	"www.velocidex.com/golang/velociraptor/json"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/server"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -66,6 +67,8 @@ func (self *counter) Inc() {
 }
 
 func doPoolClient() error {
+	logging.DisableLogging()
+
 	number_of_clients := *pool_client_number
 	if number_of_clients <= 0 {
 		number_of_clients = 2

--- a/bin/query.go
+++ b/bin/query.go
@@ -156,6 +156,8 @@ func doRemoteQuery(
 	config_obj *config_proto.Config, format string,
 	queries []string, env *ordereddict.Dict) error {
 
+	logging.DisableLogging()
+
 	ctx, cancel := install_sig_handler()
 	defer cancel()
 
@@ -254,6 +256,8 @@ func doRemoteQuery(
 }
 
 func doQuery() error {
+	logging.DisableLogging()
+
 	config_obj, err := APIConfigLoader.WithNullLoader().LoadAndValidate()
 	if err != nil {
 		return err

--- a/bin/repack.go
+++ b/bin/repack.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
 	"www.velocidex.com/golang/velociraptor/uploads"
@@ -55,6 +56,8 @@ var (
 )
 
 func doRepack() error {
+	logging.DisableLogging()
+
 	if *repack_command_exe == "" {
 		*repack_command_exe, _ = os.Executable()
 	}

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Velocidex/yaml/v2"
 	"github.com/google/rpmpack"
-	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/constants"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
 )
@@ -210,7 +210,7 @@ exit $RETVAL
 func doClientRPM() error {
 	// Disable logging when creating a deb - we may not create the
 	// deb on the same system where the logs should go.
-	_ = config.ValidateClientConfig(&config_proto.Config{})
+	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()
@@ -335,7 +335,7 @@ func doClientRPM() error {
 func doServerRPM() error {
 	// Disable logging when creating a deb - we may not create the
 	// deb on the same system where the logs should go.
-	_ = config.ValidateClientConfig(&config_proto.Config{})
+	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
@@ -479,7 +479,7 @@ func doSingleServerRPM(
 func doClientSysVRPM() error {
 	// Disable logging when creating a deb - we may not create the
 	// deb on the same system where the logs should go.
-	_ = config.ValidateClientConfig(&config_proto.Config{})
+	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredClient().LoadAndValidate()

--- a/bin/server_service_windows.go
+++ b/bin/server_service_windows.go
@@ -68,6 +68,8 @@ var (
 )
 
 func doInstallServerService(config_obj *config_proto.Config) (err error) {
+	logging.DisableLogging()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -297,6 +299,8 @@ func removeServiceServerService(name string) error {
 }
 
 func doRemoveServerService() {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().LoadAndValidate()
 	kingpin.FatalIfError(err, "Unable to load config file")
 

--- a/bin/tools.go
+++ b/bin/tools.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Velocidex/yaml/v2"
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -53,6 +54,8 @@ var (
 )
 
 func doThirdPartyShow() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	if err != nil {
@@ -99,6 +102,8 @@ func doThirdPartyShow() error {
 }
 
 func doThirdPartyRm() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	if err != nil {
@@ -124,6 +129,8 @@ func doThirdPartyRm() error {
 }
 
 func doThirdPartyUpload() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().WithRequiredFrontend().
 		LoadAndValidate()
 	if err != nil {

--- a/bin/unzip.go
+++ b/bin/unzip.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -36,8 +37,10 @@ var (
 )
 
 func doUnzip() error {
+	logging.DisableLogging()
 
-	server_config_obj, err := makeDefaultConfigLoader().WithNullLoader().LoadAndValidate()
+	server_config_obj, err := makeDefaultConfigLoader().
+		WithNullLoader().LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
 	}

--- a/bin/users.go
+++ b/bin/users.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"www.velocidex.com/golang/velociraptor/api/authenticators"
 	"www.velocidex.com/golang/velociraptor/json"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/users"
 	"www.velocidex.com/golang/velociraptor/startup"
@@ -55,6 +56,8 @@ var (
 )
 
 func doAddUser() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().LoadAndValidate()
@@ -129,6 +132,8 @@ func doAddUser() error {
 }
 
 func doShowUser() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {
@@ -172,6 +177,8 @@ func doShowUser() error {
 }
 
 func doLockUser() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().LoadAndValidate()
 	if err != nil {

--- a/bin/vacuum.go
+++ b/bin/vacuum.go
@@ -54,6 +54,8 @@ var (
 )
 
 func doVacuum() error {
+	logging.DisableLogging()
+
 	config_obj, err := makeDefaultConfigLoader().
 		WithRequiredFrontend().
 		WithRequiredUser().
@@ -255,6 +257,7 @@ func processTask(task_chan <-chan api.DSPathSpec, wg *sync.WaitGroup,
 // On very slow filesystems we need to go low level to get any kind
 // of performance.
 func doVacuumHarder(config_obj *config_proto.Config) error {
+	logging.DisableLogging()
 
 	ctx, cancel := install_sig_handler()
 	defer cancel()

--- a/bin/vql.go
+++ b/bin/vql.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Velocidex/yaml/v2"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	logging "www.velocidex.com/golang/velociraptor/logging"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter/types"
 )
@@ -151,6 +152,8 @@ func formatFunctions(
 }
 
 func doVQLList() error {
+	logging.DisableLogging()
+
 	scope := vql_subsystem.MakeScope()
 	defer scope.Close()
 
@@ -193,6 +196,8 @@ func getOldItem(name, item_type string, old_data []*api_proto.Completion) *api_p
 }
 
 func doVQLExport() error {
+	logging.DisableLogging()
+
 	scope := vql_subsystem.MakeScope()
 	defer scope.Close()
 

--- a/crypto/utils/utils.go
+++ b/crypto/utils/utils.go
@@ -45,6 +45,9 @@ func GetPrivateKeyFromScope(scope vfilter.Scope) (*rsa.PrivateKey, error) {
 		return nil, errors.New("Must be running on server!")
 	}
 
+	if config_obj.Frontend == nil {
+		return nil, errors.New("No frontend configuration given")
+	}
 	private_key := config_obj.Frontend.PrivateKey
 
 	key, err := ParseRsaPrivateKeyFromPemStr([]byte(private_key))


### PR DESCRIPTION
Many admin commands load the config file but in that case we do not want anything to be written to the actual log files.

Examples of such commands:
- debian server
- config show