### PR TITLE
Ehancement: Add Source field to Windows.Applicaiton.History to show sync status

### DIFF
--- a/artifacts/definitions/Windows/Applications/Chrome/History.yaml
+++ b/artifacts/definitions/Windows/Applications/Chrome/History.yaml
@@ -1,17 +1,29 @@
 name: Windows.Applications.Chrome.History
 description: |
-  Enumerate the users chrome history.
+  Enumerate the users chrome history. Source based on HindSight and code review of https://source.chromium.org/chromium/chromium/src/+/master:components/history/core/browser/history_types.h
 author: Angry-Bender @angry-bender
 parameters:
   - name: historyGlobs
     default: \AppData\{Local,Roaming}\{Google\Chrome\User Data,Microsoft\Edge\User Data,BraveSoftware\Brave-Browser\User Data,Vivaldi\User Data,Opera Software\Opera*Stable}\*\History
   - name: urlSQLQuery
     default: |
-      SELECT U.id AS id, U.url AS url, V.visit_time as visit_time,
-      U.title AS title, U.visit_count, U.typed_count,
-      U.last_visit_time, U.hidden, V.from_visit, strftime('%H:%M:%f',
-      V.visit_duration/1000000.0, 'unixepoch') as visit_duration,
-      V.transition FROM urls AS U JOIN visits AS V ON U.id = V.url
+      SELECT U.id AS id, U.url AS url, V.visit_time as visit_time, U.title AS title, U.visit_count, U.typed_count, U.last_visit_time, U.hidden,
+      CASE VS.source
+        WHEN NULL THEN 'Local'
+        WHEN 0 THEN 'Synced' 
+        WHEN 1 THEN 'Local' 
+        WHEN 2 THEN 'Extension'
+        WHEN 3 THEN 'ImportFromFirefox'
+        WHEN 4 THEN 'ImportFromSafari'
+        WHEN 6 THEN 'ImportFromChrome/Edge'
+          WHEN 7 THEN 'ImportFromEdgeHTML'
+      END Source,
+          V.from_visit, 
+          strftime('%H:%M:%f', V.visit_duration/1000000.0, 'unixepoch') as visit_duration,
+          V.transition      
+      FROM urls AS U 
+        JOIN visits AS V ON U.id = V.url
+        JOIN visit_source AS VS on V.id = VS.id
   - name: userRegex
     default: .
     type: regex

--- a/artifacts/definitions/Windows/Applications/Chrome/History.yaml
+++ b/artifacts/definitions/Windows/Applications/Chrome/History.yaml
@@ -1,29 +1,36 @@
 name: Windows.Applications.Chrome.History
 description: |
-  Enumerate the users chrome history. Source based on HindSight and code review of https://source.chromium.org/chromium/chromium/src/+/master:components/history/core/browser/history_types.h
+  Enumerates a targets chrome history. Source based on Hindsight and code review of https://source.chromium.org/chromium/chromium/src/+/master:components/history/core/browser/history_types.h. NOTE: Some research has shown that older browsers may not have this table, then you should be treating it as you would in a traditional investigation, this changes is aimed at taking advantage of the newer tables to reduce false postitives.
+  
 author: Angry-Bender @angry-bender
 parameters:
   - name: historyGlobs
     default: \AppData\{Local,Roaming}\{Google\Chrome\User Data,Microsoft\Edge\User Data,BraveSoftware\Brave-Browser\User Data,Vivaldi\User Data,Opera Software\Opera*Stable}\*\History
   - name: urlSQLQuery
     default: |
-      SELECT U.id AS id, U.url AS url, V.visit_time as visit_time, U.title AS title, U.visit_count, U.typed_count, U.last_visit_time, U.hidden,
-      CASE VS.source
-        WHEN NULL THEN 'Local'
-        WHEN 0 THEN 'Synced' 
-        WHEN 1 THEN 'Local' 
-        WHEN 2 THEN 'Extension'
-        WHEN 3 THEN 'ImportFromFirefox'
-        WHEN 4 THEN 'ImportFromSafari'
-        WHEN 6 THEN 'ImportFromChrome/Edge'
-          WHEN 7 THEN 'ImportFromEdgeHTML'
-      END Source,
-          V.from_visit, 
-          strftime('%H:%M:%f', V.visit_duration/1000000.0, 'unixepoch') as visit_duration,
-          V.transition      
+      SELECT U.id AS id, 
+             U.url AS url, 
+             V.visit_time as visit_time,
+             U.title AS title, 
+             U.visit_count,
+             U.typed_count,
+             U.last_visit_time, U.hidden,
+             CASE VS.source
+             	WHEN 0 THEN 'Synced' 
+            	WHEN 1 THEN 'Local' 
+            	WHEN 2 THEN 'Extension'
+            	WHEN 3 THEN 'ImportFromFirefox'
+            	WHEN 4 THEN 'ImportFromSafari'
+            	WHEN 6 THEN 'ImportFromChrome/Edge'
+                WHEN 7 THEN 'ImportFromEdgeHTML'
+            	ELSE 'Local'
+             END Source,  
+             V.from_visit,
+             strftime('%H:%M:%f',V.visit_duration/1000000.0, 'unixepoch') as visit_duration,
+             V.transition 
       FROM urls AS U 
-        JOIN visits AS V ON U.id = V.url
-        JOIN visit_source AS VS on V.id = VS.id
+      JOIN visits AS V ON U.id = V.url
+      LEFT JOIN visit_source AS VS on V.id = VS.id
   - name: userRegex
     default: .
     type: regex
@@ -57,6 +64,7 @@ sources:
                    timestamp(winfiletime=last_visit_time * 10) AS last_visit_time,
                    hidden,
                    from_visit AS from_url_id,
+                   Source,
                    visit_duration,transition,
                    timestamp(winfiletime=last_visit_time * 10) as _SourceLastModificationTimestamp,
                    OSPath


### PR DESCRIPTION
Source based on Hindsight and code review of https://source.chromium.org/chromium/chromium/src/+/master:components/history/core/browser/history_types.h. 

NOTE: Some research has shown that older browsers may not have this table, then you should be treating it as you would in a traditional investigation, this changes is aimed at taking advantage of the newer tables to reduce false positives.

Tested on Velociraptor "0.6.9"