### PR TITLE
Update Packages.yaml for RHEL - fixed issue

### DIFF
--- a/artifacts/definitions/Linux/RHEL/Packages.yaml
+++ b/artifacts/definitions/Linux/RHEL/Packages.yaml
@@ -22,4 +22,4 @@ sources:
             a=exec(cmd=["dnf", "--quiet", "list", "installed"]),
             b=exec(cmd=["yum", "--quiet", "list", "installed"]),
             c={SELECT log(level="ERROR",message="Could not retrieve Package Information") FROM scope()}
-            )
+            ) WHERE Package


### PR DESCRIPTION
Resolved an issue when yum is returning empty lines due to line break of long package names. Therefore I am filtering out all lines in the table which do not contain package information