### PR TITLE
Bugfix: accessors should provide their underlying file

### DIFF
--- a/accessors/file/accessor_common.go
+++ b/accessors/file/accessor_common.go
@@ -293,6 +293,11 @@ func (self OSFileSystemAccessor) ReadDir(dir string) ([]accessors.FileInfo, erro
 	return self.ReadDirWithOSPath(full_path)
 }
 
+func (self *OSFileSystemAccessor) GetUnderlyingAPIFilename(
+	full_path *accessors.OSPath) (string, error) {
+	return full_path.PathSpec().Path, nil
+}
+
 func (self OSFileSystemAccessor) ReadDirWithOSPath(
 	full_path *accessors.OSPath) ([]accessors.FileInfo, error) {
 	dir := full_path.PathSpec().Path

--- a/accessors/file/auto_windows.go
+++ b/accessors/file/auto_windows.go
@@ -135,6 +135,11 @@ func (self AutoFilesystemAccessor) New(scope vfilter.Scope) (accessors.FileSyste
 	}, nil
 }
 
+func (self *AutoFilesystemAccessor) GetUnderlyingAPIFilename(
+	full_path *accessors.OSPath) (string, error) {
+	return full_path.PathSpec().Path, nil
+}
+
 func (self *AutoFilesystemAccessor) ReadDirWithOSPath(
 	path *accessors.OSPath) ([]accessors.FileInfo, error) {
 	result, err := self.file_delegate.ReadDirWithOSPath(path)

--- a/accessors/file/os_windows.go
+++ b/accessors/file/os_windows.go
@@ -151,6 +151,11 @@ func (self OSFileSystemAccessor) New(scope vfilter.Scope) (
 	return result, nil
 }
 
+func (self *OSFileSystemAccessor) GetUnderlyingAPIFilename(
+	full_path *accessors.OSPath) (string, error) {
+	return full_path.PathSpec().Path, nil
+}
+
 func discoverDriveLetters() ([]accessors.FileInfo, error) {
 	result := []accessors.FileInfo{}
 

--- a/artifacts/testdata/server/testcases/remapping.out.yaml
+++ b/artifacts/testdata/server/testcases/remapping.out.yaml
@@ -171,6 +171,7 @@ LET _ <= remap(config=format(format=RemappingTemplate, args=[ srcDir+'/artifacts
 ]SELECT * FROM parse_ntfs_i30( accessor='ntfs', device='c:/$MFT', inode="41-144-1")[
  {
   "MFTId": "45",
+  "SequenceNumber": 0,
   "Mtime": "2018-09-24T07:55:44.4592119Z",
   "Atime": "2022-03-18T04:09:07.2885951Z",
   "Ctime": "2018-09-24T07:55:20.6489276Z",

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	howett.net/plist v1.0.0
 	www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e
 	www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671
-	www.velocidex.com/golang/go-ntfs v0.1.2-0.20230728152253-4d399c766ed6
+	www.velocidex.com/golang/go-ntfs v0.1.2-0.20230815140127-6a3dd72bfbf1
 	www.velocidex.com/golang/go-pe v0.1.1-0.20230228112150-ef2eadf34bc3
 	www.velocidex.com/golang/go-prefetch v0.0.0-20220801101854-338dbe61982a
 	www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe

--- a/go.sum
+++ b/go.sum
@@ -1231,8 +1231,8 @@ www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e h1:AhcXPgNKhJ
 www.velocidex.com/golang/evtx v0.2.1-0.20220404133451-1fdf8be7325e/go.mod h1:ykEQ7AUF9AL+mfCefDmLwmZOnU2So6wM3qKM8xdsHhU=
 www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671 h1:pfvo7NFo0eJj6Zr7d+4vMx/Zr2JriMMPEWRHUf1YjUw=
 www.velocidex.com/golang/go-ese v0.1.1-0.20220107095505-c38622559671/go.mod h1:qnzHyB9yD2khtYO+wf3ck9FQxX3wFhXeJHFBnuUIZcc=
-www.velocidex.com/golang/go-ntfs v0.1.2-0.20230728152253-4d399c766ed6 h1:CQTXpiMZ01PJIvpelSzpWJlZEUoQM831YgHEVdaZic4=
-www.velocidex.com/golang/go-ntfs v0.1.2-0.20230728152253-4d399c766ed6/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
+www.velocidex.com/golang/go-ntfs v0.1.2-0.20230815140127-6a3dd72bfbf1 h1:6NMITYv1pi4tzmDcqB/enNUXKmS8dnTb72HBghqhnAM=
+www.velocidex.com/golang/go-ntfs v0.1.2-0.20230815140127-6a3dd72bfbf1/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
 www.velocidex.com/golang/go-pe v0.1.1-0.20220107093716-e91743c801de/go.mod h1:j9Xy8Z9wxzY2SCB8CqDkkoSzy+eUwevnOrRm/XM2q/A=
 www.velocidex.com/golang/go-pe v0.1.1-0.20230228112150-ef2eadf34bc3 h1:W394TEIFuHFxHY8mzTJPHI5v+M+NLKEHmHn7KY/VpEM=
 www.velocidex.com/golang/go-pe v0.1.1-0.20230228112150-ef2eadf34bc3/go.mod h1:agYwYzeeytVtdwkRrvxZAjgIA8SCeM/Tg7Ym2/jBwmA=

--- a/vql/parsers/csv/csv.go
+++ b/vql/parsers/csv/csv.go
@@ -224,7 +224,7 @@ func (self _WatchCSVPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap)
 }
 
 type WriteCSVPluginArgs struct {
-	Filename string              `vfilter:"required,field=filename,doc=CSV files to open"`
+	Filename *accessors.OSPath   `vfilter:"required,field=filename,doc=CSV files to open"`
 	Accessor string              `vfilter:"optional,field=accessor,doc=The accessor to use"`
 	Query    vfilter.StoredQuery `vfilter:"required,field=query,doc=query to write into the file."`
 }
@@ -257,7 +257,14 @@ func (self WriteCSVPlugin) Call(
 				return
 			}
 
-			file, err := os.OpenFile(arg.Filename,
+			underlying_file, err := accessors.GetUnderlyingAPIFilename(
+				arg.Accessor, scope, arg.Filename)
+			if err != nil {
+				scope.Log("write_csv: %s", err)
+				return
+			}
+
+			file, err := os.OpenFile(underlying_file,
 				os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700)
 			if err != nil {
 				scope.Log("write_csv: Unable to open file %s: %s",

--- a/vql/parsers/json.go
+++ b/vql/parsers/json.go
@@ -485,7 +485,7 @@ func (self _IndexAssociativeProtocol) GetMembers(
 }
 
 type WriteJSONPluginArgs struct {
-	Filename string              `vfilter:"required,field=filename,doc=CSV files to open"`
+	Filename *accessors.OSPath   `vfilter:"required,field=filename,doc=CSV files to open"`
 	Accessor string              `vfilter:"optional,field=accessor,doc=The accessor to use"`
 	Query    vfilter.StoredQuery `vfilter:"required,field=query,doc=query to write into the file."`
 }
@@ -518,7 +518,14 @@ func (self WriteJSONPlugin) Call(
 				return
 			}
 
-			file, err := os.OpenFile(arg.Filename,
+			underlying_file, err := accessors.GetUnderlyingAPIFilename(
+				arg.Accessor, scope, arg.Filename)
+			if err != nil {
+				scope.Log("write_csv: %s", err)
+				return
+			}
+
+			file, err := os.OpenFile(underlying_file,
 				os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700)
 			if err != nil {
 				scope.Log("write_jsonl: Unable to open file %s: %s",

--- a/vql/parsers/sql.go
+++ b/vql/parsers/sql.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
+	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/acls"
 	utils "www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql"
@@ -25,12 +26,12 @@ var (
 )
 
 type SQLPluginArgs struct {
-	Driver     string      `vfilter:"required,field=driver, doc=sqlite, mysql,or postgres"`
-	ConnString string      `vfilter:"optional,field=connstring, doc=SQL Connection String"`
-	Filename   string      `vfilter:"optional,field=file, doc=Required if using sqlite driver"`
-	Accessor   string      `vfilter:"optional,field=accessor,doc=The accessor to use if using sqlite"`
-	Query      string      `vfilter:"required,field=query"`
-	Args       vfilter.Any `vfilter:"optional,field=args"`
+	Driver     string            `vfilter:"required,field=driver, doc=sqlite, mysql,or postgres"`
+	ConnString string            `vfilter:"optional,field=connstring, doc=SQL Connection String"`
+	Filename   *accessors.OSPath `vfilter:"optional,field=file, doc=Required if using sqlite driver"`
+	Accessor   string            `vfilter:"optional,field=accessor,doc=The accessor to use if using sqlite"`
+	Query      string            `vfilter:"required,field=query"`
+	Args       vfilter.Any       `vfilter:"optional,field=args"`
 }
 
 type SQLPlugin struct{}


### PR DESCRIPTION
We sometimes need to know the path to the underlying file on the filesystem if possible. This is used in cases when we need to delegate to an external library which expects a filesystem path.

Previously the code assumed that when the accessor was "file" or "auto" then the underlying path can be obtained from the filename. This works well in local trigage mode but fails when remapping - in that case the actual accessor called "file" may be a completely different remapped accessor and it is not appropriate to use its filename as an underlying API file.

This would cause issues with e.g. the yara plugin, sqlite and leveldb plugins.

This PR introduces a new interface which allows the accessor to provide the raw API accessible path if possible. For plugins that need to work with real files, this path also creates a local copy if needed.

Fixes: #2870