### PR TITLE
Bugfix: SkipVerify did not remove custom verification function.

### DIFF
--- a/artifacts/definitions/Windows/Detection/Usn.yaml
+++ b/artifacts/definitions/Windows/Detection/Usn.yaml
@@ -27,6 +27,10 @@ parameters:
     type: int
     description: How many seconds before rechecking the USN journal.
     default: "30"
+  - name: NTFS_CACHE_TIME
+    type: int
+    description: How often to flush the NTFS cache.
+    default: "30"
 
 precondition: SELECT OS from info() where OS = "windows"
 

--- a/magefile.go
+++ b/magefile.go
@@ -248,6 +248,17 @@ func LinuxMusl() error {
 		arch:          "amd64"}.Run()
 }
 
+func LinuxMusl386() error {
+	return Builder{
+		extra_tags:    " release yara disable_gui ",
+		goos:          "linux",
+		cc:            "musl-gcc",
+		extra_name:    "-musl",
+		disable_cgo:   true,
+		extra_ldflags: "-linkmode external -extldflags \"-static\"",
+		arch:          "386"}.Run()
+}
+
 // A Linux binary without the GUI
 func LinuxBare() error {
 	return Builder{

--- a/vql/networking/tls.go
+++ b/vql/networking/tls.go
@@ -246,5 +246,9 @@ func EnableSkipVerify(tlsConfig *tls.Config, config_obj *config_proto.ClientConf
 	}
 
 	tlsConfig.InsecureSkipVerify = true
+	// Remove the custom verification - there will be no verification
+	// because InsecureSkipVerify is true.
+	tlsConfig.VerifyConnection = nil
+
 	return nil
 }


### PR DESCRIPTION
By default a custom verification function is installed which means that SkipVerify just delegates to it. When the user really wanted to skip verification the TLS connection was still checking certs using the custom verification function.