### PR TITLE
Extend http_client() to support SMB urls.

### DIFF
--- a/artifacts/testdata/windows/evtx.in.yaml
+++ b/artifacts/testdata/windows/evtx.in.yaml
@@ -33,5 +33,5 @@ Queries:
     GROUP BY EventID
 
   # Add test for event log clearing and move from VSS test for improved speed
-  - SELECT ClearedLog, Message =~ "The audit log was cleared."
+  - SELECT ClearedLog, Message, Message =~ "The audit log was cleared."
     FROM Artifact.Windows.EventLogs.Cleared()

--- a/artifacts/testdata/windows/evtx.out.yaml
+++ b/artifacts/testdata/windows/evtx.out.yaml
@@ -363,7 +363,7 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "Message =~ \"The audit log was cleared.\"": true
  },
  {
-  "ClearedLog": "System",
+  "ClearedLog": null,
   "Message =~ \"The audit log was cleared.\"": false
  }
 ]

--- a/artifacts/testdata/windows/evtx.out.yaml
+++ b/artifacts/testdata/windows/evtx.out.yaml
@@ -357,13 +357,15 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
   "SourceIP": "null",
   "Description": "LOGOFF_DISCONNECT"
  }
-]SELECT ClearedLog, Message =~ "The audit log was cleared." FROM Artifact.Windows.EventLogs.Cleared()[
+]SELECT ClearedLog, Message, Message =~ "The audit log was cleared." FROM Artifact.Windows.EventLogs.Cleared()[
  {
   "ClearedLog": "Security",
+  "Message": "The audit log was cleared.%nSubject:%n%tSecurity ID:%t%1%n%tAccount Name:%t%2%n%tDomain Name:%t%3%n%tLogon ID:%t%4\r\n",
   "Message =~ \"The audit log was cleared.\"": true
  },
  {
   "ClearedLog": null,
+  "Message": "Log clear\r\n",
   "Message =~ \"The audit log was cleared.\"": false
  }
 ]

--- a/services/inventory/dummy.go
+++ b/services/inventory/dummy.go
@@ -23,12 +23,13 @@ import (
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vql/networking"
 )
 
 type Dummy struct {
 	mu        sync.Mutex
 	binaries  *artifacts_proto.ThirdParty
-	Client    HTTPClient
+	Client    networking.HTTPClient
 	Clock     utils.Clock
 	filenames []string
 }
@@ -210,7 +211,7 @@ func (self *Dummy) materializeTool(
 	return nil
 }
 
-func getGithubRelease(ctx context.Context, Client HTTPClient,
+func getGithubRelease(ctx context.Context, Client networking.HTTPClient,
 	config_obj *config_proto.Config,
 	tool *artifacts_proto.Tool) (string, error) {
 

--- a/vql/networking/tls_test.go
+++ b/vql/networking/tls_test.go
@@ -17,8 +17,10 @@ import (
 
 func testHTTPConnection(
 	config_obj *config_proto.ClientConfig, url string) ([]byte, error) {
+
+	ctx := context.Background()
 	scope := vql_subsystem.MakeScope()
-	client, err := GetHttpClient(config_obj, scope, &HttpPluginRequest{
+	client, err := GetHttpClient(ctx, config_obj, scope, &HttpPluginRequest{
 		Url:    url,
 		Method: "GET",
 	})

--- a/vql/networking/wrapper.go
+++ b/vql/networking/wrapper.go
@@ -1,0 +1,156 @@
+package networking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/accessors/smb"
+	"www.velocidex.com/golang/velociraptor/utils"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	vfilter "www.velocidex.com/golang/vfilter"
+)
+
+var (
+	unsupportedMethod = errors.New("Unsupported method for protocol")
+	usernameRequired  = errors.New("Username and password required for SMB URLs")
+	invalidSMBPath    = errors.New("Invalid SMB Path")
+)
+
+// Create a HTTPClient with superpowers to be used everywhere.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type fdWrapper struct {
+	io.ReadCloser
+	closer func()
+}
+
+func (self *fdWrapper) Close() error {
+	err := self.ReadCloser.Close()
+	self.closer()
+	return err
+}
+
+type httpClientWrapper struct {
+	http.Client
+	scope vfilter.Scope
+	ctx   context.Context
+}
+
+func (self httpClientWrapper) Do(req *http.Request) (*http.Response, error) {
+	if req.URL != nil {
+		// Handle different url schemes
+		switch req.URL.Scheme {
+		case "smb":
+			return self.doSMB(req)
+
+		case "file":
+			return self.doFile(req)
+		}
+	}
+	return self.Client.Do(req)
+}
+
+// Use the file accessor to access file urls.
+func (self httpClientWrapper) doFile(
+	req *http.Request) (*http.Response, error) {
+	if req.Method != "GET" {
+		return nil, unsupportedMethod
+	}
+
+	// Make sure the principal is allowed to access files.
+	err := vql_subsystem.CheckFilesystemAccess(self.scope, req.URL.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	accessor, err := accessors.GetAccessor(req.URL.Scheme, self.scope)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := accessor.Open(req.URL.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Body:          file,
+		ContentLength: -1,
+		Close:         true,
+		Request:       req,
+	}, nil
+}
+
+func (self httpClientWrapper) doSMB(
+	req *http.Request) (*http.Response, error) {
+	if req.Method != "GET" {
+		return nil, unsupportedMethod
+	}
+
+	username := req.URL.User.Username()
+	password, _ := req.URL.User.Password()
+	hostname := req.URL.Hostname()
+
+	if username == "" || password == "" {
+		return nil, usernameRequired
+	}
+
+	components := utils.SplitComponents(req.URL.Path)
+	if len(components) < 2 {
+		return nil, invalidSMBPath
+	}
+
+	share := components[0]
+	file_path := strings.Join(components[1:], "\\")
+
+	cache, pres := vql_subsystem.CacheGet(
+		self.scope, smb.SMB_TAG).(*smb.SMBMountCache)
+	if !pres {
+		sub_scope := self.scope.Copy()
+		sub_scope.AppendVars(ordereddict.NewDict().
+			Set("SMB_CREDENTIALS", ordereddict.NewDict().
+				Set(hostname, fmt.Sprintf("%s:%s", username, password))))
+
+		cache = smb.NewSMBMountCache(sub_scope)
+		vql_subsystem.CacheSet(self.scope, smb.SMB_TAG, cache)
+	}
+
+	connection, closer, err := cache.GetHandle(hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := connection.Session().Mount(share)
+	if err != nil {
+		closer()
+		return nil, err
+	}
+
+	fd, err := fs.Open(file_path)
+	if err != nil {
+		closer()
+		return nil, err
+	}
+
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body: &fdWrapper{
+			ReadCloser: fd,
+			closer:     closer,
+		},
+		ContentLength: -1,
+		Close:         true,
+		Request:       req,
+	}, nil
+}

--- a/vql/tools/webdav_upload.go
+++ b/vql/tools/webdav_upload.go
@@ -126,7 +126,8 @@ func upload_webdav(ctx context.Context, scope vfilter.Scope,
 		return nil, errors.New("unable to get client config")
 	}
 
-	client, err := networking.GetDefaultHTTPClient(config_obj, "", nil)
+	client, err := networking.GetDefaultHTTPClient(
+		ctx, config_obj, scope, "", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR abstracts all HTTP client objects to a special wrapper with support for additional schemes. Mainly this supports the file:// and smb:// scheme.

This allows an SMB connection to be made whenever a URL is expected. For example when serving tools to clients it is possible to provide a URL of the form:

smb://test:testpasswd@192.168.1.1/Tools/tool.exe

This will cause the clients to connect to the SMB share for downloading the tools instead of the Velociraptor server.