### PR TITLE
Added GUI dialog for exporting parts of the VFS

### DIFF
--- a/accessors/vfs/fixtures/TestVFSAccessor.golden
+++ b/accessors/vfs/fixtures/TestVFSAccessor.golden
@@ -1,0 +1,14 @@
+{
+ "DirectoryListings": [
+  "/vfs_test/C:",
+  "/vfs_test/C:/Windows",
+  "/vfs_test/C:/Windows/File1.txt",
+  "/vfs_test/C:/Windows/System32",
+  "/vfs_test/C:/Windows/System32/File.txt",
+  "/vfs_test/D:"
+ ],
+ "FileContents": {
+  "/vfs_test/C:/Windows/File1.txt": "File in Windows",
+  "/vfs_test/C:/Windows/System32/File.txt": "File in System32"
+ }
+}

--- a/accessors/vfs/vfs.go
+++ b/accessors/vfs/vfs.go
@@ -1,0 +1,243 @@
+package vfs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+	"www.velocidex.com/golang/velociraptor/services"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+)
+
+var (
+	ErrNotFound     = errors.New("file not found")
+	ErrNotAvailable = errors.New("File content not available")
+)
+
+type VFSFileSystemAccessor struct {
+	ctx                 context.Context
+	client_id           string
+	config_obj          *config_proto.Config
+	file_store_accessor accessors.FileSystemAccessor
+}
+
+func (self VFSFileSystemAccessor) New(
+	scope vfilter.Scope) (accessors.FileSystemAccessor, error) {
+
+	config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		return nil, errors.New("vfs accessor: can only run on the server")
+	}
+
+	client_id, pres := scope.Resolve("ClientId")
+	if !pres {
+		return nil, errors.New("vfs accessor: ClientId does not exist in the scope")
+	}
+
+	client_id_str, ok := client_id.(string)
+	if !ok {
+		return nil, errors.New("vfs accessor: ClientId does not exist in the scope")
+	}
+
+	accessor, err := accessors.GetAccessor("fs", scope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = vql_subsystem.GetRootScope(scope).AddDestructor(cancel)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VFSFileSystemAccessor{
+		ctx:                 ctx,
+		client_id:           client_id_str,
+		file_store_accessor: accessor,
+		config_obj:          config_obj,
+	}, nil
+}
+
+func (self VFSFileSystemAccessor) Lstat(filename string) (
+	accessors.FileInfo, error) {
+	full_path, err := self.ParsePath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return self.LstatWithOSPath(full_path)
+}
+
+func (self VFSFileSystemAccessor) LstatWithOSPath(filename *accessors.OSPath) (
+	accessors.FileInfo, error) {
+	vfs_service, err := services.GetVFSService(self.config_obj)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := vfs_service.ListDirectoryFiles(self.ctx,
+		self.config_obj, &api_proto.GetTableRequest{
+			Rows:          1000,
+			ClientId:      self.client_id,
+			VfsComponents: filename.Dirname().Components,
+		})
+	if err != nil {
+		return nil, err
+	}
+	// Find the row that matches this filename
+	for _, r := range res.Rows {
+		if len(r.Cell) < 12 {
+			continue
+		}
+
+		if r.Cell[5] == filename.Basename() {
+			return rowCellToFSInfo(r.Cell)
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+func (self VFSFileSystemAccessor) ParsePath(path string) (
+	*accessors.OSPath, error) {
+	return accessors.NewGenericOSPath(path)
+}
+
+func (self VFSFileSystemAccessor) ReadDir(filename string) (
+	[]accessors.FileInfo, error) {
+	full_path, err := self.ParsePath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return self.ReadDirWithOSPath(full_path)
+}
+
+func (self VFSFileSystemAccessor) ReadDirWithOSPath(
+	filename *accessors.OSPath) (
+	[]accessors.FileInfo, error) {
+
+	vfs_service, err := services.GetVFSService(self.config_obj)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := vfs_service.ListDirectoryFiles(self.ctx,
+		self.config_obj, &api_proto.GetTableRequest{
+			Rows:          1000,
+			ClientId:      self.client_id,
+			VfsComponents: filename.Components,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	result := []accessors.FileInfo{}
+	for _, r := range res.Rows {
+		if len(r.Cell) < 12 {
+			continue
+		}
+
+		fs_info, err := rowCellToFSInfo(r.Cell)
+		if err != nil {
+			continue
+		}
+		result = append(result, fs_info)
+	}
+
+	return result, nil
+}
+
+func (self VFSFileSystemAccessor) Open(filename string) (
+	accessors.ReadSeekCloser, error) {
+	full_path, err := self.ParsePath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return self.OpenWithOSPath(full_path)
+}
+
+func (self VFSFileSystemAccessor) OpenWithOSPath(filename *accessors.OSPath) (
+	accessors.ReadSeekCloser, error) {
+
+	vfs_service, err := services.GetVFSService(self.config_obj)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := vfs_service.ListDirectoryFiles(self.ctx,
+		self.config_obj, &api_proto.GetTableRequest{
+			Rows:          1000,
+			ClientId:      self.client_id,
+			VfsComponents: filename.Dirname().Components,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the row that matches this filename
+	for _, r := range res.Rows {
+		if len(r.Cell) < 12 {
+			continue
+		}
+
+		if r.Cell[5] == filename.Basename() {
+			// Check if it has a download link
+			record := &flows_proto.VFSDownloadInfo{}
+			err = json.Unmarshal([]byte(r.Cell[0]), record)
+			if err != nil || record.Name == "" {
+				return nil, ErrNotAvailable
+			}
+
+			return self.file_store_accessor.OpenWithOSPath(
+				accessors.MustNewFileStorePath("").Append(record.Components...))
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+func rowCellToFSInfo(cell []string) (accessors.FileInfo, error) {
+	components := []string{}
+	err := json.Unmarshal([]byte(cell[2]), &components)
+	if err != nil {
+		return nil, err
+	}
+
+	size := int64(0)
+	_ = json.Unmarshal([]byte(cell[6]), &size)
+
+	is_dir := false
+	if len(cell[7]) > 1 && cell[7][0] == 'd' {
+		is_dir = true
+	}
+
+	// The Accessor + components is the path of the item
+	path := accessors.MustNewGenericOSPath(cell[3]).Append(components...)
+	fs_info := &accessors.VirtualFileInfo{
+		Path:   path,
+		IsDir_: is_dir,
+		Size_:  size,
+		Data_:  ordereddict.NewDict(),
+	}
+
+	// The download pointer allows us to fetch the file itself.
+	record := &flows_proto.VFSDownloadInfo{}
+	err = json.Unmarshal([]byte(cell[0]), record)
+	if err == nil {
+		fs_info.Data_.Set("DownloadInfo", record)
+	}
+
+	return fs_info, nil
+}
+
+func init() {
+	accessors.Register("vfs", &VFSFileSystemAccessor{}, `Access client's VFS filesystem on the server.`)
+}

--- a/accessors/vfs/vfs_test.go
+++ b/accessors/vfs/vfs_test.go
@@ -1,0 +1,248 @@
+package vfs
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"github.com/sebdah/goldie"
+	"github.com/stretchr/testify/suite"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	"www.velocidex.com/golang/velociraptor/artifacts/assets"
+	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+	"www.velocidex.com/golang/velociraptor/glob"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/logging"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vtesting"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+
+	"www.velocidex.com/golang/velociraptor/accessors/file_store"
+	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
+	_ "www.velocidex.com/golang/velociraptor/vql/filesystem"
+	_ "www.velocidex.com/golang/velociraptor/vql/golang"
+	_ "www.velocidex.com/golang/velociraptor/vql/parsers"
+)
+
+type testCases struct {
+	Path    string
+	IsDir   bool
+	Content string
+}
+
+var (
+	Filesystem = []testCases{
+		{Path: "C:", IsDir: true},
+		{Path: "C:\\Windows", IsDir: true},
+		{Path: "C:\\Windows\\System32", IsDir: true},
+		{Path: "C:\\Windows\\File1.txt", Content: "File in Windows"},
+		{Path: "C:\\Windows\\System32\\File.txt", Content: "File in System32"},
+		{Path: "D:", IsDir: true},
+	}
+
+	artifacts_used = []string{
+		"artifacts/definitions/System/VFS/ListDirectory.yaml",
+		"artifacts/definitions/System/VFS/DownloadFile.yaml",
+	}
+)
+
+func setVirtualFilesystem() {
+	root_path := accessors.MustNewWindowsOSPath("")
+	root_fs_accessor := accessors.NewVirtualFilesystemAccessor(root_path)
+	for _, c := range Filesystem {
+		root_fs_accessor.SetVirtualFileInfo(&accessors.VirtualFileInfo{
+			Path:    accessors.MustNewWindowsOSPath(c.Path),
+			IsDir_:  c.IsDir,
+			RawData: []byte(c.Content),
+			Size_:   int64(len(c.Content)),
+		})
+	}
+
+	// Install this under a new accessor name.
+	accessors.Register("vfs_test", root_fs_accessor, "")
+}
+
+type TestSuite struct {
+	test_utils.TestSuite
+}
+
+func (self *TestSuite) SetupTest() {
+	self.ConfigObj = self.LoadConfig()
+	self.ConfigObj.Services.HuntDispatcher = true
+	self.ConfigObj.Services.HuntManager = true
+	self.ConfigObj.Services.ServerArtifacts = true
+	self.ConfigObj.Services.VfsService = true
+
+	self.TestSuite.SetupTest()
+
+	launcher, err := services.GetLauncher(self.ConfigObj)
+	assert.NoError(self.T(), err)
+	launcher.SetFlowIdForTests("F.1234")
+}
+
+func (self *TestSuite) TestVFSAccessor() {
+	closer := utils.MockTime(utils.NewMockClock(time.Unix(10, 10)))
+	defer closer()
+
+	setVirtualFilesystem()
+
+	manager, _ := services.GetRepositoryManager(self.ConfigObj)
+	repository, err := manager.GetGlobalRepository(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	assets.Init()
+
+	options := services.ArtifactOptions{
+		ValidateArtifact:     true,
+		ArtifactIsBuiltIn:    true,
+		ArtifactIsCompiledIn: false,
+	}
+
+	for _, a := range artifacts_used {
+		data, err := assets.ReadFile(a)
+		assert.NoError(self.T(), err)
+
+		_, err = repository.LoadYaml(string(data), options)
+		assert.NoError(self.T(), err)
+	}
+
+	launcher, err := services.GetLauncher(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	var acl_manager vql_subsystem.ACLManager
+
+	flow_id, err := launcher.ScheduleArtifactCollection(self.Ctx, self.ConfigObj,
+		acl_manager, repository, &flows_proto.ArtifactCollectorArgs{
+			Artifacts: []string{"System.VFS.ListDirectory", "System.VFS.DownloadFile"},
+			Specs: []*flows_proto.ArtifactSpec{
+				{
+					Artifact: "System.VFS.DownloadFile",
+					Parameters: &flows_proto.ArtifactParameters{
+						Env: []*actions_proto.VQLEnv{
+							{
+								Key:   "Accessor",
+								Value: "vfs_test",
+							},
+							{
+								Key:   "Components",
+								Value: "[]",
+							},
+							{
+								Key:   "Recursively",
+								Value: "Y",
+							},
+						},
+					},
+				},
+				{
+					Artifact: "System.VFS.ListDirectory",
+					Parameters: &flows_proto.ArtifactParameters{
+						Env: []*actions_proto.VQLEnv{
+							{
+								Key:   "Accessor",
+								Value: "vfs_test",
+							},
+							{
+								Key:   "Components",
+								Value: "[]",
+							},
+							{
+								Key:   "Depth",
+								Value: "10",
+							},
+						},
+					}},
+			},
+			ClientId: "server",
+		}, utils.SyncCompleter)
+	assert.NoError(self.T(), err)
+
+	// Wait here until the collection is completed.
+	vtesting.WaitUntil(time.Second*500, self.T(), func() bool {
+		flow, err := launcher.GetFlowDetails(self.Ctx, self.ConfigObj, "server", flow_id)
+		assert.NoError(self.T(), err)
+		return flow.Context.State == flows_proto.ArtifactCollectorContext_FINISHED
+	})
+
+	vfs_service, err := services.GetVFSService(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	// test_utils.GetMemoryFileStore(self.T(), self.ConfigObj).Debug()
+
+	// Wait until the vfs service processes it
+	vtesting.WaitUntil(time.Second*50, self.T(), func() bool {
+		dir, err := vfs_service.ListDirectoryFiles(self.Ctx, self.ConfigObj,
+			&api_proto.GetTableRequest{
+				Rows:          10,
+				ClientId:      "server",
+				VfsComponents: []string{"vfs_test", "C:", "Windows"},
+			})
+		if err != nil {
+			return false
+		}
+		return dir.TotalRows > 0
+	})
+
+	fs_factory := file_store.NewFileStoreFileSystemAccessor(self.ConfigObj)
+	accessors.Register("fs", fs_factory, "")
+
+	// Now create a download of this collection.
+	builder := services.ScopeBuilder{
+		Config:     self.ConfigObj,
+		ACLManager: acl_managers.NullACLManager{},
+		Logger:     logging.NewPlainLogger(self.ConfigObj, &logging.FrontendComponent),
+		Env:        ordereddict.NewDict().Set("ClientId", "server"),
+	}
+
+	scope := manager.BuildScope(builder)
+
+	// Now test the vfs_accessor.
+	accessor, err := accessors.GetAccessor("vfs", scope)
+	assert.NoError(self.T(), err)
+
+	globber := glob.NewGlobber()
+	glob_path, err := accessors.NewGenericOSPath("/**")
+	assert.NoError(self.T(), err)
+
+	globber.Add(glob_path)
+
+	hits := []string{}
+	file_content := ordereddict.NewDict()
+
+	for hit := range globber.ExpandWithContext(
+		self.Ctx, scope, self.ConfigObj,
+		accessors.MustNewGenericOSPath("vfs_test"), accessor) {
+		full_path := hit.OSPath().Path()
+
+		hits = append(hits, full_path)
+
+		if !hit.IsDir() {
+			data := make([]byte, 1024)
+			fd, err := accessor.OpenWithOSPath(hit.OSPath())
+			assert.NoError(self.T(), err)
+
+			n, err := fd.Read(data)
+			assert.NoError(self.T(), err)
+			file_content.Set(full_path, string(data[:n]))
+			fd.Close()
+		}
+
+	}
+	sort.Strings(hits)
+
+	golden := ordereddict.NewDict().
+		Set("DirectoryListings", hits).
+		Set("FileContents", file_content)
+
+	goldie.Assert(self.T(), "TestVFSAccessor", json.MustMarshalIndent(golden))
+}
+
+func TestVFSAccessor(t *testing.T) {
+	suite.Run(t, &TestSuite{})
+}

--- a/accessors/vfs/vfs_test.go
+++ b/accessors/vfs/vfs_test.go
@@ -164,7 +164,7 @@ func (self *TestSuite) TestVFSAccessor() {
 	assert.NoError(self.T(), err)
 
 	// Wait here until the collection is completed.
-	vtesting.WaitUntil(time.Second*500, self.T(), func() bool {
+	vtesting.WaitUntil(time.Second*5, self.T(), func() bool {
 		flow, err := launcher.GetFlowDetails(self.Ctx, self.ConfigObj, "server", flow_id)
 		assert.NoError(self.T(), err)
 		return flow.Context.State == flows_proto.ArtifactCollectorContext_FINISHED
@@ -176,7 +176,7 @@ func (self *TestSuite) TestVFSAccessor() {
 	// test_utils.GetMemoryFileStore(self.T(), self.ConfigObj).Debug()
 
 	// Wait until the vfs service processes it
-	vtesting.WaitUntil(time.Second*50, self.T(), func() bool {
+	vtesting.WaitUntil(time.Second*5, self.T(), func() bool {
 		dir, err := vfs_service.ListDirectoryFiles(self.Ctx, self.ConfigObj,
 			&api_proto.GetTableRequest{
 				Rows:          10,

--- a/accessors/virtual.go
+++ b/accessors/virtual.go
@@ -167,7 +167,7 @@ type VirtualFilesystemAccessor struct {
 
 func (self VirtualFilesystemAccessor) New(scope vfilter.Scope) (
 	FileSystemAccessor, error) {
-	return VirtualFilesystemAccessor{}, nil
+	return self, nil
 }
 
 func (self VirtualFilesystemAccessor) ParsePath(path string) (*OSPath, error) {
@@ -284,6 +284,7 @@ func (self *VirtualFilesystemAccessor) SetVirtualFileInfo(
 
 func NewVirtualFilesystemAccessor(root_path *OSPath) *VirtualFilesystemAccessor {
 	return &VirtualFilesystemAccessor{
+		root_path: root_path,
 		root: directory_node{
 			file_info: &VirtualFileInfo{
 				Path:   root_path,

--- a/api/notebooks.go
+++ b/api/notebooks.go
@@ -234,11 +234,11 @@ func (self *ApiServer) GetNotebookCell(
 	defer Instrument("GetNotebookCell")()
 
 	if !strings.HasPrefix(in.NotebookId, "N.") {
-		return nil, InvalidStatus("Invalid NoteboookId")
+		return nil, InvalidStatus("Invalid NotebookId")
 	}
 
 	if !strings.HasPrefix(in.CellId, "NC.") {
-		return nil, InvalidStatus("Invalid NoteboookCellId")
+		return nil, InvalidStatus("Invalid NotebookCellId")
 	}
 
 	users := services.GetUserManager()
@@ -279,11 +279,11 @@ func (self *ApiServer) UpdateNotebookCell(
 	defer Instrument("UpdateNotebookCell")()
 
 	if !strings.HasPrefix(in.NotebookId, "N.") {
-		return nil, InvalidStatus("Invalid NoteboookId")
+		return nil, InvalidStatus("Invalid NotebookId")
 	}
 
 	if !strings.HasPrefix(in.CellId, "NC.") {
-		return nil, InvalidStatus("Invalid NoteboookCellId")
+		return nil, InvalidStatus("Invalid NotebookCellId")
 	}
 
 	users := services.GetUserManager()
@@ -327,11 +327,11 @@ func (self *ApiServer) CancelNotebookCell(
 	defer Instrument("CancelNotebookCell")()
 
 	if !strings.HasPrefix(in.NotebookId, "N.") {
-		return nil, InvalidStatus("Invalid NoteboookId")
+		return nil, InvalidStatus("Invalid NotebookId")
 	}
 
 	if !strings.HasPrefix(in.CellId, "NC.") {
-		return nil, InvalidStatus("Invalid NoteboookCellId")
+		return nil, InvalidStatus("Invalid NotebookCellId")
 	}
 
 	users := services.GetUserManager()

--- a/artifacts/definitions/System/VFS/Export.yaml
+++ b/artifacts/definitions/System/VFS/Export.yaml
@@ -1,0 +1,21 @@
+name: System.VFS.Export
+description: |
+  Exports parts of the VFS in a server side collection.
+
+type: SERVER
+
+parameters:
+  - name: Components
+    type: json_array
+    description: The top level to recurse from.
+  - name: ClientId
+    description: The client id to apply the artifact on
+
+
+sources:
+  - query: |
+      SELECT Name, OSPath, Size, IsDir,
+             Data.DownloadInfo.flow_id AS FlowId,
+             upload(accessor="vfs", file=OSPath) AS Upload
+      FROM glob(globs="/**", root=Components, accessor="vfs")
+      WHERE NOT IsDir AND flow_id

--- a/artifacts/definitions/System/VFS/Export.yaml
+++ b/artifacts/definitions/System/VFS/Export.yaml
@@ -5,17 +5,30 @@ description: |
 type: SERVER
 
 parameters:
+  - name: Path
+    description: |
+      A vfs path under which to search for file (NOTE: VFS paths start
+      with the accessor name).
   - name: Components
     type: json_array
-    description: The top level to recurse from.
+    default: '[]'
+    description: |
+      The top level to recurse from. NOTE: The first element in the
+      list must be the accessor name.
   - name: ClientId
     description: The client id to apply the artifact on
-
+  - name: FileGlob
+    default: '**'
+    description: |
+      Only match the following files (default all of them) under the
+      Path
 
 sources:
   - query: |
+      LET components <= Components || pathspec(parse=Path).Components
       SELECT Name, OSPath, Size, IsDir,
              Data.DownloadInfo.flow_id AS FlowId,
-             upload(accessor="vfs", file=OSPath) AS Upload
-      FROM glob(globs="/**", root=Components, accessor="vfs")
-      WHERE NOT IsDir AND flow_id
+             if(condition=Data.DownloadInfo.flow_id,
+                then=upload(accessor="vfs", file=OSPath)) AS Upload
+      FROM glob(globs=FileGlob, root=components, accessor="vfs")
+      WHERE NOT IsDir

--- a/crypto/client/manager.go
+++ b/crypto/client/manager.go
@@ -400,8 +400,9 @@ func (self *CryptoManager) extractMessageInfo(
 
 	org_id, err := org_manager.OrgIdByNonce(packed_message_list.Nonce)
 	if err != nil {
-		return nil, nil, errors.New(
-			"Client Nonce is not valid - rejecting message.")
+		return nil, nil, fmt.Errorf(
+			"Client Nonce %v is not valid - rejecting message.",
+			packed_message_list.Nonce)
 	}
 
 	org_config_obj, err := org_manager.GetOrgConfig(org_id)

--- a/file_store/uploader/uploader.go
+++ b/file_store/uploader/uploader.go
@@ -45,7 +45,8 @@ func (self *FileStoreUploader) Upload(
 		return res, nil
 	}
 
-	output_path := self.root_path.AddUnsafeChild(store_as_name.Components...)
+	output_path := self.root_path.AddUnsafeChild(accessor).
+		AddUnsafeChild(store_as_name.Components...)
 	out_fd, err := self.file_store.WriteFile(output_path)
 	if err != nil {
 		scope.Log("Unable to open file %s: %v",

--- a/gui/velociraptor/src/components/vfs/file-list.jsx
+++ b/gui/velociraptor/src/components/vfs/file-list.jsx
@@ -20,7 +20,6 @@ import {CancelToken} from 'axios';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import VeloForm from "../forms/form.jsx";
 import FlowLink from "../flows/flow-link.jsx";
-import { runArtifact } from "../flows/utils.jsx";
 
 import T from '../i8n/i8n.jsx';
 
@@ -91,13 +90,23 @@ class ExportDialog extends Component {
 
     doIt = ()=>{
         let client_id = this.props.client && this.props.client.client_id;
-        runArtifact("server", "System.VFS.Export", {
-            Components: JSON.stringify(this.props.node.path),
-            ClientId: client_id,
-            FileGlob: this.state.glob || "/**",
-        }, (resp)=>{
-            this.setState({flow_id: resp.session_id});
-        }, this.source.token);
+        api.post("v1/CollectArtifact", {
+            client_id: "server",
+            artifacts: ["System.VFS.Export"],
+            specs: [{artifact: "System.VFS.Export",
+                     parameters: {env: [
+                         {key: "Components",
+                          value: JSON.stringify(this.props.node.path)},
+                         {key: "ClientId", value: client_id},
+                         {key: "FileGlob", value: this.state.glob || "/**"},
+                     ]}}],
+            max_upload_bytes: 1000000000000,
+        }, this.source.token).then((resp)=>{
+            console.log(resp);
+            if(resp.data) {
+                this.setState({flow_id: resp.data.flow_id});
+            };
+        });
     }
 
     render() {

--- a/gui/velociraptor/src/index.jsx
+++ b/gui/velociraptor/src/index.jsx
@@ -24,7 +24,7 @@ import { faHome, faCrosshairs, faWrench, faEye, faServer, faBook, faLaptop,
          faCloudDownloadAlt, faUserEdit, faFilter, faSortAlphaUp, faSortAlphaDown,
          faInfo, faBug, faUser, faList, faIndent, faTextHeight, faBars,
          faUserLargeSlash, faTriangleExclamation, faCircle, faAnglesLeft, faMaximize,
-         faMinimize, faNoteSticky, faArrowsUpDown, faBan,
+         faMinimize, faNoteSticky, faArrowsUpDown, faBan, faFileExport,
        } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faHome, faCrosshairs, faWrench, faEye, faServer, faBook, faLaptop,
@@ -42,7 +42,7 @@ library.add(faHome, faCrosshairs, faWrench, faEye, faServer, faBook, faLaptop,
             faSortAlphaUp, faSortAlphaDown, faInfo, faUser, faList, faIndent,
             faTextHeight, faBars, faUserLargeSlash, faTriangleExclamation,
             faCircle, faAnglesLeft, faMaximize, faMinimize, faNoteSticky,
-            faArrowsUpDown, faBan,
+            faArrowsUpDown, faBan, faFileExport
            );
 
 ReactDOM.render(

--- a/server/comms.go
+++ b/server/comms.go
@@ -486,6 +486,7 @@ func send_client_messages(server_obj *Server) http.Handler {
 		message_info, err := server_obj.Decrypt(req.Context(), body)
 		if err != nil {
 			// Just plain reject with a 403.
+			server_obj.Debug("Rejecting request from %v: %v", req.RemoteAddr, err)
 			http.Error(w, "", http.StatusForbidden)
 			return
 		}

--- a/services/server_artifacts/server_artifacts_test.go
+++ b/services/server_artifacts/server_artifacts_test.go
@@ -252,12 +252,12 @@ sources:
 	uploads_data := test_utils.FileReadAll(self.T(), self.ConfigObj,
 		flow_path_manager.UploadMetadata())
 	assert.Contains(self.T(), uploads_data,
-		`"_Components":["clients","server","collections","F.1234","uploads","test.txt"]`)
+		`"_Components":["clients","server","collections","F.1234","uploads","data","test.txt"]`)
 
 	// Now read the uploaded file.
 	data := test_utils.FileReadAll(self.T(), self.ConfigObj,
 		path_specs.NewUnsafeFilestorePath(
-			"clients", "server", "collections", "F.1234", "uploads", "test.txt").
+			"clients", "server", "collections", "F.1234", "uploads", "data", "test.txt").
 			SetType(api.PATH_TYPE_FILESTORE_ANY))
 	assert.Equal(self.T(), "Hello world", string(data))
 }
@@ -289,7 +289,7 @@ sources:
 		flow_path_manager.UploadMetadata())
 
 	assert.Contains(self.T(), uploads_data,
-		`"_Components":["clients","server","collections","F.1234","uploads","test_many.txt"]`)
+		`"_Components":["clients","server","collections","F.1234","uploads","data","test_many.txt"]`)
 
 	// There is only one uploaded file in the uploads file
 	assert.Equal(self.T(), 1, len(strings.Split("\n", uploads_data)))
@@ -298,7 +298,7 @@ sources:
 	data := test_utils.FileReadAll(self.T(), self.ConfigObj,
 		path_specs.NewUnsafeFilestorePath(
 			"clients", "server", "collections", "F.1234",
-			"uploads", "test_many.txt").
+			"uploads", "data", "test_many.txt").
 			SetType(api.PATH_TYPE_FILESTORE_ANY))
 	assert.Equal(self.T(), "Hello world", string(data))
 }

--- a/vql/server/downloads/downloads_test.go
+++ b/vql/server/downloads/downloads_test.go
@@ -48,6 +48,7 @@ func (self *TestSuite) SetupTest() {
 	self.ConfigObj.Services.HuntDispatcher = true
 	self.ConfigObj.Services.HuntManager = true
 	self.ConfigObj.Services.ServerArtifacts = true
+	self.ConfigObj.Services.VfsService = true
 
 	self.LoadArtifactsIntoConfig([]string{`
 name: Custom.TestArtifactUpload
@@ -99,7 +100,7 @@ func (self *TestSuite) TestExportCollectionServerArtifact() {
 	assert.NoError(self.T(), err)
 
 	// Wait here until the collection is completed.
-	vtesting.WaitUntil(time.Second*50, self.T(), func() bool {
+	vtesting.WaitUntil(time.Second*5, self.T(), func() bool {
 		flow, err := launcher.GetFlowDetails(self.Ctx, self.ConfigObj, "server", flow_id)
 		assert.NoError(self.T(), err)
 

--- a/vql/server/downloads/fixtures/TestExportCollectionServerArtifact.golden
+++ b/vql/server/downloads/fixtures/TestExportCollectionServerArtifact.golden
@@ -127,6 +127,7 @@
      "collections",
      "F.1234",
      "uploads",
+     "data",
      "test.txt"
     ]
    },
@@ -142,6 +143,7 @@
      "collections",
      "F.1234",
      "uploads",
+     "data",
      "test2.txt"
     ]
    }
@@ -154,6 +156,7 @@
    "vfs_path": "/test.txt",
    "_Components": [
     "uploads",
+    "data",
     "test.txt"
    ],
    "file_size": 9,
@@ -165,6 +168,7 @@
    "vfs_path": "/test2.txt",
    "_Components": [
     "uploads",
+    "data",
     "test2.txt"
    ],
    "file_size": 15,
@@ -172,6 +176,6 @@
   }
  ],
  "uploads.json.index": "\u0000\u0000\u0000\u0000\u0000\u0001\u0000\u0000\ufffd\u0000\u0000\u0000\u0000\u0001\u0000\u0000",
- "uploads/test.txt": "Some Data",
- "uploads/test2.txt": "Some Other Data"
+ "uploads/data/test.txt": "Some Data",
+ "uploads/data/test2.txt": "Some Other Data"
 }

--- a/vql_plugins/accessors.go
+++ b/vql_plugins/accessors.go
@@ -17,5 +17,6 @@ import (
 	_ "www.velocidex.com/golang/velociraptor/accessors/s3"
 	_ "www.velocidex.com/golang/velociraptor/accessors/smb"
 	_ "www.velocidex.com/golang/velociraptor/accessors/sparse"
+	_ "www.velocidex.com/golang/velociraptor/accessors/vfs"
 	_ "www.velocidex.com/golang/velociraptor/accessors/zip"
 )


### PR DESCRIPTION
Added a VFS accessor for accessing files inside the client's vfs.

This is used by the System.VFS.Export artifact to export parts of the VFS as a flow collection.

Now there is a GUI that allows automated export of parts of the VFS into a separate collection (which can be exported as zip).