### PR TITLE
Add details field to sigma matches

### DIFF
--- a/artifacts/testdata/server/testcases/sigma.out.yaml
+++ b/artifacts/testdata/server/testcases/sigma.out.yaml
@@ -53,6 +53,7 @@ SELECT * FROM Artifact.Windows.Sigma.EventLogs( EventLogDirectory=srcDir + "/art
    "ParentCommandLine": "c:\\Windows\\System32\\cmd.exe"
   },
   "Message": "",
+  "Details": null,
   "_Match": {
    "Match": true,
    "SearchResults": {
@@ -64,11 +65,108 @@ SELECT * FROM Artifact.Windows.Sigma.EventLogs( EventLogDirectory=srcDir + "/art
     true
    ]
   },
-  "_Rule": "Run Whoami as SYSTEM",
-  "_References": [
-   "https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment"
-  ],
-  "Level": "high",
+  "_Rule": {
+   "Title": "Run Whoami as SYSTEM",
+   "Logsource": {
+    "Category": "process_creation",
+    "Product": "windows"
+   },
+   "Detection": {
+    "Searches": {
+     "process_creation": {
+      "EventMatchers": [
+       [
+        {
+         "Field": "EventID",
+         "Values": [
+          1
+         ]
+        },
+        {
+         "Field": "Channel",
+         "Values": [
+          "Microsoft-Windows-Sysmon/Operational"
+         ]
+        }
+       ]
+      ]
+     },
+     "selection_img": {
+      "EventMatchers": [
+       [
+        {
+         "Field": "OriginalFileName",
+         "Values": [
+          "whoami.exe"
+         ]
+        }
+       ],
+       [
+        {
+         "Field": "Image",
+         "Modifiers": [
+          "endswith"
+         ],
+         "Values": [
+          "\\whoami.exe"
+         ]
+        }
+       ]
+      ]
+     },
+     "selection_user": {
+      "EventMatchers": [
+       [
+        {
+         "Field": "User",
+         "Modifiers": [
+          "contains"
+         ],
+         "Values": [
+          "AUTHORI",
+          "AUTORI"
+         ]
+        }
+       ]
+      ]
+     }
+    },
+    "condition": [
+     {
+      "Search": [
+       {
+        "Name": "process_creation"
+       },
+       {
+        "Pattern": "selection*"
+       }
+      ]
+     }
+    ]
+   },
+   "ID": "80167ada-7a12-41ed-b8e9-aa47195c66a1",
+   "Status": "deprecated",
+   "Description": "Detects a whoami.exe executed by LOCAL SYSTEM. This may be a sign of a successful local privilege escalation.",
+   "Author": "Teymur Kheirkhabarov, Florian Roth",
+   "Level": "high",
+   "References": [
+    "https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment"
+   ],
+   "Tags": [
+    "attack.privilege_escalation",
+    "attack.discovery",
+    "attack.t1033",
+    "sysmon"
+   ],
+   "AdditionalFields": {
+    "date": "2019/10/23",
+    "falsepositives": [
+     "Possible name overlap with NT AUHTORITY substring to cover all languages"
+    ],
+    "modified": "2023/02/28",
+    "ruletype": "Sigma"
+   }
+  },
   "_Source": "Windows.Sigma.EventLogs"
  }
 ]

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,6 @@ require (
 // replace github.com/Velocidex/ttlcache/v2 => /home/mic/projects/ttlcache
 // replace github.com/Velocidex/zip => /home/mic/projects/zip
 // replace github.com/Velocidex/sflags => /home/mic/projects/sflags
-
 // replace github.com/Velocidex/etw => /home/mic/projects/etw
 // replace github.com/Velocidex/grpc-go-pool => /home/mic/projects/grpc-go-pool
 // replace www.velocidex.com/golang/oleparse => /home/matt/git/oleparse
@@ -252,3 +251,5 @@ go 1.18
 replace github.com/alecthomas/chroma => github.com/Velocidex/chroma v0.6.8-0.20200418131129-82edc291369c
 
 replace github.com/go-errors/errors => github.com/Velocidex/errors v0.0.0-20221019164655-9ace6bf61e26
+
+replace github.com/bradleyjkemp/sigma-go => github.com/Velocidex/sigma-go v0.0.0-20231015053605-117f1827960e

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a h1:H7dVazNcaE80V8c
 github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a/go.mod h1:/fy/Eg4TQz9KkJduvZfGCnbWTQ/LKaknS2wYB52cU6c=
 github.com/Velocidex/sflags v0.3.1-0.20231011011525-620ab7ca8617 h1:pxAOaYTYwbWhoSwRoJOT3TJmUAjD2D011A1c8M2yyEE=
 github.com/Velocidex/sflags v0.3.1-0.20231011011525-620ab7ca8617/go.mod h1:TTYBEgQFkjJvyBOC2s7G1+mNPZ3IHuqLZmVFRzyPfq4=
+github.com/Velocidex/sigma-go v0.0.0-20231015053605-117f1827960e h1:OyrCQ2wjJ0Y/pgClrOE+oIYlJCnzQyR0uz5bbwcdO3U=
+github.com/Velocidex/sigma-go v0.0.0-20231015053605-117f1827960e/go.mod h1:fHCN8y8cC1l5CYY7oOhPIznHmj/yeGxUvU+vAV7alr4=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20230724083715-1eb048b1f6d6 h1:3HSrLwAt64gM7FNTPRXYMszpS5bRijQ6xaPVq2vsbuI=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20230724083715-1eb048b1f6d6/go.mod h1:3/pI9BBAF7gydBWvMVtV7W1qRwshEG9lBwed/d8xfFg=
 github.com/Velocidex/yaml/v2 v2.2.5/go.mod h1:VBjrsTMc/b1h0ankOOnJPYoCbJNwhpGYpnDgICEs2mk=
@@ -199,8 +201,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
-github.com/bradleyjkemp/sigma-go v0.6.4 h1:J6Sqwbgv7wsEuP7xbsG8dvTrTc9lhkf5BvYF+gO9vzc=
-github.com/bradleyjkemp/sigma-go v0.6.4/go.mod h1:fHCN8y8cC1l5CYY7oOhPIznHmj/yeGxUvU+vAV7alr4=
 github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=
 github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/vql/sigma/details.go
+++ b/vql/sigma/details.go
@@ -1,0 +1,58 @@
+package sigma
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vql/sigma/evaluator"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+var (
+	expandRegEx = regexp.MustCompile("%[A-Za-z]+%")
+)
+
+func (self *SigmaContext) AddDetail(
+	ctx context.Context,
+	scope vfilter.Scope,
+	row *evaluator.Event,
+	rule *evaluator.VQLRuleEvaluator) *ordereddict.Dict {
+
+	details, pres := rule.AdditionalFields["details"]
+	if !pres {
+		// Try to get the default details using the details lambda.
+		if self.default_details != nil {
+			details = self.default_details.Reduce(ctx, scope, []types.Any{row.Dict})
+		}
+
+		if utils.IsNil(details) {
+			details = &vfilter.Null{}
+		}
+	}
+
+	details_str, ok := details.(string)
+	if ok {
+		details = expandRegEx.ReplaceAllStringFunc(details_str, func(in string) string {
+			if len(in) <= 2 {
+				return in
+			}
+			in = in[1 : len(in)-1]
+
+			resolved, err := rule.GetFieldValuesFromEvent(ctx, scope, in, row)
+			if err != nil || len(resolved) == 0 {
+				return in
+			}
+
+			res, ok := resolved[0].(string)
+			if ok {
+				return res
+			}
+			return in
+		})
+	}
+
+	return row.Copy().Set("Details", details)
+}

--- a/vql/sigma/fixtures/TestSigma.golden
+++ b/vql/sigma/fixtures/TestSigma.golden
@@ -3,6 +3,7 @@
   {
    "Foo": "Bar",
    "Baz": "Hello",
+   "Details": null,
    "_Match": {
     "Match": true,
     "SearchResults": {
@@ -12,15 +13,138 @@
      true
     ]
    },
-   "_Rule": "SingleField",
-   "_References": null,
-   "Level": ""
+   "_Rule": {
+    "Title": "SingleField",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Values": [
+           "Bar"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ],
+ "Rule With Details": [
+  {
+   "Foo": "Bar",
+   "Baz": "Hello",
+   "Details": "This is column Foo=Bar",
+   "_Match": {
+    "Match": true,
+    "SearchResults": {
+     "selection": true
+    },
+    "ConditionResults": [
+     true
+    ]
+   },
+   "_Rule": {
+    "Title": "RuleWithDetails",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Values": [
+           "Bar"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    },
+    "AdditionalFields": {
+     "details": "This is column Foo=%Foo%"
+    }
+   }
+  }
+ ],
+ "Default Details in callback": [
+  {
+   "Foo": "Bar",
+   "Baz": "Hello",
+   "Details": "I'm a scope var:Default Detail Foo=Bar",
+   "_Match": {
+    "Match": true,
+    "SearchResults": {
+     "selection": true
+    },
+    "ConditionResults": [
+     true
+    ]
+   },
+   "_Rule": {
+    "Title": "RuleWithDetails",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Values": [
+           "Bar"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    }
+   }
   }
  ],
  "Match field with regex": [
   {
    "Foo": "Bar",
    "Baz": "Hello",
+   "Details": null,
    "_Match": {
     "Match": true,
     "SearchResults": {
@@ -30,15 +154,46 @@
      true
     ]
    },
-   "_Rule": "RegexField",
-   "_References": null,
-   "Level": ""
+   "_Rule": {
+    "Title": "RegexField",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Modifiers": [
+           "re"
+          ],
+          "Values": [
+           "b.r"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    }
+   }
   }
  ],
  "Match field with logical operators": [
   {
    "Foo": "Bar",
    "Baz": "Hello",
+   "Details": null,
    "_Match": {
     "Match": true,
     "SearchResults": {
@@ -49,15 +204,66 @@
      true
     ]
    },
-   "_Rule": "AndRule",
-   "_References": null,
-   "Level": ""
+   "_Rule": {
+    "Title": "AndRule",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Modifiers": [
+           "re"
+          ],
+          "Values": [
+           "b.r"
+          ]
+         }
+        ]
+       ]
+      },
+      "selection2": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Baz",
+          "Modifiers": [
+           "re"
+          ],
+          "Values": [
+           "h.+lo"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": [
+        {
+         "Name": "selection"
+        },
+        {
+         "Name": "selection2"
+        }
+       ]
+      }
+     ]
+    }
+   }
   }
  ],
  "Match field with logical or operator": [
   {
    "Foo": "Bar",
    "Baz": "Hello",
+   "Details": null,
    "_Match": {
     "Match": true,
     "SearchResults": {
@@ -68,9 +274,59 @@
      true
     ]
    },
-   "_Rule": "OrRule",
-   "_References": null,
-   "Level": ""
+   "_Rule": {
+    "Title": "OrRule",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Modifiers": [
+           "re"
+          ],
+          "Values": [
+           "b.r"
+          ]
+         }
+        ]
+       ]
+      },
+      "selection2": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Baz",
+          "Modifiers": [
+           "re"
+          ],
+          "Values": [
+           "something"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": [
+        {
+         "Name": "selection"
+        },
+        {
+         "Name": "selection2"
+        }
+       ]
+      }
+     ]
+    }
+   }
   }
  ],
  "Match simple logsource": [
@@ -78,6 +334,7 @@
    "System": {
     "EventID": 2
    },
+   "Details": null,
    "_Match": {
     "Match": true,
     "SearchResults": {
@@ -87,9 +344,36 @@
      true
     ]
    },
-   "_Rule": "NoopRule",
-   "_References": null,
-   "Level": ""
+   "_Rule": {
+    "Title": "NoopRule",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "EID",
+          "Values": [
+           2
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    }
+   }
   }
  ]
 }

--- a/vql/sigma/pool.go
+++ b/vql/sigma/pool.go
@@ -40,11 +40,10 @@ func (self *workerJob) Run() {
 
 		// Make a copy here because another thread might match at the same
 		// time.
-		event_copy := self.event.Copy()
+		event_copy := self.sigma_context.AddDetail(
+			self.ctx, self.scope, self.event, rule)
 		event_copy.Set("_Match", match).
-			Set("_Rule", rule.Title).
-			Set("_References", rule.References).
-			Set("Level", rule.Level)
+			Set("_Rule", rule)
 
 		select {
 		case <-self.ctx.Done():

--- a/vql/sigma/runner.go
+++ b/vql/sigma/runner.go
@@ -38,6 +38,8 @@ type SigmaContext struct {
 
 	output_chan chan types.Row
 	wg          sync.WaitGroup
+
+	default_details *vfilter.Lambda
 }
 
 func (self *SigmaContext) IncHitCount() {
@@ -98,6 +100,7 @@ func NewSigmaContext(
 	rules []sigma.Rule,
 	fieldmappings *ordereddict.Dict,
 	log_sources *LogSourceProvider,
+	default_details *vfilter.Lambda,
 	debug bool) (*SigmaContext, error) {
 
 	// Compile the field mappings.  NOTE: The compiled_fieldmappings
@@ -151,11 +154,12 @@ func NewSigmaContext(
 
 	output_chan := make(chan vfilter.Row)
 	result := &SigmaContext{
-		output_chan:   output_chan,
-		runners:       runners,
-		fieldmappings: compiled_fieldmappings,
-		total_rules:   total_rules,
-		debug:         debug,
+		output_chan:     output_chan,
+		runners:         runners,
+		fieldmappings:   compiled_fieldmappings,
+		total_rules:     total_rules,
+		default_details: default_details,
+		debug:           debug,
 	}
 	result.pool = NewWorkerPool(ctx, &result.wg, result, output_chan)
 	return result, nil

--- a/vql/sigma/sigma.go
+++ b/vql/sigma/sigma.go
@@ -17,11 +17,12 @@ import (
 /* This provides support for direct evaluation of sigma rules. */
 
 type SigmaPluginArgs struct {
-	Rules         []string          `vfilter:"required,field=rules,doc=A list of sigma rules to compile."`
-	LogSources    vfilter.Any       `vfilter:"required,field=log_sources,doc=A log source object as obtained from the sigma_log_sources() VQL function."`
-	FieldMappings *ordereddict.Dict `vfilter:"optional,field=field_mapping,doc=A dict containing a mapping between a rule field name and a VQL Lambda to get the value of the field from the event."`
-	Debug         bool              `vfilter:"optional,field=debug,doc=If enabled we emit all match objects with description of what would match."`
-	RuleFilter    *vfilter.Lambda   `vfilter:"optional,field=rule_filter,doc=If specified we use this callback to filter the rules for inclusion."`
+	Rules          []string          `vfilter:"required,field=rules,doc=A list of sigma rules to compile."`
+	LogSources     vfilter.Any       `vfilter:"required,field=log_sources,doc=A log source object as obtained from the sigma_log_sources() VQL function."`
+	FieldMappings  *ordereddict.Dict `vfilter:"optional,field=field_mapping,doc=A dict containing a mapping between a rule field name and a VQL Lambda to get the value of the field from the event."`
+	Debug          bool              `vfilter:"optional,field=debug,doc=If enabled we emit all match objects with description of what would match."`
+	RuleFilter     *vfilter.Lambda   `vfilter:"optional,field=rule_filter,doc=If specified we use this callback to filter the rules for inclusion."`
+	DefaultDetails *vfilter.Lambda   `vfilter:"optional,field=default_details,doc=If specified we use this callback to determine a details column if the sigma rule does not specify it."`
 }
 
 type SigmaPlugin struct{}
@@ -72,8 +73,9 @@ func (self SigmaPlugin) Call(
 		// will be evaluated - i.e. only those that have some rules
 		// watching them.
 		sigma_context, err := NewSigmaContext(
-			ctx, scope, rules, arg.FieldMappings, log_sources,
-			arg.Debug)
+			ctx, scope, rules,
+			arg.FieldMappings, log_sources,
+			arg.DefaultDetails, arg.Debug)
 		if err != nil {
 			scope.Log("sigma: %v", err)
 			return


### PR DESCRIPTION
This allows rule or external code to facilitate a more user friendly description of why the event matched.