### PR TITLE
Add RDP cache (#43)

### DIFF
--- a/artifacts/definitions/Windows/Forensics/RDPcache.yaml
+++ b/artifacts/definitions/Windows/Forensics/RDPcache.yaml
@@ -1,0 +1,42 @@
+name: Windows.Forensics.RDPCache
+author: Matt Green - @mgreen27
+description: |
+   This artifact views and enables simplified upload of RDP 
+   cache files. 
+   
+   Filters include User regex to target a user and Accessor to target
+   vss via ntfs_vss.
+
+   Best combined with:
+
+   - Windows.EventLogs.RDPAuth to collect RDP focused event logs.
+   - Windows.Registry.RDP to collect user RDP mru and server info
+
+reference:
+   - https://github.com/ANSSI-FR/bmc-tools
+   - https://github.com/BSI-Bund/RdpCacheStitcher
+
+parameters:
+   - name: RDPCacheGlob
+     default: C:\{{Users,Windows.old\Users}\*\AppData\Local,Documents and Settings\*\Local Settings\Application Data}\Microsoft\Terminal Server Client\Cache\*
+   - name: Accessor
+     description: Set accessor to use. blank is default, file for api, ntfs for raw, ntfs_vss for vss
+   - name: UserRegex
+     default: .
+     description: Regex filter of user to target. StartOf(^) and EndOf($)) regex may behave unexpectanly.
+     type: regex
+   - name: UploadRDPCache
+     type: bool
+
+sources:
+  - query: |
+      LET results = SELECT OSPath, Size, Mtime, Atime, Ctime, Btime
+        FROM glob(globs=RDPCacheGlob,accessor=Accessor)
+        WHERE OSPath =~ UserRegex
+      
+      LET upload_results = SELECT *, upload(file=OSPath) as CacheUpload
+        FROM results
+      
+      SELECT * FROM if(condition= UploadRDPCache,
+        then= upload_results,
+        else= results )

--- a/artifacts/definitions/Windows/Registry/RDP.yaml
+++ b/artifacts/definitions/Windows/Registry/RDP.yaml
@@ -1,0 +1,103 @@
+name: Windows.Registry.RDP
+author: Matt Green - @mgreen27
+description: |
+   This artifact will collect historical RDP server names and MRU items stored 
+   in each users NTUser.dat
+   
+   1. Servers - list of all RDP connections that have ever been established by 
+   this user.   
+    UsernameHint shows the username used to connect to the RDP/RDS host.  
+    CertHash variable contains the RDP server SSL certificate thumbprint.
+
+   2. MRU 10 - Most recently used RDP connections 
+   
+   UserRegex and SidRegex can be used to target a specific user.
+
+type: CLIENT
+
+parameters:
+   - name: KeyGlob
+     default: Software\Microsoft\Terminal Server Client\{Default,Servers}\**
+   - name: UserRegex
+     default: .
+     description: Regex filter to select a target username
+     type: regex
+   - name: SidRegex
+     default: .
+     description: Regex filter to select a target SID
+     type: regex
+     
+
+precondition: SELECT OS From info() where OS = 'windows'
+      
+sources:
+  - name: Servers
+    query: |
+      LET servers <= SELECT 
+            Mtime as LastWriteTime,
+            basename(path=OSPath.Dirname) as Server,
+            OSPath.Basename as KeyName,
+            Data.value as KeyValue,
+            Data.data_len as ValueLength,
+            OSPath.Dirname.Path as Key,
+            OSPath.DelegatePath as HiveName,
+            OSPath,
+            Username,
+            UUID as SID
+        FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob)
+        WHERE NOT Data.type = 'Key'
+            AND OSPath =~ '''Terminal Server Client\\\\Servers\\'''
+
+      LET find_value(path, sid, keyname ) = SELECT KeyValue,
+            format(format='%x',args=read_file(accessor='data',filename=KeyValue,length=ValueLength)) as CertHash
+        FROM servers 
+        WHERE KeyName = keyname AND Key=path AND SID=sid
+        
+      LET results = SELECT 
+            Username || dirname(path=HiveName).Basename as Username,  
+            SID,
+            HiveName,
+            Key,  
+            LastWriteTime,
+            Server
+        FROM servers
+        WHERE Username =~ UserRegex AND SID =~ SidRegex
+        GROUP BY SID,Key,HiveName,LastWriteTime
+            
+      
+      SELECT *
+        find_value(path=Key,sid=SID,keyname='UsernameHint')[0].KeyValue as UsernameHint,
+        find_value(path=Key,sid=SID,keyname='CertHash')[0].CertHash as CertHash
+      FROM results
+
+  - name: Mru
+    query: |
+      LET mru <= SELECT 
+            Mtime as LastWriteTime,
+            OSPath.Basename as KeyName,
+            Data.value as KeyValue,
+            OSPath.Dirname.Path as Key,
+            OSPath.DelegatePath as HiveName,
+            Username,
+            UUID as SID
+        FROM Artifact.Windows.Registry.NTUser(KeyGlob=KeyGlob)
+        WHERE NOT Data.type = 'Key'
+            AND OSPath =~ '''Terminal Server Client\\\\Default\\\\MRU'''
+    
+      LET find_mru(sid) = SELECT KeyValue FROM mru 
+        WHERE SID=sid
+        
+      LET results = SELECT *,
+            Username || dirname(path=HiveName).Basename as Username
+        FROM mru 
+        WHERE Username =~ UserRegex AND SID =~ SidRegex
+        GROUP BY Sid,HiveName
+      
+      SELECT 
+        Username,
+        SID,  
+        HiveName,
+        Key,
+        LastWriteTime,
+        find_mru(sid=SID).KeyValue as Mru
+      FROM results


### PR DESCRIPTION
Add Windows.Forensics.RDPCache to enable upload of RDP cache and user targetting.
Add Windows.Registry.RDP to enable collecting RDP mru and server data from user hives.