### PR TITLE
Report process names as well as pid for errors

### DIFF
--- a/artifacts/definitions/Windows/System/VAD.yaml
+++ b/artifacts/definitions/Windows/System/VAD.yaml
@@ -9,9 +9,9 @@ description: |
   or by content with yara.
 
   NOTE:
-  
+
    - ProtectionChoice is a choice to filter on section protection. Default is
-  all sections and ProtectionRegex can override selection.   
+  all sections and ProtectionRegex can override selection.
   - To filter on unmapped sections the MappingNameRegex: ^$ can be used.
 
 parameters:
@@ -51,7 +51,7 @@ sources:
   - query: |
       -- firstly find processes in scope
       LET processes = SELECT int(int=Pid) AS Pid,
-              Name, Exe, CommandLine, CreateTime
+              Name, Exe, CommandLine, StartTime
         FROM process_tracker_pslist()
         WHERE Name =~ ProcessRegex
             AND format(format="%d", args=Pid) =~ PidRegex
@@ -61,7 +61,7 @@ sources:
       LET sections = SELECT * FROM foreach(
           row=processes,
           query={
-            SELECT CreateTime as ProcessCreateTime,Pid, Name,MappingName  ,
+            SELECT StartTime as ProcessCreateTime,Pid, Name, MappingName,
                 format(format='%x-%x', args=[Address, Address+Size]) AS AddressRange,
                 Address as _Address,
                 State,Type,ProtectionMsg,Protection,

--- a/vql/tools/process/dummy.go
+++ b/vql/tools/process/dummy.go
@@ -36,6 +36,10 @@ func (self *DummyProcessTracker) getLookup(
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	if self.lookup == nil {
+		self.lookup = make(map[string]*ProcessEntry)
+	}
+
 	// Expire old looksup after 10 seconds
 	now := time.Now()
 	if now.Before(self.age.Add(10 * time.Second)) {

--- a/vql/tools/process/protocols.go
+++ b/vql/tools/process/protocols.go
@@ -34,6 +34,10 @@ func (self ProcessTrackerUpdater) Call(
 	go func() {
 		defer close(output_chan)
 
+		if tracker == nil {
+			return
+		}
+
 		// First message is a full sync message.
 		update := ordereddict.NewDict()
 		for _, p := range tracker.Processes(ctx, scope) {

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -42,6 +42,10 @@ func GetGlobalTracker() IProcessTracker {
 	clock_mu.Lock()
 	defer clock_mu.Unlock()
 
+	if g_tracker == nil {
+		g_tracker = &DummyProcessTracker{}
+	}
+
 	return g_tracker
 }
 

--- a/vql/windows/process/token.go
+++ b/vql/windows/process/token.go
@@ -50,11 +50,15 @@ func (self TokenFunction) Call(
 		scope.Log("token: %s", err.Error())
 		return vfilter.Null{}
 	}
+
+	TryToGrantSeDebugPrivilege()
+
 	handle, err := windows.OpenProcess(
 		syscall.PROCESS_QUERY_INFORMATION, false, uint32(arg.Pid))
 
 	if err != nil {
-		scope.Log("token: %s", err.Error())
+		scope.Log("token: OpenProcess for %v: %s",
+			GetProcessContext(ctx, scope, uint64(arg.Pid)), err.Error())
 		return vfilter.Null{}
 	}
 	defer windows.CloseHandle(handle)
@@ -64,7 +68,8 @@ func (self TokenFunction) Call(
 	// Find process token via win32
 	err = windows.OpenProcessToken(handle, syscall.TOKEN_QUERY, &token)
 	if err != nil {
-		scope.Log("token: %s", err.Error())
+		scope.Log("token: OpenProcessToken for %v: %s",
+			GetProcessContext(ctx, scope, uint64(arg.Pid)), err.Error())
 		return vfilter.Null{}
 	}
 	defer token.Close()
@@ -72,7 +77,8 @@ func (self TokenFunction) Call(
 	// Find the token user
 	tokenUser, err := token.GetTokenUser()
 	if err != nil {
-		scope.Log("token: %s", err.Error())
+		scope.Log("token: GetTokenUser for %v: %s",
+			GetProcessContext(ctx, scope, uint64(arg.Pid)), err.Error())
 		return vfilter.Null{}
 	}
 

--- a/vql/windows/process/utils.go
+++ b/vql/windows/process/utils.go
@@ -1,0 +1,24 @@
+package process
+
+import (
+	"context"
+	"fmt"
+
+	"www.velocidex.com/golang/velociraptor/vql/tools/process"
+	"www.velocidex.com/golang/vfilter"
+)
+
+func GetProcessContext(
+	ctx context.Context, scope vfilter.Scope, pid uint64) string {
+	tracker := process.GetGlobalTracker()
+	record, ok := tracker.Get(ctx, scope, fmt.Sprintf("%v", pid))
+	if ok {
+		name, _ := record.Data.GetString("Name")
+		if name == "" {
+			name = "unknown"
+		}
+		return fmt.Sprintf(" %v (%v) ", record.Id, name)
+	}
+
+	return fmt.Sprintf(" %v ", pid)
+}

--- a/vql/windows/processes.go
+++ b/vql/windows/processes.go
@@ -195,7 +195,7 @@ func (self PslistPlugin) Call(
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {
-			scope.Log("pslist: %s", err)
+			scope.Log("pslist: %v", err)
 			return
 		}
 
@@ -206,7 +206,7 @@ func (self PslistPlugin) Call(
 
 		err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 		if err != nil {
-			scope.Log("pslist: %s", err.Error())
+			scope.Log("pslist: %v", err)
 			return
 		}
 


### PR DESCRIPTION
In Windows many processes are protected so we can not access them. Previously Velociraptor only reported the pid but this PR also reports the process name for inaccessible processes