### PR TITLE
Grow the Generic Embedded Config container to fit large config

### DIFF
--- a/actions/client_info.go
+++ b/actions/client_info.go
@@ -12,7 +12,7 @@ import (
 
 // Return essential information about the client used for indexing
 // etc. This augments the interrogation workflow via the
-// Server.Internal.ClientInfo artifact. We send this message tothe
+// Server.Internal.ClientInfo artifact. We send this message to the
 // server periodically to avoid having to issue Generic.Client.Info
 // hunts all the time.
 func GetClientInfo(

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -470,6 +470,8 @@ sources:
                dict(name="SleepDuration", type="int", default="0"),
                dict(name="ToolName"),
                dict(name="ToolInfo"),
+               dict(name="TemporaryOnly", type="bool"),
+               dict(name="Version"),
                dict(name="IsExecutable", type="bool", default="Y"),
             ) AS parameters,
             (

--- a/config/embedded.go
+++ b/config/embedded.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/Velocidex/yaml/v2"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+)
+
+func ExtractEmbeddedConfig(
+	embedded_file string) (*config_proto.Config, error) {
+
+	fd, err := os.Open(embedded_file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read a lot of the file into memory so we can extract the
+	// configuration. This solution only loads the first 10mb into
+	// memory which should be sufficient for most practical config
+	// files. If there are embedded binaries they will not be read and
+	// will be ignored at this stage (thay can be extracted with the
+	// 'me' accessor).
+	buf, err := ioutil.ReadAll(io.LimitReader(fd, 10*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the embedded marker in the buffer.
+	match := embedded_re.FindIndex(buf)
+	if match == nil {
+		return nil, noEmbeddedConfig
+	}
+
+	embedded_string := buf[match[0]:]
+	return decode_embedded_config(embedded_string)
+}
+
+func read_embedded_config() (*config_proto.Config, error) {
+	return decode_embedded_config(FileConfigDefaultYaml)
+}
+
+func decode_embedded_config(encoded_string []byte) (*config_proto.Config, error) {
+	// Get the first line which is never disturbed
+	idx := bytes.IndexByte(encoded_string, '\n')
+
+	if len(encoded_string) < idx+10 {
+		return nil, noEmbeddedConfig
+	}
+
+	// If the following line still starts with # then the file is not
+	// repacked - the repacker will replace all further data with the
+	// compressed string.
+	if encoded_string[idx+1] == '#' {
+		return nil, noEmbeddedConfig
+	}
+
+	// Decompress the rest of the data - note that zlib will ignore
+	// any padding anyway because the zlib header already contains the
+	// length of the compressed data so it is safe to just feed it the
+	// whole string here.
+	r, err := zlib.NewReader(bytes.NewReader(encoded_string[idx+1:]))
+	if err != nil {
+		return nil, err
+	}
+
+	b := &bytes.Buffer{}
+	_, err = io.Copy(b, r)
+	if err != nil {
+		return nil, err
+	}
+	r.Close()
+
+	result := &config_proto.Config{}
+	err = yaml.Unmarshal(b.Bytes(), result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -262,7 +262,7 @@ message ClientConfig {
     uint64 default_server_flow_stats_update = 39;
 
     // Clients will send a Server.Internal.ClientInfo message to the
-    // server every this many seconds.This helps to keep the server
+    // server every this many seconds. This helps to keep the server
     // info up to date about each client. This should not be sent too
     // frequently. The default is 1 day (86400 seconds).
     int64 client_info_update_time = 40;

--- a/services/interrogation/interrogation.go
+++ b/services/interrogation/interrogation.go
@@ -264,12 +264,12 @@ func modifyRecord(ctx context.Context,
 	label_array, ok := row.GetStrings("Labels")
 	if ok {
 		client_info.Labels = append(client_info.Labels, label_array...)
+		client_info.Labels = utils.Uniquify(client_info.Labels)
 	}
 
 	mac_addresses, ok := row.GetStrings("MACAddresses")
 	if ok {
-		client_info.MacAddresses = mac_addresses
-		client_info.MacAddresses = utils.Uniquify(client_info.MacAddresses)
+		client_info.MacAddresses = utils.Uniquify(mac_addresses)
 	}
 
 	if client_info.FirstSeenAt == 0 {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -153,6 +153,20 @@ func SlicesEqual(a []string, b []string) bool {
 	return true
 }
 
+func BytesEqual(a []byte, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for idx, a_item := range a {
+		if a_item != b[idx] {
+			return false
+		}
+	}
+
+	return true
+}
+
 func ToString(x interface{}) string {
 	switch t := x.(type) {
 	case string:


### PR DESCRIPTION
With very large artifacts, the embedded config space reserved in the binary may be exceeded. In this case it should still be possible to use the Generic Collector container to hold large embedded artifact definitions.

This PR allows larger configs to be embedded in the GenericCollector container.