### PR TITLE
Bugfix: Trace file generator regression

### DIFF
--- a/responder/flow_context.go
+++ b/responder/flow_context.go
@@ -13,6 +13,7 @@ import (
 	constants "www.velocidex.com/golang/velociraptor/constants"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
@@ -340,6 +341,12 @@ func (self *FlowContext) MaybeSendStats() *crypto_proto.VeloMessage {
 func (self *FlowContext) sendStats() {
 	if !self.final_stats_sent {
 		stats := self.getStats()
+		if self.final_stats_sent {
+			logger := logging.GetLogger(self.config_obj, &logging.ClientComponent)
+			logger.Debug("Sending final message for %v: %v",
+				self.flow_id, json.MustMarshalString(stats))
+		}
+
 		select {
 		case <-self.ctx.Done():
 		case self.output <- stats:

--- a/vql/golang/trace.go
+++ b/vql/golang/trace.go
@@ -81,12 +81,12 @@ func (self *TraceFunction) Call(ctx context.Context,
 
 	subscope := scope.Copy()
 	subscope.AppendVars(ordereddict.NewDict().
-		Set("ZipFile.zip", buf.Bytes()))
+		Set("ZipFile", buf.Bytes()))
 
 	return (&networking.UploadFunction{}).Call(
 		ctx, subscope, ordereddict.NewDict().
 			Set("accessor", "scope").
-			Set("file", "ZipFile.zip").
+			Set("file", "ZipFile").
 			Set("name", fmt.Sprintf("Trace%d.zip",
 				utils.GetTime().Now().Unix())))
 }


### PR DESCRIPTION
The scope accessor was modified to interpret a '.' in the filename as an associative operator, but the trace function stored the file in a variable named with a .zip extension.