### PR TITLE
Update Netstat.yaml - fixed Bug

### DIFF
--- a/artifacts/definitions/Linux/Network/Netstat.yaml
+++ b/artifacts/definitions/Linux/Network/Netstat.yaml
@@ -40,7 +40,7 @@ sources:
 
         -- Enumerate all the sockets and cache them in memory for
         -- reverse lookup. The following is basically lsof.
-        LET X = SELECT OSPath[2] AS Pid,
+        LET X = SELECT OSPath[1] AS Pid,
                Data.Link AS Filename,
                parse_string_with_regex(
                   string=Data.Link,


### PR DESCRIPTION
OSPath[2] is the wrong path. The PID is mentioned in OSPath[1]. Anyhow, this Artifact should not be used any longer as it is not using connections(). Use NetstatEnriched instead. Maybe this artifact should be deleted.