### PR TITLE
Fix issues in AptSources artifact and support deb822 format

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     # We used to build on ubuntu-18.04 but that is now deprecated by
     # GitHub. Earlier distributions will have to use the musl build.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Check out code into the Go module directory

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -271,7 +271,12 @@ export: |
 parameters:
   - name: linuxAptSourcesGlobs
     description: Globs to find apt source *.list and .sources files.
-    default: /etc/apt/sources.list,/etc/apt/sources.list.d/*.{list,sources}
+    type: csv
+    default: |
+        ListGlobs
+        /etc/apt/sources.list
+        /etc/apt/sources.list.d/*.list
+        /etc/apt/sources.list.d/*.sources
   - name: aptCacheDirectory
     description: Location of the apt cache directory.
     default: /var/lib/apt/lists/
@@ -283,7 +288,7 @@ sources:
   - name: Sources
     query: |
         LET files = SELECT OSPath FROM glob(
-           globs=split(string=linuxAptSourcesGlobs, sep=''',\s*'''))
+           globs=linuxAptSourcesGlobs.ListGlobs)
         
         /* Output sources in a readable format: */
         SELECT * FROM foreach(row=files,

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -235,6 +235,8 @@ export: |
                A file must be split into sections, fed individually to this function
         */
         LET Deb822_KeyValues___(section) = SELECT Key,
+            /* Signed-By is special (it could be an embedded GPG key),and
+               shouldn't be split: */
             if(condition=NormaliseOpts(string=Key)!='Signed-By',
                 then=split(sep_string=' ',
                 string=MaybeReplaceComma(key=Key,

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -3,32 +3,32 @@ description: |
   Parse Debian apt sources.
 
   This Artifact searches for all apt sources files and parses all
-  fields in both one–line \*.list files and \*.sources files
+  fields in both one–line `*.list` files and `*.sources` files
   (deb822-style format). The results are presented both in a readable
   table and a flattened version for parsing.
 
-  \*.list files contains lines of the form
+  `*.list` files contains lines of the form
 
-  .. code:: console
-
-     deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
-     deb-src [arch=amd64,i386 signed-by=/usr/share/keyrings/foo.gpg] https://foo.bar.baz/ubuntu/main jammy main restricted universe multiverse # Comment
+  ```
+  deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
+  deb-src [arch=amd64,i386 signed-by=/usr/share/keyrings/foo.gpg] https://foo.bar.baz/ubuntu/main jammy main restricted universe multiverse # Comment
+  ```
 
   deb indicates a source for binary packages, and deb-src instructs APT where
   to find source code for packages.
 
-  \*.sources files (deb822-style format) are in the form of key–value
+  `*.sources` files (deb822-style format) are in the form of key–value
   lines, and as opposed to the one–line format, they can contain
   multiple URIs, components and types (deb/deb-src), along with
   embedded GPG keys. Example:
 
-  .. code:: console
+  ```
+  Types: deb deb-src
+  URIs: file:/home/apt/debian http://foo.bar.baz/main
+  Suites: unstable
+  Components: main contrib non-free
+  ```
 
-     Types: deb deb-src
-     URIs: file:/home/apt/debian http://foo.bar.baz/main
-     Suites: unstable
-     Components: main contrib non-free
-     
   The exported function parse_aptsources(OSPath, flatten) parses
   both formats and returns a (optionally flattened) table with
    - OSPath
@@ -42,7 +42,7 @@ description: |
   Any option is added to an individual column. Typical options are
    - Architectures (e.g. amd64/i386/armel)
    - Signed-By (e.g. /usr/share/keyrings/osquery.gpg)
-   
+
   All known option names are transformed to the plural PascalCase
   variants as listed in the sources.list man page. Any undocumented
   options will still be included in the results, with names unchanged.
@@ -56,7 +56,7 @@ description: |
   exported functions DebTrue()/DebFalse() to correctly parse all
   accepted true/false strings, or use the VQL suggestion "Enabled"
   to filter on this column (true), if present.
-   
+
   If the GPG key is embedded in a .sources file, the whole GPG key
   will be included in the cell. Otherwise the value will be a file
   path.
@@ -81,10 +81,10 @@ export: |
             `(?m)^\\s+`='',
             `(?m)\\s+$`=''
         ))
-        
+
         /* Replace any repeating whitespace with a single space: */
         LET Simplify(string) = regex_replace(source=string, re='''\s+''', replace=' ')
-        
+
         /* The syntax in lists (deb822) and sources (one-line) files varies a bit,
            and deb822 is case-insensitive. Normalise all known fields (as per
            the man page): */
@@ -132,7 +132,7 @@ export: |
                 regex='''(?P<Key>[^ ]+?)(?P<Op>-|\+)?=(?P<Value>[^ ]+)''',
                 accessor='data', file=string
         )
-        
+
         /* Since option values may have multiple words, split them and flatten
            the results for further processing: */
         LET OptStringToKeyValues_(string) = SELECT *
@@ -142,7 +142,7 @@ export: |
                     split(sep_string=',', string=Value) AS Value
                     FROM OptStringToKeyValues__(string=string)
             })
-        
+
         /* Since options may be repeated, enumerate and group all values
            per key and operation: */
         LET OptStringToKeyValues(string) = SELECT Key,
@@ -150,7 +150,7 @@ export: |
             enumerate(items=Value) AS Value
             FROM OptStringToKeyValues_(string=string)
             GROUP BY Key, Op
-        
+
         /* When an option is specified with +/-, represent this by appending
            -Add/-Remove to the option name. These names match the syntax in
            the deb822 format (i.e. "arch-=i386" == "Arhitectures-Remove: i386").
@@ -159,7 +159,7 @@ export: |
            values: */
         LET OpName(op) = if(condition=op='+',then='-Add',else=
             if(condition=op='-',then='-Remove',else=''))
-        
+
         /* Convert a string of key–value pairs to a dict, and use consistent
            option names: */
         LET OptStringToDict(string, flatten) = to_dict(item={
@@ -181,7 +181,7 @@ export: |
                    ("" and []) are actually allowed to certain degree by the
                    apt source code, but this is considered obscure syntax and
                    is not expected to be found in the wild. The exception is
-                   "cdrom:[word word…]", which is capture correctly in order 
+                   "cdrom:[word word…]", which is capture correctly in order
                    to not end up with incorrectly captured words: */
                 regex='''(?m)^\s*(?P<Type>deb(-src)?)(?:\s+\[(?P<Options>[^\]#]+)(?:#[^\]]+)?\])?\s+"?(?P<URI>(?P<Transport>[^:]+):(?://)?(?P<URIBase>\[.+?\]|\S+?))"?\s+(?P<Suite>\S+)\s+(?P<Components>[^\n#]+)'''
             )
@@ -197,13 +197,13 @@ export: |
                         FROM scope()
                     })
                 })
-        
+
         /* Parse a one-line deb sources.list file with options in individual columns: */
         LET DebOneLine(OSPath) = SELECT OSPath, * FROM foreach(
             row=DebOneLine_Dict(OSPath=OSPath, flatten=false),
             column='Contents'
         )
-        
+
         /* Parse a one-line deb sources.list file with options in individual
            columns and flatten: */
         LET DebOneLine_Flattened(OSPath) = SELECT OSPath, * FROM flatten(
@@ -212,7 +212,7 @@ export: |
                 column='Contents'
                 )
             })
-        
+
         /* Extract the transport/protocol and base from a URI: */
         LET URIComponents(URI) = parse_string_with_regex(
             regex='''(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+)''',
@@ -229,7 +229,7 @@ export: |
             condition=key=~'(?i)^(?:arch|lang|targets)',
             then=regex_replace(re='\s*,\s*', source=value, replace=' '),
             else=value)
-        
+
         /* Parse a deb822 sources file section into a series of key–value pairs.
            Notes about the format:
              - Keys must be at the beginning of the line (no whitespace allowed)
@@ -278,7 +278,7 @@ export: |
         LET Deb822_KeyValues__(section) = SELECT * FROM flatten(query={
             SELECT * FROM Deb822_KeyValues___(section=section)
         })
-        
+
         LET Deb822_KeyValues_(section) = SELECT Key,
             enumerate(items=Value) AS Value
             FROM Deb822_KeyValues__(section=section)
@@ -294,11 +294,11 @@ export: |
                 FROM Deb822_KeyValues_(section=section)
             }) AS Contents
             FROM scope()
-                
+
         /* Split paragraphs in a file (separated by one or several empty
            lines) into rows. ('regex' is just anything that is illegal in Deb822Sections
            to prevent splitting data into records.): */
-        LET Deb822Sections(OSPath) = SELECT * FROM split_records(
+        LET Deb822Sections(OSPath) = SELECT OSPath,* FROM split_records(
             filenames=OSPath,
             columns='Section',
             regex='^ #', record_regex='''\n{2,}'''
@@ -317,7 +317,7 @@ export: |
                 )
             })}
         )
-        
+
         /* Parse a deb822 sources file with options in individual columns.
            Note that, as opposed to DebOneLine and Deb822_Flattened, this
            function does not return the columns _URIBase and _Transport, since
@@ -329,7 +329,7 @@ export: |
                 column='Contents'
             )}
         )
-        
+
         /* Parse a deb822 sources file with options in individual columns, flattened: */
         LET Deb822_Flattened(OSPath) = SELECT * FROM flatten(query={
             SELECT OSPath, *, URIComponents(URI=URIs).URIBase AS _URIBase,
@@ -349,6 +349,14 @@ export: |
                 else=Deb822(OSPath=OSPath)
             )
         )
+
+        LET files = SELECT OSPath FROM glob(
+           globs=linuxAptSourcesGlobs.ListGlobs)
+
+        LET deb_sources = SELECT * FROM foreach(row=files,
+            query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=true)}
+        )
+
 parameters:
   - name: linuxAptSourcesGlobs
     description: Globs to find apt source *.list and .sources files.
@@ -368,9 +376,6 @@ precondition:
 sources:
   - name: Sources
     query: |
-        LET files = SELECT OSPath FROM glob(
-           globs=linuxAptSourcesGlobs.ListGlobs)
-        
         /* Output sources in a readable format: */
         SELECT * FROM foreach(row=files,
             query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=false)}
@@ -390,13 +395,9 @@ sources:
 
   - name: SourcesFlattened
     query: |
-        LET deb_sources = SELECT * FROM foreach(row=files,
-            query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=true)}
-        )
-        
         /* Output sources flattened for ease of analysis: */
         SELECT * FROM deb_sources
-        
+
   - name: SourcesCacheFiles
     query: |
         /* We try to get at the Release file in /var/lib/apt/ by munging
@@ -457,7 +458,7 @@ sources:
             },
             then=add_stat_to_parsed_cache_file(file=cache_file + '_Release'),
             else={
-            SELECT Source, Null as Mtime, Null as Ctime,
+            SELECT Source, NULL AS OSPath, Null as Mtime, Null as Ctime,
                Null as Atime, Types,
                Null as Record, Architectures, URIs, Name from scope()
             })
@@ -465,5 +466,7 @@ sources:
 
          -- For each parsed apt .list file line produce some output.
          SELECT * from foreach(
-             row=parsed_apt_lines,
-             query=parse_cache_or_pass)
+             row={SELECT * FROM parsed_apt_lines},
+             query={
+                SELECT * FROM parse_cache_or_pass
+              })

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -65,6 +65,7 @@ description: |
 reference:
   - https://manpages.debian.org/bookworm/apt/sources.list.5.en.html
   - https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html
+  - https://salsa.debian.org/apt-team/apt/-/blob/main/apt-pkg/sourcelist.cc
   - https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files
 
 export: |
@@ -163,7 +164,14 @@ export: |
             Simplify(string=Trim(string=Components)) AS Components
             FROM parse_records_with_regex(
                 file=OSPath,
-                regex='''(?m)^\s*(?P<Type>deb(-src)?)(?:\s+\[(?P<Options>[^\]]+)\])?\s+(?P<URI>(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+))\s+(?P<Suite>\S+)\s+(?P<Components>[^\n#]+)'''
+                /* This regex attemps to cover most of the ways a sources
+                   line can be written without being overly complex. Quotes
+                   ("" and []) are actually allowed to certain degree by the
+                   apt source code, but this is considered obscure syntax and
+                   is not expected to be found in the wild. The exception is
+                   "cdrom:[word word…]", which is capture correctly in order 
+                   to not end up with incorrectly captured words: */
+                regex='''(?m)^\s*(?P<Type>deb(-src)?)(?:\s+\[(?P<Options>[^\]#]+)(?:#[^\]]+)?\])?\s+"?(?P<URI>(?P<Transport>[^:]+):(?://)?(?P<URIBase>\[.+?\]|\S+?))"?\s+(?P<Suite>\S+)\s+(?P<Components>[^\n#]+)'''
             )
 
         /* Parse a one-line deb sources.list file and output a dict: */

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -43,9 +43,12 @@ description: |
    - Architectures (e.g. amd64/i386/armel)
    - Signed-By (e.g. /usr/share/keyrings/osquery.gpg)
    
-  All known option names are transformed to the plural SnakeCase
+  All known option names are transformed to the plural PascalCase
   variants as listed in the sources.list man page. Any undocumented
   options will still be included in the results, with names unchanged.
+  Options in the one-line format of the form "lang+=de"/"arch-=i386"
+  will be in columns named "Languages-Add"/"Architectures-Remove",
+  matching the option names having the same effect in deb822.
    
   If the GPG key is embedded in a .sources file, the whole GPG key
   will be included in the cell. Otherwise the value will be a file
@@ -82,9 +85,15 @@ export: |
             `(?i)uris|uri`='URIs',
             `(?i)suites|suite`='Suites',
             `(?i)components|component`='Components',
-            `(?i)architectures|arch`='Architectures',
-            `(?i)languages|lang`='Languages',
-            `(?i)targets|target`='Targets',
+            `(?i)architectures$|arch$`='Architectures',
+            `(?i)architectures-add`='Architectures-Add',
+            `(?i)architectures-remove`='Architectures-Remove',
+            `(?i)languages$|lang$`='Languages',
+            `(?i)languages-add`='Languages-Add',
+            `(?i)languages-remove`='Languages-Remove',
+            `(?i)targets$|target$`='Targets',
+            `(?i)targets-add`='Targets-Add',
+            `(?i)targets-remove`='Targets-Remove',
             `(?i)pdiffs`='PDiffs',
             `(?i)by-hash`='By-Hash',
             `(?i)allow-insecure`='Allow-Insecure',
@@ -106,14 +115,17 @@ export: |
         /* Get keys and values from 'key=value' strings: */
         LET OptStringToKeyValues(string) = SELECT *
             FROM parse_records_with_regex(
-                regex='''(?P<Key>[^= ]+)=(?P<Value>[^ ]+)''',
+                regex='''(?P<Key>[^ ]+?)(?P<Op>-|\+)?=(?P<Value>[^ ]+)''',
                 accessor='data', file=string
         )
         
+        LET OpName(op) = if(condition=op='+',then='-Add',else=
+            if(condition=op='-',then='-Remove',else=''))
+
         /* Convert a string of key–value pairs to a dict, and use consistent
            option names: */
         LET OptStringToDict(string, flatten) = to_dict(item={
-            SELECT NormaliseOpts(string=Key) AS _key,
+            SELECT NormaliseOpts(string=Key)+OpName(op=Op) AS _key,
                 if(condition=flatten, then=split(sep_string=',', string=Value),
                     else=regex_replace(source=Value, re=',', replace=' ')) AS _value
             FROM OptStringToKeyValues(string=string)
@@ -163,7 +175,9 @@ export: |
         
         /* Whether the field from deb822 may contain multiple values: */
         LET Is822MultiValue(field) = field in ('Types', 'URIs', 'Suites',
-            'Components', 'Architectures', 'Languages', 'Targets')
+            'Components', 'Architectures', 'Architectures-Add',
+            'Architectures-Remove', 'Languages', 'Languages-Add',
+            'Languages-Remove', 'Targets')
         
         /* Parse a deb822 sources file section into a series of key–value pairs.
            Notes about the format:

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -93,10 +93,10 @@ export: |
             `(?i)trusted`='Trusted',
             `(?i)signed-by`='Signed-By',
             `(?i)check-valid-until`='Check-Valid-Until',
-            `(?i)valid-until-min`='Check-Until-Min',
+            `(?i)valid-until-min`='Valid-Until-Min',
             `(?i)valid-until-max`='Valid-Until-Max',
             `(?i)check-date`='Check-Date',
-            `(?i)date-max-future`='Date-Max-Futere',
+            `(?i)date-max-future`='Date-Max-Future',
             `(?i)inrelease-path`='InRelease-Path'
         ))
         

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -124,7 +124,6 @@ export: |
             Simplify(string=Options) AS Options, URI AS URIs,
             Transport AS _Transport, URIBase AS _URIBase, Suite AS Suites,
             Simplify(string=Trim(string=Components)) AS Components
-            /* test */
             FROM parse_records_with_regex(
                 file=OSPath,
                 regex='''(?m)^\s*(?P<Type>deb(-src)?)(?:\s+\[(?P<Options>[^\]]+)\])?\s+(?P<URI>(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+))\s+(?P<Suite>\S+)\s+(?P<Components>[^\n#]+)'''

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -323,9 +323,6 @@ sources:
         FROM deb_sources
         GROUP BY URIs, Suites
 
-        // fixed: gnupg in InRelease
-        // fixed: no duplicate entries, group by ospath
-        // fixed: allow multi-value
         /* This runs if the file was found. Read the entire file into
             memory and parse the same record using multiple RegExps.
         */

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -378,7 +378,7 @@ sources:
                 ),
                 regex=["Codename: (?P<Release>[^\\n]+)",
                        "Version: (?P<Version>[^\\n]+)",
-                       "Origin: (?P<Maintainer>[^\\n]+)",
+                       "Origin: (?P<Origin>[^\\n]+)",
                        "Architectures: (?P<Architectures>[^\\n]+)",
                        "Components: (?P<Components>[^\\n]+)"]) as Record
            FROM parse_records_with_regex(file=file, regex="(?sm)(?P<Record>.+)")

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -252,7 +252,6 @@ export: |
             FROM Deb822_KeyValues__(section=section)
             GROUP BY Key
 
-        // TODO: Keep as array instead of joining to string? Here and in oneline?
         /* Parse a deb822 sources file section into a dict with consistent option
            names: */
         LET Deb822_KeyValues(section, flatten) = SELECT to_dict(
@@ -272,8 +271,7 @@ export: |
             columns='Section',
             regex='^ #', record_regex='''\n{2,}'''
         )
-        
-        /* TODO: flattened works on components, but not arch and suites: */
+
         LET Deb822_Flattened_(OSPath) = SELECT * FROM foreach(
             row=Deb822Sections(OSPath=OSPath),
             query={SELECT OSPath, * FROM flatten(query={

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -1,7 +1,7 @@
 name: Linux.Debian.AptSources
 description: |
   Parse Debian apt sources.
-  
+
   This Artifact searches for all apt sources files and parses all
   fields in both one–line \*.list files and \*.sources files
   (deb822-style format). The results are presented both in a readable
@@ -13,7 +13,7 @@ description: |
 
      deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
      deb-src [arch=amd64,i386 signed-by=/usr/share/keyrings/foo.gpg] https://foo.bar.baz/ubuntu/main jammy main restricted universe multiverse # Comment
-  
+
   deb indicates a source for binary packages, and deb-src instructs APT where
   to find source code for packages.
 
@@ -21,9 +21,9 @@ description: |
   lines, and as opposed to the one–line format, they can contain
   multiple URIs, components and types (deb/deb-src), along with
   embedded GPG keys. Example:
-  
+
   .. code:: console
-  
+
      Types: deb deb-src
      URIs: file:/home/apt/debian http://foo.bar.baz/main
      Suites: unstable
@@ -38,7 +38,7 @@ description: |
    - _URIBase (.e.g us.archive.ubuntu.com/ubuntu/)
    - _Transport (e.g. http/https/file/cdrom/ftp)
    - URIs (e.g. http://us.archive.ubuntu.com/ubuntu/)
-  
+
   Any option is added to an individual column. Typical options are
    - Architectures (e.g. amd64/i386/armel)
    - Signed-By (e.g. /usr/share/keyrings/osquery.gpg)
@@ -60,7 +60,7 @@ description: |
   If the GPG key is embedded in a .sources file, the whole GPG key
   will be included in the cell. Otherwise the value will be a file
   path.
-  
+
   If flatten is False, multi–value fields (like Components) will
   be combined in a single-space-separated string in each row.
 

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -303,6 +303,10 @@ export: |
             columns='Section',
             regex='^ #', record_regex='''\n{2,}'''
         )
+        /* Sections may be empty due to several newlines or comments on their own
+           separated by newlines. Ensure that at least one field is present
+           (URIs are mandatory): */
+        WHERE URIs
 
         LET Deb822_Flattened_(OSPath) = SELECT * FROM foreach(
             row=Deb822Sections(OSPath=OSPath),

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -466,7 +466,9 @@ sources:
 
          -- For each parsed apt .list file line produce some output.
          SELECT * from foreach(
-             row={SELECT * FROM parsed_apt_lines},
+             row={
+                 SELECT * FROM parsed_apt_lines
+             },
              query={
                 SELECT * FROM parse_cache_or_pass
               })

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -30,7 +30,7 @@ description: |
      Components: main contrib non-free
      
   The exported function parse_aptsources(OSPath, flatten) parses
-  both formats and returns a flattened table with
+  both formats and returns a (optionally flattened) table with
    - OSPath
    - Types (deb/deb-src)
    - Components (e.g. main/contrib/non-free/restricted,universe)
@@ -39,7 +39,7 @@ description: |
    - _Transport (e.g. http/https/file/cdrom/ftp)
    - URIs (e.g. http://us.archive.ubuntu.com/ubuntu/)
   
-  Any option is added to individuals column. Typical options are
+  Any option is added to an individual column. Typical options are
    - Architectures (e.g. amd64/i386/armel)
    - Signed-By (e.g. /usr/share/keyrings/osquery.gpg)
    
@@ -47,8 +47,8 @@ description: |
   variants as listed in the sources.list man page. Any undocumented
   options will still be included in the results, with names unchanged.
   Options in the one-line format of the form "lang+=de"/"arch-=i386"
-  will be in columns named "Languages-Add"/"Architectures-Remove",
-  matching the option names having the same effect in deb822.
+  will be in columns like "Languages-Add"/"Architectures-Remove", matching
+  the option names having the same effect in deb822.
    
   If the GPG key is embedded in a .sources file, the whole GPG key
   will be included in the cell. Otherwise the value will be a file
@@ -227,7 +227,7 @@ export: |
                may contain comments (prefixed by whitespace or not). Empty lines
                part of a multi-line value must be prefixed by whitespace and "."
              - A file may contain multiple entries, separated by empty lines.
-               A file must be split into sections fed individuall to this function
+               A file must be split into sections, fed individually to this function
         */
         LET Deb822_KeyValues___(section) = SELECT Key,
             if(condition=NormaliseOpts(string=Key)!='Signed-By',
@@ -274,7 +274,7 @@ export: |
             FROM scope()
                 
         /* Split paragraphs in a file (separated by one or several empty
-           lines) into rows. ('regex' is anything that is illegal in Deb822Sections
+           lines) into rows. ('regex' is just anything that is illegal in Deb822Sections
            to prevent splitting data into records.): */
         LET Deb822Sections(OSPath) = SELECT * FROM split_records(
             filenames=OSPath,

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -109,9 +109,6 @@ export: |
             `(?i)date-max-future`='Date-Max-Future',
             `(?i)inrelease-path`='InRelease-Path'
         ))
-        
-        /* Whether the field may contain multiple values (one–line): */
-        LET IsMultiValue(field) = field in ('Architectures', 'Languages', 'Targets')
 
         /* Extract Key–Value pairs from option string. If assignment is -=/+=,
            the -/+ operator is captured in Op: */
@@ -206,12 +203,6 @@ export: |
             regex='''(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+)''',
             string=URI
         )
-        
-        /* Whether the field from deb822 may contain multiple values: */
-        LET Is822MultiValue(field) = field in ('Types', 'URIs', 'Suites',
-            'Components', 'Architectures', 'Architectures-Add',
-            'Architectures-Remove', 'Languages', 'Languages-Add',
-            'Languages-Remove', 'Targets')
         
         /* Parse a deb822 sources file section into a series of key–value pairs.
            Notes about the format:

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -1,86 +1,350 @@
 name: Linux.Debian.AptSources
 description: |
   Parse Debian apt sources.
+  
+  This Artifact searches for all apt sources files and parses all
+  fields in both one–line \*.list files and \*.sources files
+  (deb822-style format). The results are presented both in a readable
+  table and a flattened version for parsing.
 
-  We first search for \*.list files which contain lines of the form
+  \*.list files contains lines of the form
 
   .. code:: console
 
      deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted
+     deb-src [arch=amd64,i386 signed-by=/usr/share/keyrings/foo.gpg] https://foo.bar.baz/ubuntu/main jammy main restricted universe multiverse # Comment
+  
+  deb indicates a source for binary packages, and deb-src instructs APT where
+  to find source code for packages.
 
-  For each line we construct the cache file by spliting off the
-  section (last component) and replacing / and " " with _.
+  \*.sources files (deb822-style format) are in the form of key–value
+  lines, and as opposed to the one–line format, they can contain
+  multiple URIs, components and types (deb/deb-src), along with
+  embedded GPG keys. Example:
+  
+  .. code:: console
+  
+     Types: deb deb-src
+     URIs: file:/home/apt/debian http://foo.bar.baz/main
+     Suites: unstable
+     Components: main contrib non-free
+     
+  The exported function parse_aptsources(OSPath, flatten) parses
+  both formats and returns a flattened table with
+   - OSPath
+   - Types (deb/deb-src)
+   - Components (e.g. main/contrib/non-free/restricted,universe)
+   - Suites (e.g. unstable/bookworm/jammy)
+   - _URIBase (.e.g us.archive.ubuntu.com/ubuntu/)
+   - _Transport (e.g. http/https/file/cdrom/ftp)
+   - URIs (e.g. http://us.archive.ubuntu.com/ubuntu/)
+  
+  Any option is added to individuals column. Typical options are
+   - Architectures (e.g. amd64/i386/armel)
+   - Signed-By (e.g. /usr/share/keyrings/osquery.gpg)
+   
+  All known option names are transformed to the plural SnakeCase
+  variants as listed in the sources.list man page. Any undocumented
+  options will still be included in the results, with names unchanged.
+   
+  If the GPG key is embedded in a .sources file, the whole GPG key
+  will be included in the cell. Otherwise the value will be a file
+  path.
+  
+  If flatten is False, multi–value fields (like Components) will
+  be combined in a single-space-separated string in each row.
 
-  We then try to open the file. If the file exists we parse some
-  metadata from it. If not we leave those columns empty.
+  In addition to the two apt sources tables, a third table correlates
+  information from InRelease and Release files to provide additional
+  metadata. The modification timestamps may tell when the package
+  lists where last updated.
 
 reference:
-  - https://osquery.io/schema/3.2.6#apt_sources
+  - https://manpages.debian.org/bookworm/apt/sources.list.5.en.html
+  - https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html
+  - https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files
+
+export: |
+        /* Remove whitespace from the beginning and end of a string: */
+        LET Trim(string) = regex_transform(source=string, map=dict(
+            `(?m)^\\s+`='',
+            `(?m)\\s+$`=''
+        ))
+        
+        /* Replace any repeating whitespace with a single space: */
+        LET Simplify(string) = regex_replace(source=string, re='''\s+''', replace=' ')
+        
+        /* The syntax in lists (deb822) and sources (one-line) files varies a bit,
+           and deb822 is case-insensitive. Normalise all known fields (as per
+           the man page): */
+        LET NormaliseOpts(string) = regex_transform(source=string, map=dict(
+            `(?i)types|type`='Types',
+            `(?i)uris|uri`='URIs',
+            `(?i)suites|suite`='Suites',
+            `(?i)components|component`='Components',
+            `(?i)architectures|arch`='Architectures',
+            `(?i)languages|lang`='Languages',
+            `(?i)targets|target`='Targets',
+            `(?i)pdiffs`='PDiffs',
+            `(?i)by-hash`='By-Hash',
+            `(?i)allow-insecure`='Allow-Insecure',
+            `(?i)allow-weak`='Allow-Weak',
+            `(?i)allow-downgrade-to-insecure`='Allow-Downgrade-To-Insecure',
+            `(?i)trusted`='Trusted',
+            `(?i)signed-by`='Signed-By',
+            `(?i)check-valid-until`='Check-Valid-Until',
+            `(?i)valid-until-min`='Check-Until-Min',
+            `(?i)valid-until-max`='Valid-Until-Max',
+            `(?i)check-date`='Check-Date',
+            `(?i)date-max-future`='Date-Max-Futere',
+            `(?i)inrelease-path`='InRelease-Path'
+        ))
+        
+        /* Whether the field may contain multiple values (one–line): */
+        LET IsMultiValue(field) = field in ('Architectures', 'Languages', 'Targets')
+
+        /* Get keys and values from 'key=value' strings: */
+        LET OptStringToKeyValues(string) = SELECT *
+            FROM parse_records_with_regex(
+                regex='''(?P<Key>[^= ]+)=(?P<Value>[^ ]+)''',
+                accessor='data', file=string
+        )
+        
+        /* Convert a string of key–value pairs to a dict, and use consistent
+           option names: */
+        LET OptStringToDict(string, flatten) = to_dict(item={
+            SELECT NormaliseOpts(string=Key) AS _key,
+                if(condition=flatten, then=split(sep_string=',', string=Value),
+                    else=regex_replace(source=Value, re=',', replace=' ')) AS _value
+            FROM OptStringToKeyValues(string=string)
+        })
+
+        /* Parse a one-line deb sources.list file with options as a single string: */
+        LET DebOneLine_Opts(OSPath) = SELECT OSPath, Type AS Types,
+            Simplify(string=Options) AS Options, URI AS URIs,
+            Transport AS _Transport, URIBase AS _URIBase, Suite AS Suites,
+            Simplify(string=Trim(string=Components)) AS Components
+            /* test */
+            FROM parse_records_with_regex(
+                file=OSPath,
+                regex='''(?m)^\s*(?P<Type>deb(-src)?)(?:\s+\[(?P<Options>[^\]]+)\])?\s+(?P<URI>(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+))\s+(?P<Suite>\S+)\s+(?P<Components>[^\n#]+)'''
+            )
+
+        /* Parse a one-line deb sources.list file and output a dict: */
+        LET DebOneLine_Dict(OSPath, flatten) = SELECT OSPath, *
+            FROM foreach(row=DebOneLine_Opts(OSPath=OSPath),
+                query={SELECT _value + OptStringToDict(string=Options, flatten=flatten) AS Contents
+                    FROM items(item={SELECT Types, URIs, _Transport, _URIBase, Suites,
+                        if(condition=flatten, then=split(sep_string=' ',
+                            string=Components), else=Components) AS Components
+                        FROM scope()
+                    })
+                })
+        
+        /* Parse a one-line deb sources.list file with options in individual columns: */
+        LET DebOneLine(OSPath) = SELECT OSPath, * FROM foreach(
+            row=DebOneLine_Dict(OSPath=OSPath, flatten=false),
+            column='Contents'
+        )
+        
+        /* Parse a one-line deb sources.list file with options in individual
+           columns and flatten: */
+        LET DebOneLine_Flattened(OSPath) = SELECT OSPath, * FROM flatten(
+            query={SELECT * FROM foreach(
+                row=DebOneLine_Dict(OSPath=OSPath, flatten=true),
+                column='Contents'
+                )
+            })
+        
+        /* Extract the transport/protocol and base from a URI: */
+        LET URIComponents(URI) = parse_string_with_regex(
+            regex='''(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+)''',
+            string=URI
+        )
+        
+        /* Whether the field from deb822 may contain multiple values: */
+        LET Is822MultiValue(field) = field in ('Types', 'URIs', 'Suites',
+            'Components', 'Architectures', 'Languages', 'Targets')
+        
+        /* Parse a deb822 sources file section into a series of key–value pairs.
+           Notes about the format:
+             - Keys must be at the beginning of the line (no whitespace allowed)
+             - Keys are case-insensitive
+             - Comments may only appear at the beginning of the line
+             - Values may be multi-line (like when containing an embedded GPG key),
+               but following lines must be prefixed by whitespace. Multilines
+               may contain comments (prefixed by whitespace or not). Empty lines
+               part of a multi-line value must be prefixed by whitespace and "."
+             - A file may contain multiple entries, separated by empty lines.
+               A file must be split into sections fed individuall to this function
+        */
+        LET Deb822_KeyValues_(section) = SELECT Key,
+            Simplify(string=Trim(string=Value)) AS Value
+            FROM parse_records_with_regex(
+                accessor='data',
+                /* A key is anything but whitespace up to a colon
+                   Values can continue on several lines, but only if the following
+                   lines are indented with whitespace
+                */
+                regex='''(?m)^(?P<Key>[^#:\s]+)\s*:[^\S\n]*(?P<Value>[^\n]*(?:\n[^\S\n]+[^\n]+)*)''',
+                /* Before parsing the key–values, remove all comments from the file
+                   (otherwise forming a regex without lookarounds would be very
+                   difficult, if not impossible), Luckily, comments follow strict
+                   rules and must start with ^#.
+                */
+                file=regex_replace(
+                    re='''(?m)^#.+\n''',
+                    source=section
+                )
+            )
+
+        /* Parse a deb822 sources file section into a dict with consistent option
+           names: */
+        LET Deb822_KeyValues(section) = SELECT to_dict(
+            item={
+                SELECT  NormaliseOpts(string=Key) as _key,
+                        Value AS _value
+                FROM    Deb822_KeyValues_(section=section)
+                
+            }) AS Contents
+            FROM scope()
+
+        /* Parse a deb822 sources file section into a dict with consistent option
+           names, multi-value fields as arrays: */
+        LET Deb822_KeyValuesArrays(section) = SELECT to_dict(
+            item={
+                SELECT  NormaliseOpts(string=Key) as _key,
+                        if(condition=IsMultiValue(field=Key),
+                            then=split(sep_string=' ', string=Value),
+                            else=Value) AS _value
+                FROM    Deb822_KeyValues_(section=section)
+                
+            }) AS Contents
+            FROM scope()
+                
+        /* Split paragraphs in a file (separated by one or several empty
+           lines) into rows. ('regex' is anything that is illegal in Deb822Sections
+           to prevent splitting data into records.): */
+        LET Deb822Sections(OSPath) = SELECT * FROM split_records(
+            filenames=OSPath,
+            columns='Section',
+            regex='^ #', record_regex='''\n{2,}'''
+        )
+        
+        LET Deb822_Flattened_(OSPath) = SELECT * FROM foreach(
+            row=Deb822Sections(OSPath=OSPath),
+            query={SELECT OSPath, * FROM flatten(query={
+                SELECT * FROM foreach(
+                    row=Deb822_KeyValuesArrays(section=Section),
+                    column='Contents'
+                )
+            })}
+        )
+        
+        /* Parse a deb822 sources file with options in individual columns: */
+        LET Deb822(OSPath) = SELECT * FROM foreach(
+            row=Deb822Sections(OSPath=OSPath),
+            query={SELECT OSPath, * FROM foreach(
+                row=Deb822_KeyValues(section=Section),
+                column='Contents'
+            )}
+        )
+        
+        /* Parse a deb822 sources file with options in individual columns, flattened: */
+        LET Deb822_Flattened(OSPath) = SELECT * FROM flatten(query={
+            SELECT OSPath, *, URIComponents(URI=URIs).URIBase AS _URIBase,
+                URIComponents(URI=URIs).Transport AS _Transport
+            FROM Deb822_Flattened_(OSPath=OSPath)
+        })
+
+        /* Parse an apt sources/list file */
+        LET parse_aptsources(OSPath, flatten) = if(
+            condition=OSPath=~'.list$',
+            then=if(condition=flatten,
+                then=DebOneLine_Flattened(OSPath=OSPath),
+                else=DebOneLine(OSPath=OSPath)
+            ),
+            else=if(condition=flatten,
+                then=Deb822_Flattened(OSPath=OSPath),
+                else=Deb822(OSPath=OSPath)
+            )
+        )
 parameters:
   - name: linuxAptSourcesGlobs
-    description: Globs to find apt source *.list files.
-    default: /etc/apt/sources.list,/etc/apt/sources.list.d/*.list
-  - name:  aptCacheDirectory
+    description: Globs to find apt source *.list and .sources files.
+    default: /etc/apt/sources.list,/etc/apt/sources.list.d/*.{list,sources}
+  - name: aptCacheDirectory
     description: Location of the apt cache directory.
     default: /var/lib/apt/lists/
+
+precondition:
+    SELECT OS From info() where OS = 'linux'
+
 sources:
-  - precondition:
-      SELECT OS From info() where OS = 'linux'
+  - name: Sources
     query: |
-         /* Search for files which may contain apt sources. The user can
-            pass new globs here. */
-         LET files = SELECT OSPath from glob(
-           globs=split(string=linuxAptSourcesGlobs, sep=","))
+        LET files = SELECT OSPath FROM glob(
+           globs=split(string=linuxAptSourcesGlobs, sep=''',\s*'''))
+        
+        /* Output sources in a readable format: */
+        SELECT * FROM foreach(row=files,
+            query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=false)}
+        )
 
-         /* Read each line in the sources which is not commented.
-            Deb lines look like:
-            deb [arch=amd64] http://dl.google.com/linux/chrome-remote-desktop/deb/ stable main
-            Contains URL, base_uri and components.
-         */
-         LET deb_sources = SELECT *
-           FROM parse_records_with_regex(
-             file=files.OSPath,
-             regex="(?m)^ *(?P<Type>deb(-src)?) (?:\\[arch=(?P<Arch>[^\\]]+)\\] )?" +
-                  "(?P<URL>https?://(?P<base_uri>[^ ]+))" +
-                  " +(?P<components>.+)")
-
-         /* We try to get at the Release file in /var/lib/apt/ by munging
+  - name: SourcesFlattened
+    query: |
+        LET deb_sources = SELECT * FROM foreach(row=files,
+            query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=true)}
+        )
+        
+        /* Output sources flattened for ease of analysis: */
+        SELECT * FROM deb_sources
+        
+  - name: SourcesCacheFiles
+    query: |
+        /* We try to get at the Release file in /var/lib/apt/ by munging
            the components and URL.
            Strip the last component off, convert / and space to _ and
-           add _Release to get the filename.
-         */
-         LET parsed_apt_lines = SELECT Arch, URL,
-            base_uri + " " + components as Name, Type,
+           add _Release/_InRelease to get the filename.
+        */
+        LET parsed_apt_lines = SELECT get(field='Architectures', default='') AS Architectures, URIs,
+            _URIBase + " " + Suites + " " + Components as Name, Types,
             OSPath as Source, aptCacheDirectory + regex_replace(
               replace="_",
               re="_+",
               source=regex_replace(
                 replace="_", re="[ /]",
-                source=base_uri + "_dists_" + regex_replace(
-                   source=components,
-                   replace="", re=" +[^ ]+$")) + "_Release"
-              )  as cache_file
-         FROM deb_sources
+                source=_URIBase + "_dists_" + Suites
+              )) as cache_file
+        FROM deb_sources
+        GROUP BY URIs, Suites
 
-         /* This runs if the file was found. Read the entire file into
+        // fixed: gnupg in InRelease
+        // fixed: no duplicate entries, group by ospath
+        // fixed: allow multi-value
+        /* This runs if the file was found. Read the entire file into
             memory and parse the same record using multiple RegExps.
-         */
-         LET parsed_cache_files = SELECT Name, Arch, URL, Type,
-           Source, parse_string_with_regex(
-                string=Record,
-                regex=["Codename: (?P<Release>[^\\s]+)",
-                       "Version: (?P<Version>[^\\s]+)",
-                       "Origin: (?P<Maintainer>[^\\s]+)",
-                       "Architectures: (?P<Architectures>[^\\s]+)",
-                       "Components: (?P<Components>[^\\s]+)"]) as Record
-           FROM parse_records_with_regex(file=cache_file, regex="(?sm)(?P<Record>.+)")
+        */
+        LET parsed_cache_files(file) = SELECT Name, Architectures, URIs, Types,
+            Source, parse_string_with_regex(
+                string=regex_replace(source=Record,
+                    re='(?m)^Version: GnuPG v.+$', replace=''
+                ),
+                regex=["Codename: (?P<Release>[^\\n]+)",
+                       "Version: (?P<Version>[^\\n]+)",
+                       "Origin: (?P<Maintainer>[^\\n]+)",
+                       "Architectures: (?P<Architectures>[^\\n]+)",
+                       "Components: (?P<Components>[^\\n]+)"]) as Record
+           FROM parse_records_with_regex(file=file, regex="(?sm)(?P<Record>.+)")
 
          // Foreach row in the parsed cache file, collect the FileInfo too.
-         LET add_stat_to_parsed_cache_file = SELECT * from foreach(
+         LET add_stat_to_parsed_cache_file(file) = SELECT * from foreach(
            query={
-             SELECT OSPath, Mtime, Ctime, Atime, Record, Type,
-               Name, Arch, URL, Source from stat(filename=cache_file)
-           }, row=parsed_cache_files)
+             SELECT OSPath, Mtime, Ctime, Atime, Record, Types,
+               Name, Architectures, URIs, Source from stat(filename=file)
+           }, row=parsed_cache_files(file=file))
+           WHERE Record
+           GROUP BY OSPath
 
          /* For each row in the parsed file, run the appropriate query
             depending on if the cache file exists.
@@ -90,13 +354,19 @@ sources:
          */
          LET parse_cache_or_pass = SELECT * from if(
            condition={
-              SELECT * from stat(filename=cache_file)
+              SELECT * from stat(filename=cache_file + '_InRelease')
            },
-           then=add_stat_to_parsed_cache_file,
-           else={
-           SELECT Source, Null as Mtime, Null as Ctime,
-               Null as Atime, Type,
-               Null as Record, Arch, URL, Name from scope()
+           then=add_stat_to_parsed_cache_file(file=cache_file + '_InRelease'),
+           else={SELECT * FROM if(
+            condition={
+              SELECT * from stat(filename=cache_file + '_Release')
+            },
+            then=add_stat_to_parsed_cache_file(file=cache_file + '_Release'),
+            else={
+            SELECT Source, Null as Mtime, Null as Ctime,
+               Null as Atime, Types,
+               Null as Record, Architectures, URIs, Name from scope()
+            })
            })
 
          -- For each parsed apt .list file line produce some output.

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -112,22 +112,47 @@ export: |
         /* Whether the field may contain multiple values (one–line): */
         LET IsMultiValue(field) = field in ('Architectures', 'Languages', 'Targets')
 
-        /* Get keys and values from 'key=value' strings: */
-        LET OptStringToKeyValues(string) = SELECT *
+        /* Extract Key–Value pairs from option string. If assignment is -=/+=,
+           the -/+ operator is captured in Op: */
+        LET OptStringToKeyValues__(string) = SELECT *
             FROM parse_records_with_regex(
                 regex='''(?P<Key>[^ ]+?)(?P<Op>-|\+)?=(?P<Value>[^ ]+)''',
                 accessor='data', file=string
         )
         
+        /* Since option values may have multiple words, split them and flatten
+           the results for further processing: */
+        LET OptStringToKeyValues_(string) = SELECT *
+            FROM flatten(query={
+                SELECT Key,
+                    Op,
+                    split(sep_string=',', string=Value) AS Value
+                    FROM OptStringToKeyValues__(string=string)
+            })
+        
+        /* Since options may be repeated, enumerate and group all values
+           per key and operation: */
+        LET OptStringToKeyValues(string) = SELECT Key,
+            Op,
+            enumerate(items=Value) AS Value
+            FROM OptStringToKeyValues_(string=string)
+            GROUP BY Key, Op
+        
+        /* When an option is specified with +/-, represent this by appending
+           -Add/-Remove to the option name. These names match the syntax in
+           the deb822 format (i.e. "arch-=i386" == "Arhitectures-Remove: i386").
+           The purpose of these assignments is to keep the default values
+           (rather than overriding them), but add or remove one or several
+           values: */
         LET OpName(op) = if(condition=op='+',then='-Add',else=
             if(condition=op='-',then='-Remove',else=''))
-
+        
         /* Convert a string of key–value pairs to a dict, and use consistent
            option names: */
         LET OptStringToDict(string, flatten) = to_dict(item={
             SELECT NormaliseOpts(string=Key)+OpName(op=Op) AS _key,
-                if(condition=flatten, then=split(sep_string=',', string=Value),
-                    else=regex_replace(source=Value, re=',', replace=' ')) AS _value
+                if(condition=flatten, then=Value,
+                    else=join(array=Value, sep=' ')) AS _value
             FROM OptStringToKeyValues(string=string)
         })
 
@@ -144,7 +169,8 @@ export: |
         /* Parse a one-line deb sources.list file and output a dict: */
         LET DebOneLine_Dict(OSPath, flatten) = SELECT OSPath, *
             FROM foreach(row=DebOneLine_Opts(OSPath=OSPath),
-                query={SELECT _value + OptStringToDict(string=Options, flatten=flatten) AS Contents
+                query={SELECT _value +
+                        OptStringToDict(string=Options, flatten=flatten) AS Contents
                     FROM items(item={SELECT Types, URIs, _Transport, _URIBase, Suites,
                         if(condition=flatten, then=split(sep_string=' ',
                             string=Components), else=Components) AS Components
@@ -183,6 +209,10 @@ export: |
            Notes about the format:
              - Keys must be at the beginning of the line (no whitespace allowed)
              - Keys are case-insensitive
+             - Keys may be repeated. Values are not overridden, but combined
+             - Special keys that end in -Add/-Remove uses the default values,
+               but add or remove individual values. These keys are treated as
+               individual option names.
              - Comments may only appear at the beginning of the line
              - Values may be multi-line (like when containing an embedded GPG key),
                but following lines must be prefixed by whitespace. Multilines
@@ -191,8 +221,11 @@ export: |
              - A file may contain multiple entries, separated by empty lines.
                A file must be split into sections fed individuall to this function
         */
-        LET Deb822_KeyValues_(section) = SELECT Key,
-            Simplify(string=Trim(string=Value)) AS Value
+        LET Deb822_KeyValues___(section) = SELECT Key,
+            if(condition=NormaliseOpts(string=Key)!='Signed-By',
+                then=split(sep_string=' ',
+                string=Simplify(string=Trim(string=Value))),
+                else=Value) AS Value
             FROM parse_records_with_regex(
                 accessor='data',
                 /* A key is anything but whitespace up to a colon
@@ -211,27 +244,24 @@ export: |
                 )
             )
 
+        LET Deb822_KeyValues__(section) = SELECT * FROM flatten(query={
+            SELECT * FROM Deb822_KeyValues___(section=section)
+        })
+        
+        LET Deb822_KeyValues_(section) = SELECT Key,
+            enumerate(items=Value) AS Value
+            FROM Deb822_KeyValues__(section=section)
+            GROUP BY Key
+
+        // TODO: Keep as array instead of joining to string? Here and in oneline?
         /* Parse a deb822 sources file section into a dict with consistent option
            names: */
-        LET Deb822_KeyValues(section) = SELECT to_dict(
+        LET Deb822_KeyValues(section, flatten) = SELECT to_dict(
             item={
-                SELECT  NormaliseOpts(string=Key) as _key,
-                        Value AS _value
-                FROM    Deb822_KeyValues_(section=section)
-                
-            }) AS Contents
-            FROM scope()
-
-        /* Parse a deb822 sources file section into a dict with consistent option
-           names, multi-value fields as arrays: */
-        LET Deb822_KeyValuesArrays(section) = SELECT to_dict(
-            item={
-                SELECT  NormaliseOpts(string=Key) as _key,
-                        if(condition=IsMultiValue(field=Key),
-                            then=split(sep_string=' ', string=Value),
-                            else=Value) AS _value
-                FROM    Deb822_KeyValues_(section=section)
-                
+                SELECT NormaliseOpts(string=Key) as _key,
+                    if(condition=flatten, then=Value,
+                        else=join(array=Value, sep=' ')) AS _value
+                FROM Deb822_KeyValues_(section=section)
             }) AS Contents
             FROM scope()
                 
@@ -244,21 +274,25 @@ export: |
             regex='^ #', record_regex='''\n{2,}'''
         )
         
+        /* TODO: flattened works on components, but not arch and suites: */
         LET Deb822_Flattened_(OSPath) = SELECT * FROM foreach(
             row=Deb822Sections(OSPath=OSPath),
             query={SELECT OSPath, * FROM flatten(query={
                 SELECT * FROM foreach(
-                    row=Deb822_KeyValuesArrays(section=Section),
+                    row=Deb822_KeyValues(section=Section, flatten=true),
                     column='Contents'
                 )
             })}
         )
         
-        /* Parse a deb822 sources file with options in individual columns: */
+        /* Parse a deb822 sources file with options in individual columns.
+           Note that, as opposed to DebOneLine and Deb822_Flattened, this
+           function does not return the columns _URIBase and _Transport, since
+           this format supports mulitple URIs to be specified: */
         LET Deb822(OSPath) = SELECT * FROM foreach(
             row=Deb822Sections(OSPath=OSPath),
             query={SELECT OSPath, * FROM foreach(
-                row=Deb822_KeyValues(section=Section),
+                row=Deb822_KeyValues(section=Section, flatten=false),
                 column='Contents'
             )}
         )

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -49,6 +49,13 @@ description: |
   Options in the one-line format of the form "lang+=de"/"arch-=i386"
   will be in columns like "Languages-Add"/"Architectures-Remove", matching
   the option names having the same effect in deb822.
+
+  Entries in deb822 sources files may be disabled by including
+  "Enabled: no" instead of commenting out all lines. If this field
+  is not present with a falsly value, the entry is enabled. Use the
+  exported functions DebTrue()/DebFalse() to correctly parse all
+  accepted true/false strings, or use the VQL suggestion "Enabled"
+  to filter on this column (true), if present.
    
   If the GPG key is embedded in a .sources file, the whole GPG key
   will be included in the cell. Otherwise the value will be a file
@@ -107,8 +114,16 @@ export: |
             `(?i)valid-until-max`='Valid-Until-Max',
             `(?i)check-date`='Check-Date',
             `(?i)date-max-future`='Date-Max-Future',
-            `(?i)inrelease-path`='InRelease-Path'
+            `(?i)inrelease-path`='InRelease-Path',
+            `(?i)enabled`='Enabled'
         ))
+
+        LET DebTrue(string) = if(
+            condition=string=~'(?i)^(?:yes|true|with|on|enable)$',
+            then=true, else=false)
+        LET DebFalse(string) = if(
+            condition=string=~'(?i)^(?:no|false|without|off|disable)$',
+            then=true, else=false)
 
         /* Extract Key–Value pairs from option string. If assignment is -=/+=,
            the -/+ operator is captured in Op: */
@@ -356,6 +371,18 @@ sources:
         SELECT * FROM foreach(row=files,
             query={SELECT * FROM parse_aptsources(OSPath=OSPath, flatten=false)}
         )
+    notebook:
+      - type: vql_suggestion
+        name: Only enabled sources
+        template: |
+            SELECT * FROM source(artifact='Custom.Linux.Debian.AptSources/Sources')
+            WHERE get(field='Enabled', default='yes') =~ '(?i)^(?:yes|true|with|on|enable)$'
+
+      - type: vql_suggestion
+        name: Trusted sources (apt-secure bypassed)
+        template: |
+            SELECT * FROM source(artifact='Custom.Linux.Debian.AptSources/Sources')
+            WHERE get(field='Trusted', default='') =~ '(?i)^(?:yes|true|with|on|enable)$'
 
   - name: SourcesFlattened
     query: |

--- a/artifacts/definitions/Linux/Debian/AptSources.yaml
+++ b/artifacts/definitions/Linux/Debian/AptSources.yaml
@@ -203,6 +203,17 @@ export: |
             regex='''(?P<Transport>[^:]+):(?://)?(?P<URIBase>[^\s]+)''',
             string=URI
         )
+
+        /* Although the documentation says to use whitespace and not comma
+           for multi-values in deb822, comma still appears to be supported,
+           and this use is seen in the wild. Treat these values correctly.
+           Note that this does not affect all keys, like suites and
+           components:
+        */
+        LET MaybeReplaceComma(key, value) = if(
+            condition=key=~'(?i)^(?:arch|lang|targets)',
+            then=regex_replace(re='\s*,\s*', source=value, replace=' '),
+            else=value)
         
         /* Parse a deb822 sources file section into a series of key–value pairs.
            Notes about the format:
@@ -213,6 +224,9 @@ export: |
                but add or remove individual values. These keys are treated as
                individual option names.
              - Comments may only appear at the beginning of the line
+             - Multiple values are separated by whitespace, not comma. However,
+               some multi-value fields separated by comma are still split, even
+               if this is not mentioned in the documentation.
              - Values may be multi-line (like when containing an embedded GPG key),
                but following lines must be prefixed by whitespace. Multilines
                may contain comments (prefixed by whitespace or not). Empty lines
@@ -223,7 +237,8 @@ export: |
         LET Deb822_KeyValues___(section) = SELECT Key,
             if(condition=NormaliseOpts(string=Key)!='Signed-By',
                 then=split(sep_string=' ',
-                string=Simplify(string=Trim(string=Value))),
+                string=MaybeReplaceComma(key=Key,
+                    value=Simplify(string=Trim(string=Value)))),
                 else=Value) AS Value
             FROM parse_records_with_regex(
                 accessor='data',

--- a/artifacts/testdata/files/debian/.gitattributes
+++ b/artifacts/testdata/files/debian/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/artifacts/testdata/files/debian/au.archive.ubuntu.com_ubuntu_dists_jammy_InRelease
+++ b/artifacts/testdata/files/debian/au.archive.ubuntu.com_ubuntu_dists_jammy_InRelease
@@ -1,0 +1,32 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Origin: Ubuntu
+Label: Ubuntu
+Suite: jammy
+Version: 22.04
+Codename: jammy
+Date: Thu, 21 Apr 2022 17:16:08 UTC
+Architectures: amd64 arm64 armhf i386 ppc64el riscv64 s390x
+Components: main restricted universe multiverse
+Description: Ubuntu Jammy 22.04
+MD5Sum:
+ 8f73d18065a4f05ee7362c50553ea4b26ca2b4b3786472676b6b1ee58b4cff72         17832892 universe/source/Sources.xz
+Acquire-By-Hash: yes
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iQIcBAEBCgAGBQJiYZF3AAoJEIcZINGZG8k8oMMQAJGLXDzjk/IxqaxUwhgx8F/S
+ultWd3vuBeWK1guBZAl4dbmunNZBbKNYcOGlOmpVF9jBZtVQ0jVWhcuVbTPfkUO/
+sz1fVWn12lzBnETsV5v6Nscz03NgNlojkD8jlEWV7xxPWh9r+CNZ8y5LzwTwlufZ
+e4dm8L5d2nhHDsajX8f7ZRcch4TH7jPN2AwHWtn7yASTzUbrQ/S9shQjP1dQI38Z
+VrKbBzvma9neoTzRalDf+CGGmtykfhdbT0nMGFdHXtUGNZU0QUoSw+0KxWuXwo8O
+nJ5H8bN5w1+Dur8LUn2yPXZcjF7GkeGnIk1FSyleV+UOzGN1f/0T7OpId36spQ9Y
+2w24Fij4xvRHQC+uD6VYSz+YXjB5qD6u00PrzqBHP8wDgJwJPBHbncuwBbpsiJBv
+HQ4mYRLPWz9UCmWXXVOao/nYM+Y++M1FYwhUuptFx9HHJFuR/UILzP4/WFJTMfzs
+UGVcOfyoXqi/cTZJ+Rr/S6jhecpNbUAoA2VG4ZjX1ZSaS3Hupd4t7PdCHoWB7ODT
+AscDVBEidU5kimmZzo6nWNDU8LfhSUrS0inbX0YMcBweaLWpMMtB+Ffu6mvy6Ejn
+P+w15a4DgOg53uxHaq/pzp7IIEfhJGfwyhznN4f86pOX6BHWikGcGHBL62WywHSK
+pxgP/fNHYqIhYWCgUWeM
+=DmDL
+-----END PGP SIGNATURE-----

--- a/artifacts/testdata/files/debian/sources.list
+++ b/artifacts/testdata/files/debian/sources.list
@@ -1,0 +1,52 @@
+## EOL upgrade sources.list
+# Required
+deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+
+# Optional
+deb http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://au.archive.ubuntu.com/ubuntu jammy main restricted
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://au.archive.ubuntu.com/ubuntu jammy-updates main restricted
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://au.archive.ubuntu.com/ubuntu jammy universe
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy universe
+deb http://au.archive.ubuntu.com/ubuntu jammy-updates universe
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://au.archive.ubuntu.com/ubuntu jammy multiverse
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy multiverse
+deb http://au.archive.ubuntu.com/ubuntu jammy-updates multiverse
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://au.archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-backports main restricted universe multiverse
+
+
+deb http://au.archive.ubuntu.com/ubuntu jammy-security main restricted
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-security main restricted
+deb http://au.archive.ubuntu.com/ubuntu jammy-security universe
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-security universe
+deb http://au.archive.ubuntu.com/ubuntu jammy-security multiverse
+# deb-src http://au.archive.ubuntu.com/ubuntu groovy-security multiverse

--- a/artifacts/testdata/files/debian/status
+++ b/artifacts/testdata/files/debian/status
@@ -1,0 +1,138 @@
+Package: adduser
+Status: install ok installed
+Priority: important
+Section: admin
+Installed-Size: 608
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: all
+Multi-Arch: foreign
+Version: 3.118ubuntu5
+Depends: passwd, debconf (>= 0.5) | debconf-2.0
+Suggests: liblocale-gettext-perl, perl, ecryptfs-utils (>= 67-1)
+Conffiles:
+ /etc/deluser.conf 773fb95e98a27947de4a95abb3d3f2a2
+Description: add and remove users and groups
+ This package includes the 'adduser' and 'deluser' commands for creating
+ and removing users.
+ .
+  - 'adduser' creates new users and groups and adds existing users to
+    existing groups;
+  - 'deluser' removes users and groups and removes users from a given
+    group.
+ .
+ Adding users with 'adduser' is much easier than adding them manually.
+ Adduser will choose appropriate UID and GID values, create a home
+ directory, copy skeletal user configuration, and automate setting
+ initial values for the user's password, real name and so on.
+ .
+ Deluser can back up and remove users' home directories
+ and mail spool or all the files they own on the system.
+ .
+ A custom script can be executed after each of the commands.
+Original-Maintainer: Debian Adduser Developers <adduser@packages.debian.org>
+
+Package: adwaita-icon-theme
+Status: install ok installed
+Priority: optional
+Section: gnome
+Installed-Size: 5234
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: all
+Multi-Arch: foreign
+Version: 41.0-1ubuntu1
+Replaces: adwaita-icon-theme-full (<< 41.0-1ubuntu1), gnome-themes-standard-data (<< 3.18.0-2~)
+Depends: hicolor-icon-theme, gtk-update-icon-cache, ubuntu-mono | adwaita-icon-theme-full
+Recommends: librsvg2-common
+Breaks: adwaita-icon-theme-full (<< 41.0-1ubuntu1), gnome-themes-standard-data (<< 3.18.0-2~)
+Description: default icon theme of GNOME (small subset)
+ This package contains the default icon theme used by the GNOME desktop.
+ The icons are used in many of the official gnome applications like eog,
+ evince, system monitor, and many more.
+ .
+ This package only contains a small subset of the original GNOME icons which
+ are not provided by the Humanity icon theme, to avoid installing many
+ duplicated icons. Please install adwaita-icon-theme-full if you want the full
+ set.
+Original-Maintainer: Debian GNOME Maintainers <pkg-gnome-maintainers@lists.alioth.debian.org>
+
+Package: adwaita-icon-theme-full
+Status: install ok installed
+Priority: optional
+Section: gnome
+Installed-Size: 21330
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: all
+Multi-Arch: foreign
+Source: adwaita-icon-theme
+Version: 41.0-1ubuntu1
+Replaces: adwaita-icon-theme (<< 41.0-1ubuntu1), gnome-themes-standard-data (<< 3.18.0-2~)
+Provides: gnome-icon-theme-symbolic
+Depends: adwaita-icon-theme (= 41.0-1ubuntu1), gtk-update-icon-cache
+Recommends: librsvg2-common
+Breaks: adwaita-icon-theme (<< 41.0-1ubuntu1), gnome-themes-standard-data (<< 3.18.0-2~)
+Description: default icon theme of GNOME
+ This package contains the default icon theme used by the GNOME desktop.
+ The icons are used in many of the official GNOME applications like eog,
+ Evince, system monitor, and many more.
+Original-Maintainer: Debian GNOME Maintainers <pkg-gnome-maintainers@lists.alioth.debian.org>
+
+Package: alsa-topology-conf
+Status: install ok installed
+Priority: optional
+Section: libs
+Installed-Size: 420
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: all
+Multi-Arch: foreign
+Version: 1.2.5.1-2
+Replaces: libasound2-data (<< 1.2.1)
+Breaks: libasound2-data (<< 1.2.1)
+Enhances: libasound2-data
+Description: ALSA topology configuration files
+ This package contains ALSA topology configuration files that can be used
+ by libasound2 for specific audio hardware.
+ .
+ ALSA is the Advanced Linux Sound Architecture.
+Original-Maintainer: Debian ALSA Maintainers <pkg-alsa-devel@lists.alioth.debian.org>
+Homepage: https://www.alsa-project.org/
+
+Package: alsa-ucm-conf
+Status: install ok installed
+Priority: optional
+Section: libs
+Installed-Size: 560
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: all
+Multi-Arch: foreign
+Version: 1.2.6.3-1ubuntu1.7
+Depends: libasound2 (>= 1.2.4)
+Description: ALSA Use Case Manager configuration files
+ This package contains ALSA Use Case Manager configuration of audio
+ input/output names and routing for specific audio hardware. They can be
+ used with the alsaucm tool.
+ .
+ ALSA is the Advanced Linux Sound Architecture.
+Homepage: https://www.alsa-project.org/
+Original-Maintainer: Debian ALSA Maintainers <pkg-alsa-devel@lists.alioth.debian.org>
+
+Package: amd64-microcode
+Status: install ok installed
+Priority: standard
+Section: non-free/admin
+Installed-Size: 82
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: amd64
+Version: 3.20191218.1ubuntu2.1
+Recommends: initramfs-tools (>= 0.113~) | dracut (>= 044) | tiny-initramfs
+Breaks: intel-microcode (<< 2)
+Conffiles:
+ /etc/default/amd64-microcode eaa8a5fa3fb59af4f0f55e851a6e9b20
+ /etc/modprobe.d/amd64-microcode-blacklist.conf 71327241f6583b34944e638a955aba91
+Description: Processor microcode firmware for AMD CPUs
+ This package contains microcode patches for all AMD AMD64
+ processors.  AMD releases microcode patches to correct
+ processor behavior as documented in the respective processor
+ revision guides.
+ .
+ For Intel processors, please refer to the intel-microcode package.
+Original-Maintainer: Henrique de Moraes Holschuh <hmh@debian.org>

--- a/artifacts/testdata/server/testcases/debian.in.yaml
+++ b/artifacts/testdata/server/testcases/debian.in.yaml
@@ -1,0 +1,26 @@
+Queries:
+ - SELECT OSPath.Basename AS OSPath, *
+   FROM Artifact.Linux.Debian.AptSources(
+      source="Sources",
+      linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")],
+      aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/"
+   )
+
+ - SELECT OSPath.Basename AS OSPath, *
+   FROM Artifact.Linux.Debian.AptSources(
+      source="SourcesFlattened",
+      linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")],
+      aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/"
+   )
+
+ - SELECT "" AS Source, OSPath.Basename as OSPath, *
+   FROM Artifact.Linux.Debian.AptSources(
+      source="SourcesCacheFiles",
+      linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")],
+      aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/"
+   )
+   WHERE OSPath
+
+ - SELECT *
+   FROM Artifact.Linux.Debian.Packages(
+      linuxDpkgStatus=srcDir + "/artifacts/testdata/files/debian/status")

--- a/artifacts/testdata/server/testcases/debian.in.yaml
+++ b/artifacts/testdata/server/testcases/debian.in.yaml
@@ -13,13 +13,19 @@ Queries:
       aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/"
    )
 
- - SELECT "" AS Source, OSPath.Basename as OSPath, *
+ - SELECT OSPath.Basename as OSPath,
+      NULL AS Mtime,
+      NULL AS Ctime,
+      NULL AS Atime,
+      NULL AS Source, *
+
    FROM Artifact.Linux.Debian.AptSources(
       source="SourcesCacheFiles",
       linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")],
       aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/"
    )
-   WHERE OSPath
+   WHERE Record
+
 
  - SELECT *
    FROM Artifact.Linux.Debian.Packages(

--- a/artifacts/testdata/server/testcases/debian.out.yaml
+++ b/artifacts/testdata/server/testcases/debian.out.yaml
@@ -1,0 +1,524 @@
+SELECT OSPath.Basename AS OSPath, * FROM Artifact.Linux.Debian.AptSources( source="Sources", linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")], aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/" )[
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "Suites": "jammy",
+  "Components": "main restricted universe multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-updates",
+  "Components": "main restricted universe multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-security",
+  "Components": "main restricted universe multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-backports",
+  "Components": "main restricted universe multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy",
+  "Components": "main restricted",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-updates",
+  "Components": "main restricted",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy",
+  "Components": "universe",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-updates",
+  "Components": "universe",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy",
+  "Components": "multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-updates",
+  "Components": "multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-backports",
+  "Components": "main restricted universe multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-security",
+  "Components": "main restricted",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-security",
+  "Components": "universe",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ },
+ {
+  "OSPath": "sources.list",
+  "Types": "deb",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "Suites": "jammy-security",
+  "Components": "multiverse",
+  "_Source": "Linux.Debian.AptSources/Sources"
+ }
+]SELECT OSPath.Basename AS OSPath, * FROM Artifact.Linux.Debian.AptSources( source="SourcesFlattened", linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")], aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/" )[
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-updates",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-updates",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-updates",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-updates",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-security",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-security",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-security",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-security",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-backports",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-backports",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-backports",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-backports",
+  "_URIBase": "archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-updates",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-updates",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-updates",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-updates",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-backports",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-backports",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-backports",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-backports",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "main",
+  "Suites": "jammy-security",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "restricted",
+  "Suites": "jammy-security",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "universe",
+  "Suites": "jammy-security",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ },
+ {
+  "OSPath": "sources.list",
+  "Components": "multiverse",
+  "Suites": "jammy-security",
+  "_URIBase": "au.archive.ubuntu.com/ubuntu",
+  "_Transport": "http",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "Types": "deb",
+  "_Source": "Linux.Debian.AptSources/SourcesFlattened"
+ }
+]SELECT "" AS Source, OSPath.Basename as OSPath, * FROM Artifact.Linux.Debian.AptSources( source="SourcesCacheFiles", linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")], aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/" ) WHERE OSPath[
+ {
+  "Source": "",
+  "OSPath": "au.archive.ubuntu.com_ubuntu_dists_jammy_InRelease",
+  "Mtime": "2023-08-23T10:45:25Z",
+  "Ctime": "2023-08-23T10:45:25Z",
+  "Atime": "2023-08-23T10:55:22Z",
+  "Record": {
+   "Release": "jammy",
+   "Version": "22.04",
+   "Origin": "Ubuntu",
+   "Architectures": "amd64 arm64 armhf i386 ppc64el riscv64 s390x",
+   "Components": "main restricted universe multiverse"
+  },
+  "Types": "deb",
+  "Name": "au.archive.ubuntu.com_ubuntu_dists_jammy_InRelease",
+  "Architectures": "",
+  "URIs": "http://au.archive.ubuntu.com/ubuntu",
+  "_Source": "Linux.Debian.AptSources/SourcesCacheFiles"
+ }
+]SELECT * FROM Artifact.Linux.Debian.Packages( linuxDpkgStatus=srcDir + "/artifacts/testdata/files/debian/status")[
+ {
+  "Package": "adduser",
+  "InstalledSize": 608,
+  "Version": "3.118ubuntu5",
+  "Source": null,
+  "Architecture": "all",
+  "_Source": "Linux.Debian.Packages"
+ },
+ {
+  "Package": "adwaita-icon-theme",
+  "InstalledSize": 5234,
+  "Version": "41.0-1ubuntu1",
+  "Source": null,
+  "Architecture": "all",
+  "_Source": "Linux.Debian.Packages"
+ },
+ {
+  "Package": "adwaita-icon-theme-full",
+  "InstalledSize": 21330,
+  "Version": "41.0-1ubuntu1",
+  "Source": "adwaita-icon-theme",
+  "Architecture": "all",
+  "_Source": "Linux.Debian.Packages"
+ },
+ {
+  "Package": "alsa-topology-conf",
+  "InstalledSize": 420,
+  "Version": "1.2.5.1-2",
+  "Source": null,
+  "Architecture": "all",
+  "_Source": "Linux.Debian.Packages"
+ },
+ {
+  "Package": "alsa-ucm-conf",
+  "InstalledSize": 560,
+  "Version": "1.2.6.3-1ubuntu1.7",
+  "Source": null,
+  "Architecture": "all",
+  "_Source": "Linux.Debian.Packages"
+ }
+]

--- a/artifacts/testdata/server/testcases/debian.out.yaml
+++ b/artifacts/testdata/server/testcases/debian.out.yaml
@@ -460,13 +460,14 @@ SELECT OSPath.Basename AS OSPath, * FROM Artifact.Linux.Debian.AptSources( sourc
   "Types": "deb",
   "_Source": "Linux.Debian.AptSources/SourcesFlattened"
  }
-]SELECT "" AS Source, OSPath.Basename as OSPath, * FROM Artifact.Linux.Debian.AptSources( source="SourcesCacheFiles", linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")], aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/" ) WHERE OSPath[
+]SELECT OSPath.Basename as OSPath, NULL AS Mtime, NULL AS Ctime, NULL AS Atime, NULL AS Source, *
+FROM Artifact.Linux.Debian.AptSources( source="SourcesCacheFiles", linuxAptSourcesGlobs=[dict(ListGlobs=srcDir + "/artifacts/testdata/files/debian/sources.list")], aptCacheDirectory=srcDir + "/artifacts/testdata/files/debian/" ) WHERE Record[
  {
-  "Source": "",
   "OSPath": "au.archive.ubuntu.com_ubuntu_dists_jammy_InRelease",
-  "Mtime": "2023-08-23T10:45:25Z",
-  "Ctime": "2023-08-23T10:45:25Z",
-  "Atime": "2023-08-23T10:55:22Z",
+  "Mtime": null,
+  "Ctime": null,
+  "Atime": null,
+  "Source": null,
   "Record": {
    "Release": "jammy",
    "Version": "22.04",


### PR DESCRIPTION
# Linux.Debian.AptSources

The Linux.Debian.AptSources artifact has a number of limitations, all of which
the changes in this pull request aims to resolve. The new artifact also provides
parsers that can be imported in other artifacts for inspecting every single
field in these configuration files.

## Resolved issues

The artifact does not work on current Debian-based systems. One reason is an
increased usage of the option "signed-by", used to manually specify the gpg key
file location. The original regex only supports the option "arch" or no
options. The main reason is the that Release files have been replaced with
InRelease files. The format is similar, just with a gpg key embedded at the end
of the file. Note that these keys often contain a gpg header "Version: […] that
confuses the original VQL.

**Fixes and enhancements**:

- Support for sources files (multi-line [deb822 format](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT))
- Support options other than "arch" in list files
- Support for any valid usage of whitespace in list files
- Support for comments in (at the end of) list files
- Support for protocols other than http/https in list files
- Support for multiple values in fields/options (arch, lang, targets, components)
- Parse InRelease files as well as Release files, and prevent the "Version:
  GnuPG" header line from interfering with the "Version" field
- Group the query results by cache file, preventing duplicate entries without
  records

After improving the list file parser, I also added a parser for the new file
format, likely to replace the one-line list file format in the future: deb822.
This file format allows each entry to have multiple values (deb + deb-src,
multiple URIs and options), and each file may contain multiple entries
separated by blank lines. GPG keys may be embedded, and the format is very
lenient on whitespace usage and allowing multi-line values.

The parser should handle any kind of strange, but valid, formatting, like

```
Key: Value
Key2  : Value
Key3:
# Comment
# Comment
		  Value
```

and so on. Due to limitations in the go regex library (no support for
look-arounds) and the complexity of multi-value fields and options, the parser
VQL is complex and split in a number of functions.

Columns are dynamic in order to support every known (and future/unknown)
options. This has pros and cons, but it is future-proof. Every known option
name is normalised to the names referred to in the man page, which are
camel-cased (pascal-cased) and plural.

## Considerations

The main motivation behind improving this artifact was to have a working apt
sources parser. Since this artifact is part of velociraptor and not the
exchange (velociraptor-docs), I've tried to make the parsers handle everything
I can throw at it. I am happy to include tests, but before I do that, I would
like to get some feedback.

I kept the original query, but I also included two others. I feel that a table
including every parsed field, like all options, is handy. Likewise, a flattened
version is also very useful to work on in a notebook. This results in two
rounds of parsing sources files (due to how flatting happens at an early
stage), and the third query parses cache files as well, like before. This
shouldn't have any noticeable effect on any normal system, but if there are
ways I can rewrite the VQL do only parse the files once, for both the combined
and flattened results, that would of course by much nicer. And perhaps
something belongs in notebook suggestions?

I see lots of potential in this artifact, but for starters, I'd like it to
work and be useful for importing in other artifacts. Working with
inrelease-path and signed-by options in future enhancements may be useful.

I find it a bit tricky to get an overview of all the supported features of
artifact YAML, so feel free to point out how I may improve the documentation,
ways to export functions (without including all "private" helper functions),
and how to improve the current three–query solution.