### PR TITLE
Fix the issue of full cpus/ram when handling corrupted org

### DIFF
--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -227,6 +227,12 @@ func (self *OrgManager) Scan() error {
 
 		delete(existing, org_id)
 
+		if org_record.Id == "" || org_record.Nonce == "" {
+			logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
+			logger.Info("<yellow>Org is corrupted %v</>", org_id)
+			continue
+		}
+
 		_, err = self.GetOrgConfig(org_id)
 		if err != nil {
 			err = self.startOrg(org_record)


### PR DESCRIPTION
When the disk was full, some strange things happened.

Some files are created but the files are empty.

In my case, my disk was full, so an organization's .json.db file was created with zero length content, causing a loop of the startOrg call.

This commit will fix that problem by checking if the organization's .json.db file is corrupted.