### PR TITLE
Additional parameter for ACE Editor - relativeLineNumber 

### DIFF
--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
@@ -285,6 +285,7 @@ export default class NotebookCellRenderer extends React.Component {
         ace.setOptions({
             autoScrollEditorIntoView: true,
             maxLines: 25,
+            relativeLineNumbers: false,
             placeholder: this.getPlaceholder(),
         });
 


### PR DESCRIPTION
Hello!
By default when you work with Notebooks, numbers of the lines are in `relative` order. 
It looks like this:
<img width="215" alt="rln" src="https://github.com/Velocidex/velociraptor/assets/9745163/53725f67-62ca-4ba6-83c6-8739f821e017">
For a long time I was thinking it is a bug, till I decide to fix it and realized that it is a feature 😄 . 
Once you set `relativeLineNumbers: false,` , numbers are fixed. 
<img width="272" alt="rln_disabled" src="https://github.com/Velocidex/velociraptor/assets/9745163/4a629fa6-81ef-4144-b445-db93ee356be3">
So, maybe I'm not the only one who got confused. 
Normal order especially useful when you get a line number within an error message. 
