### PR TITLE
Allow SQLite files to be copied always.

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -105,6 +105,9 @@ const (
 	// Set in the scope with one or more passwords
 	ZIP_PASSWORDS = "ZIP_PASSWORDS"
 
+	// If this is set we always copy SQLite files to a tempfile
+	SQLITE_ALWAYS_MAKE_TEMPFILE = "SQLITE_ALWAYS_MAKE_TEMPFILE"
+
 	PinnedServerName = "VelociraptorServer"
 
 	CLIENT_API_VERSION = uint32(4)

--- a/vql/parsers/sql.go
+++ b/vql/parsers/sql.go
@@ -20,6 +20,10 @@ import (
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
 
+var (
+	notValidDatabase = errors.New("Not a valid database")
+)
+
 type SQLPluginArgs struct {
 	Driver     string      `vfilter:"required,field=driver, doc=sqlite, mysql,or postgres"`
 	ConnString string      `vfilter:"optional,field=connstring, doc=SQL Connection String"`
@@ -115,6 +119,10 @@ func (self SQLPlugin) Call(
 			}
 
 			handle, err = GetHandleSqlite(ctx, arg, scope)
+			if err == notValidDatabase {
+				return
+			}
+
 			if err != nil {
 				scope.Log("sql: %s", err)
 				return

--- a/vql/parsers/sqlite.go
+++ b/vql/parsers/sqlite.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
 	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/constants"
 	utils "www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	vfilter "www.velocidex.com/golang/vfilter"
@@ -68,6 +69,29 @@ func VFSPathToFilesystemPath(path string) string {
 	return strings.TrimPrefix(path, "\\")
 }
 
+// Check the file header - ignore if this is not really an sqlite
+// file.
+func checkSQLiteHeader(scope vfilter.Scope, accessor, filename string) bool {
+	fs, err := accessors.GetAccessor(accessor, scope)
+	if err != nil {
+		return false
+	}
+
+	file, err := fs.Open(filename)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	header := make([]byte, 12)
+	_, err = file.Read(header)
+	if err != nil {
+		return false
+	}
+
+	return string(header) == "SQLite forma"
+}
+
 func GetHandleSqlite(ctx context.Context,
 	arg *SQLPluginArgs, scope vfilter.Scope) (
 	handle *sqlx.DB, err error) {
@@ -80,7 +104,18 @@ func GetHandleSqlite(ctx context.Context,
 	key := "sqlite_" + filename + arg.Accessor
 	handle, ok := vql_subsystem.CacheGet(scope, key).(*sqlx.DB)
 	if !ok {
-		if arg.Accessor == "file" || arg.Accessor == "" {
+		// Check the header quickly to ensure that we dont copy the
+		// file needlessly.
+		if !checkSQLiteHeader(scope, arg.Accessor, filename) {
+			return nil, notValidDatabase
+		}
+
+		should_make_copy := vql_subsystem.GetBoolFromRow(scope, scope, constants.SQLITE_ALWAYS_MAKE_TEMPFILE)
+		if arg.Accessor != "file" && arg.Accessor != "" {
+			should_make_copy = true
+		}
+
+		if !should_make_copy {
 			handle, err = sqlx.Connect("sqlite3", filename)
 			if err != nil {
 				// An error occurred maybe the database
@@ -125,6 +160,7 @@ func GetHandleSqlite(ctx context.Context,
 			if err != nil {
 				return nil, err
 			}
+			scope.Log("Using local copy %v", filename)
 		}
 
 		// Try once again to connect to the new file
@@ -143,6 +179,7 @@ func GetHandleSqlite(ctx context.Context,
 			handle.Close()
 		})
 		if err != nil {
+			scope.Log("Unable to set destructor for %v", filename)
 			handle.Close()
 			return nil, err
 		}


### PR DESCRIPTION
When the SQLite file is in use, the SQLite driver takes about 10 seconds to retry opening the file. This slows down processing a lot. This PR just copied the file to a temp file for every valid SQLite file because it is much faster than attempting to open the original.