### PR TITLE
Correct `scope` plugin reference typo

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -4988,7 +4988,7 @@
     ### Example
 
     ```sql
-    SELECT 1+1 As Two FROM scop()
+    SELECT 1+1 As Two FROM scope()
     ```
   type: Plugin
   category: plugin


### PR DESCRIPTION
Correct `scope` plugin reference typo