### PR TITLE
Include MAC addresses in client host dashboard

### DIFF
--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -18,8 +18,7 @@ sources:
       This source is used internally to populate agent info. Do not
       modify or remove this query.
     query: |
-        LET Interfaces = SELECT format(format='%02x:%02x:%02x:%02x:%02x:%02x',
-            args=HardwareAddr) AS MAC
+        LET Interfaces = SELECT HardwareAddrString AS MAC
         FROM interfaces()
         WHERE HardwareAddr
 

--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -38,7 +38,7 @@ sources:
     precondition: SELECT OS From info() where OS = 'linux'
     query: |
       SELECT
-      { SELECT * FROM linux_sysinfo() } AS `Computer Info`,
+      sysinfo() AS `Computer Info`,
       { SELECT Name, HardwareAddrString AS MACAddress, Up, PointToPoint,
                join(array=AddrsString, sep=', ') AS IPAddresses
                FROM interfaces() WHERE HardwareAddr} AS `Network Info`

--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -33,6 +33,17 @@ sources:
                Interfaces.MAC AS MACAddresses
         FROM info()
 
+  - name: LinuxInfo
+    description: Linux specific information about the host
+    precondition: SELECT OS From info() where OS = 'linux'
+    query: |
+      SELECT
+      { SELECT * FROM linux_sysinfo() } AS `Computer Info`,
+      { SELECT Name, HardwareAddrString AS MACAddress, Up, PointToPoint,
+               join(array=AddrsString, sep=', ') AS IPAddresses
+               FROM interfaces() WHERE HardwareAddr} AS `Network Info`
+      FROM scope()
+
   - name: WindowsInfo
     description: Windows specific information about the host
     precondition: SELECT OS From info() where OS = 'windows'

--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -39,9 +39,10 @@ sources:
     query: |
       SELECT
       sysinfo() AS `Computer Info`,
-      { SELECT Name, HardwareAddrString AS MACAddress, Up, PointToPoint,
-               join(array=AddrsString, sep=', ') AS IPAddresses
-               FROM interfaces() WHERE HardwareAddr} AS `Network Info`
+      { SELECT Name, HardwareAddrString AS MACAddress,
+               Up, PointToPoint,
+               AddrsString AS IPAddresses
+        FROM interfaces() WHERE HardwareAddr} AS `Network Info`
       FROM scope()
 
   - name: WindowsInfo
@@ -134,14 +135,39 @@ reports:
          })
       {{ end }}
 
+      {{ define "computerinfo" }}
+      LET X <= SELECT *
+        FROM source(artifact='Generic.Client.Info/LinuxInfo')
+        LIMIT 1
+
+      SELECT humanize(bytes=TotalPhysicalMemory) AS  TotalPhysicalMemory,
+             humanize(bytes=TotalFreeMemory) AS  TotalFreeMemory,
+             humanize(bytes=TotalSharedMemory) AS  TotalSharedMemory,
+             humanize(bytes=TotalSwap) AS  TotalSwap,
+             humanize(bytes=FreeSwap) AS  FreeSwap
+      FROM foreach(row=X[0].`Computer Info`)
+      {{ end }}
+
       <div>
       {{ Query "resources" | LineChart "xaxis_mode" "time" "RSS.yaxis" 2 }}
       </div>
 
       {{ $windows_info := Query "SELECT * FROM source(source='WindowsInfo')" }}
-      {{ if $windows_info }}
+      {{ if $windows_info | Expand }}
       # Windows agent information
         {{ $windows_info | Table }}
+      {{ end }}
+
+      {{ $linux_info := Query "LET X <= SELECT * FROM source(artifact='Generic.Client.Info/LinuxInfo') LIMIT 1 SELECT * FROM X" }}
+      {{ if Query "SELECT * FROM source(artifact='Generic.Client.Info/LinuxInfo')" | Expand }}
+      # Linux agent information
+
+      ### Network Info
+        {{ Query "SELECT * FROM foreach(row=X[0].`Network Info`)" | Table }}
+
+      ### Computer Info
+        {{ Query "computerinfo" | Table }}
+
       {{ end }}
 
       # Active Users

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2933,9 +2933,9 @@
     description: The accessor to use.
   metadata:
     permissions: FILESYSTEM_READ
-- name: linux_sysinfo
+- name: sysinfo
   description: Collect system information on Linux clients
-  type: Plugin
+  type: Function
   metadata:
     permissions: MACHINE_STATE
 - name: log

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2933,6 +2933,11 @@
     description: The accessor to use.
   metadata:
     permissions: FILESYSTEM_READ
+- name: linux_sysinfo
+  description: Collect system information on Linux clients
+  type: Plugin
+  metadata:
+    permissions: MACHINE_STATE
 - name: log
   description: |
     Log the message and return TRUE.

--- a/gui/velociraptor/src/components/clients/host-info.jsx
+++ b/gui/velociraptor/src/components/clients/host-info.jsx
@@ -370,6 +370,12 @@ class VeloHostInfo extends Component {
                         <dd className="col-sm-9">
                           { info.os_info.machine }
                         </dd>
+			<dt className="col-sm-3">MAC Addresses</dt>
+			<dd className="col-sm-9">
+			  { _.map(info.os_info.mac_addresses, (address, idx) => {
+			      return <div>{address}</div>
+			  })}
+			</dd>
                       </dl>
                       <hr />
                       <Card.Header>{T("Client Metadata")}</Card.Header>

--- a/vql/linux/sysinfo.go
+++ b/vql/linux/sysinfo.go
@@ -15,49 +15,40 @@ import (
 	"www.velocidex.com/golang/vfilter"
 )
 
-type LinuxSysinfoPlugin struct{}
+type LinuxSysinfoFunction struct{}
 
-func (self LinuxSysinfoPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.PluginInfo {
-	return &vfilter.PluginInfo{
-		Name:     "linux_sysinfo",
+func (self LinuxSysinfoFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:     "sysinfo",
 		Doc:      "Collect system information on Linux clients",
 		Metadata: vql.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
 	}
 }
 
-func (self LinuxSysinfoPlugin) Call(
-	ctx context.Context, scope vfilter.Scope,
-	args *ordereddict.Dict) <-chan vfilter.Row {
-	output_chan := make(chan vfilter.Row)
+func (self LinuxSysinfoFunction) Call(ctx context.Context, scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
 
-	go func() {
-		defer close(output_chan)
+	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
+	if err != nil {
+		scope.Log("sysinfo: %s", err)
+		return vfilter.Null{}
+	}
 
-		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
-		if err != nil {
-			scope.Log("linux_sysinfo: %s", err)
-			return
-		}
+	in := &syscall.Sysinfo_t{}
+	err = syscall.Sysinfo(in)
+	if err != nil {
+		scope.Log("sysinfo: sysinfo() failed: %s", err)
+		return vfilter.Null{}
+	}
 
-		in := &syscall.Sysinfo_t{}
-		err = syscall.Sysinfo(in)
-		if err != nil {
-			scope.Log("linux_sysinfo: sysinfo() failed: %s", err)
-			return
-		}
-
-		row := ordereddict.NewDict().
-			Set("TotalPhysicalMemory", uint64(in.Totalram)*uint64(in.Unit)).
-			Set("TotalFreeMemory", uint64(in.Freeram)*uint64(in.Unit)).
-			Set("TotalSharedMemory", uint64(in.Sharedram)*uint64(in.Unit)).
-			Set("TotalSwap", uint64(in.Totalswap)*uint64(in.Unit)).
-			Set("FreeSwap", uint64(in.Freeswap)*uint64(in.Unit))
-		output_chan <- row
-	}()
-
-	return output_chan
+	return ordereddict.NewDict().
+		Set("TotalPhysicalMemory", uint64(in.Totalram)*uint64(in.Unit)).
+		Set("TotalFreeMemory", uint64(in.Freeram)*uint64(in.Unit)).
+		Set("TotalSharedMemory", uint64(in.Sharedram)*uint64(in.Unit)).
+		Set("TotalSwap", uint64(in.Totalswap)*uint64(in.Unit)).
+		Set("FreeSwap", uint64(in.Freeswap)*uint64(in.Unit))
 }
 
 func init() {
-	vql_subsystem.RegisterPlugin(&LinuxSysinfoPlugin{})
+	vql_subsystem.RegisterFunction(&LinuxSysinfoFunction{})
 }

--- a/vql/linux/sysinfo.go
+++ b/vql/linux/sysinfo.go
@@ -1,0 +1,63 @@
+//go:build linux
+// +build linux
+
+package linux
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/Velocidex/ordereddict"
+
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/vql"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+)
+
+type LinuxSysinfoPlugin struct{}
+
+func (self LinuxSysinfoPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.PluginInfo {
+	return &vfilter.PluginInfo{
+		Name:     "linux_sysinfo",
+		Doc:      "Collect system information on Linux clients",
+		Metadata: vql.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
+	}
+}
+
+func (self LinuxSysinfoPlugin) Call(
+	ctx context.Context, scope vfilter.Scope,
+	args *ordereddict.Dict) <-chan vfilter.Row {
+	output_chan := make(chan vfilter.Row)
+
+	go func() {
+		defer close(output_chan)
+
+		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
+		if err != nil {
+			scope.Log("linux_sysinfo: %s", err)
+			return
+		}
+
+		in := &syscall.Sysinfo_t{}
+		err = syscall.Sysinfo(in)
+		if err != nil {
+			scope.Log("linux_sysinfo: sysinfo() failed: %s", err)
+			return
+		}
+
+		row := ordereddict.NewDict().
+			Set("TotalPhysicalMemory", uint64(in.Totalram)*uint64(in.Unit)).
+			Set("TotalFreeMemory", uint64(in.Freeram)*uint64(in.Unit)).
+			Set("TotalSharedMemory", uint64(in.Sharedram)*uint64(in.Unit)).
+			Set("TotalSwap", uint64(in.Totalswap)*uint64(in.Unit)).
+			Set("FreeSwap", uint64(in.Freeswap)*uint64(in.Unit))
+		output_chan <- row
+	}()
+
+	return output_chan
+}
+
+func init() {
+	vql_subsystem.RegisterPlugin(&LinuxSysinfoPlugin{})
+}

--- a/vql/networking/network.go
+++ b/vql/networking/network.go
@@ -28,32 +28,107 @@ import (
 	"www.velocidex.com/golang/vfilter"
 )
 
+type InterfacesPlugin struct {
+}
+
+func (self InterfacesPlugin) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.PluginInfo {
+	return &vfilter.PluginInfo{
+		Name: "interfaces",
+		Doc: "List all active interfaces.",
+		Metadata:   vql.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
+	}
+}
+
+func (self InterfacesPlugin) Call(
+	ctx context.Context, scope vfilter.Scope,
+	args *ordereddict.Dict) <-chan vfilter.Row {
+	output_chan := make(chan vfilter.Row)
+
+	go func() {
+		defer close(output_chan)
+
+		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
+		if err != nil {
+			scope.Log("interfaces: %s", err)
+			return
+		}
+
+		interfaces, err := net.Interfaces()
+		if err != nil {
+			scope.Log("interfaces: failed to enumerate interfaces: %s", err)
+			return
+		}
+
+		for _, iface := range interfaces {
+			row := ordereddict.NewDict().
+				Set("Name", iface.Name).
+				Set("HardwareAddr", iface.HardwareAddr).
+				Set("MTU", iface.MTU).
+				Set("Index", iface.Index).
+				Set("Flags", iface.Flags.String())
+
+			// Enumerate some useful flags
+			if (iface.Flags & net.FlagLoopback) == net.FlagLoopback {
+				row.Set("Loopback", "Y")
+			} else {
+				row.Set("Loopback", "N")
+			}
+
+			if (iface.Flags & net.FlagPointToPoint) == net.FlagPointToPoint {
+				row.Set("PointToPoint", "Y")
+			} else {
+				row.Set("PointToPoint", "N")
+			}
+
+			if (iface.Flags & net.FlagUp) == net.FlagUp {
+				row.Set("Up", "Y")
+			} else {
+				row.Set("Up", "N")
+			}
+
+			// Add net.FlagRunning once we require go 1.20
+//			if (iface.Flags & net.FlagRunning) == net.FlagRunning {
+//				row.Set("Running", "Y")
+//			} else {
+//				row.Set("Running", "N")
+//			}
+
+			row.Set("HardwareAddrString", iface.HardwareAddr.String())
+
+			addrs, err := iface.Addrs()
+			if err != nil {
+				scope.Log("interfaces: Failed to get addresses for interface %s: %s",
+					  iface.Name, err)
+				continue
+			}
+			row.Set("Addrs", addrs)
+
+			addrList := []string{}
+			for _, addr := range addrs {
+				addrList = append(addrList, addr.String())
+			}
+			row.Set("AddrsString", addrList)
+
+			addrs, err = iface.MulticastAddrs()
+			if err != nil {
+				scope.Log("interfaces: Failed to get multicast addresses for interface %s: %s",
+					  iface.Name, err)
+			}
+			row.Set("MulticastAddrs", addrs)
+
+			addrList = []string{}
+			for _, addr := range addrs {
+				addrList = append(addrList, addr.String())
+			}
+			row.Set("MulticastAddrsString", addrList)
+
+			output_chan <- row
+		}
+	}()
+
+	return output_chan
+}
+
 func init() {
-	vql_subsystem.RegisterPlugin(
-		&vfilter.GenericListPlugin{
-			PluginName: "interfaces",
-			Metadata:   vql.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
-			Function: func(
-				ctx context.Context,
-				scope vfilter.Scope,
-				args *ordereddict.Dict) []vfilter.Row {
-				var result []vfilter.Row
-
-				err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
-				if err != nil {
-					scope.Log("interfaces: %s", err)
-					return result
-				}
-
-				if interfaces, err := net.Interfaces(); err == nil {
-					for _, item := range interfaces {
-						local_item := item
-						result = append(result, &local_item)
-					}
-				}
-
-				return result
-			},
-			Doc: "List all active interfaces.",
-		})
+	vql_subsystem.RegisterPlugin(&InterfacesPlugin{})
 }


### PR DESCRIPTION
This PR extends the Generic.Client.Info artifact to add network interface information to the output for Linux clients. Then, we can use the mac address information for both Windows and Linux clients in the host info dashboard.