### PR TITLE
Protect CryptCATAdmin functions behind dangerous api flag

### DIFF
--- a/vql/parsers/authenticode/authenticode.go
+++ b/vql/parsers/authenticode/authenticode.go
@@ -127,7 +127,7 @@ func (self *AuthenticodeFunction) Call(ctx context.Context,
 		}
 
 		cat_file, err := VerifyCatalogSignature(
-			config_obj, fd, normalized_path, output)
+			config_obj, scope, fd, normalized_path, output)
 		if err == nil {
 			_ = ParseCatFile(cat_file, output, arg.Verbose)
 		}

--- a/vql/parsers/authenticode/compat.go
+++ b/vql/parsers/authenticode/compat.go
@@ -21,6 +21,7 @@ func VerifyFileSignature(
 
 func VerifyCatalogSignature(
 	config_obj *config_proto.Config,
+	scope vfilter.Scope,
 	fd *os.File, normalized_path string,
 	output *ordereddict.Dict) (string, error) {
 	return "Unknown (No API access)", nil


### PR DESCRIPTION
These sometimes cause crashes due to not being thread safe