### PR TITLE
frontend: Detect, log duplicate minion names

### DIFF
--- a/services/frontend/frontend.go
+++ b/services/frontend/frontend.go
@@ -200,6 +200,12 @@ func (self *MasterFrontendManager) processMetrics(ctx context.Context,
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	if _, ok := self.stats[metric.NodeName]; ok {
+		logger := logging.GetLogger(self.config_obj,
+			&logging.FrontendComponent)
+		logger.Error("Multipe frontend metric sets for '%s' received. Check minion configurations for duplicate names.",
+			metric.NodeName)
+	}
 	self.stats[metric.NodeName] = metric
 
 	return nil
@@ -262,6 +268,9 @@ func (self *MasterFrontendManager) prepareOrgStats() (
 			Set("MemoryUse", total_ProcessResidentMemoryBytes).
 			Set("client_comms_current_connections", total)
 	}
+
+	// Reset
+	self.stats = make(map[string]*FrontendMetrics)
 
 	return result, nil
 }


### PR DESCRIPTION
If two or more minions reported metrics using the same name, they would just overwrite each other, leading to only the last set of metrics in each 10s interval to be reported via the Prometheus interface.