### PR TITLE
Add Modify() method to client info manager.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     # We used to build on ubuntu-18.04 but that is now deprecated by
     # GitHub. Earlier distributions will have to use the musl build.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Check out code into the Go module directory

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -349,7 +349,9 @@ parameters:
                 remove_last=TRUE,
                 permissions=if(condition=IsExecutable, then="x")))
 
-       SELECT copy(filename=Filename, accessor="me", dest=temp_binary) AS OSPath,
+       LET FullPath <= copy(filename=Filename, accessor="me", dest=temp_binary)
+
+       SELECT FullPath, FullPath AS OSPath,
               Filename AS Name
        FROM matching_tools
 

--- a/artifacts/proto/artifact.proto
+++ b/artifacts/proto/artifact.proto
@@ -202,7 +202,7 @@ message Artifact {
     // Artifact was already compiled.
     bool compiled = 14;
 
-    // The artifact is considered built and and can not be overriden by the GUI
+    // The artifact is considered built in and can not be overriden by the GUI
     bool built_in = 20;
 
     // The artifact is built into the Velociraptor binary.

--- a/services/client_info.go
+++ b/services/client_info.go
@@ -64,9 +64,17 @@ func (self ClientInfo) OS() ClientOS {
 type ClientInfoManager interface {
 	ListClients(ctx context.Context) <-chan string
 
-	// Used to set a new client record.
+	// Used to set a new client record. To modify an existing record -
+	// or set a new one use Modify()
 	Set(ctx context.Context,
 		client_info *ClientInfo) error
+
+	// Modify a record or set a new one - if the record is not found,
+	// modifier will receive a nil client_info. The ClientInfoManager
+	// can not be accessed within the modifier function as it is
+	// locked for the duration of the change.
+	Modify(ctx context.Context, client_id string,
+		modifier func(client_info *ClientInfo) (new_record *ClientInfo, err error)) error
 
 	Get(ctx context.Context,
 		client_id string) (*ClientInfo, error)

--- a/services/client_info/client_info.go
+++ b/services/client_info/client_info.go
@@ -414,6 +414,13 @@ func (self *ClientInfoManager) ProcessPing(
 	return nil
 }
 
+func (self *ClientInfoManager) Modify(
+	ctx context.Context, client_id string,
+	modifier func(client_info *services.ClientInfo) (
+		*services.ClientInfo, error)) error {
+	return self.storage.Modify(ctx, client_id, modifier)
+}
+
 func (self *ClientInfoManager) Get(
 	ctx context.Context, client_id string) (*services.ClientInfo, error) {
 	record, err := self.storage.GetRecord(client_id)

--- a/services/interrogation/interrogation_test.go
+++ b/services/interrogation/interrogation_test.go
@@ -84,7 +84,8 @@ func (self *ServicesTestSuite) TestInterrogationService() {
 	flow_id := self.EmulateCollection(
 		"Generic.Client.Info/BasicInformation", []*ordereddict.Dict{
 			ordereddict.NewDict().
-				Set("ClientId", self.client_id).
+				Set("Name", "velociraptor").
+				Set("OS", "windows").
 				Set("Hostname", hostname).
 				Set("Labels", []string{"Foo"}),
 		})

--- a/vtesting/assert/wrapper.go
+++ b/vtesting/assert/wrapper.go
@@ -85,3 +85,7 @@ func True(t TestingT, expected bool, msgAndArgs ...interface{}) {
 func NotNil(t TestingT, expected interface{}, msgAndArgs ...interface{}) {
 	assert.NotNil(t, expected, msgAndArgs...)
 }
+
+func Nil(t TestingT, expected interface{}, msgAndArgs ...interface{}) {
+	assert.Nil(t, expected, msgAndArgs...)
+}


### PR DESCRIPTION
This is required to ensure client info records can be modified atomically. Fixes certain edge cases arising due to server monitoring queries assigning labels racing with interrogations.