### PR TITLE
logscale: fix stats_interval parameter handling

### DIFF
--- a/vql/tools/logscale/plugin.go
+++ b/vql/tools/logscale/plugin.go
@@ -224,7 +224,7 @@ func (self logscalePlugin) Call(ctx context.Context,
 
 		var tickerChan <- chan time.Time
 		if arg.StatsInterval != 0 {
-			ticker := time.NewTicker(time.Duration(arg.StatsInterval))
+			ticker := time.NewTicker(time.Duration(arg.StatsInterval) * time.Second)
 			tickerChan = ticker.C
 			defer ticker.Stop()
 		} else {


### PR DESCRIPTION
stats_interval describes seconds but is not being scaled up to seconds.