### PR TITLE
Add a button to the Download Password setting

### DIFF
--- a/gui/velociraptor/src/components/users/user-label.jsx
+++ b/gui/velociraptor/src/components/users/user-label.jsx
@@ -155,6 +155,7 @@ class UserSettings extends React.PureComponent {
         default_password: "",
         org: "",
         org_changed: false,
+        edited: false
     }
 
     saveSettings = ()=> {
@@ -183,6 +184,7 @@ class UserSettings extends React.PureComponent {
     }
 
     render() {
+
         return (
             <Modal show={true}
                    dialogClassName="modal-70w"
@@ -247,14 +249,33 @@ class UserSettings extends React.PureComponent {
                     </Form.Control>
                   </Col>
                 </Form.Group>
-                <VeloForm
-                  param={{name: "Downloads Password",
-                          friendly_name: T("Downloads Password"),
-                          description: T("Default password to use for downloads"),
-                          type: "string"}}
-                  value={this.state.default_password}
-                  setValue={value=>this.setState({default_password: value})}
-                />
+
+
+                <Form.Group as={Row}>
+                    <Form.Label column sm="3">
+                    <OverlayTrigger
+                        delay={{show: 250, hide: 400}}
+                        overlay={(props)=><Tooltip {...props}>
+                            {T("Default password to use for downloads")}
+                                </Tooltip>}>
+                        <div>{T("Downloads Password")}</div>
+                    </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm="8">
+                    <InputGroup className="mb-3">
+                        <Form.Control
+                            placeholder = {(this.state.default_password)}
+                            onChange = {e => {this.setState({"edited": true});
+                                        this.setState({"default_password": e.currentTarget.value})}
+                            }
+                            />
+                        <Button variant="default"
+                                disabled = {!this.state.edited}
+                                onClick={e => {this.props.setSetting({"default_password": this.state.default_password});
+                                    this.setState({"edited": false})}}>Set</Button>
+                    </InputGroup></Col>
+                </Form.Group>
+
                 <Form.Group as={Row}>
                   <Form.Label column sm="3">
                     <OverlayTrigger

--- a/gui/velociraptor/src/components/users/user-label.jsx
+++ b/gui/velociraptor/src/components/users/user-label.jsx
@@ -20,7 +20,7 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import api from '../core/api-service.jsx';
 import {CancelToken} from 'axios';
-import VeloForm from '../forms/form.jsx';
+//import VeloForm from '../forms/form.jsx';
 import T from '../i8n/i8n.jsx';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';

--- a/gui/velociraptor/src/components/users/user-label.jsx
+++ b/gui/velociraptor/src/components/users/user-label.jsx
@@ -20,7 +20,6 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import api from '../core/api-service.jsx';
 import {CancelToken} from 'axios';
-//import VeloForm from '../forms/form.jsx';
 import T from '../i8n/i8n.jsx';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
@@ -199,8 +198,8 @@ class UserSettings extends React.PureComponent {
                       <OverlayTrigger
                         delay={{show: 250, hide: 400}}
                         overlay={(props)=><Tooltip {...props}>
-                                  {T("Switch to a different org")}
-                                </Tooltip>}>
+                                            {T("Switch to a different org")}
+                                          </Tooltip>}>
                         <div>{T("Organization")}</div>
                       </OverlayTrigger>
                     </Form.Label>
@@ -208,8 +207,7 @@ class UserSettings extends React.PureComponent {
                       <Form.Control as="select"
                                     value={this.state.org}
                                     placeholder={T("Select an org")}
-                                    onChange={e=>this.changeOrg(e.currentTarget.value)}
-                  >
+                                    onChange={e=>this.changeOrg(e.currentTarget.value)}>
                         {_.map(this.context.traits.orgs || [], function(x) {
                             return <option key={x.id} value={x.id}>{x.name}</option>;
                         })}
@@ -250,29 +248,38 @@ class UserSettings extends React.PureComponent {
                   </Col>
                 </Form.Group>
 
-
                 <Form.Group as={Row}>
-                    <Form.Label column sm="3">
+                  <Form.Label column sm="3">
                     <OverlayTrigger
-                        delay={{show: 250, hide: 400}}
-                        overlay={(props)=><Tooltip {...props}>
-                            {T("Default password to use for downloads")}
-                                </Tooltip>}>
-                        <div>{T("Downloads Password")}</div>
+                      delay={{show: 250, hide: 400}}
+                      overlay={(props)=><Tooltip {...props}>
+                                                {T("Default password to use for downloads")}
+                                              </Tooltip>}>
+                      <div>{T("Downloads Password")}</div>
                     </OverlayTrigger>
-                    </Form.Label>
-                    <Col sm="8">
+                  </Form.Label>
+                  <Col sm="8">
                     <InputGroup className="mb-3">
-                        <Form.Control
-                            placeholder = {(this.state.default_password)}
-                            onChange = {e => {this.setState({"edited": true});
-                                        this.setState({"default_password": e.currentTarget.value})}
-                            }
-                            />
-                        <Button variant="default"
+                      <Form.Control
+                        type="text"
+                        placeholder = {(this.state.default_password)}
+                        onChange = {e => {this.setState({"edited": true});
+                                          this.setState({
+                                              default_password: e.currentTarget.value
+                                          });
+                                         }}/>
+                      <div className="input-group-append">
+                        <Button as="button" variant="default"
                                 disabled = {!this.state.edited}
-                                onClick={e => {this.props.setSetting({"default_password": this.state.default_password});
-                                    this.setState({"edited": false})}}>Set</Button>
+                                onClick={e => {
+                                    this.props.setSetting({
+                                        default_password: this.state.default_password
+                                    });
+                                    this.setState({"edited": false});
+                                }}>
+                          <FontAwesomeIcon icon="save" />
+                        </Button>
+                      </div>
                     </InputGroup></Col>
                 </Form.Group>
 


### PR DESCRIPTION
A few users have commented to me that the download password setting is unintuitive.  Other settings in the form take effect once you click away from the field and persist if the form disappears without closing.  The download password only updates with the close button.

To provide a visual cue and feedback, I added a Set button that changes the password immediately.  The button defaults to disabled until any input is entered (including a blank password), and disables itself again after submitting. I left the other setSetting calls in place as well.

In local testing, the password changes/button behavior worked as expected.  Collection downloads were encrypted using the saved password.