### PR TITLE
Linux.RHEL.Packages: Silence dnf output

### DIFF
--- a/artifacts/definitions/Linux/RHEL/Packages.yaml
+++ b/artifacts/definitions/Linux/RHEL/Packages.yaml
@@ -14,6 +14,6 @@ sources:
     query: |
         SELECT * FROM foreach(row={
           SELECT grok(grok=DNFGrokExpression, data=Stdout) AS Parsed
-          FROM execve(argv=["dnf", "list", "installed"], sep="\n")
+          FROM execve(argv=["dnf", "--quiet", "list", "installed"], sep="\n")
           WHERE count() > 2
         }, column="Parsed")


### PR DESCRIPTION
On an "unregistered" RHEL9 test instance, dnf tells us all sorts of nonsense at start:

```
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.
```

The last line bleeds into the package list. Adding the `--quiet` switch fixes this.