### PR TITLE
Bugfix: Allow `user_grant` to set roles through the policy

### DIFF
--- a/utils/slice.go
+++ b/utils/slice.go
@@ -31,3 +31,12 @@ func ConvertToStringSlice(a interface{}) []string {
 	}
 	return result
 }
+
+func DeduplicateStringSlice(in []string) (out []string) {
+	for _, i := range in {
+		if !InString(out, i) {
+			out = append(out, i)
+		}
+	}
+	return out
+}

--- a/vql/server/users/grant.go
+++ b/vql/server/users/grant.go
@@ -64,7 +64,7 @@ func (self GrantFunction) Call(
 		scope.Log("user_grant: You must provide either roles or a policy object")
 		return vfilter.Null{}
 	}
-	policy.Roles = arg.Roles
+	policy.Roles = utils.DeduplicateStringSlice(append(policy.Roles, arg.Roles...))
 
 	principal := vql_subsystem.GetPrincipal(scope)
 	err = users.GrantUserToOrg(ctx, principal, arg.Username, orgs, policy)


### PR DESCRIPTION
Allows `user_grant` to set roles through the policy argument, using the policy obtained either through the `Server.Audit.Logs` events (e.g. logged on `user_create` or `user_grant`)  as well as obtained through `gui_users` (see #2768)

```
SELECT * FROM foreach(row={SELECT _policy AS Policy FROM gui_users() WHERE name = 'admin'}, query={
    SELECT user_grant(user='foo', orgs=['root'], policy=Policy) FROM scope()
})
```

![image](https://github.com/Velocidex/velociraptor/assets/46688461/19d4936f-32ce-42a9-8ccd-b738fcdfbcd4)
