### PR TITLE
Fix JSX leading space in translations

### DIFF
--- a/gui/velociraptor/src/components/i8n/de.jsx
+++ b/gui/velociraptor/src/components/i8n/de.jsx
@@ -178,8 +178,8 @@ const Deutsch = {
     "Permanently delete collection": "Sammlung endgültig löschen",
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      Sie sind im Begriff, die Artefaktsammlung endgültig zu löschen
-      <b>{session_id}</b>.
+      Sie sind im Begriff, die Artefaktsammlung endgültig zu
+      löschen <b>{session_id}</b>.
       <br/>
       Diese Sammlung hatte die Artefakte <b className="wrapped-text">
          {artifacts}
@@ -382,15 +382,16 @@ const Deutsch = {
     </>,
     "ServedFromURL": (base_path, url)=>
     <>
-    Die Clients rufen das Tool bei Bedarf direkt von
-    <a href={base_path + url}>{url}</a> ab. Wenn der Hashwert nicht mit dem
+    Die Clients rufen das Tool bei Bedarf direkt
+    von <a href={base_path + url}>{url}</a> ab. Wenn der Hashwert nicht mit dem
     erwarteten Hashwert übereinstimmt, weisen die Clients die Datei zurück.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
-    Die Tool-URL wird von GitHub als die neueste Version des Projekts
-    <b>{github_project}</b>, die mit <b>{github_asset_regex}</b>
-    übereinstimmt, aktualisiert.
+    Die Tool-URL wird von GitHub als die neueste Version des
+    Projekts <b>{github_project}</b>, die
+    mit <b>{github_asset_regex}</b> übereinstimmt,
+    aktualisiert.
     </>,
     "PlaceHolder":
     <>

--- a/gui/velociraptor/src/components/i8n/en.jsx
+++ b/gui/velociraptor/src/components/i8n/en.jsx
@@ -63,8 +63,8 @@ const English = {
     "Import Artifacts": length=><>Import {length} Artifacts</>,
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      You are about to permanently delete the artifact collection
-      <b>{session_id}</b>.
+      You are about to permanently delete the artifact
+      collection <b>{session_id}</b>.
       <br/>
       This collection had the artifacts <b className="wrapped-text">
                                           {artifacts}</b>
@@ -101,17 +101,17 @@ const English = {
     </>,
     "ServedFromURL": (base_path, url)=>
     <>
-      Clients will fetch the tool directly from
-      <a href={base_path + url}>{url}</a> if
+      Clients will fetch the tool directly 
+      from <a href={base_path + url}>{url}</a> if
       needed. Note that if the hash does not match the
       expected hash the clients will reject the file.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
       Tool URL will be refreshed from
-      GitHub as the latest release from the project
-      <b>{github_project}</b> that matches
-      <b>{github_asset_regex}</b>
+      GitHub as the latest release from the
+      project <b>{github_project}</b> that
+      matches <b>{github_asset_regex}</b>
     </>,
     "PlaceHolder":
     <>

--- a/gui/velociraptor/src/components/i8n/es.jsx
+++ b/gui/velociraptor/src/components/i8n/es.jsx
@@ -179,8 +179,8 @@ const Spanish = {
     "Permanently delete collection": "Eliminar colección de forma permanente",
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      Está a punto de eliminar de forma permanente la colección de artefactos
-      <b>{session_id}</b>.
+      Está a punto de eliminar de forma permanente la colección de
+      artefactos <b>{session_id}</b>.
       <br/>
       Esta colección comprende los artefactos <b className="wrapped-text">
          {artifacts}
@@ -382,17 +382,17 @@ const Spanish = {
     </>,
     "ServedFromURL": (base_path, url)=>
     <>
-    Los hosts descargarán la herramienta directamente de
-    <a href={base_path + url}>{url}</a> si es
+    Los hosts descargarán la herramienta directamente
+    de <a href={base_path + url}>{url}</a> si es
     necesario. Tenga en cuenta que si el hash no coincide con el
     hash esperado, los hosts rechazarán el archivo.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
     La URL de la herramienta será actualizada por
-    GitHub como la última versión del proyecto
-    <b>{github_project}</b>  que coincida con
-    <b>{github_asset_regex}</b>
+    GitHub como la última versión del 
+    proyecto <b>{github_project}</b> que coincida
+    con <b>{github_asset_regex}</b>
     </>,
     "PlaceHolder":
     <>

--- a/gui/velociraptor/src/components/i8n/fr.jsx
+++ b/gui/velociraptor/src/components/i8n/fr.jsx
@@ -182,8 +182,8 @@ const French = {
     "Permanently delete collection": "Supprimer définitivement la collection",
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-       Vous êtes sur le point de supprimer définitivement la collection d'artefacts
-       <b>{session_id}</b>.
+       Vous êtes sur le point de supprimer définitivement la collection
+       d'artefacts <b>{session_id}</b>.
        <br/>
        Cette collection avait les artefacts <b className="wrapped-text">
           {artifacts}
@@ -386,17 +386,17 @@ const French = {
     </>,
     "ServedFromURL": (base_path, url)=>
     <>
-    Les clients iront chercher l'outil directement à partir de
-    <a href={base_path + url}>{url}</a> si
+    Les clients iront chercher l'outil directement à partir
+    de <a href={base_path + url}>{url}</a> si
     nécessaire. Notez que si le hachage ne correspond pas au
     hachage attendu, les clients rejetteront le fichier.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
     L'URL de l'outil est mise à jour par
-    GitHub comme dernière version du projet
-    <b>{github_project}</b> qui correspond
-    <b>{github_asset_regex}</b>
+    GitHub comme dernière version du
+    projet <b>{github_project}</b> qui
+    correspond <b>{github_asset_regex}</b>
     </>,
     "PlaceHolder":
     <>

--- a/gui/velociraptor/src/components/i8n/jp.jsx
+++ b/gui/velociraptor/src/components/i8n/jp.jsx
@@ -178,8 +178,7 @@ const Japanese = {
     "Permanently delete collection": "コレクションを永久に削除する",
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      アーティファクトコレクションを永久に削除しようとしています。
-      <b>{session_id}</b>.
+      アーティファクトコレクションを永久に削除しようとしています。<b>{session_id}</b>.
       <br/>
       コレクションのアーティファクト： <b className="wrapped-text">
          {artifacts}

--- a/gui/velociraptor/src/components/i8n/por.jsx
+++ b/gui/velociraptor/src/components/i8n/por.jsx
@@ -181,8 +181,8 @@ const Portuguese = {
     "Permanently delete collection": "Excluir coleta permanentemente",
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      Você está prestes a excluir permanentemente a coleta de artefatos
-      <b>{session_id}</b>.
+      Você está prestes a excluir permanentemente a coleta de
+      artefatos <b>{session_id}</b>.
       <br/>
       Esta coleta tinha os artefatos <b className="wrapped-text">
                     {artifacts}
@@ -383,17 +383,17 @@ const Portuguese = {
         </>,
     "ServedFromURL": (base_path, url)=>
     <>
-      Os clientes obtêm a ferramenta diretamente de
-      <a href={base_path + url}>{url}</a> se
+      Os clientes obtêm a ferramenta diretamente
+      de <a href={base_path + url}>{url}</a> se
       necessário. Observe que, se o hash não corresponder ao
       hash esperado, os clientes rejeitarão o arquivo.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
       O URL da ferramenta é atualizado por
-      GitHub como a versão mais recente do projeto
-      <b>{github_project}</b> que se encaixa
-      <b>{github_asset_regex}</b>
+      GitHub como a versão mais recente do
+      projeto <b>{github_project}</b> que se
+      encaixa <b>{github_asset_regex}</b>
     </>,
     "PlaceHolder":
         <>

--- a/gui/velociraptor/src/components/i8n/vi.jsx
+++ b/gui/velociraptor/src/components/i8n/vi.jsx
@@ -35,8 +35,7 @@ const Vietnamese = {
     "Notebook for Collection": name=>"Ghi chú cho Collection "+name,
     "ArtifactDeletionDialog": (session_id, artifacts, total_bytes, total_rows)=>
     <>
-      Chuẩn bị xoá vĩnh viễn artifact collection
-      <b>{session_id}</b>.
+      Chuẩn bị xoá vĩnh viễn artifact collection <b>{session_id}</b>.
       <br/>
       Collection này có các artifacts <b className="wrapped-text">
          {artifacts}
@@ -70,13 +69,13 @@ const Vietnamese = {
     </>,
     "ServedFromURL": (base_path, url)=>
     <>
-    Máy trạm sẽ tải trực tiếp công cụ từ
-    <a href={base_path + url}>{url}</a> nếu cần thiết. Lưu ý rằng nếu hàm băm không khớp với hàm băm dự kiến, máy trạm sẽ từ chối tệp.
+    Máy trạm sẽ tải trực tiếp công cụ
+    từ <a href={base_path + url}>{url}</a> nếu cần thiết. Lưu ý rằng nếu hàm băm không khớp với hàm băm dự kiến, máy trạm sẽ từ chối tệp.
     </>,
     "ServedFromGithub": (github_project, github_asset_regex)=>
     <>
-    Công cụ sẽ được tải xuống từ GitHub dưới dạng release mới nhất từ
-    <b>{github_project}</b>, phù hợp với <b>{github_asset_regex}</b>
+    Công cụ sẽ được tải xuống từ GitHub dưới dạng release mới nhất
+    từ <b>{github_project}</b>, phù hợp với <b>{github_asset_regex}</b>
     </>,
     "PlaceHolder":
     <>


### PR DESCRIPTION
Fix JSX leading space for tags in translations. As an example, [malmoeb's post](https://infosec.exchange/@malmoeb/111675841615532732) displays the following capture where the link is not spaced from the text (`fromhttps://`).

<img width="475" alt="cdbf6801ad02d31e" src="https://github.com/Velocidex/velociraptor/assets/46688461/cf8c387c-69d7-4c46-ab76-6534d8599cd2">

This commit ensures any tags within the JSX translations are prefixed with text to avoid accidental white space trimming.

![image](https://github.com/Velocidex/velociraptor/assets/46688461/6ba458aa-ef2a-4825-bb07-610b6766e55a)

