### PR TITLE
Fixed IPv6 formatting in Windows.Forensics.UserAccessLogs

### DIFF
--- a/artifacts/definitions/Windows/Forensics/UserAccessLogs.yaml
+++ b/artifacts/definitions/Windows/Forensics/UserAccessLogs.yaml
@@ -21,13 +21,26 @@ reference:
 
 export: |
     LET IPProfile = '''[
-      ["X", 0, [
+      ["IP4", 0, [
         ["A", 0, "uint8"],
         ["B", 1, "uint8"],
         ["C", 2, "uint8"],
         ["D", 3, "uint8"],
         ["IP", 0, "Value", {
            value: "x=> format(format='%d.%d.%d.%d', args=[x.A, x.B, x.C, x.D])"
+        }]
+      ]],
+     ["IP6", 0, [
+        ["A", 0, "uint16be"],
+        ["B", 2, "uint16be"],
+        ["C", 4, "uint16be"],
+        ["D", 6, "uint16be"],
+        ["E", 8, "uint16be"],
+        ["F", 10, "uint16be"],
+        ["G", 12, "uint16be"],
+        ["H", 14, "uint16be"],
+        ["IP", 0, "Value", {
+           value: "x=> format(format='%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x', args=[x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H])"
         }]
       ]]
     ]'''
@@ -37,12 +50,14 @@ export: |
 
          -- IPv4 address should be formatted in dot notation
          then=parse_binary(accessor="data",
-                           filename=Address, struct="X",
+                           filename=Address, struct="IP4",
                            profile=IPProfile).IP,
+
          else=if(condition=len(list=Address)=16,
            -- IPv6 addresses are usually shortened
-           then=regex_replace(source=format(format="%x", args=Address),
-                              re="(00)+", replace=":"),
+           then=parse_binary(accessor="data",
+                           filename=Address, struct="IP6",
+                           profile=IPProfile).IP,
 
            -- We dont know what kind of address it is.
            else=format(format="%x", args=Address)))

--- a/artifacts/testdata/server/testcases/ual.out.yaml
+++ b/artifacts/testdata/server/testcases/ual.out.yaml
@@ -8,7 +8,7 @@ SELECT *, basename(path=_OSPath) AS _OSPath FROM Artifact.Windows.Forensics.User
   "AuthenticatedUserName": "win-e5k9rc5gu23\\administrator",
   "RoleName": "File Server",
   "RawAddress": "00000000000000000000000000000001",
-  "Address": ":01",
+  "Address": "0000:0000:0000:0000:0000:0000:0000:0001",
   "Days": {
    "Day233": 1
   },


### PR DESCRIPTION
Fixes: #2968 