### PR TITLE
Bugfix: Store the repository in the scope for use in VQL

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -328,10 +328,24 @@ func (self *ApiServer) LabelClients(
 			case "set":
 				err = labeler.SetClientLabel(ctx,
 					org_config_obj, client_id, label)
+				if err == nil {
+					services.LogAudit(ctx,
+						org_config_obj, principal, "SetClientLabel",
+						ordereddict.NewDict().
+							Set("client_id", client_id).
+							Set("label", label))
+				}
 
 			case "remove":
 				err = labeler.RemoveClientLabel(ctx,
 					org_config_obj, client_id, label)
+				if err == nil {
+					services.LogAudit(ctx,
+						org_config_obj, principal, "RemoveClientLabel",
+						ordereddict.NewDict().
+							Set("client_id", client_id).
+							Set("label", label))
+				}
 
 			default:
 				return nil, errors.New("Unknown label operation")

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -59,6 +59,7 @@ const (
 	SCOPE_ROOT              = "$root"
 	SCOPE_STACK             = "$stack"
 	SCOPE_DEVICE_MANAGER    = "$device_manager"
+	SCOPE_REPOSITORY        = "$repository"
 	SCOPE_RESPONDER_CONTEXT = "_Context"
 
 	// Artifact names from packs should start with this

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -1455,7 +1455,6 @@
     or quoting issues (since there is no shell involved). Additionally
     it does not invoke powershell which means that any execution
     artifacts are not trampled by this VQL.
-
   type: Plugin
   args:
   - name: argv
@@ -2254,6 +2253,46 @@
   category: plugin
   metadata:
     permissions: FILESYSTEM_READ
+- name: host
+  description: |
+    Perform a DNS resolution.
+
+    This function allows DNS to be resolved from within VQL. You can
+    use the regular system resolver (for example on windows will go
+    through the resolver cache service).
+
+    You can also specify an external DNS server, causing the query to
+    contact the DNS server for resolving the names.
+
+    NOTE: No cachig is currently provided so this may generate a lot
+    of load on DNS servers when scanning many rows.
+
+    Example: The first query resolves through an external DNS server
+    while the second uses the local resolver.
+
+    ```
+    SELECT host(name='www.google.com', server='8.8.8.8:53'),
+       host(name='www.google.com')
+    FROM scope()
+    ```
+
+  type: Function
+  args:
+  - name: name
+    type: string
+    description: The name to lookup
+    required: true
+  - name: server
+    type: string
+    description: A DNS server to query - if not provided uses the system resolver.
+  - name: type
+    type: string
+    description: Type of lookup, can be CNAME, NS, SOA, TXT, DNSKEY, AXFR, A (default)
+  - name: prefer_go
+    type: bool
+    description: Prefer calling the native Go implementation rather than the system.
+  metadata:
+    permissions: MACHINE_STATE
 - name: http_client
   description: |
     Make a http request.
@@ -2345,10 +2384,10 @@
     description: The URL to fetch
     required: true
   - name: params
-    type: Any
+    type: ordereddict.Dict
     description: Parameters to encode as POST or GET query strings
   - name: headers
-    type: Any
+    type: ordereddict.Dict
     description: A dict of headers to send.
   - name: method
     type: string
@@ -2383,6 +2422,10 @@
   - name: user_agent
     type: string
     description: If specified, set a HTTP User-Agent.
+  - name: secret
+    type: string
+    description: If specified, use this managed secret. The secret should be of type
+      'HTTP Secrets'. Alternatively specify the Url as secret://name
   category: plugin
   metadata:
     permissions: COLLECT_SERVER
@@ -6295,7 +6338,6 @@
   - name: region
     type: string
     description: The region the bucket is in
-    required: true
   - name: credentialskey
     type: string
     description: The AWS key credentials to use
@@ -6323,6 +6365,10 @@
   - name: skip_verify
     type: bool
     description: Skip TLS Verification
+  - name: secret
+    type: string
+    description: Alternatively use a secret from the secrets service. Secret must
+      be of type 'AWS S3 Creds'
   category: plugin
   metadata:
     permissions: FILESYSTEM_READ
@@ -6770,6 +6816,23 @@
   category: event
   metadata:
     permissions: FILESYSTEM_READ
+- name: watch_jsonl
+  description: Watch a jsonl file and stream events from it.
+  type: Plugin
+  args:
+  - name: filename
+    type: accessors.OSPath
+    description: A list of log files to parse.
+    repeated: true
+    required: true
+  - name: accessor
+    type: string
+    description: The accessor to use.
+  - name: buffer_size
+    type: int
+    description: Maximum size of line buffer.
+  metadata:
+    permissions: FILESYSTEM_READ
 - name: watch_monitoring
   description: |
     Watch clients' monitoring log. This is an event plugin. This
@@ -6922,6 +6985,9 @@
     type: StoredQuery
     description: query to write into the file.
     required: true
+  - name: buffer_size
+    type: int
+    description: Maximum size of buffer before flushing to file.
   metadata:
     permissions: FILESYSTEM_WRITE
 - name: xattr

--- a/services/repository/plugin.go
+++ b/services/repository/plugin.go
@@ -272,6 +272,7 @@ func (self *ArtifactRepositoryPlugin) copyScope(
 		constants.SCOPE_THROTTLE,
 		constants.SCOPE_ROOT,
 		constants.SCOPE_RESPONDER,
+		constants.SCOPE_REPOSITORY,
 		constants.SCOPE_UPLOADER} {
 		value, pres := scope.Resolve(field)
 		if pres {

--- a/vql/darwin/xattr.go
+++ b/vql/darwin/xattr.go
@@ -4,7 +4,8 @@ package darwin
 
 import (
 	"context"
-	"x/sys/unix"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/accessors"

--- a/vql/networking/host.go
+++ b/vql/networking/host.go
@@ -1,0 +1,110 @@
+package networking
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/vql"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/functions"
+	vfilter "www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+)
+
+type HostFunctionArgs struct {
+	Name     string `vfilter:"required,field=name,doc=The name to lookup"`
+	Server   string `vfilter:"optional,field=server,doc=A DNS server to query - if not provided uses the system resolver."`
+	Type     string `vfilter:"optional,field=type,doc=Type of lookup, can be CNAME, NS, SOA, TXT, DNSKEY, AXFR, A (default)"`
+	PreferGo bool   `vfilter:"optional,field=prefer_go,doc=Prefer calling the native Go implementation rather than the system."`
+}
+
+type HostFunction struct{}
+
+func (self *HostFunction) Call(ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+	arg := &HostFunctionArgs{}
+
+	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
+	if err != nil {
+		scope.Log("host: %v", err)
+		return false
+	}
+
+	err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+	if err != nil {
+		scope.Log("host: %v", err)
+		return false
+	}
+
+	resolver := net.Resolver{
+		PreferGo: arg.PreferGo,
+	}
+
+	// Override connection if we need to.
+	if arg.Server != "" {
+		// If the user specified a server then we must do the resolving
+		// outside the C library.
+		resolver.PreferGo = true
+		resolver.Dial = func(ctx context.Context,
+			network, address string) (net.Conn, error) {
+			dialer := net.Dialer{}
+			return dialer.DialContext(ctx, network, arg.Server)
+		}
+	}
+
+	var addresses interface{}
+
+	switch arg.Type {
+	case "", "A":
+		addresses, err = resolver.LookupHost(ctx, arg.Name)
+
+	case "PTR":
+		addresses, err = resolver.LookupAddr(ctx, arg.Name)
+
+	case "NS":
+		addresses, err = resolver.LookupNS(ctx, arg.Name)
+
+	case "MX":
+		addresses, err = resolver.LookupMX(ctx, arg.Name)
+
+	case "SRV":
+		_, addresses, err = resolver.LookupSRV(ctx, "", "", arg.Name)
+
+	case "TXT":
+		addresses, err = resolver.LookupTXT(ctx, arg.Name)
+
+	case "CNAME":
+		addresses, err = resolver.LookupCNAME(ctx, arg.Name)
+
+	case "IP":
+		addresses, err = resolver.LookupIPAddr(ctx, arg.Name)
+
+	default:
+		addresses = vfilter.Null{}
+		err = errors.New(
+			"Invalid lookup type: should be one of A,PTR,NS,MX,SRV,TXT,CNAME,Port,IP")
+	}
+
+	if err != nil {
+		functions.DeduplicatedLog(ctx, scope,
+			"host: Lookup error "+arg.Type+": %v", err)
+	}
+	return addresses
+}
+
+func (self *HostFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:     "host",
+		Doc:      "Perform a DNS resolution.",
+		ArgType:  type_map.AddType(scope, &HostFunctionArgs{}),
+		Metadata: vql.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&HostFunction{})
+}

--- a/vql/server/flows/create.go
+++ b/vql/server/flows/create.go
@@ -30,6 +30,7 @@ import (
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/velociraptor/vql/tools/collector"
+	vql_utils "www.velocidex.com/golang/velociraptor/vql/utils"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
@@ -120,12 +121,7 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 		}
 	}
 
-	manager, err := services.GetRepositoryManager(config_obj)
-	if err != nil {
-		scope.Log("collect_client: Command can only run on the server")
-		return vfilter.Null{}
-	}
-	repository, err := manager.GetGlobalRepository(config_obj)
+	repository, err := vql_utils.GetRepository(scope)
 	if err != nil {
 		scope.Log("collect_client: Command can only run on the server")
 		return vfilter.Null{}

--- a/vql/server/flows/parallel.go
+++ b/vql/server/flows/parallel.go
@@ -150,7 +150,7 @@ func breakIntoScopes(
 	// the parameters, we need to get the reader from different
 	// places.
 	result_set_reader, err := getResultSetReader(
-		ctx, config_obj, &SourcePluginArgs{
+		ctx, config_obj, scope, &SourcePluginArgs{
 			ClientId:          arg.ClientId,
 			FlowId:            arg.FlowId,
 			Artifact:          arg.Artifact,

--- a/vql/server/hunts/create.go
+++ b/vql/server/hunts/create.go
@@ -34,6 +34,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/velociraptor/vql/functions"
 	"www.velocidex.com/golang/velociraptor/vql/tools/collector"
+	vql_utils "www.velocidex.com/golang/velociraptor/vql/utils"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 
 	"www.velocidex.com/golang/vfilter"
@@ -112,12 +113,7 @@ func (self *ScheduleHuntFunction) Call(ctx context.Context,
 		arg.OrgIds = append(arg.OrgIds, config_obj.OrgId)
 	}
 
-	manager, err := services.GetRepositoryManager(config_obj)
-	if err != nil {
-		scope.Log("hunt: %v", err)
-		return vfilter.Null{}
-	}
-	repository, err := manager.GetGlobalRepository(config_obj)
+	repository, err := vql_utils.GetRepository(scope)
 	if err != nil {
 		scope.Log("hunt: %v", err)
 		return vfilter.Null{}

--- a/vql/server/hunts/hunts.go
+++ b/vql/server/hunts/hunts.go
@@ -34,6 +34,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/services/hunt_dispatcher"
 	"www.velocidex.com/golang/velociraptor/vql"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	vql_utils "www.velocidex.com/golang/velociraptor/vql/utils"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
@@ -196,12 +197,7 @@ func (self HuntResultsPlugin) Call(
 			// first named source from the artifact
 			// definition.
 			if arg.Source == "" {
-				manager, err := services.GetRepositoryManager(config_obj)
-				if err != nil {
-					scope.Log("hunt_results: %v", err)
-					return
-				}
-				repo, err := manager.GetGlobalRepository(config_obj)
+				repo, err := vql_utils.GetRepository(scope)
 				if err == nil {
 					artifact_def, ok := repo.Get(ctx, config_obj, arg.Artifact)
 					if ok {

--- a/vql/server/labels.go
+++ b/vql/server/labels.go
@@ -62,6 +62,7 @@ func (self *AddLabels) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
+	principal := vql_subsystem.GetPrincipal(scope)
 	labeler := services.GetLabeler(config_obj)
 	for _, label := range arg.Labels {
 		if label == "" {
@@ -71,9 +72,24 @@ func (self *AddLabels) Call(ctx context.Context,
 		switch arg.Op {
 		case "set":
 			err = labeler.SetClientLabel(ctx, config_obj, arg.ClientId, label)
+			if err == nil {
+				services.LogAudit(ctx,
+					config_obj, principal, "SetClientLabel",
+					ordereddict.NewDict().
+						Set("client_id", arg.ClientId).
+						Set("label", label))
+			}
 
 		case "remove":
-			err = labeler.RemoveClientLabel(ctx, config_obj, arg.ClientId, label)
+			err = labeler.RemoveClientLabel(
+				ctx, config_obj, arg.ClientId, label)
+			if err == nil {
+				services.LogAudit(ctx,
+					config_obj, principal, "RemoveClientLabel",
+					ordereddict.NewDict().
+						Set("client_id", arg.ClientId).
+						Set("label", label))
+			}
 
 		case "check":
 			if !labeler.IsLabelSet(ctx, config_obj, arg.ClientId, label) {

--- a/vql/server/monitoring/add_monitoring.go
+++ b/vql/server/monitoring/add_monitoring.go
@@ -10,6 +10,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/vql"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	vql_utils "www.velocidex.com/golang/velociraptor/vql/utils"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
@@ -47,13 +48,7 @@ func (self AddClientMonitoringFunction) Call(
 	}
 
 	// Now verify the artifact actually exists
-	manager, err := services.GetRepositoryManager(config_obj)
-	if err != nil {
-		scope.Log("add_client_monitoring: %v", err)
-		return vfilter.Null{}
-	}
-
-	repository, err := manager.GetGlobalRepository(config_obj)
+	repository, err := vql_utils.GetRepository(scope)
 	if err != nil {
 		scope.Log("add_client_monitoring: %v", err)
 		return vfilter.Null{}
@@ -211,13 +206,7 @@ func (self AddServerMonitoringFunction) Call(
 	}
 
 	// Now verify the artifact actually exists
-	manager, err := services.GetRepositoryManager(config_obj)
-	if err != nil {
-		scope.Log("add_server_monitoring: %v", err)
-		return vfilter.Null{}
-	}
-
-	repository, err := manager.GetGlobalRepository(config_obj)
+	repository, err := vql_utils.GetRepository(scope)
 	if err != nil {
 		scope.Log("add_server_monitoring: %v", err)
 		return vfilter.Null{}

--- a/vql/tools/collector/collector_manager.go
+++ b/vql/tools/collector/collector_manager.go
@@ -28,6 +28,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/velociraptor/vql/psutils"
+	vql_utils "www.velocidex.com/golang/velociraptor/vql/utils"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/types"
 )
@@ -73,12 +74,7 @@ func (self *collectionManager) GetRepository(extra_artifacts vfilter.Any) (err e
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	manager, err := services.GetRepositoryManager(self.config_obj)
-	if err != nil {
-		return err
-	}
-
-	self.repository, err = manager.GetGlobalRepository(self.config_obj)
+	self.repository, err = vql_utils.GetRepository(self.scope)
 	if err != nil {
 		return err
 	}
@@ -276,8 +272,8 @@ func (self *collectionManager) collectQuery(
 			status.ResultRows++
 			row_dict := vfilter.RowToDict(self.ctx, subscope, row)
 			if query.Name != "" {
-        			row_dict.Set("_Source", query.Name)
-     			}
+				row_dict.Set("_Source", query.Name)
+			}
 			select {
 			case <-self.ctx.Done():
 				query_log.Close()

--- a/vql/utils/repository.go
+++ b/vql/utils/repository.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"errors"
+
+	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/vfilter"
+)
+
+func GetRepository(scope vfilter.Scope) (services.Repository, error) {
+	any_obj, pres := scope.Resolve(constants.SCOPE_REPOSITORY)
+	if !pres {
+		return nil, errors.New("Repository not found in scope!!")
+	}
+	repository, ok := any_obj.(services.Repository)
+	if !ok {
+		return nil, errors.New("Repository not found in scope!!")
+	}
+	return repository, nil
+}


### PR DESCRIPTION
This fixes #3299 in which the VQL running on the client was accessing the local client side repository instead of the artifacts that were being sent by the VQL request.

This made it impossible to automatically package custom artifacts in the vql request, although built in artifacts would work from the local client artifact repository.

This changes forces the collect() plugin to use the query side repository which is empty other than those artifacts explicitely sent. This means that collect() will not be able to find built in artifacts any more and everything needs to be sent.

```
name: Custom.CollectTest
sources:
  - query: |
      LET _ = SELECT * FROM Artifact.Custom.Artifact()
      SELECT * FROM collect(artifacts="Custom.Artifact")
```