### PR TITLE
Allow setting notebook artifacts from VQL (artifact_set)

### DIFF
--- a/vql/server/repository.go
+++ b/vql/server/repository.go
@@ -70,7 +70,7 @@ func (self *ArtifactSetFunction) Call(ctx context.Context,
 	switch def_type {
 	case "client", "client_event", "":
 		permission = acls.ARTIFACT_WRITER
-	case "server", "server_event":
+	case "server", "server_event", "notebook":
 		permission = acls.SERVER_ARTIFACT_WRITER
 	default:
 		scope.Log("artifact_set: artifact type %v invalid", definition.Type)


### PR DESCRIPTION
"(*ApiServer) SetArtifactFile" as used in the UI allows setting notebook artifacts – artifact_set() should not behave differently.