### PR TITLE
Update NTFS.yaml

### DIFF
--- a/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
+++ b/artifacts/definitions/Windows/Detection/Yara/NTFS.yaml
@@ -35,7 +35,7 @@ parameters:
     default: ^kernel32\.dll$
   - name: PathRegex
     description: Only paths that match this regular expression will be scanned.
-    default: ^C:\\Windows\\System32\\
+    default: C:\\Windows\\System32\\
   - name: DriveLetter
     description: "Target drive. Default is a C:"
     default: "C:"


### PR DESCRIPTION
removing hardcoded ^ as running outside of test may not return results when OSPath = `\\.\C:\Windows\System32\termsrv.dll`