### PR TITLE
Disable Zip Decryption auth check. 

### DIFF
--- a/accessors/collector/collector.go
+++ b/accessors/collector/collector.go
@@ -252,7 +252,11 @@ func (self *CollectorAccessor) maybeSetZipPassword(
 			}
 
 			self.scope.SetContext(constants.ZIP_PASSWORDS, string(zip_pass))
-
+			value, pres := self.scope.Resolve(constants.REPORT_ZIP_PASSWORD)
+			if pres && self.scope.Bool(value) {
+				self.scope.Log("CollectorAccessor: X509 Decrypted password is %q",
+					string(zip_pass))
+			}
 			// Transform the path so it can be used by the zip
 			// collector.
 			return collectorPathToDelegatePath(full_path), nil

--- a/accessors/zip/zip.go
+++ b/accessors/zip/zip.go
@@ -295,6 +295,12 @@ func (self *ZipFileCache) Open(full_path *accessors.OSPath) (
 		return nil, err
 	}
 
+	// Disable stream authentication because the library unpacks the
+	// entire stream into memory to verify it. In practice, the
+	// embedded data.zip file provides sufficient authentication
+	// anyway. See https://github.com/Velocidex/velociraptor/issues/3150
+	info.member_file.DeferAuth = true
+
 	fd, err := info.member_file.Open()
 	if err == zip.ErrPassword {
 		password := self.maybeGetPassword()

--- a/bin/unzip.go
+++ b/bin/unzip.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -18,8 +19,9 @@ import (
 )
 
 var (
-	unzip_cmd        = app.Command("unzip", "Unzip a container file")
-	unzip_cmd_filter = unzip_cmd.Flag("where", "A WHERE condition for the query").String()
+	unzip_cmd                 = app.Command("unzip", "Unzip a container file")
+	unzip_cmd_report_password = unzip_cmd.Flag("report_password", "Log the X509 session password").Bool()
+	unzip_cmd_filter          = unzip_cmd.Flag("where", "A WHERE condition for the query").String()
 
 	unzip_path = unzip_cmd.Flag("dump_dir", "Directory to dump output files.").
 			Default(".").String()
@@ -77,7 +79,8 @@ func doUnzip() error {
 		Env: ordereddict.NewDict().
 			Set("ZipPath", filename).
 			Set("DumpDir", *unzip_path).
-			Set("MemberGlob", *unzip_cmd_member),
+			Set("MemberGlob", *unzip_cmd_member).
+			Set(constants.REPORT_ZIP_PASSWORD, *unzip_cmd_report_password),
 	}
 
 	if *unzip_cmd_list {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -108,6 +108,9 @@ const (
 	// accessor to open password protected zip files.
 	ZIP_PASSWORDS = "ZIP_PASSWORDS"
 
+	// If this is set, the logs will report the decrypted password
+	REPORT_ZIP_PASSWORD = "REPORT_ZIP_PASSWORD"
+
 	// If this is set we always copy SQLite files to a tempfile. Used
 	// by the sqlite() plugin.
 	SQLITE_ALWAYS_MAKE_TEMPFILE = "SQLITE_ALWAYS_MAKE_TEMPFILE"


### PR DESCRIPTION
This default causes zip members to be decompressed into a memory
buffer leading to huge memory consumption.

In practice the embedded zip file has sufficient structure to be
fortified against bit manipulation attacks anyway and there are
checksums.

Optionally report the derived session password.  This allows decryption by other tools (e.g. 7zip).