### PR TITLE
Bugfix: http_client parameters did not handle url().Query objects

### DIFF
--- a/artifacts/testdata/server/testcases/http_client.in.yaml
+++ b/artifacts/testdata/server/testcases/http_client.in.yaml
@@ -1,0 +1,22 @@
+# This tests the http client against a live test server - it might be
+# a bit flakey on the CI pipeline
+Queries:
+
+# Common use case - take a url, extract the query string, add some
+# more parameters and make a new request.
+- LET URL <= url(parse="http://www.google.com/?q=Hello&lang=fr")
+
+# Dict addition can be used to override the original map replacing the
+# value of lang
+- LET NewQuery = URL.Query + dict(lang="en")
+
+## Encode parameters in GET query. Check that we can send headers.
+- SELECT parse_json(data=Content).url, parse_json(data=Content).headers.`Foo-Bar`
+  FROM http_client(url="https://httpbin.org/get",
+      params=NewQuery, headers=dict(`foo-bar`="baz"),
+      method="GET")
+
+## Encode parameters in POST query
+- SELECT parse_json(data=Content).data
+  FROM http_client(url="https://httpbin.org/post",
+       params=NewQuery, method="POST")

--- a/artifacts/testdata/server/testcases/http_client.out.yaml
+++ b/artifacts/testdata/server/testcases/http_client.out.yaml
@@ -1,0 +1,10 @@
+LET URL <= url(parse="http://www.google.com/?q=Hello&lang=fr")[]LET NewQuery = URL.Query + dict(lang="en")[]SELECT parse_json(data=Content).url, parse_json(data=Content).headers.`Foo-Bar` FROM http_client(url="https://httpbin.org/get", params=NewQuery, headers=dict(`foo-bar`="baz"), method="GET")[
+ {
+  "parse_json(data=Content).url": "https://httpbin.org/get?lang=en\u0026q=Hello",
+  "parse_json(data=Content).headers.`Foo-Bar`": "baz"
+ }
+]SELECT parse_json(data=Content).data FROM http_client(url="https://httpbin.org/post", params=NewQuery, method="POST")[
+ {
+  "parse_json(data=Content).data": "lang=en\u0026q=Hello"
+ }
+]

--- a/gui/velociraptor/src/components/clients/metadata.css
+++ b/gui/velociraptor/src/components/clients/metadata.css
@@ -1,0 +1,3 @@
+.metadata-key {
+    width: 20em;
+}

--- a/gui/velociraptor/src/components/clients/metadata.jsx
+++ b/gui/velociraptor/src/components/clients/metadata.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import "./metadata.css";
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {CancelToken} from 'axios';
@@ -20,6 +21,7 @@ const POLL_TIME = 5000;
 export default class MetadataEditor extends Component {
     static propTypes = {
         client_id: PropTypes.string,
+        valueRenderer: PropTypes.func,
     }
 
     state = {
@@ -102,11 +104,13 @@ export default class MetadataEditor extends Component {
             sort: true,
             editable: true,
             filtered: true,
+            classes: "metadata-key",
             text: T("Key"),
         }, {
             dataField: "value",
             editable: true,
             sort: true,
+            formatter: this.props.valueRenderer,
             text: T("Value"),
         }]);
 

--- a/gui/velociraptor/src/components/server/server-info.jsx
+++ b/gui/velociraptor/src/components/server/server-info.jsx
@@ -8,6 +8,8 @@ import MetadataEditor from "../clients/metadata.jsx";
 
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import ToggleButton from 'react-bootstrap/ToggleButton';
+import Button from 'react-bootstrap/Button';
+import T from '../i8n/i8n.jsx';
 import CardDeck from 'react-bootstrap/CardDeck';
 import Card from 'react-bootstrap/Card';
 
@@ -56,7 +58,16 @@ class ServerInfo extends Component {
                   <Card>
                     <Card.Header>Server configuration</Card.Header>
                     <Card.Body>
-                      <MetadataEditor client_id="server" />
+                      <MetadataEditor
+                        valueRenderer={(cell, row)=>{
+                            return <Button
+                                     className="btn-tooltip"
+                                     data-tooltip={T("Click to view or edit")}
+                                     variant="default-outline" size="sm">
+                                     <FontAwesomeIcon icon="wrench"/>
+                                   </Button>;
+                        }}
+                        client_id="server" />
                     </Card.Body>
                   </Card>
                 </CardDeck>

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -237,9 +237,9 @@ func encodeParams(arg *HttpPluginRequest, scope vfilter.Scope) *url.Values {
 						item, ok := value.(string)
 						if ok {
 							data.Add(member, item)
-							continue
 						}
 					}
+					continue
 				}
 				switch value.(type) {
 				case vfilter.Null, *vfilter.Null:

--- a/vql/parsers/json.go
+++ b/vql/parsers/json.go
@@ -286,11 +286,13 @@ func (self _MapInterfaceAssociativeProtocol) Associative(
 
 func (self _MapInterfaceAssociativeProtocol) GetMembers(
 	scope vfilter.Scope, a vfilter.Any) []string {
+
 	result := []string{}
-	a_map, ok := a.(map[string]interface{})
-	if ok {
-		for k := range a_map {
-			result = append(result, k)
+	map_value := reflect.ValueOf(a)
+	if map_value.Kind() == reflect.Map {
+		for _, map_key_value := range map_value.MapKeys() {
+			result = append(result, map_key_value.String())
+
 		}
 	}
 


### PR DESCRIPTION
A common use case is to parse a URL, extract the query string then modify it before passing to http_client()

Added test.

Also modified server metadata screen to hide all values by default.