### PR TITLE
Restrict VerifyFileSignature to only run on a single thread.

### DIFF
--- a/responder/flow_context.go
+++ b/responder/flow_context.go
@@ -152,6 +152,12 @@ func (self *FlowContext) IsFlowComplete() bool {
 }
 
 func (self *FlowContext) isFlowComplete() bool {
+	// If we have no responders then we have not started executing
+	// anything yet.
+	if len(self.responders) == 0 {
+		return false
+	}
+
 	for _, r := range self.responders {
 		if !r.IsComplete() {
 			return false
@@ -333,9 +339,10 @@ func (self *FlowContext) MaybeSendStats() *crypto_proto.VeloMessage {
 // send the stats immediately.
 func (self *FlowContext) sendStats() {
 	if !self.final_stats_sent {
+		stats := self.getStats()
 		select {
 		case <-self.ctx.Done():
-		case self.output <- self.getStats():
+		case self.output <- stats:
 		}
 	}
 }

--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -306,6 +306,8 @@ func (self *Indexer) searchClientIndexNameOnly(
 		}
 	}
 
+	sort.Strings(result.Names)
+
 	return result, nil
 }
 

--- a/vql/parsers/authenticode/pefile.go
+++ b/vql/parsers/authenticode/pefile.go
@@ -5,12 +5,23 @@ package authenticode
 import (
 	"fmt"
 	"runtime"
+	"sync"
 	"unsafe"
 
 	windows "www.velocidex.com/golang/velociraptor/vql/windows"
 )
 
+var (
+	mu sync.Mutex
+)
+
 func VerifyFileSignature(normalized_path string) string {
+	// This API function can not run on multiple threads
+	// safely. Restrict to running on a single thread at the time. See
+	// #2574
+	mu.Lock()
+	defer mu.Unlock()
+
 	// Try to lock to OS thread to ensure safer API call
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()


### PR DESCRIPTION
This might fix crashes we are seeing in #2574