### PR TITLE
Support EWF files for deaddisk command.

### DIFF
--- a/accessors/ewf/ewf.go
+++ b/accessors/ewf/ewf.go
@@ -5,16 +5,11 @@ import (
 	"errors"
 	"io"
 	"os"
-	"regexp"
 
 	"github.com/Velocidex/go-ewf/parser"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/accessors/zip"
 	"www.velocidex.com/golang/vfilter"
-)
-
-var (
-	extension_regex = regexp.MustCompile("\\.[eE][0-9][0-9]")
 )
 
 type EWFReader struct {
@@ -107,5 +102,19 @@ SELECT * FROM glob(
     Path="/",
     DelegateAccessor="ewf",
     DelegatePath="C:/test.ntfs.dd.E01"))
+
+The next example reads a FAT partition through the offset
+accessor (32256 is the byte offset of the first FAT partition).
+
+    SELECT OSPath.Path AS OSPath, Size, Mode.String
+    FROM glob(
+       globs="*", accessor="fat", root=pathspec(
+          Path="/",
+          DelegateAccessor="offset",
+          DelegatePath=pathspec(
+            Path="/32256",
+            DelegateAccessor="ewf",
+            DelegatePath="/tmp/ubnist1.gen3.E01")))
+
 `)
 }

--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -37,8 +37,7 @@ sources:
     description: Linux specific information about the host
     precondition: SELECT OS From info() where OS = 'linux'
     query: |
-      SELECT
-      sysinfo() AS `Computer Info`,
+      SELECT if(condition=version(function='sysinfo') != NULL, then=sysinfo()) AS `Computer Info`,
       { SELECT Name, HardwareAddrString AS MACAddress,
                Up, PointToPoint,
                AddrsString AS IPAddresses

--- a/artifacts/definitions/Windows/Forensics/PartitionTable.yaml
+++ b/artifacts/definitions/Windows/Forensics/PartitionTable.yaml
@@ -15,6 +15,8 @@ parameters:
   - name: ImagePath
     default: "\\\\?\\GLOBALROOT\\Device\\Harddisk0\\DR0"
     description: Raw Device for main disk containing partition table to parse.
+  - name: Accessor
+    default: "raw_file"
   - name: SectorSize
     type: int
     default: 512
@@ -99,13 +101,13 @@ export: |
 sources:
   - query: |
         LET GPTHeader <= parse_binary(filename=ImagePath,
-           accessor="raw_file",
+           accessor=Accessor,
            profile=MBRProfile,
            struct="GPTHeader",
            offset=SectorSize)
 
         LET PrimaryPartitions <= parse_binary(filename=ImagePath,
-           accessor="raw_file",
+           accessor=Accessor,
            profile=MBRProfile,
            struct="MBRHeader",
            offset=0)
@@ -145,7 +147,7 @@ sources:
 
         LET PartitionList = SELECT StartOffset, EndOffset, Size, name,
             magic(accessor="data", path=read_file(
-              accessor="raw_file",
+              accessor=Accessor,
               filename=ImagePath,
               offset=StartOffset, length=10240)) AS Magic,
 
@@ -153,7 +155,7 @@ sources:
             pathspec(
               DelegateAccessor="offset",
               DelegatePath=pathspec(
-                 DelegateAccessor="raw_file",
+                 DelegateAccessor=Accessor,
                  DelegatePath=ImagePath,
                  Path=format(format="%d", args=StartOffset))) AS _PartitionPath
         FROM chain(a=PARTS, b=GPT)

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/Velocidex/file-rotatelogs v0.0.0-20211221020724-d12e4dae4e11
-	github.com/Velocidex/go-ewf v0.0.0-20231221151253-96290a08e96a
+	github.com/Velocidex/go-ewf v0.0.0-20231222082421-349320bae93a
 	github.com/Velocidex/go-fat v0.0.0-20230923165230-3e6c4265297a
 	github.com/Velocidex/grok v0.0.1
 	github.com/Velocidex/ordereddict v0.0.0-20230909174157-2aa49cc5d11d
@@ -131,7 +131,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0
 	github.com/lpar/gzipped v1.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/rogpeppe/go-internal v1.10.0
+	github.com/rogpeppe/go-internal v1.12.0
 	github.com/shirou/gopsutil/v3 v3.21.11
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/valyala/fastjson v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/Velocidex/file-rotatelogs v0.0.0-20211221020724-d12e4dae4e11 h1:pQY9p
 github.com/Velocidex/file-rotatelogs v0.0.0-20211221020724-d12e4dae4e11/go.mod h1:Ya1f4Kowt2GC7gbnu1MbNncvI1Lp3i1plN2xLiETJfg=
 github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b h1:XaAmLVXrqPv60nbiQtzj5Sch7lwz3XH8x5IocQwRPJg=
 github.com/Velocidex/go-elasticsearch/v7 v7.3.1-0.20191001125819-fee0ef9cac6b/go.mod h1:draN67DBVJDAVmLWDIJ85CrV0UxmIGfWZ4njukhINQs=
-github.com/Velocidex/go-ewf v0.0.0-20231221151253-96290a08e96a h1:Dm8KkKs0/xH28O7glaJgoS5cUgcXELJkapCen0wG/LU=
-github.com/Velocidex/go-ewf v0.0.0-20231221151253-96290a08e96a/go.mod h1:hUJpwwfJLnrv5VAx3yyBB29hBeYO/M91NJUR1jKEJyY=
+github.com/Velocidex/go-ewf v0.0.0-20231222082421-349320bae93a h1:2s9rIVswf984MGUwQe5lFiDdzpZJmufpvp+JxavVhHo=
+github.com/Velocidex/go-ewf v0.0.0-20231222082421-349320bae93a/go.mod h1:JrGP9QRoPe63ijMmU1UTfoGySg+zpgx68XcsGV/dItI=
 github.com/Velocidex/go-fat v0.0.0-20230923165230-3e6c4265297a h1:dWHPlB3C86vh+M5P14dZxF6Hh8o2/u8FTRF/bs2EM+Q=
 github.com/Velocidex/go-fat v0.0.0-20230923165230-3e6c4265297a/go.mod h1:g74FCv59tsVP48V2o1eyIK8aKbNKPLJIJ+HuiUPVc6E=
 github.com/Velocidex/go-magic v0.0.0-20211018155418-c5dc48282f28 h1:3FMhXfGzZR4oNHmV8NizrviyaTv+2SmLuj+43cMJCUQ=
@@ -601,8 +601,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
-github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russellhaering/goxmldsig v1.3.0 h1:DllIWUgMy0cRUMfGiASiYEa35nsieyD3cigIwLonTPM=
 github.com/russellhaering/goxmldsig v1.3.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=


### PR DESCRIPTION
It is now possible to create remapping files on an EWF file - simply use the "ewf" accessor instead of the "file" accessor in the remapping definitions. The `deaddisk` command can now automatically handle an E01 file.

To generate a remapping file for an E01 volume:

velociraptor-v0.7.1-linux-amd64 deaddisk -v --add_windows_disk /shared/tmp/TestVm2.E01 /tmp/test.remap.yaml

This will create a remapping file on /tmp/test.remap.yaml by trying to find the windows directory on the partitions. Note that all other EWF segments will be automatically searched for in the same directory (e.g. .E02, .E03 etc)

If successful a remapping file will allow any query or artifact to run on the image, for example:

velociraptor-v0.7.1-linux-amd64 --remap /tmp/test.remap.yaml query -v "SELECT * FROM glob(globs='C:/*')"