### PR TITLE
Optimize performance of registry accessor.

### DIFF
--- a/accessors/mount.go
+++ b/accessors/mount.go
@@ -123,6 +123,8 @@ type FileInfoWrapper struct {
 	// mount path.
 	prefix        *OSPath
 	remove_prefix *OSPath
+
+	_ospath *OSPath
 }
 
 func (self FileInfoWrapper) FullPath() string {
@@ -134,10 +136,16 @@ func (self FileInfoWrapper) Name() string {
 }
 
 func (self FileInfoWrapper) OSPath() *OSPath {
+	if self._ospath != nil {
+		return self._ospath
+	}
+
 	delegate_path := self.FileInfo.OSPath()
 	trimmed_path := delegate_path.TrimComponents(
 		self.remove_prefix.Components...)
-	return self.prefix.Append(trimmed_path.Components...)
+
+	self._ospath = self.prefix.Append(trimmed_path.Components...)
+	return self._ospath
 }
 
 // A mount accessor maps several delegate accessors inside the same

--- a/accessors/raw_registry/lru.go
+++ b/accessors/raw_registry/lru.go
@@ -1,0 +1,8 @@
+package raw_registry
+
+import "www.velocidex.com/golang/velociraptor/accessors"
+
+type readDirLRUItem struct {
+	children []accessors.FileInfo
+	err      error
+}

--- a/accessors/registry/lru.go
+++ b/accessors/registry/lru.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+package registry
+
+import "www.velocidex.com/golang/velociraptor/accessors"
+
+type readDirLRUItem struct {
+	children []accessors.FileInfo
+	err      error
+}

--- a/accessors/registry/registry_windows_test.go
+++ b/accessors/registry/registry_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package registry
@@ -14,7 +15,9 @@ import (
 )
 
 func TestRegistryFilesystemAccessor(t *testing.T) {
-	accessor := &RegFileSystemAccessor{}
+	scope := vql_subsystem.MakeScope()
+	accessor, err := &RegFileSystemAccessor{}.New(scope)
+	assert.NoError(t, err)
 
 	ls := func(path string, filter string) []string {
 		filter_re := regexp.MustCompile(filter)

--- a/accessors/registry/registry_windows_test.go
+++ b/accessors/registry/registry_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"github.com/sebdah/goldie"
 	"www.velocidex.com/golang/velociraptor/json"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 )
 

--- a/accessors/registry/registry_windows_test.go
+++ b/accessors/registry/registry_windows_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRegistryFilesystemAccessor(t *testing.T) {
 	scope := vql_subsystem.MakeScope()
-	accessor, err := &RegFileSystemAccessor{}.New(scope)
+	accessor, err := (&RegFileSystemAccessor{}).New(scope)
 	assert.NoError(t, err)
 
 	ls := func(path string, filter string) []string {

--- a/accessors/registry/values.go
+++ b/accessors/registry/values.go
@@ -1,0 +1,129 @@
+//go:build windows
+// +build windows
+
+package registry
+
+import (
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows/registry"
+	"www.velocidex.com/golang/velociraptor/vql/windows"
+)
+
+const (
+	_ERROR_NO_MORE_ITEMS syscall.Errno = 259
+)
+
+var pool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 1024)
+		return &buffer
+	},
+}
+
+// A more optimized key.GetValue() - avoid unnecessary syscalls and allocations
+func getValue(key registry.Key, value_name string) (
+	buf_size int, value_type uint32, value interface{}, err error) {
+
+	metricsReadValue.Inc()
+
+	// Use the pool to avoid allocations.
+	cached_buffer := pool.Get().(*[]byte)
+	defer pool.Put(cached_buffer)
+
+	data := *cached_buffer
+
+	buf_size, value_type, err = key.GetValue(value_name, data)
+	if err == syscall.ERROR_MORE_DATA {
+
+		// Try again with larger buffer.
+		buf := make([]byte, buf_size)
+		buf_size, value_type, err = key.GetValue(value_name, buf)
+		if err != nil {
+			return buf_size, value_type, "", err
+		}
+		data = buf
+	}
+	if err != nil {
+		return buf_size, value_type, "", err
+	}
+
+	// Now parse the value based on the type.
+	// Following code is based on https://cs.opensource.google/go/x/sys/+/refs/tags/v0.18.0:windows/registry/value.go
+	switch value_type {
+	case registry.DWORD:
+		if buf_size == 4 {
+			var val32 uint32
+			copy((*[4]byte)(unsafe.Pointer(&val32))[:], data)
+			return buf_size, value_type, uint64(val32), nil
+		}
+
+	case registry.QWORD:
+		if buf_size == 8 {
+			var val64 uint64
+			copy((*[8]byte)(unsafe.Pointer(&val64))[:], data)
+			return buf_size, value_type, uint64(val64), nil
+		}
+
+	case registry.BINARY:
+		// Need to make a copy of the data so the buffer may be
+		// returned to the pool.
+		new_buff := append([]byte{}, data[:buf_size]...)
+		return buf_size, value_type, new_buff, nil
+
+		// We deliberately do not expand this because it depends on
+		// the process env.
+	case registry.MULTI_SZ, registry.SZ, registry.EXPAND_SZ:
+		u := (*[1 << 29]uint16)(unsafe.Pointer(&data[0]))[: len(data)/2 : len(data)/2]
+		return buf_size, value_type, syscall.UTF16ToString(u), nil
+
+	default:
+	}
+
+	// Otherwise just return the binary buffer.
+	new_buff := append([]byte{}, data[:buf_size]...)
+	return buf_size, value_type, new_buff, nil
+}
+
+func ReadValueNames(k registry.Key) ([]string, error) {
+	ki, err := k.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, ki.ValueCount)
+	// Use the pool to avoid allocations.
+	cached_buffer := pool.Get().(*[]byte)
+	defer pool.Put(cached_buffer)
+
+	buf := *cached_buffer
+
+loopItems:
+	for i := uint32(0); ; i++ {
+		l := uint32(len(buf)) / 2
+		for {
+			err := windows.RegEnumValue(syscall.Handle(k), i, &buf[0], &l, nil, nil, nil, nil)
+			if err == nil {
+				break
+			}
+			if err == syscall.ERROR_MORE_DATA {
+				// Double buffer size and try again.
+				buf = make([]byte, 2*len(buf))
+				l = uint32(len(buf)) / 2
+				continue
+			}
+
+			if err == _ERROR_NO_MORE_ITEMS {
+				break loopItems
+			}
+
+			return names, err
+		}
+
+		u := (*[1 << 29]uint16)(unsafe.Pointer(&buf[0]))[: len(buf)/2 : len(buf)/2]
+		names = append(names, syscall.UTF16ToString(u))
+	}
+	return names, nil
+}

--- a/artifacts/definitions/Windows/Registry/NTUser.yaml
+++ b/artifacts/definitions/Windows/Registry/NTUser.yaml
@@ -40,8 +40,8 @@ export: |
     -- HivePath: The path to the hive on disk
     -- RegistryPath: The path in the registry to mount the hive
     -- RegMountPoint: The path inside the hive to mount (usually /)
-    LET _map_file_to_reg_path(HivePath, RegistryPath, RegMountPoint, Accessor) = dict(
-       type="mount",
+    LET _map_file_to_reg_path(HivePath, RegistryPath, RegMountPoint, Accessor, Description) = dict(
+       type="mount", description=Description,
        `from`=dict(accessor='raw_reg',
                    prefix=pathspec(
                       Path=RegMountPoint,
@@ -52,42 +52,62 @@ export: |
                   prefix=RegistryPath,
                   path_type='registry'))
 
+    -- This needs to always be mapped because it is normally denied through the API
+    LET _required_mappings = (
+       _map_file_to_reg_path(
+          HivePath="C:/Windows/System32/Config/SECURITY",
+          RegistryPath="HKEY_LOCAL_MACHINE\\Security",
+          RegMountPoint="/",
+          Accessor='ntfs',
+          Description="Map SECURITY Hive to HKEY_LOCAL_MACHINE"),
+    )
+
     LET _standard_mappings = (
        _map_file_to_reg_path(
           HivePath="C:/Windows/System32/Config/SYSTEM",
           RegistryPath="HKEY_LOCAL_MACHINE\\System\\CurrentControlSet",
           RegMountPoint="/ControlSet001",
-          Accessor='ntfs'),
-
+          Accessor='ntfs',
+          Description="Map SYSTEM Hive to CurrentControlSet"),
        _map_file_to_reg_path(
           HivePath="C:/Windows/System32/Config/SOFTWARE",
           RegistryPath="HKEY_LOCAL_MACHINE\\Software",
           RegMountPoint="/",
-          Accessor='ntfs'),
+          Accessor='ntfs',
+          Description="Map Software hive to HKEY_LOCAL_MACHINE"),
        _map_file_to_reg_path(
           HivePath="C:/Windows/System32/Config/System",
           RegistryPath="HKEY_LOCAL_MACHINE\\System",
           RegMountPoint="/",
-          Accessor='ntfs')
+          Accessor='ntfs',
+          Description="Map System hive to HKEY_LOCAL_MACHINE")
     )
 
-    LET _make_ntuser_mappings = SELECT _map_file_to_reg_path(
+    LET _make_ntuser_mappings(Accessor, Hive, Subpath) = SELECT _map_file_to_reg_path(
       HivePath=NTUserPath,
       RegMountPoint="/",
-      Accessor='ntfs',
+      Accessor=Accessor,
+      Description=format(format="Map NTUSER.dat from User %v to HKEY_USERS", args=NTUserPath[2]),
       -- This is technically the SID but it is clearer to just use the username
-      RegistryPath="HKEY_USERS/" + NTUserPath[-2]) AS Mapping
+      RegistryPath="HKEY_USERS\\" + NTUserPath[2] + Subpath) AS Mapping
     FROM foreach(row={
-       SELECT pathspec(parse=expand(path=Directory), path_type="windows") + "NTUser.dat"  AS NTUserPath
+       SELECT pathspec(parse=expand(path=Directory),
+                       path_type="windows") + Hive  AS NTUserPath
        FROM Artifact.Windows.Sys.Users()
     }, query={
         -- Verify the file actually exists
         SELECT NTUserPath FROM stat(filename=NTUserPath)
     })
 
+    LET _user_mappings =
+      _make_ntuser_mappings(Accessor='auto', Hive="NTUser.dat", Subpath="").Mapping +
+      _make_ntuser_mappings(Accessor='auto',
+        Hive="\\AppData\\Local\\Microsoft\\Windows\\UsrClass.dat",
+        Subpath="\\Software\\Classes", Subpath="\\Software\\Classes").Mapping
+
     // Use this like `LET _ <= MapRawRegistryHives`
     LET MapRawRegistryHives =remap(config=dict(
-       remappings=_make_ntuser_mappings.Mapping + _standard_mappings))
+       remappings=_user_mappings + _standard_mappings + _required_mappings))
 
 sources:
  - query: |

--- a/artifacts/testdata/server/testcases/memoize.in.yaml
+++ b/artifacts/testdata/server/testcases/memoize.in.yaml
@@ -1,0 +1,9 @@
+Queries:
+- LET AllData <= SELECT "A" AS Key, "B" AS Value
+    FROM scope()
+
+- LET Mem <= memoize(query={
+   SELECT * FROM AllData
+  }, key="Key")
+
+- SELECT get(item=Mem, field="A") FROM scope()

--- a/artifacts/testdata/server/testcases/memoize.out.yaml
+++ b/artifacts/testdata/server/testcases/memoize.out.yaml
@@ -1,0 +1,8 @@
+LET AllData <= SELECT "A" AS Key, "B" AS Value FROM scope()[]LET Mem <= memoize(query={ SELECT * FROM AllData }, key="Key")[]SELECT get(item=Mem, field="A") FROM scope()[
+ {
+  "get(item=Mem, field=\"A\")": {
+   "Key": "A",
+   "Value": "B"
+  }
+ }
+]

--- a/bin/artifacts.go
+++ b/bin/artifacts.go
@@ -1,19 +1,19 @@
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package main
 
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/Velocidex/yaml/v2"
@@ -35,6 +34,7 @@ import (
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 )
 
@@ -236,12 +236,11 @@ func doArtifactCollect() error {
 		Nanny.Start(ctx, &sync.WaitGroup{})
 	}
 
-	now := time.Now()
+	start := utils.GetTime().Now()
 	defer func() {
 		logging.GetLogger(config_obj, &logging.ToolComponent).
 			Info("Collection completed in %v Seconds",
-				time.Now().Unix()-now.Unix())
-
+				utils.GetTime().Now().Sub(start))
 	}()
 
 	if *trace_vql_flag {

--- a/gui/velociraptor/src/components/hunts/hunt-list.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-list.jsx
@@ -475,7 +475,7 @@ class HuntList extends React.Component {
                         <Button data-tooltip={T("Modify Hunt")}
                             data-position="right"
                             className="btn-tooltip"
-                            disabled={!this.props.selected_hunt}
+                            disabled={!selected_hunt}
                             onClick={() => this.setState({ showModifyHuntDialog: true })}
                             variant="default">
                             <FontAwesomeIcon icon="wrench" />

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -538,6 +538,16 @@ func compileArtifact(
 			source.Queries = queries
 		}
 	}
+
+	// Also compile the export section to alert immediately about any
+	// problems.
+	if artifact.Export != "" {
+		_, err := splitQueryToQueries(artifact.Export)
+		if err != nil {
+			return fmt.Errorf("While compiling Exports from %v: %w",
+				artifact.Name, err)
+		}
+	}
 	artifact.Compiled = true
 
 	return updateTools(ctx, config_obj, artifact)

--- a/vql/common/cache.go
+++ b/vql/common/cache.go
@@ -37,7 +37,7 @@ func (self *_CacheObj) Get(key string) (vfilter.Any, bool) {
 	if time.Now().After(self.expires) {
 		self.cache = make(map[string]vfilter.Any)
 		self.expires = time.Now().Add(self.period)
-		self.Materialize()
+		self.materialize()
 	}
 
 	value, pres := self.cache[key]
@@ -55,6 +55,10 @@ func (self *_CacheObj) Materialize() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	self.materialize()
+}
+
+func (self *_CacheObj) materialize() {
 	self.cache = make(map[string]vfilter.Any)
 	stored_query := arg_parser.ToStoredQuery(self.ctx, self.expression)
 
@@ -159,6 +163,7 @@ func (self _CacheFunc) Call(ctx context.Context, scope vfilter.Scope,
 		}
 
 		new_cache_obj := NewCacheObj(ctx, scope, "", arg.Name)
+		new_cache_obj.expression = arg.Func
 		new_cache_obj.period = time.Duration(arg.Period) * time.Second
 		cache_obj = new_cache_obj
 	}

--- a/vql/tools/collector/collector.go
+++ b/vql/tools/collector/collector.go
@@ -82,6 +82,11 @@ func (self CollectPlugin) Call(
 
 		collection_manager := newCollectionManager(ctx, config_obj,
 			output_chan, int(arg.Concurrency), scope)
+
+		// Make sure the Close() is called under any circumstances.
+		vql_subsystem.GetRootScope(scope).AddDestructor(func() {
+			collection_manager.Close()
+		})
 		defer collection_manager.Close()
 
 		request, err := self.configureCollection(ctx, collection_manager, arg)

--- a/vql/tools/collector/collector_manager.go
+++ b/vql/tools/collector/collector_manager.go
@@ -457,6 +457,7 @@ func newCollectionManager(
 	output_chan chan vfilter.Row,
 	concurrency int,
 	scope vfilter.Scope) *collectionManager {
+
 	subctx, cancel := context.WithCancel(ctx)
 
 	if concurrency == 0 {

--- a/vql/windows/win32_windows.go
+++ b/vql/windows/win32_windows.go
@@ -1,21 +1,22 @@
+//go:build windows && amd64
 // +build windows,amd64
 
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package windows
 
@@ -388,6 +389,7 @@ type PROCESS_MEMORY_COUNTERS struct {
 //sys NetUserEnum(servername *uint16, level uint32, filter uint32, bufptr *uintptr, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (status NET_API_STATUS) = netapi32.NetUserEnum
 //sys NetUserGetGroups(servername *LPCWSTR, username *LPCWSTR, level DWORD, bufptr *LPBYTE, prefmaxlen DWORD, entriesread *LPDWORD, totalentries *LPDWORD) (status NET_API_STATUS) = netapi32.NetUserGetGroups
 //sys QueryAllTracesW(PropertyArray uintptr, PropertyArrayCount uint32, LoggerCount *uint32) (status uint32) = advapi32.QueryAllTracesA
+//sys RegEnumValue(key syscall.Handle, index uint32, name *byte, nameLen *uint32, reserved *uint32, valtype *uint32, buf *byte, buflen *uint32) (regerrno error) = advapi32.RegEnumValueW
 
 // Converts a pointer to a wide string to a regular go string. The
 // underlying buffer may be freed afterwards by the Windows API.

--- a/vql/windows/win32_windows_32.go
+++ b/vql/windows/win32_windows_32.go
@@ -1,21 +1,22 @@
+//go:build windows && 386
 // +build windows,386
 
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package windows
 
@@ -384,6 +385,7 @@ type PROCESS_MEMORY_COUNTERS struct {
 //sys NetApiBufferFree(Buffer uintptr) (status NET_API_STATUS) = netapi32.NetApiBufferFree
 //sys NetUserEnum(servername *uint16, level uint32, filter uint32, bufptr *uintptr, prefmaxlen uint32, entriesread *uint32, totalentries *uint32, resume_handle *uint32) (status NET_API_STATUS) = netapi32.NetUserEnum
 //sys NetUserGetGroups(servername *LPCWSTR, username *LPCWSTR, level DWORD, bufptr *LPBYTE, prefmaxlen DWORD, entriesread *LPDWORD, totalentries *LPDWORD) (status NET_API_STATUS) = netapi32.NetUserGetGroups
+//sys RegEnumValue(key syscall.Handle, index uint32, name *byte, nameLen *uint32, reserved *uint32, valtype *uint32, buf *byte, buflen *uint32) (regerrno error) = advapi32.RegEnumValueW
 
 // Converts a pointer to a wide string to a regular go string. The
 // underlying buffer may be freed afterwards by the Windows API.

--- a/vql/windows/zwin32_windows_386.go
+++ b/vql/windows/zwin32_windows_386.go
@@ -37,6 +37,7 @@ func errnoErr(e syscall.Errno) error {
 
 var (
 	modAdvapi32 = NewLazySystemDLL("Advapi32.dll")
+	modadvapi32 = NewLazySystemDLL("advapi32.dll")
 	modkernel32 = NewLazySystemDLL("kernel32.dll")
 	modnetapi32 = NewLazySystemDLL("netapi32.dll")
 	modntdll    = NewLazySystemDLL("ntdll.dll")
@@ -44,6 +45,7 @@ var (
 
 	procAdjustTokenPrivileges      = modAdvapi32.NewProc("AdjustTokenPrivileges")
 	procLookupPrivilegeValueW      = modAdvapi32.NewProc("LookupPrivilegeValueW")
+	procRegEnumValueW              = modadvapi32.NewProc("RegEnumValueW")
 	procCloseHandle                = modkernel32.NewProc("CloseHandle")
 	procCreateToolhelp32Snapshot   = modkernel32.NewProc("CreateToolhelp32Snapshot")
 	procGetProcessIoCounters       = modkernel32.NewProc("GetProcessIoCounters")
@@ -83,6 +85,14 @@ func LookupPrivilegeValue(lpSystemName uintptr, lpName uintptr, out uintptr) (er
 	r1, _, e1 := syscall.Syscall(procLookupPrivilegeValueW.Addr(), 3, uintptr(lpSystemName), uintptr(lpName), uintptr(out))
 	if r1 == 0 {
 		err = errnoErr(e1)
+	}
+	return
+}
+
+func RegEnumValue(key syscall.Handle, index uint32, name *byte, nameLen *uint32, reserved *uint32, valtype *uint32, buf *byte, buflen *uint32) (regerrno error) {
+	r0, _, _ := syscall.Syscall9(procRegEnumValueW.Addr(), 8, uintptr(key), uintptr(index), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(valtype)), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(buflen)), 0)
+	if r0 != 0 {
+		regerrno = syscall.Errno(r0)
 	}
 	return
 }

--- a/vql/windows/zwin32_windows_amd64.go
+++ b/vql/windows/zwin32_windows_amd64.go
@@ -48,6 +48,7 @@ var (
 	procLookupPrivilegeNameW                 = modAdvapi32.NewProc("LookupPrivilegeNameW")
 	procLookupPrivilegeValueW                = modAdvapi32.NewProc("LookupPrivilegeValueW")
 	procQueryAllTracesA                      = modadvapi32.NewProc("QueryAllTracesA")
+	procRegEnumValueW                        = modadvapi32.NewProc("RegEnumValueW")
 	procCloseHandle                          = modkernel32.NewProc("CloseHandle")
 	procCreateToolhelp32Snapshot             = modkernel32.NewProc("CreateToolhelp32Snapshot")
 	procGetProcessIoCounters                 = modkernel32.NewProc("GetProcessIoCounters")
@@ -112,6 +113,14 @@ func LookupPrivilegeValue(lpSystemName uintptr, lpName uintptr, out uintptr) (er
 func QueryAllTracesW(PropertyArray uintptr, PropertyArrayCount uint32, LoggerCount *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall(procQueryAllTracesA.Addr(), 3, uintptr(PropertyArray), uintptr(PropertyArrayCount), uintptr(unsafe.Pointer(LoggerCount)))
 	status = uint32(r0)
+	return
+}
+
+func RegEnumValue(key syscall.Handle, index uint32, name *byte, nameLen *uint32, reserved *uint32, valtype *uint32, buf *byte, buflen *uint32) (regerrno error) {
+	r0, _, _ := syscall.Syscall9(procRegEnumValueW.Addr(), 8, uintptr(key), uintptr(index), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(nameLen)), uintptr(unsafe.Pointer(reserved)), uintptr(unsafe.Pointer(valtype)), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(buflen)), 0)
+	if r0 != 0 {
+		regerrno = syscall.Errno(r0)
+	}
 	return
 }
 


### PR DESCRIPTION
When running large globs over the registry the accessor's performance left a lot to be desired. This PR supercharges performance by using:

* Caching of registry keys and directory listings
* Lazy evaluations of value decoding
* Use of sync.Pool to reduce memory allocations