### PR TITLE
Optionally disable TdhGetEventMapInformation calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/Velocidex/ahocorasick v0.0.0-20180712114356-e1c353eeaaee
 	github.com/Velocidex/amsi v0.0.0-20200608120838-e5d93b76f119
-	github.com/Velocidex/etw v0.0.0-20231114035413-83537eef0ba7
+	github.com/Velocidex/etw v0.0.0-20231115144702-0b885b292f0f
 	github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b
 	github.com/Velocidex/go-magic v0.0.0-20211018155418-c5dc48282f28
 	github.com/Velocidex/go-yara v1.1.10-0.20221202090138-c7dde4c43aa4

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/Velocidex/chroma v0.6.8-0.20200418131129-82edc291369c h1:ipQHX4FX5HKR
 github.com/Velocidex/chroma v0.6.8-0.20200418131129-82edc291369c/go.mod h1:sko8vR34/90zvl5QdcUdvzL3J8NKjAUx9va9jPuFNoM=
 github.com/Velocidex/errors v0.0.0-20221019164655-9ace6bf61e26 h1:VwbeNpMRuS3bRieg7WLaSYIMaI8RjH/wGxd37oj6H1g=
 github.com/Velocidex/errors v0.0.0-20221019164655-9ace6bf61e26/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
-github.com/Velocidex/etw v0.0.0-20231114035413-83537eef0ba7 h1:6KiWXlV6D72LX1NS58LrmnixbpxbCr1MxqNDpunYOfY=
-github.com/Velocidex/etw v0.0.0-20231114035413-83537eef0ba7/go.mod h1:F3/xFKE2Puol7bJKW5xcj/9H2O8n/sJN87Xgm66G6sc=
+github.com/Velocidex/etw v0.0.0-20231115144702-0b885b292f0f h1:j/s1qRr+sBknAcDELkGVqt5TOqDVlVhcNEBJVI+ldUo=
+github.com/Velocidex/etw v0.0.0-20231115144702-0b885b292f0f/go.mod h1:F3/xFKE2Puol7bJKW5xcj/9H2O8n/sJN87Xgm66G6sc=
 github.com/Velocidex/file-rotatelogs v0.0.0-20211221020724-d12e4dae4e11 h1:pQY9p6hvmbFKXJg8suzGSG9/t8Ij9ece32GUFIdHgqg=
 github.com/Velocidex/file-rotatelogs v0.0.0-20211221020724-d12e4dae4e11/go.mod h1:Ya1f4Kowt2GC7gbnu1MbNncvI1Lp3i1plN2xLiETJfg=
 github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b h1:XaAmLVXrqPv60nbiQtzj5Sch7lwz3XH8x5IocQwRPJg=

--- a/services/interrogation/interrogation.go
+++ b/services/interrogation/interrogation.go
@@ -268,8 +268,8 @@ func modifyRecord(ctx context.Context,
 
 	mac_addresses, ok := row.GetStrings("MACAddresses")
 	if ok {
-		client_info.MacAddresses = append(
-			client_info.MacAddresses, mac_addresses...)
+		client_info.MacAddresses = mac_addresses
+		client_info.MacAddresses = utils.Uniquify(client_info.MacAddresses)
 	}
 
 	if client_info.FirstSeenAt == 0 {

--- a/utils/string.go
+++ b/utils/string.go
@@ -7,3 +7,17 @@ func Elide(in string, length int) string {
 
 	return in[:length] + " ..."
 }
+
+func Uniquify(in []string) []string {
+	result := make([]string, 0, len(in))
+	seen := make(map[string]bool)
+	for _, i := range in {
+		_, pres := seen[i]
+		if pres {
+			continue
+		}
+		seen[i] = true
+		result = append(result, i)
+	}
+	return result
+}

--- a/vql/windows/etw/options.go
+++ b/vql/windows/etw/options.go
@@ -1,0 +1,8 @@
+package etw
+
+type ETWOptions struct {
+	AnyKeyword, AllKeyword uint64
+	Level                  int64
+	CaptureState           bool
+	EnableMapInfo          bool
+}

--- a/vql/windows/etw/watcher.go
+++ b/vql/windows/etw/watcher.go
@@ -43,16 +43,14 @@ func NewEventTraceWatcherService() *EventTraceWatcherService {
 func (self *EventTraceWatcherService) Register(
 	ctx context.Context,
 	scope vfilter.Scope,
-	session_name string,
-	any_keyword uint64, all_keyword uint64, level int64,
-	wGuid windows.GUID, capture_state bool) (closer func(), output_chan chan vfilter.Row, err error) {
+	session_name string, options ETWOptions,
+	wGuid windows.GUID) (closer func(), output_chan chan vfilter.Row, err error) {
 	session, err := self.SessionContext(session_name, scope)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return session.Register(
-		ctx, scope, any_keyword, all_keyword, level, wGuid, capture_state)
+	return session.Register(ctx, scope, options, wGuid)
 }
 
 func (self *EventTraceWatcherService) SessionContext(


### PR DESCRIPTION
To improve ETW efficiency we disable TdhGetEventMapInformation() calls by default.