### PR TITLE
Refactored notebook storage to have in memory index

### DIFF
--- a/api/hunts.go
+++ b/api/hunts.go
@@ -9,6 +9,7 @@ import (
 	errors "github.com/go-errors/errors"
 
 	context "golang.org/x/net/context"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"www.velocidex.com/golang/velociraptor/acls"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
@@ -17,6 +18,7 @@ import (
 	vjson "www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/hunt_dispatcher"
+	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 )
@@ -243,8 +245,14 @@ func (self *ApiServer) CreateHunt(
 			continue
 		}
 
+		// In the root org mark the org ids that we are launching.
+		org_hunt_request := proto.Clone(in).(*api_proto.Hunt)
+		if !utils.IsRootOrg(org_id) {
+			org_hunt_request.OrgIds = nil
+		}
+
 		new_hunt, err := hunt_dispatcher.CreateHunt(
-			ctx, org_config_obj, acl_manager, in)
+			ctx, org_config_obj, acl_manager, org_hunt_request)
 		if err != nil {
 			errors_msg = append(errors_msg, fmt.Sprintf(
 				"%v: CreateHunt: GetOrgConfig %v", org_id, err))

--- a/artifacts/definitions/Windows/System/TaskScheduler.yaml
+++ b/artifacts/definitions/Windows/System/TaskScheduler.yaml
@@ -15,6 +15,13 @@ parameters:
     default: c:/Windows/System32/Tasks/**
   - name: AlsoUpload
     type: bool
+    description: |
+      If set we also upload the task XML files.
+  - name: UploadCommands
+    type: bool
+    description: |
+      If set we attempt to upload the commands that are
+      mentioned in the scheduled tasks
 
 sources:
   - name: Analysis
@@ -35,10 +42,23 @@ sources:
                     replace='')) AS XML
         FROM read_file(filenames=OSPath)
 
-      SELECT OSPath,
+      LET Results = SELECT OSPath,
             XML.Task.Actions.Exec.Command as Command,
+            expand(path=XML.Task.Actions.Exec.Command)  AS ExpandedCommand,
             XML.Task.Actions.Exec.Arguments as Arguments,
             XML.Task.Actions.ComHandler.ClassId as ComHandler,
             XML.Task.Principals.Principal.UserId as UserId,
             XML as _XML
         FROM foreach(row=Uploads, query=parse_task)
+
+      SELECT *,
+         authenticode(filename=ExpandedCommand) AS Authenticode,
+         if(condition=UploadCommands and ExpandedCommand,
+            then=upload(file=ExpandedCommand)) AS Upload
+      FROM Results
+
+column_types:
+- name: Upload
+  type: upload_preview
+- name: Authenticode
+  type: folded

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -30,6 +30,12 @@ func (self *MultiGetSubjectRequest) Message() proto.Message {
 	return proto.Clone(self.message)
 }
 
+func (self *MultiGetSubjectRequest) Error() error {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+	return self.Err
+}
+
 func NewMultiGetSubjectRequest(message proto.Message, path api.DSPathSpec, data interface{}) *MultiGetSubjectRequest {
 	return &MultiGetSubjectRequest{
 		message: proto.Clone(message),

--- a/docs/references/sample_config/main.go
+++ b/docs/references/sample_config/main.go
@@ -107,6 +107,8 @@ var (
 		"defaults.disable_inventory_service_external_access",
 		"lockdown",
 		"debug_mode",
+		"Client.proxy_config.ignore_environment",
+		"Frontend.proxy_config.ignore_environment",
 	}
 )
 
@@ -158,6 +160,10 @@ func is_set(a reflect.Value) bool {
 
 	if a.Kind() == reflect.Float32 {
 		return a.Interface().(float32) != 0
+	}
+
+	if a.Kind() == reflect.Map {
+		return a.Len() > 0
 	}
 
 	spew.Dump(a.Kind())

--- a/docs/references/server.config.yaml
+++ b/docs/references/server.config.yaml
@@ -122,10 +122,17 @@ Client:
   ## A list of one or more URLs the clients will try to connect
   ## to. When all connections fail the client will back off for a
   ## while. Clients will choose one of these at random so it is a good
-  ## way of achieving fault tolerance and load balancing.
+  ## way of achieving fault tolerance and load balancing.  As of
+  ## version 0.72, You can choose to use websockets here for a better
+  ## experience by setting the URL to start with wss://
   server_urls:
+  - wss://192.168.1.1:8000/
   - https://192.168.1.1:8000/
   - https://192.168.1.2:8000/
+
+  ## When using websockets the server will ping the client every this
+  ## many seconds.
+  ws_ping_wait_sec: 60
 
   ## A URL to a proxy that will be used to connect to the server. Some
   ## environments have egress filtering requiring Velociraptor to use
@@ -134,6 +141,28 @@ Client:
   ## you might need to add an allow rule to the proxy config to allow
   ## the Velociraptor server URL without authentication.
   proxy: https://proxy:3128/
+
+  ## Some proxy configurations are more complex. You can specify a
+  ## more detailed configuration here instead of the proxy parameter
+  ## above.
+  proxy_config:
+    # The proxy configuration for http and https urs.
+    http:  "<not set>"
+    https: "<not set>"
+
+    # A list of url regexp to match the url and connect to the
+    # target. Use an empty string to denote direct connection.
+    proxy_url_regexp:
+       "^https://localhost/": ""
+
+    # Location of a PAC file (overrides the above settings). This can
+    # be a file:// URL or even a data: url.
+    pac: "<not set>"
+
+    # If this is set we ignore the HTTP_PROXY and HTTPS_PROXY
+    # environment variables. By default we allow these environment
+    # variables to override the settings in this file.
+    ignore_environment: false
 
   ## The Internal Velociraptor CA certificate used to verify the
   ## server certificates. Do not change this! This will be generated
@@ -557,6 +586,16 @@ Frontend:
   # an non existent setting (e.g. http://127.0.0.1:3128).
   proxy: "http://127.0.0.1:3128"
 
+  # These proxy settings are exactly the same as the
+  # Cllient.proxy_config settings but apply to the server.
+  proxy_config:
+    http: "<not set>"
+    https: "<not set>"
+    proxy_url_regexp:
+       "^https://localhost/": ""
+    pac: "<not set>"
+    ignore_environment: false
+
   ## Velociraptor can attempt to obfuscate artifact names when
   ## compiling them into raw VQL. If this is set this obfuscation is
   ## removed.
@@ -599,10 +638,16 @@ Frontend:
   ## DNS server with its public IP address. Currently we only support
   ## Google Domains although other providers may also work.
   dyn_dns:
+    # The type of DynDNS provider (Can be cloudfront or noip)
+    type: noip
+
     # The hostname to update
     hostname: www.velo.com
     ddns_username: 1234233452
     ddns_password: 2313e2324
+
+    # The hostname to update - if empty we use Frontend.hostname
+    ddns_hostname: "<not set>"
 
     # If empty we use Google Domains.
     update_url: http://dyndns.provider.com/
@@ -617,6 +662,12 @@ Frontend:
     # DNS server we query for our own hostname/ip mapping (default
     # 8.8.8.8:53)
     dns_server: "8.8.8.8:53"
+
+    # Used by the cloudfront provider
+    api_token: <not set>
+
+    # The zone to update (dns domain).
+    zone_name: <not set>
 
   # Header defined by the proxy containing the remote address. If this
   # is not set we use the remote IP address from the TCP

--- a/gui/velociraptor/src/components/core/table.jsx
+++ b/gui/velociraptor/src/components/core/table.jsx
@@ -562,6 +562,14 @@ export function formatColumns(columns, env, column_formatter) {
             x.type = null;
             break;
 
+        case "collapsed":
+            x.formatter = (cell, row) => {
+                return <VeloValueRenderer
+                         value={cell} collapsed={true}/>;
+            };
+            x.type = null;
+            break;
+
         case "preview_upload":
         case "upload_preview":
             x.formatter = (cell, row) => {

--- a/gui/velociraptor/src/components/hunts/hunt-notebook.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-notebook.jsx
@@ -60,6 +60,7 @@ export default class HuntNotebook extends React.Component {
                 return;
             }
 
+            let orgs = this.props.hunt.org_ids || [];
             let request = {
                 name: T("Notebook for Hunt", hunt_id),
                 description: this.props.hunt.description ||
@@ -73,6 +74,7 @@ export default class HuntNotebook extends React.Component {
                 public: true,
                 env: [
                     {key: "HuntId", value: hunt_id},
+                    {key: "Orgs", value: orgs.join(",")},
                 ],
             };
 

--- a/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
@@ -15,7 +15,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 const column_types = [
     "string", "number", "mb", "timestamp", "nobreak", "tree", "url",
     "safe_url", "flow", "preview_uploads", "client", "hex",
-    "base64",
+    "base64", "collapsed"
 ];
 
 const column_type_regex = /^([\s\S]*)LET ColumnTypes<=dict\((.+)\)\n\n([\S\s]+)$/m;

--- a/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
@@ -14,7 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 // components/core/table.jsx formatColumns
 const column_types = [
     "string", "number", "mb", "timestamp", "nobreak", "tree", "url",
-    "safe_url", "flow", "preview_uploads", "client", "hex",
+    "safe_url", "flow", "preview_upload", "client", "hex",
     "base64", "collapsed"
 ];
 

--- a/gui/velociraptor/src/components/utils/value.jsx
+++ b/gui/velociraptor/src/components/utils/value.jsx
@@ -60,6 +60,7 @@ export default class VeloValueRenderer extends React.Component {
     static contextType = UserConfig;
     static propTypes = {
         value: PropTypes.any,
+        collapsed: PropTypes.bool,
     };
 
     getTheme = ()=> {
@@ -108,7 +109,7 @@ export default class VeloValueRenderer extends React.Component {
         return (
             <ContextMenu value={v}>
               <ReactJson name={false}
-                         collapsed={1}
+                         collapsed={this.props.collapsed}
                          theme={theme}
                          enableClipboard={false}
                          collapseStringsAfterLength={100}

--- a/services/notebook.go
+++ b/services/notebook.go
@@ -23,6 +23,8 @@ type NotebookManager interface {
 	GetSharedNotebooks(ctx context.Context,
 		username string, offset, count uint64) ([]*api_proto.NotebookMetadata, error)
 
+	GetAllNotebooks() ([]*api_proto.NotebookMetadata, error)
+
 	NewNotebook(ctx context.Context,
 		username string, in *api_proto.NotebookMetadata) (
 		*api_proto.NotebookMetadata, error)
@@ -32,8 +34,6 @@ type NotebookManager interface {
 		*api_proto.NotebookMetadata, error)
 
 	UpdateNotebook(ctx context.Context, in *api_proto.NotebookMetadata) error
-
-	UpdateShareIndex(notebook *api_proto.NotebookMetadata) error
 
 	GetNotebookCell(ctx context.Context,
 		notebook_id, cell_id, version string) (*api_proto.NotebookCell, error)

--- a/services/notebook/calculate.go
+++ b/services/notebook/calculate.go
@@ -8,6 +8,7 @@ import (
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 func (self *NotebookManager) UpdateNotebookCell(
@@ -61,7 +62,7 @@ func (self *NotebookManager) UpdateNotebookCell(
 		Input:             in.Input,
 		CellId:            in.CellId,
 		Type:              in.Type,
-		Timestamp:         time.Now().Unix(),
+		Timestamp:         utils.GetTime().Now().Unix(),
 		CurrentlyEditing:  in.CurrentlyEditing,
 		Calculating:       true,
 		Env:               in.Env,

--- a/services/notebook/calculate_test.go
+++ b/services/notebook/calculate_test.go
@@ -25,9 +25,11 @@ type: SERVER
 
 type NotebookManagerTestSuite struct {
 	test_utils.TestSuite
+	closer func()
 }
 
 func (self *NotebookManagerTestSuite) SetupTest() {
+	self.closer = utils.MockTime(utils.NewMockClock(time.Unix(10, 10)))
 	self.ConfigObj = self.TestSuite.LoadConfig()
 	self.ConfigObj.Services.NotebookService = true
 	self.ConfigObj.Services.SchedulerService = true
@@ -44,10 +46,12 @@ func (self *NotebookManagerTestSuite) SetupTest() {
 	utils.SetIdGenerator(&gen)
 }
 
-func (self *NotebookManagerTestSuite) TestNotebookManagerUpdateCell() {
-	closer := utils.MockTime(utils.NewMockClock(time.Unix(10, 10)))
-	defer closer()
+func (self *NotebookManagerTestSuite) TearDownTest() {
+	self.TestSuite.TearDownTest()
+	self.closer()
+}
 
+func (self *NotebookManagerTestSuite) TestNotebookManagerUpdateCell() {
 	notebook_manager, err := services.GetNotebookManager(self.ConfigObj)
 	assert.NoError(self.T(), err)
 

--- a/services/notebook/notebook.go
+++ b/services/notebook/notebook.go
@@ -177,7 +177,7 @@ func NewNotebookManagerService(
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) (services.NotebookManager, error) {
 
-	store, err := NewNotebookStore(ctx, config_obj)
+	store, err := NewNotebookStore(ctx, wg, config_obj)
 	if err != nil {
 		return nil, err
 	}

--- a/services/notebook/storage.go
+++ b/services/notebook/storage.go
@@ -55,12 +55,15 @@ type NotebookStoreImpl struct {
 
 func NewNotebookStore(
 	ctx context.Context,
+	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) (*NotebookStoreImpl, error) {
 	result := &NotebookStoreImpl{
 		config_obj: config_obj,
 	}
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-ctx.Done():

--- a/services/sanity/sanity.go
+++ b/services/sanity/sanity.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -18,7 +17,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
-	"www.velocidex.com/golang/velociraptor/services/notebook"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
@@ -128,27 +126,7 @@ func (self *SanityChecks) Check(
 		}
 	}
 
-	// Reindex all the notebooks.
-	notebooks, err := notebook.GetAllNotebooks(config_obj)
-	if err != nil {
-		return err
-	}
-
-	notebook_manager, err := services.GetNotebookManager(config_obj)
-	if err != nil {
-		return err
-	}
-	for _, notebook := range notebooks {
-		if !strings.HasPrefix(notebook.NotebookId, "N.H.") &&
-			!strings.HasPrefix(notebook.NotebookId, "N.F.") {
-			err = notebook_manager.UpdateShareIndex(notebook)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	err = configServerMetadata(ctx, config_obj)
+	err := configServerMetadata(ctx, config_obj)
 	if err != nil {
 		return err
 	}

--- a/utils/clock.go
+++ b/utils/clock.go
@@ -75,7 +75,7 @@ func (self *MockClock) After(d time.Duration) <-chan time.Time {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	self.mockNow = self.mockNow.Add(d)
+	//self.mockNow = self.mockNow.Add(d)
 	res := make(chan time.Time)
 	close(res)
 	return res

--- a/vql/server/downloads/fixtures/TestExportHunt.golden
+++ b/vql/server/downloads/fixtures/TestExportHunt.golden
@@ -263,7 +263,10 @@
   "artifact_sources": [
    "Custom.TestArtifactUpload"
   ],
-  "state": "PAUSED"
+  "state": "PAUSED",
+  "org_ids": [
+   "root"
+  ]
  },
  "results/All Custom.TestArtifactUpload.csv": [
   "Upload,SparseUpload,FlowId,ClientId,Fqdn",

--- a/vql/server/flows/results.go
+++ b/vql/server/flows/results.go
@@ -1,19 +1,19 @@
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package flows
 
@@ -83,6 +83,8 @@ type SourcePluginArgs struct {
 
 	StartRow int64 `vfilter:"optional,field=start_row,doc=Start reading the result set from this row"`
 	Limit    int64 `vfilter:"optional,field=count,doc=Maximum number of clients to fetch (default unlimited)'"`
+
+	OrgIds []string `vfilter:"optional,field=orgs,doc=Run the query over these orgs. If empty use the current org.'"`
 }
 
 type SourcePlugin struct{}
@@ -129,7 +131,8 @@ func (self SourcePlugin) Call(
 		new_args := ordereddict.NewDict().
 			Set("hunt_id", arg.HuntId).
 			Set("artifact", arg.Artifact).
-			Set("source", arg.Source)
+			Set("source", arg.Source).
+			Set("orgs", arg.OrgIds)
 
 		// Just delegate to the hunt_results() plugin.
 		return hunts.HuntResultsPlugin{}.Call(ctx, scope, new_args)

--- a/vql/server/hunts/create.go
+++ b/vql/server/hunts/create.go
@@ -110,7 +110,7 @@ func (self *ScheduleHuntFunction) Call(ctx context.Context,
 
 	} else {
 		// Schedule on the current org
-		arg.OrgIds = append(arg.OrgIds, config_obj.OrgId)
+		arg.OrgIds = append(arg.OrgIds, utils.NormalizedOrgId(config_obj.OrgId))
 	}
 
 	repository, err := vql_utils.GetRepository(scope)

--- a/vql/server/hunts/create.go
+++ b/vql/server/hunts/create.go
@@ -1,19 +1,19 @@
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package hunts
 
@@ -243,8 +243,15 @@ func (self *ScheduleHuntFunction) Call(ctx context.Context,
 			continue
 		}
 
+		// Only mark the org ids in the root org version of the hunt.
+		org_hunt_request := hunt_request
+		if utils.IsRootOrg(org_id) {
+			org_hunt_request = proto.Clone(hunt_request).(*api_proto.Hunt)
+			org_hunt_request.OrgIds = arg.OrgIds
+		}
+
 		new_hunt, err = hunt_dispatcher.CreateHunt(
-			ctx, org_config_obj, acl_manager, hunt_request)
+			ctx, org_config_obj, acl_manager, org_hunt_request)
 		if err != nil {
 			scope.Log("hunt: %v", err)
 			continue

--- a/vql/server/hunts/fixtures/TestCreateHunt.golden
+++ b/vql/server/hunts/fixtures/TestCreateHunt.golden
@@ -33,7 +33,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  },
  "exclude label hunt": {
@@ -70,7 +73,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  },
  "include label hunt": {
@@ -107,7 +113,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  },
  "include and exclude label hunt": {
@@ -149,7 +158,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  },
  "os hunt": {
@@ -184,7 +196,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  },
  "os and label hunt": {
@@ -219,7 +234,10 @@
    "artifacts": [
     "Test.Artifact"
    ],
-   "state": "RUNNING"
+   "state": "RUNNING",
+   "org_ids": [
+    "root"
+   ]
   }
  }
 }

--- a/vql/server/hunts/hunts.go
+++ b/vql/server/hunts/hunts.go
@@ -220,6 +220,8 @@ func (self HuntResultsPlugin) Call(
 			arg.Orgs = append(arg.Orgs, config_obj.OrgId)
 		}
 
+		principal := vql_subsystem.GetPrincipal(scope)
+
 		org_manager, err := services.GetOrgManager()
 		if err != nil {
 			return
@@ -228,6 +230,14 @@ func (self HuntResultsPlugin) Call(
 		for _, org_id := range arg.Orgs {
 			org_config_obj, err := org_manager.GetOrgConfig(org_id)
 			if err != nil {
+				continue
+			}
+
+			// Make sure the principal has read access in this org.
+			permissions := acls.READ_RESULTS
+			perm, err := services.CheckAccess(
+				org_config_obj, principal, permissions)
+			if !perm || err != nil {
 				continue
 			}
 


### PR DESCRIPTION
Notebook sharing was implemented using an on disk index keyed by the username. This resulted in being unable to detect public notebooks when these notebooks were not directly shared with the user as well.

This PR refactores the notebook manager storage to maintain an in memory cache of all global notebooks. This should make listing and viewing global notebooks faster as well as removing the need for notebook share index completely.