### PR TITLE
Fix dangling pointers around WinVerifyTrust

### DIFF
--- a/artifacts/testdata/windows/evtx.out.yaml
+++ b/artifacts/testdata/windows/evtx.out.yaml
@@ -455,5 +455,9 @@ SELECT * FROM parse_evtx(filename=srcDir + '/artifacts/testdata/files/Security_1
  {
   "ClearedLog": "Security",
   "Message =~ \"The audit log was cleared.\"": true
+ },
+ {
+  "ClearedLog": "System",
+  "Message =~ \"The audit log was cleared.\"": false
  }
 ]

--- a/vql/windows/aliases.go
+++ b/vql/windows/aliases.go
@@ -19,3 +19,7 @@ func UTF16ToString(in []uint16) string {
 func UTF16FromString(in string) ([]uint16, error) {
 	return windows.UTF16FromString(in)
 }
+
+func UTF16PtrFromString(in string) (*uint16, error) {
+	return windows.UTF16PtrFromString(in)
+}

--- a/vql/windows/win32_windows.go
+++ b/vql/windows/win32_windows.go
@@ -453,44 +453,64 @@ func HasWintrustDll() error {
 
 type WINTRUST_FILE_INFO struct {
 	CbStruct       uint32
-	PcwszFilePath  uintptr
+	PcwszFilePath  *uint16
 	HFile          uintptr
 	PgKnownSubject *GUID
 }
 
 type CATALOG_INFO struct {
 	CbStruct       uint32
-	WszCatalogFile [1024]byte
+	WszCatalogFile [512]uint16
 }
 
 type WINTRUST_CATALOG_INFO struct {
 	CbStruct             uint32
 	DwCatalogVersion     uint32
-	PcwszCatalogFilePath uintptr
-	PcwszMemberTag       uintptr
-	PcwszMemberFilePath  uintptr
-	HMemberFile          uintptr
-	PbCalculatedFileHash uintptr
+	PcwszCatalogFilePath *uint16
+	PcwszMemberTag       *uint16
+	PcwszMemberFilePath  *uint16
+	HMemberFile          syscall.Handle
+	PbCalculatedFileHash *uint8
 	CbCalculatedFileHash uint32
 	PcCatalogContext     uintptr
 	HCatAdmin            syscall.Handle
 }
 
-type WINTRUST_DATA struct {
-	CbStruct            uint32                       //0-4
-	PPolicyCallbackData uintptr                      //4-12
-	PSIPClientData      uintptr                      //12-20
-	DwUIChoice          uint32                       //20-24
-	FdwRevocationChecks uint32                       //24-28
-	DwUnionChoice       uint32                       //28-32
-	Union               uintptr                      //32-40
-	DwStateAction       uint32                       //40-44
-	HWVTStateData       syscall.Handle               //44-48
-	PwszURLReference    uintptr                      //48-56
-	DwProvFlags         uint32                       //56-60
-	DwUIContext         uint32                       // 60-64
-	PSignatureSettings  *WINTRUST_SIGNATURE_SETTINGS // 64-72
-} // 72
+type WINTRUST_DATA_FILE_INFO struct {
+	CbStruct            uint32
+	PPolicyCallbackData uintptr
+	PSIPClientData      uintptr
+	DwUIChoice          uint32
+	FdwRevocationChecks uint32
+	DwUnionChoice       uint32
+	PFile               *WINTRUST_FILE_INFO
+	DwStateAction       uint32
+	HWVTStateData       syscall.Handle
+	PwszURLReference    uintptr
+	DwProvFlags         uint32
+	DwUIContext         uint32
+	PSignatureSettings  *WINTRUST_SIGNATURE_SETTINGS
+}
+
+type WINTRUST_DATA_CATALOG_INFO struct {
+	CbStruct            uint32
+	PPolicyCallbackData uintptr
+	PSIPClientData      uintptr
+	DwUIChoice          uint32
+	FdwRevocationChecks uint32
+	DwUnionChoice       uint32
+	PCatalog            *WINTRUST_CATALOG_INFO
+	DwStateAction       uint32
+	HWVTStateData       syscall.Handle
+	PwszURLReference    uintptr
+	DwProvFlags         uint32
+	DwUIContext         uint32
+	PSignatureSettings  *WINTRUST_SIGNATURE_SETTINGS
+}
+
+type WINTRUST_DATA interface {
+	WINTRUST_DATA_CATALOG_INFO | WINTRUST_DATA_FILE_INFO
+}
 
 type WINTRUST_SIGNATURE_SETTINGS struct {
 	CbStruct           uint32

--- a/vql/windows/zwin32_windows_amd64.go
+++ b/vql/windows/zwin32_windows_amd64.go
@@ -410,7 +410,7 @@ func CryptCATAdminReleaseCatalogContext(handle syscall.Handle, handle2 syscall.H
 	return
 }
 
-func WinVerifyTrust(handle syscall.Handle, action *GUID, data *WINTRUST_DATA) (ret uint32, err error) {
+func WinVerifyTrust[dataT WINTRUST_DATA](handle syscall.Handle, action *GUID, data *dataT) (ret uint32, err error) {
 	r0, _, e1 := syscall.Syscall(procWinVerifyTrust.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(action)), uintptr(unsafe.Pointer(data)))
 	ret = uint32(r0)
 	if ret != 0 {


### PR DESCRIPTION
This addresses the crash related to https://github.com/Velocidex/velociraptor/issues/2574. The underlying issue is the lack of references to go-managed objects due to unsafe unsafe.Pointer usage, allowing them to be garbage collected before use in `WinVerifyTrust`. 

Alternative approaches to this could be using an unmanaged buffer or `runtime.Pinner` (requires go 1.21).

Garbage collection on necessary object example (ci, fi, filename, etc.)
https://go.dev/play/p/pAOR_bE7wh9 