### PR TITLE
Update Bam.yaml due to a dead link. Previous link is dead due to a website restructuring.

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Bam.yaml
+++ b/artifacts/definitions/Windows/Forensics/Bam.yaml
@@ -8,7 +8,7 @@ description: |
   system and last execution date/time
 
 reference:
-  - https://www.andreafortuna.org/dfir/forensic-artifacts-evidences-of-program-execution-on-windows-systems/
+  - https://andreafortuna.org/2018/05/23/forensic-artifacts-evidences-of-program-execution-on-windows-systems/
 
 parameters:
   - name: bamKeys


### PR DESCRIPTION
Updated the link. Previous link is dead due to a website restructuring.