### PR TITLE
RPM packaging: architecture autodetection & spec compliance

### DIFF
--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/binary"
+	"debug/elf"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -28,20 +26,16 @@ var (
 		"server", "Create a server package from a server config file.")
 
 	server_rpm_command_output = server_rpm_command.Flag(
-		"output", "Filename to output").Default(
-		fmt.Sprintf("velociraptor_%s_server.rpm", constants.VERSION)).
-		String()
+		"output", "Filename to output").String()
 
 	server_rpm_command_binary = server_rpm_command.Flag(
 		"binary", "The binary to package").String()
 
 	client_rpm_command_use_sysv = client_rpm_command.Flag(
-		"use_sysv", "Use sys V style services (Centos 6)").Bool()
+		"use_sysv", "Use SysV style services (CentOS 6)").Bool()
 
 	client_rpm_command_output = client_rpm_command.Flag(
-		"output", "Filename to output").Default(
-		fmt.Sprintf("velociraptor_%s_client.rpm", constants.VERSION)).
-		String()
+		"output", "Filename to output").String()
 
 	client_rpm_command_binary = client_rpm_command.Flag(
 		"binary", "The binary to package").String()
@@ -204,12 +198,24 @@ case "$1" in
 esac
 exit $RETVAL
 `
+
+	// rpmArchMap maps ELF machine strings to RPM architectures
+	// See https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf-em.h
+	//     https://fedoraproject.org/wiki/Architectures
+	rpmArchMap = map[string]string{
+		"EM_X86_64":  "x86_64",
+		"EM_386":     "i386",
+		"EM_AARCH64": "aarch64",
+		"EM_RISCV":   "riscv64",
+		"EM_ARM":     "armhfp",
+		"EM_PPC64":   "ppc64le",
+	}
 )
 
 // Systemd based start up scripts (Centos 7, 8)
 func doClientRPM() error {
-	// Disable logging when creating a deb - we may not create the
-	// deb on the same system where the logs should go.
+	// Disable logging when creating a package - we may not create the
+	// package on the same system where the logs should go.
 	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
@@ -238,44 +244,39 @@ func doClientRPM() error {
 	if input == "" {
 		input, err = os.Executable()
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return fmt.Errorf("Unable to find executable: %w", err)
 		}
 	}
 
-	fd, err := os.Open(input)
+	e, err := elf.Open(input)
 	if err != nil {
-		return fmt.Errorf("Unable to open executable: %w", err)
-	}
-	defer fd.Close()
-
-	header := make([]byte, 4)
-	_, err = fd.Read(header)
-	if err != nil {
-		return fmt.Errorf("Unable to open executable: %w", err)
+		return fmt.Errorf("Unable to parse ELF executable: %w", err)
 	}
 
-	if binary.LittleEndian.Uint32(header) != 0x464c457f {
-		return fmt.Errorf("Binary does not appear to be an " +
-			"ELF binary. Please specify the linux binary " +
-			"using the --binary flag.")
+	arch, ok := rpmArchMap[e.Machine.String()]
+	if !ok {
+		return fmt.Errorf("unknown binary architecture: %q", e.Machine.String())
 	}
 
-	_, err = fd.Seek(0, io.SeekStart)
+	binary_content, err := os.ReadFile(input)
 	if err != nil {
 		return fmt.Errorf("Unable to read executable: %w", err)
 	}
 
-	binary_text, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return fmt.Errorf("Unable to read executable: %w", err)
+	version := strings.ReplaceAll(constants.VERSION, "-", ".")
+
+	output_path := fmt.Sprintf("velociraptor-client-%s.%s.rpm", version, arch)
+	if *client_rpm_command_output != "" {
+		output_path = *client_rpm_command_output
 	}
-	fd.Close()
+
+	fmt.Printf("Creating client package at %s\n", output_path)
 
 	r, err := rpmpack.NewRPM(rpmpack.RPMMetaData{
 		Name:    "velociraptor-client",
-		Version: constants.VERSION,
+		Version: version,
 		Release: "A",
-		Arch:    "x86_64",
+		Arch:    arch,
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to create RPM: %w", err)
@@ -293,7 +294,7 @@ func doClientRPM() error {
 	r.AddFile(
 		rpmpack.RPMFile{
 			Name:  "/usr/local/bin/velociraptor_client",
-			Body:  binary_text,
+			Body:  binary_content,
 			Mode:  0755,
 			Owner: "root",
 			Group: "root",
@@ -321,8 +322,8 @@ func doClientRPM() error {
 /bin/systemctl stop velociraptor_client.service
 `)
 
-	fd, err = os.OpenFile(*client_rpm_command_output,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fd, err := os.OpenFile(output_path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("Unable to create output file: %w", err)
 	}
@@ -331,10 +332,10 @@ func doClientRPM() error {
 	return r.Write(fd)
 }
 
-// Systemd based start up scripts (Centos 7, 8)
+// Systemd based start up scripts (CentOS 7+)
 func doServerRPM() error {
-	// Disable logging when creating a deb - we may not create the
-	// deb on the same system where the logs should go.
+	// Disable logging when creating a package - we may not create the
+	// package on the same system where the logs should go.
 	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
@@ -369,7 +370,7 @@ func doServerRPM() error {
 func doSingleServerRPM(
 	config_obj *config_proto.Config,
 	variant string, extra_args []string) error {
-	// Debian packages always use the "velociraptor" user.
+	// Linux packages always use the "velociraptor" user.
 	config_obj.Frontend.RunAsUser = "velociraptor"
 	config_obj.ServerType = "linux"
 
@@ -379,27 +380,23 @@ func doSingleServerRPM(
 	if input == "" {
 		input, err = os.Executable()
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return fmt.Errorf("Unable to find executable: %w", err)
 		}
 	}
 
-	fd, err := os.Open(input)
+	e, err := elf.Open(input)
 	if err != nil {
-		return fmt.Errorf("Unable to open executable: %w", err)
+		return fmt.Errorf("Unable to parse ELF executable: %w", err)
 	}
-	defer fd.Close()
 
-	binary_text, err := ioutil.ReadAll(fd)
+	arch, ok := rpmArchMap[e.Machine.String()]
+	if !ok {
+		return fmt.Errorf("unknown binary architecture: %q", e.Machine.String())
+	}
+
+	binary_content, err := os.ReadFile(input)
 	if err != nil {
 		return fmt.Errorf("Unable to read executable: %w", err)
-	}
-	fd.Close()
-
-	if len(binary_text) < 4 ||
-		binary.LittleEndian.Uint32(binary_text[:4]) != 0x464c457f {
-		return fmt.Errorf("Binary does not appear to be an " +
-			"ELF binary. Please specify the linux binary " +
-			"using the --binary flag.")
 	}
 
 	config_file_yaml, err := yaml.Marshal(config_obj)
@@ -407,11 +404,28 @@ func doSingleServerRPM(
 		return err
 	}
 
+	version := strings.ReplaceAll(constants.VERSION, "-", ".")
+
+	kind := "server"
+	if variant != "" {
+		kind = kind + "-" + variant
+	}
+
+	output_path := fmt.Sprintf("velociraptor-%s-%s.%s.rpm", kind, version, arch)
+	if *server_rpm_command_output != "" {
+		output_path = *server_rpm_command_output
+		if variant != "" {
+			output_path = strings.TrimSuffix(output_path, ".rpm") + variant + ".rpm"
+		}
+	}
+
+	fmt.Printf("Creating %s package at %s\n", variant, output_path)
+
 	r, err := rpmpack.NewRPM(rpmpack.RPMMetaData{
 		Name:    "velociraptor-server",
-		Version: constants.VERSION,
+		Version: version,
 		Release: "A",
-		Arch:    "x86_64",
+		Arch:    arch,
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to create RPM: %w", err)
@@ -429,7 +443,7 @@ func doSingleServerRPM(
 	r.AddFile(
 		rpmpack.RPMFile{
 			Name:  "/usr/local/bin/velociraptor",
-			Body:  binary_text,
+			Body:  binary_content,
 			Mode:  0755,
 			Owner: "root",
 			Group: "root",
@@ -458,15 +472,8 @@ func doSingleServerRPM(
 /bin/systemctl stop velociraptor_server.service
 `)
 
-	output_file := *server_rpm_command_output
-	if variant != "" {
-		output_file = strings.TrimSuffix(output_file, ".rpm") + variant + ".rpm"
-	}
-
-	fmt.Printf("Creating a package for %v\n", output_file)
-
-	fd, err = os.OpenFile(output_file,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fd, err := os.OpenFile(output_path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("Unable to create output file: %w", err)
 	}
@@ -475,10 +482,10 @@ func doSingleServerRPM(
 	return r.Write(fd)
 }
 
-// Simple startup scripts for Sys V based systems (Centos 6)
+// Simple startup scripts for SysV-style init systems (Centos 6)
 func doClientSysVRPM() error {
-	// Disable logging when creating a deb - we may not create the
-	// deb on the same system where the logs should go.
+	// Disable logging when creating a package - we may not create the
+	// package on the same system where the logs should go.
 	logging.DisableLogging()
 
 	config_obj, err := makeDefaultConfigLoader().
@@ -507,44 +514,39 @@ func doClientSysVRPM() error {
 	if input == "" {
 		input, err = os.Executable()
 		if err != nil {
-			return fmt.Errorf("Unable to open executable: %w", err)
+			return fmt.Errorf("Unable to find executable: %w", err)
 		}
 	}
 
-	fd, err := os.Open(input)
+	e, err := elf.Open(input)
 	if err != nil {
-		return fmt.Errorf("Unable to open executable: %w", err)
-	}
-	defer fd.Close()
-
-	header := make([]byte, 4)
-	_, err = fd.Read(header)
-	if err != nil {
-		return fmt.Errorf("Unable to read executable: %w", err)
+		return fmt.Errorf("Unable to parse ELF executable: %w", err)
 	}
 
-	if binary.LittleEndian.Uint32(header) != 0x464c457f {
-		return fmt.Errorf("Binary does not appear to be an " +
-			"ELF binary. Please specify the linux binary " +
-			"using the --binary flag.")
+	arch, ok := rpmArchMap[e.Machine.String()]
+	if !ok {
+		return fmt.Errorf("unknown binary architecture: %q", e.Machine.String())
 	}
 
-	_, err = fd.Seek(0, io.SeekStart)
+	binary_content, err := os.ReadFile(input)
 	if err != nil {
 		return fmt.Errorf("Unable to read executable: %w", err)
 	}
 
-	binary_text, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return fmt.Errorf("Unable to read executable: %w", err)
+	version := strings.ReplaceAll(constants.VERSION, "-", ".")
+
+	output_path := fmt.Sprintf("velociraptor-client-%s.%s.rpm", version, arch)
+	if *client_rpm_command_output != "" {
+		output_path = *client_rpm_command_output
 	}
-	fd.Close()
+
+	fmt.Printf("Creating SysV-init client package at %s\n", output_path)
 
 	r, err := rpmpack.NewRPM(rpmpack.RPMMetaData{
 		Name:    "velociraptor-client",
-		Version: constants.VERSION,
+		Version: version,
 		Release: "A",
-		Arch:    "x86_64",
+		Arch:    arch,
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to create RPM: %w", err)
@@ -560,7 +562,7 @@ func doClientSysVRPM() error {
 	r.AddFile(
 		rpmpack.RPMFile{
 			Name:  "/usr/local/bin/velociraptor",
-			Body:  binary_text,
+			Body:  binary_content,
 			Mode:  0755,
 			Owner: "root",
 			Group: "root",
@@ -593,10 +595,10 @@ fi
 /sbin/service velociraptor condrestart > /dev/null 2>&1 || :
 `)
 
-	fd, err = os.OpenFile(*client_rpm_command_output,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fd, err := os.OpenFile(output_path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return fmt.Errorf("Unable to  create output file: %w", err)
+		return fmt.Errorf("Unable to create output file: %w", err)
 	}
 	defer fd.Close()
 


### PR DESCRIPTION
This PR fixes up RPM generation so that it generates more compliant packages across architectures (#2793). Please let me know if you would rather see this split into multiple PRs:

* Rather than hardcode `amd64`, read the appropriate architecture from the ELF binary.
* When building from HEAD (`-dev`), replace the `-` in the version number with a `.`
* Change the default output filenames to be compliant with the Debian packaging spec:
  * Old: `velociraptor_<version>_server<variant>.rpm`
  * New: `velociraptor-server-<variant>-<version>.<arch>.rpm`
* Fix minor typos found in comments (deb->package, CentOs to CentOS)

I've tested this for client and server RPM packages for x86-64, arm64, and ppc64le. Here's an example for building an arm64 RPM from an amd64 host:

```
./output/velociraptor rpm client \
  --use_sysv \
  --config config.yaml \
  --verbose \
  --binary ./output/velociraptor-v0.7.0-dev-linux-arm64-nocgo                                                      

go run make.go -v autoDev
Running target: AutoDev
...
[INFO] 2023-07-07T17:12:56Z Loaded 0 custom artifacts in 81.745µs 
[ERROR] 2023-07-07T17:12:56Z Unable to open file /var/tmp/velociraptor/config/inventory.json.db: open /var/tmp/velociraptor/config/inventory.json.db: permission denied 
[WARNING] 2023-07-07T17:12:56Z Unable to store inventory - will run with an in memory one. 
Creating SysV-init client package at velociraptor-client-0.7.0.dev.aarch64.rpm
[INFO] 2023-07-07T17:13:25Z Compiled all artifacts. 
```
