### PR TITLE
Bugfix: specify monospace font explicitly. #3259

### DIFF
--- a/gui/velociraptor/src/themes/ncurses.css
+++ b/gui/velociraptor/src/themes/ncurses.css
@@ -141,6 +141,10 @@ body.ncurses {
   font-size: var(--font-size-base) !important;
 }
 
+.ncurses .ace_editor, .ace_editor * {
+  font-family: "Monaco", "Menlo", "Ubuntu Mono", "Droid Sans Mono", "Consolas", monospace !important;
+}
+
 /* this is for the context help popup */
 .ncurses .ace_editor {
   font-family: var(--font-family-monospace) !important;


### PR DESCRIPTION
## What Changed
- Fixed: #3259
  - I have applied the following workaround.
    - https://github.com/ajaxorg/ace/issues/2548#issuecomment-699484043


## Evidence
### Enviroment
- OS: macOS Sonoma version 14.2.1
- Velociraptor: 0.7.1

### Test(Google Chrome)
I run the steps to reproduce #3259 and confirmed that the issue was resolved as follows.
<img width="1234" alt="スクリーンショット 2024-02-01 5 59 58" src="https://github.com/Velocidex/velociraptor/assets/41001169/25ac1752-d249-442d-8b54-6c3532f2ed6b">

### Test(Firefox)
<img width="1245" alt="スクリーンショット 2024-02-01 6 05 34" src="https://github.com/Velocidex/velociraptor/assets/41001169/88a7430c-85c2-4d30-b727-7ea2acba9f67">


### Test(Safari)
<img width="1174" alt="スクリーンショット 2024-02-01 6 10 09" src="https://github.com/Velocidex/velociraptor/assets/41001169/1030485a-018b-487b-a5eb-61e1488af0aa">


Thank you for your time.
Best,
