### PR TITLE
Improve JSONL EOF and error handling

### DIFF
--- a/artifacts/testdata/server/testcases/json.in.yaml
+++ b/artifacts/testdata/server/testcases/json.in.yaml
@@ -16,3 +16,19 @@ Queries:
        filename=T,
        query={SELECT * FROM range(end=3)})
   - SELECT * FROM parse_jsonl(filename=T)
+
+
+  # Missing final \n is allowed and should return both rows
+  - SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n{"Foo":"Second"}')
+
+  # Empty line should be ignore
+  - SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n\n{"Foo":"Second"}')
+
+  # Skip corrupted lines but try to get other lines
+  - SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First}\n{"Foo":"Second"}')
+
+  # Corrupted last line is ignored
+  - SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n{"Foo":\n{"Foo":\n{"Foo":"Second"}')
+
+  # JSONL files with non-dict lines
+  - SELECT * FROM parse_jsonl(accessor="data", filename='1\ntrue\n[1,2,3]\n{"Foo":"First"}\n')

--- a/artifacts/testdata/server/testcases/json.out.yaml
+++ b/artifacts/testdata/server/testcases/json.out.yaml
@@ -36,4 +36,46 @@ SELECT parse_json_array(data=JSONArrayWithDicts) FROM scope()[
  {
   "_value": 2
  }
+]SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n{"Foo":"Second"}')[
+ {
+  "Foo": "First"
+ },
+ {
+  "Foo": "Second"
+ }
+]SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n\n{"Foo":"Second"}')[
+ {
+  "Foo": "First"
+ },
+ {
+  "Foo": "Second"
+ }
+]SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First}\n{"Foo":"Second"}')[
+ {
+  "Foo": "Second"
+ }
+]SELECT * FROM parse_jsonl(accessor="data", filename='{"Foo":"First"}\n{"Foo":\n{"Foo":\n{"Foo":"Second"}')[
+ {
+  "Foo": "First"
+ },
+ {
+  "Foo": "Second"
+ }
+]SELECT * FROM parse_jsonl(accessor="data", filename='1\ntrue\n[1,2,3]\n{"Foo":"First"}\n')[
+ {
+  "_value": 1
+ },
+ {
+  "_value": true
+ },
+ {
+  "_value": [
+   1,
+   2,
+   3
+  ]
+ },
+ {
+  "Foo": "First"
+ }
 ]

--- a/vql/parsers/json.go
+++ b/vql/parsers/json.go
@@ -20,6 +20,8 @@ package parsers
 import (
 	"bufio"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"reflect"
 	"strconv"
@@ -174,12 +176,16 @@ func (self ParseJsonlPlugin) Call(
 
 			default:
 				row_data, err := reader.ReadBytes('\n')
-				if err != nil {
+				if err != nil && !errors.Is(err, io.EOF) {
+					scope.Log("parse_jsonl: %v", err)
+					return
+				} else if errors.Is(err, io.EOF) && len(row_data) == 0 {
 					return
 				}
 				item := ordereddict.NewDict()
 				err = item.UnmarshalJSON(row_data)
 				if err != nil {
+					scope.Log("parse_jsonl: %v", err)
 					return
 				}
 


### PR DESCRIPTION
This commit improves JSONL parsing by allowing files to not be terminated by a new line:
> The last character in the file **_may_** be a line separator, and it will be treated the same as if there was no line separator present.
>
> _Source: https://jsonlines.org_

The commit further ensures that any error other than a graceful EOF (w/ no data) is logged. The code uses `errors.Is(...)` to maintain abstraction of the reader and allow future wrapping of the error.

This commit makes `parse_jsonl` suitable for single-line JSON files such as the Chromium `...\User Data\Default\Preferences` evidence.