### PR TITLE
Add proc_yara to Windows.Detection.Yara.Process

### DIFF
--- a/artifacts/definitions/Windows/Detection/Yara/Process.yaml
+++ b/artifacts/definitions/Windows/Detection/Yara/Process.yaml
@@ -89,7 +89,7 @@ sources:
     query: |
       -- check which Yara to use
       LET yara_rules <= YaraUrl || YaraRule
-
+      
       -- find velociraptor process
       LET me = SELECT Pid FROM pslist(pid=getpid())
 
@@ -112,8 +112,8 @@ sources:
                 ExePath,
                 CommandLine,
                 Pid,
-                Namespace,
                 Rule,
+                Tags,
                 Meta,
                 String.Name as YaraString,
                 String.Offset as HitOffset,
@@ -124,25 +124,26 @@ sources:
                         split(string=ProcessName, sep='\\.')[0], Pid,
                         String.Offset ]
                     )) as HitContext
-             FROM yara(
-                files=format(format="/%d", args=Pid),
-                accessor='process',
-                rules=yara_rules,
-                context=ContextBytes,
-                number=NumberOfHits)
+                
+            FROM proc_yara(
+                            pid=int(int=Pid),
+                            rules=yara_rules,
+                            context=ContextBytes,
+                            number=NumberOfHits
+                        )
           })
 
       -- upload hits using proc_dump plugin
       LET upload_hits = SELECT * FROM foreach(
         row=hits,
         query={
-            SELECT
+            SELECT 
                 ProcessName,
                 ExePath,
                 CommandLine,
                 Pid,
-                Namespace,
                 Rule,
+                Tags,
                 Meta,
                 YaraString,
                 HitOffset,
@@ -154,7 +155,7 @@ sources:
                 ) as ProcessDump
             FROM proc_dump(pid=Pid)
           })
-
+          
       -- return rows
       SELECT * FROM if(condition=UploadHits,
         then=upload_hits,


### PR DESCRIPTION
Update Windows.Detection.Yara.Process to use proc_yara and output same fields( Tag =~ Namespace )
Block scanning edgecases are resolved.