### PR TITLE
Velo linux upgrade fixes

### DIFF
--- a/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
@@ -26,7 +26,7 @@ parameters:
 
 sources:
   - precondition:
-      SELECT OS From info() where OS = 'linux'
+      SELECT OS From info() where OS =~ 'linux'
 
     query:  |
       // FetchBinary downloads to /tmp on linux
@@ -35,10 +35,10 @@ sources:
          ToolName="VelociraptorDebian", IsExecutable=FALSE,
          SleepDuration=SleepDuration)
 
-      // Version handling for older clients. 
+      // Version handling for older clients.
       LET Rm(X) = if(
-        condition=version(function='rm')!=NULL, 
-        then=rm(filename=X), 
+        condition=version(function='rm')!=NULL,
+        then=rm(filename=X),
         else={ SELECT * FROM execve(argv=["rm", "-f", X]) })
 
       // Call the binary and return all its output in a single row.
@@ -46,10 +46,13 @@ sources:
       SELECT * FROM foreach(row=bin,
       query={
         SELECT * FROM chain(
-          // Remove the existing
+          // Remove the existing prerm - Previous versions had a bug that
+          // would shutdown the service during uninstall. See #3122
           a={SELECT * FROM Rm(X="/var/lib/dpkg/info/velociraptor-client.prerm")},
+
           // Install the new client
           b={SELECT * FROM execve(argv=["dpkg", "-i", str(str=Dest)])},
+
           // Restart the client
           c={SELECT * FROM execve(argv=["systemctl", "restart", ServiceName])}
         )

--- a/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
@@ -20,15 +20,13 @@ parameters:
 
 sources:
   - precondition:
-      SELECT OS From info() where OS = 'Linux'
+      SELECT OS From info() where OS = 'linux'
 
     query:  |
-      // Force the file to be copied to the real temp directory since
-      // we are just about to remove the Tools directory.
-      LET bin <= SELECT copy(filename=OSPath,
-          dest=expand(path="/tmp/") + basename(path=OSPath)) AS Dest
+      // FetchBinary downloads to /tmp on linux
+      LET bin <= SELECT OSPath AS Dest
       FROM Artifact.Generic.Utils.FetchBinary(
-         ToolName="VelociraptorLinux", IsExecutable=FALSE,
+         ToolName="VelociraptorDebian", IsExecutable=FALSE,
          SleepDuration=SleepDuration)
 
       // Call the binary and return all its output in a single row.
@@ -36,6 +34,6 @@ sources:
       SELECT * FROM foreach(row=bin,
       query={
          SELECT * FROM execve(
-              argv=["dpkg", "-i", Dest],
+              argv=["/bin/bash", "-c", "rm /var/lib/dpkg/info/velociraptor-client.prerm && dpkg -i " + str(str=Dest) + " && systemctl restart velociraptor_client"],
               length=10000000)
       })

--- a/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/Debian.yaml
@@ -18,6 +18,12 @@ parameters:
       overwhelm the server so we stagger the download over this many
       seconds.
 
+  - name: ServiceName
+    default: "velociraptor_client"
+    type: str
+    description: |
+      The name of the service to restart after the upgrade.
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'linux'
@@ -29,11 +35,22 @@ sources:
          ToolName="VelociraptorDebian", IsExecutable=FALSE,
          SleepDuration=SleepDuration)
 
+      // Version handling for older clients. 
+      LET Rm(X) = if(
+        condition=version(function='rm')!=NULL, 
+        then=rm(filename=X), 
+        else={ SELECT * FROM execve(argv=["rm", "-f", X]) })
+
       // Call the binary and return all its output in a single row.
       // If we fail to download the binary we do not run the command.
       SELECT * FROM foreach(row=bin,
       query={
-         SELECT * FROM execve(
-              argv=["/bin/bash", "-c", "rm /var/lib/dpkg/info/velociraptor-client.prerm && dpkg -i " + str(str=Dest) + " && systemctl restart velociraptor_client"],
-              length=10000000)
+        SELECT * FROM chain(
+          // Remove the existing
+          a={SELECT * FROM Rm(X="/var/lib/dpkg/info/velociraptor-client.prerm")},
+          // Install the new client
+          b={SELECT * FROM execve(argv=["dpkg", "-i", str(str=Dest)])},
+          // Restart the client
+          c={SELECT * FROM execve(argv=["systemctl", "restart", ServiceName])}
+        )
       })

--- a/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
@@ -20,13 +20,11 @@ parameters:
 
 sources:
   - precondition:
-      SELECT OS From info() where OS = 'Linux'
+      SELECT OS From info() where OS = 'linux'
 
     query:  |
-      // Force the file to be copied to the real temp directory since
-      // we are just about to remove the Tools directory.
-      LET bin <= SELECT copy(filename=OSPath,
-          dest=expand(path="/tmp/") + basename(path=OSPath)) AS Dest
+       // FetchBinary downloads to /tmp on linux
+      LET bin <= SELECT OSPath AS Dest
       FROM Artifact.Generic.Utils.FetchBinary(
          ToolName="VelociraptorRedHat", IsExecutable=FALSE,
          SleepDuration=SleepDuration)
@@ -36,6 +34,6 @@ sources:
       SELECT * FROM foreach(row=bin,
       query={
          SELECT * FROM execve(
-              argv=["rpm", "-U", Dest],
+              argv=["/bin/bash", "-c", "rpm --nopreun -U " + str(str=Dest) + " && systemctl restart velociraptor_client"],
               length=10000000)
       })

--- a/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
@@ -23,7 +23,7 @@ sources:
       SELECT OS From info() where OS = 'linux'
 
     query:  |
-       // FetchBinary downloads to /tmp on linux
+      // FetchBinary downloads to /tmp on linux
       LET bin <= SELECT OSPath AS Dest
       FROM Artifact.Generic.Utils.FetchBinary(
          ToolName="VelociraptorRedHat", IsExecutable=FALSE,

--- a/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
@@ -26,7 +26,7 @@ parameters:
 
 sources:
   - precondition:
-      SELECT OS From info() where OS = 'linux'
+      SELECT OS From info() where OS =~ 'linux'
 
     query:  |
       // FetchBinary downloads to /tmp on linux
@@ -40,9 +40,10 @@ sources:
       SELECT * FROM foreach(row=bin,
       query={
         SELECT * FROM chain(
-          // Install the new client
+          // Install the new client (Disabled preun because older versions
+          // had a bug where preun would shut down the service - see #3122).
+
           b={SELECT * FROM execve(argv=["rpm", "--nopreun", "-U", str(str=Dest)])},
-          // Restart the client
           c={SELECT * FROM execve(argv=["systemctl", "restart", ServiceName])}
         )
       })

--- a/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
+++ b/artifacts/definitions/Admin/Client/Upgrade/RedHat.yaml
@@ -18,6 +18,12 @@ parameters:
       overwhelm the server so we stagger the download over this many
       seconds.
 
+  - name: ServiceName
+    default: "velociraptor_client"
+    type: str
+    description: |
+      The name of the service to restart after the upgrade.
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'linux'
@@ -33,7 +39,10 @@ sources:
       // If we fail to download the binary we do not run the command.
       SELECT * FROM foreach(row=bin,
       query={
-         SELECT * FROM execve(
-              argv=["/bin/bash", "-c", "rpm --nopreun -U " + str(str=Dest) + " && systemctl restart velociraptor_client"],
-              length=10000000)
+        SELECT * FROM chain(
+          // Install the new client
+          b={SELECT * FROM execve(argv=["rpm", "--nopreun", "-U", str(str=Dest)])},
+          // Restart the client
+          c={SELECT * FROM execve(argv=["systemctl", "restart", ServiceName])}
+        )
       })

--- a/artifacts/testdata/server/testcases/orgs.in.yaml
+++ b/artifacts/testdata/server/testcases/orgs.in.yaml
@@ -9,7 +9,7 @@ Queries:
 
 - SELECT * FROM test_read_logs() WHERE Log =~ "Org not found" AND NOT Log =~ "SELECT"
 
-- SELECT * FROM gui_users(all_orgs=TRUE) ORDER BY name
+- SELECT *, name+org_id AS Key FROM gui_users(all_orgs=TRUE) ORDER BY Key
 
 # Now create a new org
 - LET _ <= org_create(name="MyOrg", org_id="ORGID")

--- a/artifacts/testdata/server/testcases/orgs.out.yaml
+++ b/artifacts/testdata/server/testcases/orgs.out.yaml
@@ -7,7 +7,7 @@ SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
  {
   "Log": "Velociraptor: user_create: Org not found\n"
  }
-]SELECT * FROM gui_users(all_orgs=TRUE) ORDER BY name[]LET _ <= org_create(name="MyOrg", org_id="ORGID")[]SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
+]SELECT *, name+org_id AS Key FROM gui_users(all_orgs=TRUE) ORDER BY Key[]LET _ <= org_create(name="MyOrg", org_id="ORGID")[]SELECT Name, OrgId FROM orgs() ORDER BY OrgId[
  {
   "Name": "MyOrg",
   "OrgId": "ORGID"

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -325,7 +325,7 @@ fi
 
 if [ $1 == 0 ] ; then
     /bin/systemctl disable velociraptor_client.service
-	/bin/systemctl stop velociraptor_client.service
+    /bin/systemctl stop velociraptor_client.service
 fi
 `)
 

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -317,9 +317,16 @@ func doClientRPM() error {
 /bin/systemctl start velociraptor_client.service
 `)
 
+	// check for upgrade vs uninstall
 	r.AddPreun(`
-/bin/systemctl disable velociraptor_client.service
-/bin/systemctl stop velociraptor_client.service
+if [ $1 == 1 ] ; then
+    /bin/systemctl restart velociraptor_client.service
+fi
+
+if [ $1 == 0 ] ; then
+    /bin/systemctl disable velociraptor_client.service
+	/bin/systemctl stop velociraptor_client.service
+fi
 `)
 
 	fd, err := os.OpenFile(output_path,


### PR DESCRIPTION
Encountered some issues testing the new Linux Upgrade artifacts and created this PR as an attempt to address them. Issues observed:

1. Artifacts were not running due to precondition using capital 'L'. Corrected precondition to lowercase. 

2. The copy function coupled with Artifact.Generic.Utils.FetchBinary was causing the resultant file to be empty, thus resulting in an error when upgrade command was run. This is due to Artifact.Generic.Utils.FetchBinary already storing the file in /tmp on linux. Skipped by removing the copy. 

3. Artifacts would error if tool (updated package) was already cached. This is due to Artifact.Generic.Utils.FetchBinary returning an OSPath object when the tool is cached vs returning a string when the tool is downloaded. Fixed by explicitly casting `Dest` to str.

4. Running `rpm -U new-velo-package.rpm` directly on a shell on a host would result in the package being upgraded but the velociraptor_client service would be disabled and stopped. This is due to the upgrade order-of-operations in RPM (see https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering). Updates to rpm.go address this by only stopping/disabling service on true uninstall vs an upgrade. 

5. Debian upgrade artifact was loading the incorrect tool via Artifact.Generic.Utils.FetchBinary. Changed to the correct tool. 

6. Encountered a fundamental issue with the upgrade commands for both Debian and RedHat in that the packages have pre-removal steps that stop the velociraptor service which instantly terminates the upgrade command ( ie `rpm -U ` and `dpkg -i`) ; resulting in the upgrade command not being successful. The commands were modified to skip any pre-removal steps that stop the velociraptor service and then the service is restarted to switch to the updated binary. This workaround, so to speak, is the only way I have found to make velociraptor upgrade itself on linux to work. On debian we delete the pre-removal script before performing the upgrade and since with dpkg the old package is "removed" before the new package is installed the pre-removal files get re-created after the upgrade so the package can be properly uninstalled in the future. On redhat with rpm we can just call a flag (`--nopreun`) to just skip the pre-removal scriptlet; thus leaving it intact if the package ever needs to be properly uninstalled. 

 Ref: (Deb order of operations https://www.debian.org/doc/debian-policy/ap-flowcharts.html and RPM order of operations https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering). 