### PR TITLE
Log error messages during rekeying

### DIFF
--- a/http_comms/comms.go
+++ b/http_comms/comms.go
@@ -502,12 +502,15 @@ func (self *HTTPConnector) rekeyNextServer(ctx context.Context) error {
 	}
 
 	if resp.StatusCode != 200 {
-		return errors.New("Invalid status while downloading PEM")
+		err = errors.New("Invalid status while downloading PEM")
+		self.logger.Info("While getting %v: %v (%d)", url, err, resp.StatusCode)
+		return err
 	}
 
 	pem, err := ioutil.ReadAll(io.LimitReader(resp.Body, constants.MAX_MEMORY))
 	if err != nil {
 		self.server_name = ""
+		self.logger.Info("While reading %v: %v", url, err)
 		return errors.Wrap(err, 0)
 	}
 


### PR DESCRIPTION
The PR logs any error message returned from the rekeying function, providing insights into what might have caused the rekeying to fail. An example of such a previously non-logged message would be:
```
[INFO] 2023-06-09T13:09:00+02:00 While rekeying https://example.com/: Invalid status while downloading PEM
```