### PR TITLE
Fixed bug in KapeFiles Extract

### DIFF
--- a/artifacts/testdata/server/testcases/kapefiles_extract.in.yaml
+++ b/artifacts/testdata/server/testcases/kapefiles_extract.in.yaml
@@ -11,6 +11,12 @@ Queries:
   # Should refuse to pad out very sparse files.
   - SELECT * FROM test_read_logs() WHERE Log =~ "is too sparse - unable to expand it" AND NOT Log =~ "SELECT"
 
+  # On Windows we can adjust all the timestamps but only Linux on the
+  # mtime
+  - LET CheckTime(Time, Default) = if(condition={ SELECT * FROM info() WHERE OS=~"windows" }, then=Time, else=Default)
+
   # Make sure that timestamps are properly adjusted
-  - SELECT Name, Mtime.Unix
+  - SELECT Name, Mtime.Unix AS Mtime,
+        CheckTime(Time=Ctime.Unix, Default=1629576251) AS Ctime,
+        CheckTime(Time=Atime.Unix, Default=1629576251) AS Atime
     FROM glob(globs="/**", root=tmpdir) WHERE NOT IsDir

--- a/artifacts/testdata/server/testcases/kapefiles_extract.out.yaml
+++ b/artifacts/testdata/server/testcases/kapefiles_extract.out.yaml
@@ -31,13 +31,17 @@ LET tmpdir <= tempdir()[]SELECT Timestamp, vfs_path, FileUpload, Metadata, Uploa
  {
   "Log": "Velociraptor: Error: File /uploads/ntfs/%5C%5C.%5CC%3A/$Extend/$UsnJrnl%3A$J is too sparse - unable to expand it.\n"
  }
-]SELECT Name, Mtime.Unix FROM glob(globs="/**", root=tmpdir) WHERE NOT IsDir[
+]LET CheckTime(Time, Default) = if(condition={ SELECT * FROM info() WHERE OS=~"windows" }, then=Time, else=Default)[]SELECT Name, Mtime.Unix AS Mtime, CheckTime(Time=Ctime.Unix, Default=1629576251) AS Ctime, CheckTime(Time=Atime.Unix, Default=1629576251) AS Atime FROM glob(globs="/**", root=tmpdir) WHERE NOT IsDir[
  {
   "Name": "$UsnJrnl%3A$J",
-  "Mtime.Unix": 1629576251
+  "Mtime": 1629576251,
+  "Ctime": 1629576251,
+  "Atime": 1629576251
  },
  {
   "Name": "$UsnJrnl%3A$Max",
-  "Mtime.Unix": 1629576251
+  "Mtime": 1629576251,
+  "Ctime": 1629576251,
+  "Atime": 1629576251
  }
 ]

--- a/uploads/file_based_windows.go
+++ b/uploads/file_based_windows.go
@@ -23,7 +23,9 @@ func setFileTimestamps(file_path string,
 	defer syscall.Close(handle)
 
 	mtime_ := syscall.NsecToFiletime(mtime.UnixNano())
-	atime_ := syscall.NsecToFiletime(mtime.UnixNano())
-	ctime_ := syscall.NsecToFiletime(mtime.UnixNano())
-	return syscall.SetFileTime(handle, &ctime_, &atime_, &mtime_)
+	atime_ := syscall.NsecToFiletime(atime.UnixNano())
+	ctime_ := syscall.NsecToFiletime(ctime.UnixNano())
+	err = syscall.SetFileTime(handle, &ctime_, &atime_, &mtime_)
+
+	return err
 }


### PR DESCRIPTION
Only mtime was set but on Windows we can also set the Ctime and Atime.