### PR TITLE
Updated the uploads() VQL function to include an Upload object 

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -336,13 +336,15 @@ sources:
 
           */
 
-          LET ColumnTypes = dict(`StartDate`='timestamp',
+          LET ColumnTypes = dict(`StartDate`='timestamp', Download='download',
                                  Hex='hex', Upload='preview_upload')
           LET Hex = "B0 EC 48 5F 18 77"
 
           SELECT Hex, StartDate, hash(accessor="data", path="Hello") AS Hash,
                  upload(accessor="data", file="Hello world",
-                        name="test.txt") AS Upload
+                        name="test.txt") AS Upload,
+                 upload(accessor="data", file="Hello world",
+                        name="test.txt") AS Download
           FROM source()
 
       - type: VQL

--- a/artifacts/testdata/server/testcases/artifacts.out.yaml
+++ b/artifacts/testdata/server/testcases/artifacts.out.yaml
@@ -16,6 +16,21 @@ SELECT *, basename(path=file_store(path=vfs_path)) FROM uploads(client_id='C.4f5
   "file_size": 1319,
   "uploaded_size": 1319,
   "client_path": "C:\\1.zip",
+  "Upload": {
+   "Path": "C:\\1.zip",
+   "Size": 1319,
+   "StoredSize": 1319,
+   "Components": [
+    "clients",
+    "C.4f5e52adf0a337a9",
+    "collections",
+    "F.BN2HJCPOF5U7U",
+    "uploads",
+    "auto",
+    "C:",
+    "1.zip"
+   ]
+  },
   "basename(path=file_store(path=vfs_path))": "1.zip"
  },
  {
@@ -23,6 +38,10 @@ SELECT *, basename(path=file_store(path=vfs_path)) FROM uploads(client_id='C.4f5
   "started": "2019-11-08 07:30:59.920512962 +0000 UTC",
   "vfs_path": "fs:/clients/C.4f5e52adf0a337a9/collections/F.BN2HJCPOF5U7U/uploads/file/C:/old_style.zip",
   "expected_size": 1319,
+  "Upload": {
+   "Path": "/clients/C.4f5e52adf0a337a9/collections/F.BN2HJCPOF5U7U/uploads/file/C:/old_style.zip",
+   "Size": 0
+  },
   "basename(path=file_store(path=vfs_path))": "old_style.zip"
  }
 ]SELECT collect_client( client_id='C.11a3013ccaXXXXX', artifacts='Windows.KapeFiles.Targets', env=dict(Device ='C:', VSSAnalysisAge=2, KapeTriage='Y')).request AS Flow FROM scope()[

--- a/gui/velociraptor/src/components/core/api-service.jsx
+++ b/gui/velociraptor/src/components/core/api-service.jsx
@@ -251,7 +251,14 @@ const href = function(url, params, options) {
     options = options || {};
     Object.assign(options, {indices: false});
 
-    return base_path + url + "?" + qs.stringify(params, options);
+    // If the URL already contains a query string, we need to append
+    // to it with &
+    let joiner = "?";
+    if (url.match(/[&]/)) {
+        joiner = "&";
+    }
+
+    return base_path + url + joiner + qs.stringify(params, options);
 };
 
 const delete_req = function(url, params, cancel_token) {

--- a/gui/velociraptor/src/components/core/table.jsx
+++ b/gui/velociraptor/src/components/core/table.jsx
@@ -33,6 +33,8 @@ import ContextMenu from '../utils/context.jsx';
 import PreviewUpload from '../widgets/preview_uploads.jsx';
 import filterFactory from 'react-bootstrap-table2-filter';
 
+import Download from "../widgets/download.jsx";
+
 // Shows the InspectRawJson modal dialog UI.
 export class InspectRawJson extends Component {
     static propTypes = {
@@ -620,6 +622,30 @@ export function formatColumns(columns, env, column_formatter) {
             x.formatter = (cell, row) => {
                 return <VeloValueRenderer
                          value={cell} collapsed={true}/>;
+            };
+            x.type = null;
+            break;
+
+        case "download":
+            x.formatter = (cell, row) => {
+                // Ideally this is a UploadResponse object described
+                // in /uploads/api.go. Such an object is emitted by
+                // the uploads() VQL plugin.
+                if(_.isObject(cell)) {
+                    let description = cell.Path;
+                    let fs_components = cell.Components || [];
+                    return <Download fs_components={fs_components}
+                                     text={description}
+                                     filename={description}/>;
+                }
+
+                let components = row._Components;
+                let description = cell;
+                let filename = row.client_path;
+
+                return <Download fs_components={components}
+                                 text={description}
+                                 filename={filename}/>;
             };
             x.type = null;
             break;

--- a/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
@@ -14,7 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 // components/core/table.jsx formatColumns
 const column_types = [
     "string", "number", "mb", "timestamp", "nobreak", "tree", "url",
-    "safe_url", "flow", "preview_upload", "client", "hex",
+    "safe_url", "flow", "preview_upload", "download", "client", "hex",
     "base64", "collapsed"
 ];
 

--- a/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
@@ -73,7 +73,7 @@ export default class FormatTableDialog extends Component {
         let selected_columns = [];
         let prefix = "";
         let suffix = "";
-        let match = vql.match(column_type_regex);
+        let match = vql && vql.match(column_type_regex);
         if(match && match.length > 0) {
             prefix = match[1];
             suffix = match[3];

--- a/gui/velociraptor/src/components/utils/json.jsx
+++ b/gui/velociraptor/src/components/utils/json.jsx
@@ -280,7 +280,7 @@ class RenderArrayModal extends PureComponent {
 
     render() {
         if (_.isEmpty(this.state.data)) {
-            return <></>;
+            return <div key="1"></div>;
         }
         let column_renderers = {};
         _.each(this.state.columns, x=>{

--- a/gui/velociraptor/src/components/utils/url.jsx
+++ b/gui/velociraptor/src/components/utils/url.jsx
@@ -42,17 +42,17 @@ export default class URLViewer extends Component {
         }
 
         if (!this.props.safe) {
-        return <Button
-                   as="a"
-                   className="url-link"
-                   size="sm"
-                   variant="outline-info"
-                   href={api.href(url, {
-                       internal: this.props.internal,
-                   })} target="_blank">
-                   <FontAwesomeIcon icon="external-link-alt"/>
-                   <span className="button-label">{desc}</span>
-               </Button>;
+            return <Button
+                     as="a"
+                     className="url-link"
+                     size="sm"
+                     variant="outline-info"
+                     href={api.href(url, {
+                         internal: this.props.internal,
+                     })} target="_blank">
+                     <FontAwesomeIcon icon="external-link-alt"/>
+                     <span className="button-label">{desc}</span>
+                   </Button>;
         };
 
         return <>

--- a/gui/velociraptor/src/components/utils/url.jsx
+++ b/gui/velociraptor/src/components/utils/url.jsx
@@ -29,7 +29,7 @@ export default class URLViewer extends Component {
     }
 
     render() {
-        let url = this.props.url;
+        let url = this.props.url || "";
         let desc = url;
         const md_regex = url.match(/\[([^\]]+)\]\(([^)]+)\)/);
         if (md_regex) {

--- a/gui/velociraptor/src/components/widgets/download.jsx
+++ b/gui/velociraptor/src/components/widgets/download.jsx
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import URLViewer from "../utils/url.jsx";
+import Alert from 'react-bootstrap/Alert';
+import api from '../core/api-service.jsx';
+import T from '../i8n/i8n.jsx';
+
+
+export default class Download extends Component {
+    static propTypes = {
+        fs_components: PropTypes.array,
+        filename: PropTypes.string,
+        text: PropTypes.any,
+    }
+
+    render() {
+        if (_.isEmpty(this.props.fs_components)) {
+            return <Alert variant="warning">{this.props.text}</Alert>;
+        };
+
+        let url = api.href(
+            "/api/v1/DownloadVFSFile",
+            {"fs_components[]": this.props.fs_components,
+             vfs_path: this.props.filename || T("Download")});
+
+        return (
+            <URLViewer url={url} desc={this.props.text} />
+        );
+    }
+}

--- a/gui/velociraptor/src/components/widgets/preview_uploads.jsx
+++ b/gui/velociraptor/src/components/widgets/preview_uploads.jsx
@@ -24,6 +24,7 @@ import Form from 'react-bootstrap/Form';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Pagination from 'react-bootstrap/Pagination';
 import classNames from "classnames";
+import Download from "../widgets/download.jsx";
 
 // https://en.wikipedia.org/wiki/List_of_file_signatures
 const patterns = [
@@ -377,6 +378,9 @@ class InspectDialog extends React.Component {
     }
 
     render() {
+        let filename = this.props.upload && this.props.upload.Path;
+        let components = this.props.upload && this.props.upload.Components;
+
         return (
             <Modal show={true}
                    dialogClassName="modal-90w"
@@ -410,9 +414,16 @@ class InspectDialog extends React.Component {
                   </Tab>
                   <Tab eventKey="details" title={T("Details")}>
                     { this.state.tab === "details" &&
-                      <div className="preview-json">
-                        <VeloValueRenderer value={this.props.upload}/>
-                      </div>}
+                      <>
+                        <Download fs_components={components}
+                                  filename={filename}
+                                  text={filename}/>
+
+                        <div className="preview-json">
+                          <VeloValueRenderer value={this.props.upload}/>
+                        </div>
+                      </>
+                    }
                   </Tab>
                 </Tabs>
               </Modal.Body>

--- a/reporting/uploader.go
+++ b/reporting/uploader.go
@@ -72,10 +72,10 @@ func (self *NotebookUploader) Upload(
 	}
 
 	result := &uploads.UploadResponse{
-		Path:       store_as_name.String(),
+		Path:       res.Path,
 		StoredName: store_as_name.String(),
 		Accessor:   accessor,
-		Components: dest_path_spec.Components(),
+		Components: res.Components,
 		Size:       res.Size,
 		StoredSize: res.StoredSize,
 		Sha256:     res.Sha256,


### PR DESCRIPTION
This makes it easier to just tag the row with "upload_preview" or
"download" to automatically add a preview GUI onto the `uploads()`
output.

This works for collections, hunts or notebooks.