### PR TITLE
Debian packaging: architecture autodetection & spec compliance

### DIFF
--- a/bin/debian.go
+++ b/bin/debian.go
@@ -221,13 +221,14 @@ func doSingleServerDeb(
 	if input == "" {
 		input, err = os.Executable()
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return fmt.Errorf("Unable to find executable: %w", err)
 		}
 	}
 
 	e, err := elf.Open(input)
 	if err != nil {
-		return fmt.Errorf("Unable to parse ELF executable: %w", err)
+		return fmt.Errorf("%s is not a valid Linux ELF binary. Use the --binary "+
+			"flag to specify the path to a Linux binary: %w", input, err)
 	}
 
 	arch, ok := debArchMap[e.Machine.String()]
@@ -336,13 +337,14 @@ func doClientDeb() error {
 	if input == "" {
 		input, err = os.Executable()
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return fmt.Errorf("Unable to find executable: %w", err)
 		}
 	}
 
 	e, err := elf.Open(input)
 	if err != nil {
-		return fmt.Errorf("Unable to parse ELF executable: %w", err)
+		return fmt.Errorf("%s is not a valid Linux ELF binary. Use the --binary "+
+			"flag to specify the path to a Linux binary: %w", input, err)
 	}
 
 	arch, ok := debArchMap[e.Machine.String()]


### PR DESCRIPTION
This PR fixes up Debian generation so that it generates more compliant packages across architectures (#2793). Please let me know if you would rather see this split into multiple PR's:

* Rather than hardcode `amd64`, read the appropriate architecture from the ELF binary.
* When building from HEAD (`-dev`), replace the `-` in the version number with a `.`
* Change the default output filenames to be compliant with the Debian packaging spec:
  * Old: `velociraptor_<version>_server<variant>.deb`
  * New: `velociraptor_server_<variant>_<version>_<arch>.deb`
* `gofmt` also inflicted some unrelated comment changes  

I've tested this for client and server debian packages for x86-64, arm64, and ppc64le. Here's an example for building an arm64 Debian package from an amd64 host:

```
./output/velociraptor debian server \
  --config config.yaml \
  --verbose \
  --binary ./output/velociraptor-v0.7.0-dev-linux-arm64-nocgo                                          

go run make.go -v autoDev
Running target: AutoDev
exec: fileb0x artifacts/b0x.yaml
...
[INFO] 2023-07-07T16:54:56Z This is Velociraptor 0.7.0-dev built on 2023-07-07T12:54:49-04:00 (678a3f0e) 
[INFO] 2023-07-07T16:54:56Z Loading config from file config.yaml 
Creating arm64 server package at velociraptor_server_0.7.0.dev_arm64.deb
```
