### PR TITLE
Remove unused parameter by Bloodhound artifact

### DIFF
--- a/artifacts/definitions/Windows/ActiveDirectory/BloodHound.yaml
+++ b/artifacts/definitions/Windows/ActiveDirectory/BloodHound.yaml
@@ -9,9 +9,6 @@ description: |
    The Sharphound collection is in json format and upload to the server for
    additional processing.
 
-   RemovePayload - Due to potential malicious use of this tool I have also
-   included an option to remove payload after execution.
-
    NOTE: Do not run this artifact as an unrestricted hunt. General recommendation
    is to run this artifact on only a handful of machines in a typical domain,
    then deduplicate output.
@@ -32,11 +29,6 @@ tools:
 
 type: CLIENT
 
-parameters:
-  - name: RemovePayload
-    description: Select to remove payload after execution.
-    type: bool
-
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
@@ -49,23 +41,12 @@ sources:
       LET payload <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(
                     ToolName="SharpHound")
 
-
       -- build tempfolder for output
       LET tempfolder <= tempdir()
-
 
       -- execute payload
       LET deploy = SELECT * FROM execve(argv=[payload.OSPath[0],'--outputdirectory',
                 tempfolder,'--nozip','--outputprefix',hostname.Fqdn[0] ])
-
-
-      -- remove payload if selected
-      LET remove <= SELECT * FROM if(condition=RemovePayload,
-                then={
-                    SELECT * FROM execve(argv=['powershell','Remove-Item',
-                                            payload.OSPath[0],'-Force' ])
-                })
-
 
       -- output rows
       SELECT * FROM if(condition= deploy.ReturnCode[0]= 0,


### PR DESCRIPTION
The executable is deleted by default.

```
[...]
[INFO] 2023-09-01T09:46:13-07:00 copy: Copying file from /uploads/SharpHound.exe into C:\Users\IEUser\AppData\Local\Temp\tmp905568840.exe
[INFO] 2023-09-01T09:46:13-07:00 Starting collection of Windows.ActiveDirectory.BloodHound
[INFO] 2023-09-01T09:46:13-07:00 shell: Running external command [C:\Users\IEUser\AppData\Local\Temp\tmp905568840.exe --outputdirectory C:\Users\IEUser\AppData\Local\Temp\tmp1873669653 --nozip --outputprefix MSEDGEWIN10.localdomain]
[...]
[INFO] 2023-09-01T09:46:37-07:00 tempfile: removing tempfile C:\Users\IEUser\AppData\Local\Temp\tmp905568840.exe
```