### PR TITLE
Add OriginalFileName to Name regex search for better hunting

### DIFF
--- a/artifacts/definitions/Windows/Detection/Amcache.yaml
+++ b/artifacts/definitions/Windows/Detection/Amcache.yaml
@@ -13,7 +13,7 @@ description: |
 
       - SHA1regex - regex entries to filter by SHA1.
       - PathRegex - filter on path if available.
-      - NameRegex - filter on EntryName / binary.
+      - NameRegex - filter on EntryName OR OriginalFileName.
 
     NOTE:
 
@@ -109,8 +109,8 @@ sources:
                     WHERE SHA1
                         AND SHA1 =~ SHA1Regex
                         AND if(condition= NameRegex,
-                            then= EntryName =~ NameRegex,
-                            else= True)
+                                then= EntryName =~ NameRegex OR OriginalFileName =~ NameRegex,
+                                else= True)
                         AND if(condition= PathRegex,
                             then= EntryPath =~ PathRegex,
                             else= True)


### PR DESCRIPTION
Added OriginalFileName OR EntryName into filter to improve hunting results on renamed binaries.