### PR TITLE
Added a Copy Cell button to notebooks

### DIFF
--- a/artifacts/definitions/Generic/Client/DiskUsage.yaml
+++ b/artifacts/definitions/Generic/Client/DiskUsage.yaml
@@ -1,0 +1,57 @@
+name: Generic.Client.DiskUsage
+description: |
+  This artifact reports the amount of space used by each directory
+  recursively (Similar to the `du` command).
+
+  Unlike the `du` command, this artifact can filter only certain file
+  name patterns.
+
+  If you change the `TopLevelDirectory` to the drive letter
+  (e.g. `C:\\`) it may take a while to complete as it will need to
+  examine every file on the drive.
+
+parameters:
+  - name: TopLevelDirectory
+    default: C:/Program Files
+    description: The top level directory to start calculating disk usage.
+
+  - name: FilenameGlob
+    default: '*'
+    description: A Glob expression for considering files
+
+  - name: DirectoryGlob
+    default: '*'
+    description: A Glob expression for considering directories to recurse into.
+
+sources:
+  - query: |
+      LET Res <= dict()
+
+      LET _DirInfo(DirPath) = SELECT DirPath, Size, sum(item=Size) AS TotalSize
+      FROM chain(a={
+        SELECT Size FROM glob(globs=FilenameGlob, root=DirPath)
+        WHERE NOT IsDir
+      }, b={
+        SELECT * FROM foreach(row={
+          SELECT OSPath FROM glob(globs=DirectoryGlob, root=DirPath)
+          WHERE IsDir
+        },
+        query={
+           SELECT TotalSize AS Size FROM DirInfo(DirPath=OSPath)
+        })
+      })
+      GROUP BY 1 -- Needed for sum()
+
+      LET DirInfo(DirPath) = SELECT * FROM _DirInfo(DirPath=DirPath)
+      WHERE set(item=Res, field=DirPath,
+                value=dict(DirPath=DirPath, TotalSize=TotalSize))
+
+      -- Recurse into the TopLevelDirectory and rely on the set()
+      -- above to store the results.
+      LET _ <= SELECT * FROM DirInfo(DirPath=TopLevelDirectory)
+
+      SELECT *, humanize(bytes=TotalSize) AS TotalSizeHuman
+      FROM foreach(row={
+        SELECT * FROM items(item=Res)
+      }, column="_value")
+      ORDER BY TotalSize DESC

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
@@ -25,6 +25,7 @@ import VeloTimestamp from "../utils/time.jsx";
 import { AddTimelineDialog, AddVQLCellToTimeline } from "./timelines.jsx";
 import T from '../i8n/i8n.jsx';
 import ViewCellLogs from "./logs.jsx";
+import CopyCellToNotebookDialog from './notebook-copy-cell.jsx';
 
 import {CancelToken} from 'axios';
 import api from '../core/api-service.jsx';
@@ -169,7 +170,7 @@ export default class NotebookCellRenderer extends React.Component {
         showAddCellFromHunt: false,
         showAddCellFromFlow: false,
         showCreateArtifactFromCell: false,
-
+        showCopyCellToNotebook: false,
         showSuggestionSubmenu: false,
         showMoreLogs: false,
 
@@ -598,6 +599,14 @@ export default class NotebookCellRenderer extends React.Component {
                  <FontAwesomeIcon icon="calendar-alt"/>
                </Button>}
 
+               <Button data-tooltip={T("Copy Cell")}
+                       data-position="right"
+                       className="btn-tooltip"
+                       onClick={()=>this.setState({showCopyCellToNotebook: true})}
+                       variant="default">
+                 <FontAwesomeIcon icon="file-import"/>
+               </Button>
+
               <Dropdown data-tooltip={T("Add Cell")}
                         data-position="right"
                         className="btn-tooltip"
@@ -786,7 +795,15 @@ export default class NotebookCellRenderer extends React.Component {
                   closeDialog={()=>this.setState({showMoreLogs: false})}
                 />
               }
+              { this.state.showCopyCellToNotebook &&
+                <CopyCellToNotebookDialog
+                  cell={this.state.cell}
+                  notebook_metadata={this.props.notebook_metadata}
+                  closeDialog={()=>this.setState({showCopyCellToNotebook: false})}
+                  >
 
+                </CopyCellToNotebookDialog>
+              }
               <div className={classNames({selected: selected, "notebook-cell": true})} >
                 <div className='notebook-input'>
                   { this.state.currently_editing && selected &&

--- a/gui/velociraptor/src/components/notebooks/notebook-copy-cell.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-copy-cell.jsx
@@ -1,0 +1,127 @@
+import _ from 'lodash';
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import Modal from 'react-bootstrap/Modal';
+import T from '../i8n/i8n.jsx';
+import Button from 'react-bootstrap/Button';
+import Spinner from '../utils/spinner.jsx';
+import NotebooksList from './notebooks-list.jsx';
+
+import api from '../core/api-service.jsx';
+import {CancelToken} from 'axios';
+
+const PAGE_SIZE = 100;
+
+
+export default class CopyCellToNotebookDialog extends Component {
+    static propTypes = {
+        closeDialog: PropTypes.func.isRequired,
+        cell: PropTypes.object,
+        notebook_metadata: PropTypes.object,
+    }
+
+    state = {
+        notebooks: [],
+        notebook_id: null,
+    }
+
+    componentDidMount = () => {
+        this.source = CancelToken.source();
+        this.fetchNotebooks();
+    }
+
+    copyCell = ()=>{
+        if(!this.props.notebook_metadata || !this.state.selected_notebook) {
+            return;
+        }
+
+        let env = this.props.cell.env || [];
+        env = _.uniqBy(env.concat(this.props.notebook_metadata.env || []),
+                     x=>x.key);
+
+        let new_cell = {
+            notebook_id: this.state.selected_notebook.notebook_id,
+            type: this.props.cell.type,
+            input: this.props.cell.input,
+            env: env,
+        };
+
+        // Add env variables as explicit VQL to make it clearer this
+        // cell came from an external notebook.
+        if (this.props.cell.type === "vql") {
+            _.each(env, x=>{
+                switch(x.key) {
+                    case "ArtifactName":
+                    case "FlowId":
+                    case "ClientId":
+                    case "HuntId":
+                    new_cell.input = `LET ${x.key} <= '''${x.value}''' \n` + new_cell.input;
+                }
+            });
+        }
+
+        this.setState({loading: true});
+        api.post('v1/NewNotebookCell',
+                 new_cell,
+                 this.source.token).then((response) => {
+                     if (response.cancel) return;
+                     this.setState({loading: false});
+                     this.props.closeDialog();
+                 });
+    }
+
+    fetchNotebooks = () => {
+        // Cancel any in flight calls.
+        this.source.cancel();
+        this.source = CancelToken.source();
+
+        api.get("v1/GetNotebooks", {
+            count: PAGE_SIZE,
+            offset: 0,
+        }, this.source.token).then(response=>{
+            if (response.cancel) return;
+
+            let notebooks = response.data.items || [];
+            this.setState({notebooks: notebooks,
+                           loading: false});
+        });
+    }
+
+    render() {
+        return (
+            <Modal show={true}
+                   size="lg"
+                   className="full-height"
+                   dialogClassName="modal-90w"
+                   onHide={this.props.closeDialog} >
+              <Modal.Header closeButton>
+                <Modal.Title>{T("Copy Cell To Global Notebook")}</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <h3>{T("Select a notebook to append this cell to ...")}</h3>
+              <Spinner loading={this.state.loading} />
+                <NotebooksList
+                  fetchNotebooks={this.fetchNotebooks}
+                  selected_notebook={this.state.selected_notebook}
+                  setSelectedNotebook={x=>this.setState({selected_notebook:x})}
+                  notebooks={this.state.notebooks}
+                  hideToolbar={true}
+                />
+              </Modal.Body>
+              <Modal.Footer>
+                <Button variant="secondary"
+                        onClick={this.props.closeDialog}>
+                  {T("Cancel")}
+                </Button>
+                <Button variant="primary"
+                        disabled={!this.state.selected_notebook}
+                        onClick={() => this.copyCell(this.state.notebook_id)}>
+                  {T("Submit")}
+                </Button>
+              </Modal.Footer>
+            </Modal>
+        );
+    }
+}

--- a/gui/velociraptor/src/components/notebooks/notebooks-list.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebooks-list.jsx
@@ -217,6 +217,7 @@ class NotebooksList extends React.Component {
         selected_notebook: PropTypes.object,
         setSelectedNotebook: PropTypes.func.isRequired,
         fetchNotebooks: PropTypes.func.isRequired,
+        hideToolbar: PropTypes.bool,
 
         // React router props.
         history: PropTypes.object,
@@ -321,70 +322,74 @@ class NotebooksList extends React.Component {
                 />
               }
 
-              <Navbar className="toolbar">
-                <ButtonGroup>
-                  <Button data-tooltip="Full Screen"
-                          data-position="right"
-                          className="btn-tooltip"
-                          disabled={!this.props.selected_notebook ||
-                                    !this.props.selected_notebook.notebook_id}
-                          onClick={this.setFullScreen}
-                          variant="default">
-                    <FontAwesomeIcon icon="expand"/>
-                    <span className="sr-only">{T("Full Screen")}</span>
-                  </Button>
+              { !this.props.hideToolbar &&
+                <Navbar className="toolbar">
+                  <ButtonGroup>
+                    <Button data-tooltip="Full Screen"
+                            data-position="right"
+                            className="btn-tooltip"
+                            disabled={!this.props.selected_notebook ||
+                                      !this.props.selected_notebook.notebook_id}
+                            onClick={this.setFullScreen}
+                            variant="default">
+                      <FontAwesomeIcon icon="expand"/>
+                      <span className="sr-only">{T("Full Screen")}</span>
+                    </Button>
 
-                  <Button data-tooltip="NewNotebook"
-                          data-position="right"
-                          className="btn-tooltip"
-                          onClick={()=>this.setState({showNewNotebookDialog: true})}
-                          variant="default">
-                    <FontAwesomeIcon icon="plus"/>
-                    <span className="sr-only">{T("New Notebook")}</span>
-                  </Button>
+                    <Button data-tooltip="NewNotebook"
+                            data-position="right"
+                            className="btn-tooltip"
+                            onClick={()=>this.setState({showNewNotebookDialog: true})}
+                            variant="default">
+                      <FontAwesomeIcon icon="plus"/>
+                      <span className="sr-only">{T("New Notebook")}</span>
+                    </Button>
 
-                  <Button data-tooltip="Delete Notebook"
-                          data-position="right"
-                          className="btn-tooltip"
-                          disabled={_.isEmpty(this.props.selected_notebook)}
-                          onClick={()=>this.setState({showDeleteNotebookDialog: true})}
-                          variant="default">
-                    <FontAwesomeIcon icon="trash"/>
-                    <span className="sr-only">{T("Delete Notebook")}</span>
-                  </Button>
+                    <Button data-tooltip="Delete Notebook"
+                            data-position="right"
+                            className="btn-tooltip"
+                            disabled={_.isEmpty(this.props.selected_notebook)}
+                            onClick={()=>this.setState({showDeleteNotebookDialog: true})}
+                            variant="default">
+                      <FontAwesomeIcon icon="trash"/>
+                      <span className="sr-only">{T("Delete Notebook")}</span>
+                    </Button>
 
-                  <Button data-tooltip="Edit Notebook"
-                          data-position="right"
-                          className="btn-tooltip"
-                          disabled={_.isEmpty(this.props.selected_notebook)}
-                          onClick={()=>this.setState({showEditNotebookDialog: true})}
-                          variant="default">
-                    <FontAwesomeIcon icon="wrench"/>
-                    <span className="sr-only">{T("Edit Notebook")}</span>
-                  </Button>
-                  <Button data-tooltip="NotebookUploads"
-                          data-position="right"
-                          className="btn-tooltip"
-                          disabled={_.isEmpty(this.props.selected_notebook)}
-                          onClick={()=>this.setState({showNotebookUploadsDialog: true})}
-                          variant="default">
-                    <FontAwesomeIcon icon="fa-file-download"/>
-                    <span className="sr-only">{T("Notebook Uploads")}</span>
-                  </Button>
-                  <Button data-tooltip="ExportNotebook"
-                          data-position="right"
-                          className="btn-tooltip"
-                          disabled={_.isEmpty(this.props.selected_notebook)}
-                          onClick={()=>this.setState({showExportNotebookDialog: true})}
-                          variant="default">
-                    <FontAwesomeIcon icon="download"/>
-                    <span className="sr-only">{T("Export Notebook")}</span>
-                  </Button>
-                </ButtonGroup>
-              </Navbar>
+                    <Button data-tooltip="Edit Notebook"
+                            data-position="right"
+                            className="btn-tooltip"
+                            disabled={_.isEmpty(this.props.selected_notebook)}
+                            onClick={()=>this.setState({showEditNotebookDialog: true})}
+                            variant="default">
+                      <FontAwesomeIcon icon="wrench"/>
+                      <span className="sr-only">{T("Edit Notebook")}</span>
+                    </Button>
+                    <Button data-tooltip="NotebookUploads"
+                            data-position="right"
+                            className="btn-tooltip"
+                            disabled={_.isEmpty(this.props.selected_notebook)}
+                            onClick={()=>this.setState({showNotebookUploadsDialog: true})}
+                            variant="default">
+                      <FontAwesomeIcon icon="fa-file-download"/>
+                      <span className="sr-only">{T("Notebook Uploads")}</span>
+                    </Button>
+                    <Button data-tooltip="ExportNotebook"
+                            data-position="right"
+                            className="btn-tooltip"
+                            disabled={_.isEmpty(this.props.selected_notebook)}
+                            onClick={()=>this.setState({showExportNotebookDialog: true})}
+                            variant="default">
+                      <FontAwesomeIcon icon="download"/>
+                      <span className="sr-only">{T("Export Notebook")}</span>
+                    </Button>
+                  </ButtonGroup>
+                </Navbar>
+              }
               <div className="fill-parent no-margins toolbar-margin selectable">
                 {_.isEmpty(this.props.notebooks) ?
-                 <div className="no-content">No notebooks available - create one first</div> :
+                 <div className="no-content">
+                   {T("No notebooks available - create one first")}
+                 </div> :
                  <BootstrapTable
                    hover
                    condensed


### PR DESCRIPTION
This allows notebook cells to be copied to the main notebooks from any flow or hunt notebook. This allows the main notebooks to be used as a central document collecting the results of specific analysis from various flows/hunts.