### PR TITLE
Update NetstatEnriched

### DIFF
--- a/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
+++ b/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
@@ -11,8 +11,12 @@ description: |
   KillProcess - attempts to use Taskill to kill the processes returned.  
   DumpProcess - dumps the process as a sparse file for post processing.  
   
-  Please only use these switches after scoping as there are no guardrails.
+  Please only use these switches after scoping as there are no guardrails on 
+  shooting yourself in the foot.
 
+required_permissions:
+  - EXECVE
+  
 precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:

--- a/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
+++ b/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
@@ -80,7 +80,7 @@ parameters:
 
   - name: ProcessNameRegex
     description: "regex search over source process name"
-    default: .
+    default: ^malware\.exe$
     type: regex
   - name: ProcessPathRegex
     description: "regex search over source process path"

--- a/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
+++ b/artifacts/definitions/Windows/Network/NetstatEnriched.yaml
@@ -1,23 +1,28 @@
 name: Windows.Network.NetstatEnriched
+author: "Matt Green - @mgreen27"
 description: |
   NetstatEnhanced adds additional data points to the Netstat artifact and
   enables verbose search options.
 
   Examples include: Process name and path, authenticode information or
   network connection details.
-
-author: "Matthew Green - @mgreen27"
+  
+  WARNING:  
+  KillProcess - attempts to use Taskill to kill the processes returned.  
+  DumpProcess - dumps the process as a sparse file for post processing.  
+  
+  Please only use these switches after scoping as there are no guardrails.
 
 precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:
   - name: IPRegex
     description: "regex search over IP address fields."
-    default:  ".*"
+    default:  .
     type: regex
   - name: PortRegex
     description: "regex search over port fields."
-    default: ".*"
+    default: .
     type: regex
   - name: Family
     description: "IP version family selection"
@@ -31,7 +36,7 @@ parameters:
     type: hidden
     default: |
       Choice,Regex
-      ALL,".*"
+      ALL,"."
       IPv4,"^IPv4$"
       IPv6,"^IPv6$"
 
@@ -47,7 +52,7 @@ parameters:
     type: hidden
     default: |
       Choice,Regex
-      ALL,".*"
+      ALL,"."
       TCP,"^TCP$"
       UDP,"^UDP$"
 
@@ -64,38 +69,38 @@ parameters:
     type: hidden
     default: |
       Choice,Regex
-      ALL,".*"
+      ALL,"."
       ESTABLISHED,"^ESTAB$"
       LISTENING,"^LISTEN$"
       OTHER,"CLOS|SENT|RCVD|LAST|WAIT|DELETE"
 
   - name: ProcessNameRegex
     description: "regex search over source process name"
-    default: ".*"
+    default: .
     type: regex
   - name: ProcessPathRegex
     description: "regex search over source process path"
-    default: ".*"
+    default: .
     type: regex
   - name: CommandLineRegex
     description: "regex search over source process commandline"
-    default: ".*"
+    default: .
     type: regex
   - name: HashRegex
     description: "regex search over source process hash"
-    default: ".*"
+    default: .
     type: regex
   - name: UsernameRegex
     description: "regex search over source process user context"
-    default: ".*"
+    default: .
     type: regex
   - name: AuthenticodeSubjectRegex
     description: "regex search over source Authenticode Subject"
-    default: ".*"
+    default: .
     type: regex
   - name: AuthenticodeIssuerRegex
     description: "regex search over source Authenticode Issuer"
-    default: ".*"
+    default: .
     type: regex
   - name: AuthenticodeVerified
     description: "Authenticode signiture selection"
@@ -110,11 +115,17 @@ parameters:
     type: hidden
     default: |
       Choice,Regex
-      ALL,".*"
+      ALL,"."
       TRUSTED,"^trusted$"
       UNSIGNED,"^unsigned$"
       NOT TRUSTED,"unsigned|disallowed|untrusted|error"
-
+  - name: DumpProcess
+    description: "WARNING: If selected will attempt to dump process from all results."
+    type: bool
+  - name: KillProcess
+    description: "WARNING: If selected will attempt to kill process from all results."
+    type: bool
+    
 sources:
   - name: Netstat
     query: |
@@ -141,36 +152,84 @@ sources:
             Username
         FROM Artifact.Windows.System.Pslist()
         WHERE Name =~ ProcessNameRegex
+            AND Exe =~ ProcessPathRegex
+            AND CommandLine =~ CommandLineRegex
 
-      SELECT Pid,
-            { SELECT Ppid FROM process WHERE PsId = Pid } as Ppid,
-            { SELECT Name FROM process WHERE PsId = Pid } as Name,
-            { SELECT Exe FROM process WHERE PsId = Pid } as Path,
-            { SELECT CommandLine FROM process WHERE PsId = Pid } as CommandLine,
-            { SELECT Hash FROM process WHERE PsId = Pid } as Hash,
-            { SELECT Username FROM process WHERE PsId = Pid } as Username,
-            { SELECT Authenticode FROM process WHERE PsId = Pid } as Authenticode,
-            FamilyString as Family,
-            TypeString as Type,
-            Status,
-            Laddr.IP, Laddr.Port,
-            Raddr.IP, Raddr.Port,
-            Timestamp
-        FROM netstat()
-        WHERE Path =~ ProcessPathRegex
-            and CommandLine =~ CommandLineRegex
-            and Username =~ UsernameRegex
-            and ( Hash.MD5 =~ HashRegex
-              or Hash.SHA1 =~ HashRegex
-              or Hash.SHA256 =~ HashRegex
-              or not Hash )
-            and ( Authenticode.IssuerName =~ AuthenticodeIssuerRegex or not Authenticode )
-            and ( Authenticode.SubjectName =~ AuthenticodeSubjectRegex or not Authenticode )
-            and ( Authenticode.Trusted =~ VerifiedRegex.Regex[0] or not Authenticode )
-            and Status =~ StatusRegex.Regex[0]
-            and Family =~ FamilyRegex.Regex[0]
-            and Type =~ TypeRegex.Regex[0]
-            and ( format(format="%v", args=Laddr.IP) =~ IPRegex
-                or format(format="%v", args=Raddr.IP) =~ IPRegex )
-            and ( format(format="%v", args=Laddr.Port) =~ PortRegex
-                or format(format="%v", args=Raddr.Port) =~ PortRegex )
+      LET results = SELECT Pid,
+                { SELECT Ppid FROM process WHERE PsId = Pid } as Ppid,
+                { SELECT Name FROM process WHERE PsId = Pid } as Name,
+                { SELECT Exe FROM process WHERE PsId = Pid } as Path,
+                { SELECT CommandLine FROM process WHERE PsId = Pid } as CommandLine,
+                { SELECT Hash FROM process WHERE PsId = Pid } as Hash,
+                { SELECT Username FROM process WHERE PsId = Pid } as Username,
+                { SELECT Authenticode FROM process WHERE PsId = Pid } as Authenticode,
+                FamilyString as Family,
+                TypeString as Type,
+                Status,
+                Laddr.IP as SrcIP, 
+                Laddr.Port as SrcPort,
+                Raddr.IP as DestIP, 
+                Raddr.Port as DestPort,
+                Timestamp
+            FROM netstat()
+            WHERE 
+                Name =~ ProcessNameRegex
+                AND Path =~ ProcessPathRegex
+                and CommandLine =~ CommandLineRegex
+                and Username =~ UsernameRegex
+                and ( Hash.MD5 =~ HashRegex
+                  or Hash.SHA1 =~ HashRegex
+                  or Hash.SHA256 =~ HashRegex
+                  or not Hash )
+                and ( Authenticode.IssuerName =~ AuthenticodeIssuerRegex or not Authenticode )
+                and ( Authenticode.SubjectName =~ AuthenticodeSubjectRegex or not Authenticode )
+                and ( Authenticode.Trusted =~ VerifiedRegex.Regex[0] or not Authenticode )
+                and Status =~ StatusRegex.Regex[0]
+                and Family =~ FamilyRegex.Regex[0]
+                and Type =~ TypeRegex.Regex[0]
+                and ( format(format="%v", args=SrcIP) =~ IPRegex
+                    or format(format="%v", args=DestIP) =~ IPRegex )
+                and ( format(format="%v", args=SrcPort) =~ PortRegex
+                    or format(format="%v", args=DestPort) =~ PortRegex )
+    
+      LET Regions(Pid) = SELECT dict(Offset=Address, Length=Size) AS Sparse
+        FROM vad(pid=Pid)
+        WHERE Protection =~ "r"
+      LET dump = SELECT *, 
+            upload(accessor="sparse",
+                    file=pathspec(
+                    Path=serialize(item=Regions(Pid=Pid).Sparse),
+                    DelegateAccessor="process",
+                    DelegatePath=format(format="/%d", args=Pid)),
+                     name=pathspec(Path=format(format="%d.dd", args=Pid))) AS ProcessMemory
+        FROM results
+      LET kill = SELECT *,
+            { 
+                SELECT 
+                    dict(ReturnCode=ReturnCode,Complete=Complete,Stdout=Stdout,Stderr=Stderr) as Execve,
+                    if(condition= Stdout=~'^SUCCESS',
+                            then= TRUE,
+                            else= FALSE) as Killed
+                FROM execve(argv=["taskkill", "/PID", Pid, "/T", "/F"])
+            } as KillProcess    
+        FROM results
+      LET dumpandkill = SELECT *,
+            { 
+                SELECT 
+                    dict(ReturnCode=ReturnCode,Complete=Complete,Stdout=Stdout,Stderr=Stderr) as Execve,
+                    if(condition= Stdout=~'^SUCCESS',
+                            then= TRUE,
+                            else= FALSE) as Killed
+                FROM execve(argv=["taskkill", "/PID", Pid, "/T", "/F"])
+            } as KillProcess 
+        FROM dump
+      
+      SELECT * FROM switch(
+            a = { SELECT * FROM if(condition= DumpProcess AND KillProcess,
+                        then= dumpandkill )},
+            b = { SELECT * FROM if(condition= DumpProcess,
+                        then= dump )},
+            c = { SELECT * FROM if(condition= KillProcess,
+                    then= kill) },
+            catch = results
+        )

--- a/artifacts/testdata/server/testcases/mock.in.yaml
+++ b/artifacts/testdata/server/testcases/mock.in.yaml
@@ -151,28 +151,33 @@ Queries:
 
   # Netcat is trusted because it is signed should show up here.
   - SELECT * FROM Artifact.Windows.Network.NetstatEnriched(
+          ProcessNameRegex='.',
           AuthenticodeVerified="TRUSTED",
           Status="LISTENING",
           PortRegex="3889")
 
   # Netcat is listening over IPv6 so not hits here.
   - SELECT * FROM Artifact.Windows.Network.NetstatEnriched(
+          ProcessNameRegex='.',
           AuthenticodeVerified="TRUSTED",
           Status="LISTENING", Family="IPv4",
           PortRegex="3889")
 
   # Netcat is listening over IPv6
   - SELECT * FROM Artifact.Windows.Network.NetstatEnriched(
+          ProcessNameRegex='.',
           AuthenticodeVerified="TRUSTED",
           Status="LISTENING", Family="IPv6",
           PortRegex="3889")
 
   # Explorer has an established connection
   - SELECT * FROM Artifact.Windows.Network.NetstatEnriched(
+          ProcessNameRegex='.',
           Status="ESTABLISHED")
 
   # Explorer has an established connection but it is trusted so wont
   # show up here.
   - SELECT * FROM Artifact.Windows.Network.NetstatEnriched(
+          ProcessNameRegex='.',
           AuthenticodeVerified="NOT TRUSTED",
           Status="ESTABLISHED")

--- a/artifacts/testdata/server/testcases/mock.out.yaml
+++ b/artifacts/testdata/server/testcases/mock.out.yaml
@@ -47,7 +47,7 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Timestamp": "2019-12-06T05:24:30Z",
   "_Source": "Windows.Network.Netstat"
  }
-]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( AuthenticodeVerified="TRUSTED", Status="LISTENING", PortRegex="3889")[
+]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( ProcessNameRegex='.', AuthenticodeVerified="TRUSTED", Status="LISTENING", PortRegex="3889")[
  {
   "Pid": 7028,
   "Ppid": 2120,
@@ -83,7 +83,7 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Timestamp": "2019-11-27T01:18:15Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }
-]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( AuthenticodeVerified="TRUSTED", Status="LISTENING", Family="IPv4", PortRegex="3889")[]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( AuthenticodeVerified="TRUSTED", Status="LISTENING", Family="IPv6", PortRegex="3889")[
+]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( ProcessNameRegex='.', AuthenticodeVerified="TRUSTED", Status="LISTENING", Family="IPv4", PortRegex="3889")[]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( ProcessNameRegex='.', AuthenticodeVerified="TRUSTED", Status="LISTENING", Family="IPv6", PortRegex="3889")[
  {
   "Pid": 7028,
   "Ppid": 2120,
@@ -119,7 +119,7 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Timestamp": "2019-11-27T01:18:15Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }
-]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( Status="ESTABLISHED")[
+]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( ProcessNameRegex='.', Status="ESTABLISHED")[
  {
   "Pid": 4888,
   "Ppid": 4856,
@@ -155,4 +155,4 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Timestamp": "2019-12-07T03:30:58Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }
-]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( AuthenticodeVerified="NOT TRUSTED", Status="ESTABLISHED")[]
+]SELECT * FROM Artifact.Windows.Network.NetstatEnriched( ProcessNameRegex='.', AuthenticodeVerified="NOT TRUSTED", Status="ESTABLISHED")[]

--- a/artifacts/testdata/server/testcases/mock.out.yaml
+++ b/artifacts/testdata/server/testcases/mock.out.yaml
@@ -76,10 +76,10 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Family": "IPv6",
   "Type": "TCP",
   "Status": "LISTEN",
-  "Laddr.IP": "::",
-  "Laddr.Port": 3889,
-  "Raddr.IP": "::",
-  "Raddr.Port": 0,
+  "SrcIP": "::",
+  "SrcPort": 3889,
+  "DestIP": "::",
+  "DestPort": 0,
   "Timestamp": "2019-11-27T01:18:15Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }
@@ -112,10 +112,10 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Family": "IPv6",
   "Type": "TCP",
   "Status": "LISTEN",
-  "Laddr.IP": "::",
-  "Laddr.Port": 3889,
-  "Raddr.IP": "::",
-  "Raddr.Port": 0,
+  "SrcIP": "::",
+  "SrcPort": 3889,
+  "DestIP": "::",
+  "DestPort": 0,
   "Timestamp": "2019-11-27T01:18:15Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }
@@ -148,10 +148,10 @@ LET X <= SELECT mock(plugin='info', results=[dict(OS='windows', foo='bar'), dict
   "Family": "IPv4",
   "Type": "TCP",
   "Status": "ESTAB",
-  "Laddr.IP": "172.168.101.128",
-  "Laddr.Port": 64371,
-  "Raddr.IP": "10.179.67.176",
-  "Raddr.Port": 443,
+  "SrcIP": "172.168.101.128",
+  "SrcPort": 64371,
+  "DestIP": "10.179.67.176",
+  "DestPort": 443,
   "Timestamp": "2019-12-07T03:30:58Z",
   "_Source": "Windows.Network.NetstatEnriched/Netstat"
  }


### PR DESCRIPTION
Update NetstatEnriched to add remediation usecase which is common for us.
Also renamed field names  to remove the . which is anoying for new users to remember to exclude.
Fixed a bug in filters when using name as there was some unexpected results in the old version.