### PR TITLE
Fix device major/minor number calculations

### DIFF
--- a/accessors/file/accessor_common.go
+++ b/accessors/file/accessor_common.go
@@ -128,8 +128,9 @@ func (self *OSFileInfo) Data() *ordereddict.Dict {
 	result := ordereddict.NewDict()
 	sys, ok := self._FileInfo.Sys().(*syscall.Stat_t)
 	if ok {
-		result.Set("DevMajor", (sys.Dev>>8)&0xff).
-			Set("DevMinor", sys.Dev&0xFF)
+		major, minor := splitDevNumber(sys.Dev)
+		result.Set("DevMajor", major).
+			Set("DevMinor", minor)
 	}
 
 	return result

--- a/accessors/file/accessor_darwin.go
+++ b/accessors/file/accessor_darwin.go
@@ -43,3 +43,10 @@ func (self *OSFileInfo) Atime() time.Time {
 	ts := self._Sys().Atimespec
 	return time.Unix(0, ts.Nsec+ts.Sec*1000000000)
 }
+
+func splitDevNumber(dev uint64) (major, minor uint64) {
+	// See xnu/bsd/sys/types.h
+	major = (dev >> 24) & 0xff
+	minor = dev & &0xffffff
+	return
+}

--- a/accessors/file/accessor_freebsd.go
+++ b/accessors/file/accessor_freebsd.go
@@ -43,3 +43,10 @@ func (self *OSFileInfo) Atime() time.Time {
 	ts := int64(self._Sys().Atimespec.Sec)
 	return time.Unix(ts, 0)
 }
+
+func splitDevNumber(dev uint64) (major, minor uint64) {
+	// See freebsd-src/sys/sys/types.h
+	major = ((dev >> 32) & 0xffffff00) | ((dev >> 8) & 0xff)
+	minor = ((dev >> 24) & 0xff00) | (dev & 0xffff00ff)
+	return
+}

--- a/accessors/file/accessor_linux.go
+++ b/accessors/file/accessor_linux.go
@@ -52,3 +52,10 @@ func NewOSFileSystemAccessor() *OSFileSystemAccessor {
 		root: root_path,
 	}
 }
+
+func splitDevNumber(dev uint64) (major, minor uint64) {
+	// See bits/sysmacros.h (glibc) or sys/sysmacros.h (musl-libc)
+	major = ((dev >> 32) & 0xfffff000) | ((dev >> 8) & 0xfff)
+	minor = ((dev >> 12) & 0xffffff00) | (dev & 0xff)
+	return
+}


### PR DESCRIPTION
So far, Velociraptor seemed to assume that Unix device numbers were evenly split 16 bit numbers, this hasn't been true in decades.

This is probably most important on Linux since there are a lot of published artifacts that treat device numbers as magic indicators for real/local filesystems.