### PR TITLE
Fix broken dashboard link to client configurations

### DIFF
--- a/artifacts/definitions/Server/Monitor/Health.yaml
+++ b/artifacts/definitions/Server/Monitor/Health.yaml
@@ -66,7 +66,7 @@ reports:
 
       {{ Query "LET ColumnTypes <= dict(ClientConfig='url_internal') \
                 SELECT Name, OrgId, \
-                       format(format='[%s](/notebooks/Dashboards/uploads/%%22%s/client.%s.config.yaml%%22)', \
+                       format(format='[%s](/notebooks/Dashboards/uploads/data/%%22%s/client.%s.config.yaml%%22)', \
                        args=[OrgId, ArtifactName, OrgId]) AS ClientConfig, \
                        upload(accessor='data', file=_client_config, \
                               name='client.'+OrgId+'.config.yaml') AS _Upload \


### PR DESCRIPTION
Fix the client configuration link broken in #2816 at https://github.com/Velocidex/velociraptor/blame/f143b88ee50f5cf14ff55a4916e24143fe61b8a6/paths/notebooks.go#L203