### PR TITLE
Fixed Issue in Packages.yaml if dnf does not exist

### DIFF
--- a/artifacts/definitions/Linux/RHEL/Packages.yaml
+++ b/artifacts/definitions/Linux/RHEL/Packages.yaml
@@ -7,8 +7,8 @@ sources:
 
     query: |
         LET Data <= SELECT * FROM switch(
-            a={ SELECT Stdout FROM execve(argv=["dnf", "--quiet", "list", "installed"], length=10000000) },
-            b={ SELECT Stdout FROM execve(argv=["yum", "--quiet", "list", "installed"], length=10000000) },
+            a={ SELECT Stdout FROM execve(argv=["dnf", "--quiet", "list", "installed"], length=10000000) WHERE Stdout },
+            b={ SELECT Stdout FROM execve(argv=["yum", "--quiet", "list", "installed"], length=10000000) WHERE Stdout },
             c={SELECT "" AS Stdout FROM scope() WHERE log(level="ERROR",message="Could not retrieve package list") })
 
         // Sometimes lines overflow to the next line, correct for that


### PR DESCRIPTION
For systems where DNF does not exist the following output is given back:

[
  {
    "Stdout": ""
  }
]

Therefore the switch statement is not proceeding with the b-variant (yum). When filtering out via a WHERE statement this is done.