### PR TITLE
Automatically detect a partition image in deaddisk command.

### DIFF
--- a/accessors/ewf/ewf.go
+++ b/accessors/ewf/ewf.go
@@ -45,6 +45,10 @@ func (self *EWFReader) Read(buff []byte) (int, error) {
 		return 0, err
 	}
 
+	if n == 0 {
+		return 0, io.EOF
+	}
+
 	self.offset += int64(n)
 	return n, err
 }

--- a/artifacts/definitions/Generic/Client/Stats.yaml
+++ b/artifacts/definitions/Generic/Client/Stats.yaml
@@ -23,6 +23,26 @@ sources:
            FROM pslist(pid=getpid())
          })
 
+    notebook:
+      - type: vql_suggestion
+        name: Graph CPU usage
+        template: |
+          /*
+          # Events from Generic.Client.Stats
+          */
+          LET StartTime <= "2024-03-20T16:33:38Z"
+          LET EndTime <= "2024-03-20T20:01:37Z"
+
+          LET resources = SELECT Timestamp, rate(x=CPU, y=Timestamp) * 100 As CPUPercent,
+               RSS / 1000000 AS MemoryUse
+          FROM source()
+          WHERE CPUPercent >= 0
+          /*
+            {{ Query "SELECT * FROM resources" | LineChart "xaxis_mode" "time" "RSS.yaxis" 2 }}
+          */
+          SELECT * FROM resources
+          LIMIT 50
+
   - precondition: SELECT OS From info() where OS != 'windows'
     query: |
       SELECT *, rate(x=CPU, y=Timestamp) AS CPUPercent

--- a/vql/sigma/fixtures/TestSigma.golden
+++ b/vql/sigma/fixtures/TestSigma.golden
@@ -641,5 +641,55 @@
    }
   }
  ],
- "Unknown modifiers": []
+ "Unknown modifiers": [],
+ "All modifier": [
+  {
+   "Foo": "Bar",
+   "Details": null,
+   "_Match": {
+    "Match": true,
+    "SearchResults": {
+     "selection": true
+    },
+    "ConditionResults": [
+     true
+    ]
+   },
+   "_Rule": {
+    "Title": "BadModifiers",
+    "Logsource": {
+     "Product": "windows",
+     "Service": "application"
+    },
+    "Detection": {
+     "Searches": {
+      "selection": {
+       "EventMatchers": [
+        [
+         {
+          "Field": "Foo",
+          "Modifiers": [
+           "contains",
+           "all"
+          ],
+          "Values": [
+           "a",
+           "B"
+          ]
+         }
+        ]
+       ]
+      }
+     },
+     "condition": [
+      {
+       "Search": {
+        "Name": "selection"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ]
 }

--- a/vql/sigma/sigma_test.go
+++ b/vql/sigma/sigma_test.go
@@ -290,6 +290,28 @@ detection:
 			},
 			log_regex: "unknown modifier somemodifier",
 		},
+		{
+			description: "All modifier",
+			rule: `
+title: BadModifiers
+logsource:
+   product: windows
+   service: application
+
+detection:
+  selection:
+     Foo|contains|all:
+       - a
+       - B
+  condition: selection
+`,
+			fieldmappings: ordereddict.NewDict().
+				Set("Foo", "x=>x.Foo"),
+			rows: []*ordereddict.Dict{
+				ordereddict.NewDict().
+					Set("Foo", "Bar"),
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
If an image does not contain a partition table, and it is a filesystem (partition) image then we need to automatically add the image offset 0