### PR TITLE
Expose user policy through `gui_users` for use with `user_grant`

### DIFF
--- a/artifacts/testdata/server/testcases/orgs.out.yaml
+++ b/artifacts/testdata/server/testcases/orgs.out.yaml
@@ -32,7 +32,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -66,7 +66,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "picture": "",
   "email": false,
   "roles": null,
-  "_policy": {},
+  "policy": {},
   "effective_policy": null
  },
  {
@@ -78,7 +78,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -113,7 +113,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "reader"
    ]
@@ -131,7 +131,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "reader"
    ]
@@ -150,7 +150,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -186,7 +186,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "reader"
    ]
@@ -203,7 +203,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "picture": "",
   "email": false,
   "roles": null,
-  "_policy": {},
+  "policy": {},
   "effective_policy": null
  },
  {
@@ -215,7 +215,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -250,7 +250,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "reader"
    ]
@@ -289,7 +289,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -324,7 +324,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "reader"
    ]

--- a/artifacts/testdata/server/testcases/users.out.yaml
+++ b/artifacts/testdata/server/testcases/users.out.yaml
@@ -25,7 +25,7 @@ SELECT whoami() FROM scope()[
    "roles": [
     "reader"
    ],
-   "_policy": {
+   "policy": {
     "roles": [
      "reader"
     ]
@@ -46,7 +46,7 @@ SELECT whoami() FROM scope()[
    "roles": [
     "reader"
    ],
-   "_policy": {
+   "policy": {
     "label_clients": true,
     "roles": [
      "reader"
@@ -68,7 +68,7 @@ SELECT whoami() FROM scope()[
   "roles": [
    "reader"
   ],
-  "_policy": {
+  "policy": {
    "label_clients": true,
    "roles": [
     "reader"
@@ -88,7 +88,7 @@ SELECT whoami() FROM scope()[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]
@@ -128,7 +128,7 @@ SELECT whoami() FROM scope()[
   "roles": [
    "administrator"
   ],
-  "_policy": {
+  "policy": {
    "roles": [
     "administrator"
    ]

--- a/vql/server/users/users.go
+++ b/vql/server/users/users.go
@@ -160,12 +160,12 @@ func getUserRecord(
 	policy, err := services.GetPolicy(org_config_obj, user_details.Name)
 	if err == nil {
 		details.Set("roles", policy.Roles)
-		details.Set("_policy",
+		details.Set("policy",
 			cleanupDict(scope, vfilter.RowToDict(ctx, scope, policy)))
 
 	} else {
 		details.Set("roles", &vfilter.Null{})
-		details.Set("_policy", ordereddict.NewDict())
+		details.Set("policy", ordereddict.NewDict())
 	}
 
 	effective_policy, err := services.GetEffectivePolicy(org_config_obj, user_details.Name)


### PR DESCRIPTION
Exposes the user policy through `gui_users`, enabling the output to be used with `user_grant` without relying on the effective ACLs.