### PR TITLE
Bugfix: Fixed crash with timeout handling on API handler

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Configure test environment
       shell: cmd
-      if: success()
+      if: always()
       run: |
         echo %PATH%
         echo %GOPATH%
@@ -37,7 +37,7 @@ jobs:
         regedit /S artifacts/testdata/windows/init.reg
 
     - name: Build
-      if: success()
+      if: always()
       env:
         CC: x86_64-w64-mingw32-gcc
       shell: bash
@@ -66,7 +66,7 @@ jobs:
 
     - name: Test
       shell: bash
-      if: success()
+      if: always()
       env:
         # Disable CGO for building tests - it takes too long and it is
         # not needed (mainly disables Yara building again).

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,6 @@
 name: Windows Test
 on: [pull_request]
+
 jobs:
   build:
     name: Windows Test

--- a/file_store/directory/listener_test.go
+++ b/file_store/directory/listener_test.go
@@ -73,7 +73,7 @@ func (self *TestSuite) TestListenerPreserveTypes() {
 		Set("B", uint64(9223372036854775808))
 	listener.Send(event_source)
 
-	vtesting.WaitUntil(time.Second, self.T(), func() bool {
+	vtesting.WaitUntil(time.Second*5, self.T(), func() bool {
 		// Make sure we wrote to the buffer file.
 		size, _ := listener.Debug().GetInt64("Size")
 		return size > directory.FirstRecordOffset

--- a/services/interrogation/interrogation_test.go
+++ b/services/interrogation/interrogation_test.go
@@ -183,7 +183,7 @@ func (self *ServicesTestSuite) TestEnrollService() {
 	}
 
 	if len(children) > 1 {
-		test_utils.GetMemoryDataStore(self.T(), self.config_obj).Debug()
+		test_utils.GetMemoryDataStore(self.T(), self.ConfigObj).Debug(self.ConfigObj)
 	}
 
 	assert.Equal(self.T(), len(children), 1)

--- a/services/interrogation/interrogation_test.go
+++ b/services/interrogation/interrogation_test.go
@@ -2,6 +2,7 @@ package interrogation_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,8 +14,10 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vtesting"
 
 	_ "www.velocidex.com/golang/velociraptor/result_sets/timed"
@@ -37,7 +40,7 @@ type: INTERNAL
 `,
 	})
 
-	self.client_id = "C.12312"
+	self.client_id = fmt.Sprintf("C.1%d", utils.GetId())
 	self.flow_id = "F.1232"
 
 	self.TestSuite.SetupTest()
@@ -180,6 +183,7 @@ func (self *ServicesTestSuite) TestEnrollService() {
 		}
 	}
 
+	json.Dump(children)
 	assert.Equal(self.T(), len(children), 1)
 	assert.Equal(self.T(), children[0].Base(),
 		client_info.LastInterrogateFlowId)

--- a/services/interrogation/interrogation_test.go
+++ b/services/interrogation/interrogation_test.go
@@ -14,7 +14,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
-	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -183,7 +182,10 @@ func (self *ServicesTestSuite) TestEnrollService() {
 		}
 	}
 
-	json.Dump(children)
+	if len(children) > 1 {
+		test_utils.GetMemoryDataStore(self.T(), self.config_obj).Debug()
+	}
+
 	assert.Equal(self.T(), len(children), 1)
 	assert.Equal(self.T(), children[0].Base(),
 		client_info.LastInterrogateFlowId)


### PR DESCRIPTION
Race condition could result in logging messages being sent after the connection is already closed.