### PR TITLE
Added a dotnet rundown artifact.

### DIFF
--- a/artifacts/definitions/Windows/ETW/DotNetRundown.yaml
+++ b/artifacts/definitions/Windows/ETW/DotNetRundown.yaml
@@ -1,0 +1,45 @@
+name: Windows.ETW.DotNetRundown
+author: @bmcder02
+description: |
+   Queries the Microsoft-Windows-DotNETRuntimeRundown provider to collect a list of
+   DotNet modules loaded into a process. This can be useful when responding to 
+   reflectively loaded DotNet malware. 
+   
+   NOTE: System.Timestamp represents when the artifact was run, NOT when the module was
+   loaded.
+
+
+type: CLIENT
+
+parameters:
+  - name: ProcessRegex
+    default: .
+    type: regex
+  - name: PidRegex
+    default: .
+    type: regex
+  - name: EventIDRegex
+    default: .
+    type: regex
+  - name: Timeout 
+    default: 20
+    type: int
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+      LET EventData = SELECT System.ID AS EventID, System.ProcessID AS ProcessID, 
+        process_tracker_get(id=System.ProcessID) AS ProcessDetails,
+        *
+      FROM watch_etw(
+        guid="{A669021C-C450-4609-A035-5AF59AF4DF18}", 
+        any=0x48, timeout=Timeout)
+        
+      SELECT EventID, ProcessID, ProcessDetails.Data.Name AS ProcessName, 
+        ProcessDetails.Data.Exe AS ProcessPath, System, EventData, ProviderGUID,
+        ProcessDetails
+      FROM EventData
+      WHERE EventID =~ EventIDRegex
+        AND ProcessID =~ PidRegex
+        AND ProcessPath =~ ProcessRegex


### PR DESCRIPTION
Uses the DotNet Rundown ETW provider to list all loaded DotNet modules within a process. This is useful for reflectively loaded modules loaded through C# API Assembly.Load()