### PR TITLE
Bugfix: Crash with pipe plugin

### DIFF
--- a/accessors/api.go
+++ b/accessors/api.go
@@ -302,6 +302,24 @@ type ReadSeekCloser interface {
 	io.Closer
 }
 
+// Some files are not really seekable (although they may pretend to
+// be). Sometimes it is important to know if the file may be rewound
+// back if we read from it - before we actually read from it. If a
+// ReadSeekCloser also implements the Seekable interface it may report
+// if it can be seeked.
+type Seekable interface {
+	IsSeekable() bool
+}
+
+func IsSeekable(fd ReadSeekCloser) bool {
+	seekable, ok := fd.(Seekable)
+	if ok {
+		return seekable.IsSeekable()
+	}
+
+	return true
+}
+
 // Interface for accessing the filesystem.
 type FileSystemAccessor interface {
 	// List a directory.

--- a/accessors/file/os_windows.go
+++ b/accessors/file/os_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -260,6 +261,10 @@ func (self OSFileSystemAccessor) ReadDirWithOSPath(
 // Wrap the os.File object to keep track of open file handles.
 type OSFileWrapper struct {
 	*os.File
+}
+
+func (self OSFileWrapper) IsSeekable() bool {
+	return true
 }
 
 func (self OSFileWrapper) Close() error {

--- a/accessors/zip/zip.go
+++ b/accessors/zip/zip.go
@@ -461,14 +461,16 @@ func (self *ZipFileCache) Close() {
 	}
 }
 
-/* Zip members are normally compressed and therefore not seekable. If
-   we read the members sequentially (e.g. for yara scanning or other
-   sequential parsing), then there is no need to unpack the
-   file. However, if the callers need to seek within the archive
-   member we must unpack it to a tempfile.
+/*
+Zip members are normally compressed and therefore not seekable. If
 
-   This wrapper manages this by wrapping the underlying zip member and
-   unpacking to a tmpfile automatically depending on usage patterns.
+We read the members sequentially (e.g. for yara scanning or other
+sequential parsing), then there is no need to unpack the
+file. However, if the callers need to seek within the archive
+member we must unpack it to a tempfile.
+
+This wrapper manages this by wrapping the underlying zip member and
+unpacking to a tmpfile automatically depending on usage patterns.
 */
 type SeekableZip struct {
 	mu sync.Mutex
@@ -486,6 +488,10 @@ type SeekableZip struct {
 	tmp_file_backing *os.File
 
 	closed bool
+}
+
+func (self *SeekableZip) IsSeekable() bool {
+	return false
 }
 
 func (self *SeekableZip) Close() error {

--- a/gui/velociraptor/src/components/clients/clients-list.jsx
+++ b/gui/velociraptor/src/components/clients/clients-list.jsx
@@ -405,6 +405,7 @@ const pageListRenderer = ({
             as="input"
             className="pagination-form"
             placeholder={T("Goto Page")}
+            id="goto-page"
             spellCheck="false"
             value={currentPage || ""}
             onChange={e=> {

--- a/gui/velociraptor/src/components/clients/search.jsx
+++ b/gui/velociraptor/src/components/clients/search.jsx
@@ -96,6 +96,7 @@ class VeloClientSearch extends Component {
                         placeholder: T("SEARCH_CLIENTS"),
                         spellCheck: "false",
                         value: this.state.query,
+                        id: "SEARCH_CLIENTS",
                         onChange: (e, {newValue, method}) => {
                             this.setState({query: newValue});
                             e.preventDefault();

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -78,6 +78,7 @@ const pageListRenderer = ({
             className="pagination-form"
             placeholder={T("Goto Page")}
             spellCheck="false"
+            id="goto-page"
             value={currentPage || ""}
             onChange={e=> {
                 let page = parseInt(e.currentTarget.value || 0);

--- a/gui/velociraptor/src/components/hunts/hunt-list.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-list.jsx
@@ -27,6 +27,16 @@ import UserConfig from '../core/user.jsx';
 import api from '../core/api-service.jsx';
 import {CancelToken} from 'axios';
 
+const SLIDE_STATES = [{
+    level: "30%",
+    icon: "arrow-down",
+}, {
+    level: "100%",
+    icon: "arrow-up",
+}, {
+    level: "42px",
+    icon: "arrows-up-down",
+}];
 
 const POLL_TIME = 5000;
 
@@ -155,6 +165,9 @@ class HuntList extends React.Component {
             this.props.history.push("/hunts");
         }
         this.interval = setInterval(this.incrementVersion, POLL_TIME);
+
+        let slider = SLIDE_STATES[this.state.slider];
+        this.props.collapseToggle(slider.level);
     }
 
     componentWillUnmount() {
@@ -177,6 +190,7 @@ class HuntList extends React.Component {
         showCopyWizard: false,
         showModifyHuntDialog: false,
 
+        slider: 0,
         filter: "",
         selected_row: undefined,
         version: 1,
@@ -332,6 +346,12 @@ class HuntList extends React.Component {
             }
         });
     }
+
+    expandSlider = ()=>{
+        let next_slide = (this.state.slider + 1) % SLIDE_STATES.length;
+        this.setState({ slider: next_slide});
+        this.props.collapseToggle(SLIDE_STATES[next_slide].level);
+    };
 
     render() {
         let selected_hunt = this.props.selected_hunt &&
@@ -501,8 +521,9 @@ class HuntList extends React.Component {
                                 data-position="left"
                                 className="btn-tooltip"
                                 variant="default"
-                                onClick={this.props.collapseToggle}>
-                          <FontAwesomeIcon icon="expand"/>
+                                onClick={this.expandSlider}>
+                          <FontAwesomeIcon
+                            icon={SLIDE_STATES[this.state.slider].icon}/>
                         </Button>
 
                       { !this.state.filter ?

--- a/gui/velociraptor/src/components/hunts/hunts.jsx
+++ b/gui/velociraptor/src/components/hunts/hunts.jsx
@@ -45,12 +45,8 @@ class VeloHunts extends React.Component {
         this.get_hunts_source.cancel();
     }
 
-    collapse = () => {
-        if (!this.state.collapsed) {
-            this.setState({topPaneSize: "100%", collapsed: true});
-        } else {
-            this.setState({topPaneSize: "30%", collapsed: false});
-        }
+    collapse = level=> {
+        this.setState({topPaneSize: level});
     }
 
     setSelectedHuntId = (hunt_id) => {

--- a/gui/velociraptor/src/components/widgets/pagination.jsx
+++ b/gui/velociraptor/src/components/widgets/pagination.jsx
@@ -32,6 +32,7 @@ export class TextPaginationControl extends React.Component {
                     "page-link": true,
                     "goto-invalid": this.state.goto_error,
                 })}
+                id="goto_page"
                 placeholder={T("Goto Offset")}
                 spellCheck="false"
                 value={this.state.goto_offset}

--- a/utils/read_seek_reader_adapter.go
+++ b/utils/read_seek_reader_adapter.go
@@ -38,6 +38,10 @@ func (self *ReadSeekReaderAdapter) Read(buf []byte) (int, error) {
 	return n, err
 }
 
+func (self *ReadSeekReaderAdapter) IsSeekable() bool {
+	return true
+}
+
 func (self *ReadSeekReaderAdapter) Seek(offset int64, whence int) (int64, error) {
 	if whence != 0 {
 		return 0, errors.New("Unsupported whence")


### PR DESCRIPTION
When pipe() was used with parse_lines() a crash occured. This happened because parse_lines() attempts to open files as gzip files first, then reopen them again if that fails.

It is not possible to safely reopen an pipe though. This PR fixes the crash and avoids opening the pipe as gzip first.