### PR TITLE
Bugfix: Only update notebooks atomically

### DIFF
--- a/api/notebooks.go
+++ b/api/notebooks.go
@@ -195,10 +195,6 @@ func (self *ApiServer) UpdateNotebook(
 		return nil, InvalidStatus("Notebook is not shared with user.")
 	}
 
-	if old_notebook.ModifiedTime != in.ModifiedTime {
-		return nil, InvalidStatus("Edit clash detected.")
-	}
-
 	// When updating an existing notebook only certain fields may
 	// be changed by the user - definitely not the creator, created time or notebookId.
 	in.ModifiedTime = time.Now().Unix()

--- a/artifacts/definitions/Server/Import/CuratedSigma.yaml
+++ b/artifacts/definitions/Server/Import/CuratedSigma.yaml
@@ -19,10 +19,10 @@ parameters:
       - Velociraptor Hayabusa Ruleset
       - Velociraptor Hayabusa Live Detection
       - Velociraptor ChopChopGo Ruleset (Linux)
+      - Velociraptor Curated Windows Ruleset
 
   - name: Prefix
     description: Add artifacts with this prefix
-    default: Sigma.
 
 sources:
   - query: |

--- a/artifacts/definitions/Server/Internal/ToolDependencies.yaml
+++ b/artifacts/definitions/Server/Internal/ToolDependencies.yaml
@@ -7,19 +7,19 @@ description: |
 
 tools:
   - name: VelociraptorWindows
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72-rc2-windows-amd64.exe
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72.0-windows-amd64.exe
     serve_locally: true
-    version: 0.72-rc2
+    version: 0.72.0
 
   - name: VelociraptorWindows_x86
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72-rc2-windows-386.exe
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72.0-windows-386.exe
     serve_locally: true
-    version: 0.72-rc2
+    version: 0.72.0
 
   - name: VelociraptorLinux
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72-rc2-linux-amd64-musl
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72.0-linux-amd64-musl
     serve_locally: true
-    version: 0.72-rc2
+    version: 0.72.0
 
   # On MacOS we can not embed the config in the binary so we use a
   # shell script stub instead. See
@@ -31,11 +31,11 @@ tools:
     serve_locally: true
 
   - name: VelociraptorWindowsMSI
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72-rc2-windows-amd64.msi
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72.0-windows-amd64.msi
     serve_locally: true
-    version: 0.72-rc2
+    version: 0.72.0
 
   - name: VelociraptorWindows_x86MSI
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72-rc2-windows-386.msi
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.72/velociraptor-v0.72.0-windows-386.msi
     serve_locally: true
-    version: 0.72-rc2
+    version: 0.72.0

--- a/docs/wix/README.md
+++ b/docs/wix/README.md
@@ -11,9 +11,10 @@ are happy with the default settings it is easier to just use the
 official distributed MSI packages.
 
 To build MSI packages you will need to download and install the WIX
-distribution from the github page (it requires .NET 3.5):
+distribution from the github page. We currently recommend the 3.14
+release series:
 
-http://wixtoolset.org/releases/
+https://github.com/wixtoolset/wix3/releases/
 
 Next, follow these steps:
 

--- a/docs/wix/build_amd64.bat
+++ b/docs/wix/build_amd64.bat
@@ -1,3 +1,3 @@
-"c:\Program Files (x86)\WiX Toolset v3.11\bin\candle.exe" velociraptor_amd64.xml -arch x64 -ext "c:\Program Files (x86)\WiX Toolset v3.11\bin\WixUtilExtension.dll"
+"c:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" velociraptor_amd64.xml -arch x64 -ext "c:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll"
 
-"c:\Program Files (x86)\WiX Toolset v3.11\bin\light.exe" velociraptor_amd64.wixobj -ext "c:\Program Files (x86)\WiX Toolset v3.11\bin\WixUtilExtension.dll"
+"c:\Program Files (x86)\WiX Toolset v3.14\bin\light.exe" velociraptor_amd64.wixobj -ext "c:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll"

--- a/docs/wix/build_x86.bat
+++ b/docs/wix/build_x86.bat
@@ -1,3 +1,3 @@
-"c:\Program Files (x86)\WiX Toolset v3.11\bin\candle.exe" velociraptor_x86.xml -arch x86 -ext "c:\Program Files (x86)\WiX Toolset v3.11\bin\WixUtilExtension.dll"
+"c:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe" velociraptor_x86.xml -arch x86 -ext "c:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll"
 
-"c:\Program Files (x86)\WiX Toolset v3.11\bin\light.exe" velociraptor_x86.wixobj -ext "c:\Program Files (x86)\WiX Toolset v3.11\bin\WixUtilExtension.dll"
+"c:\Program Files (x86)\WiX Toolset v3.14\bin\light.exe" velociraptor_x86.wixobj -ext "c:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll"

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20220801101854-338dbe61982a
 	www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe
 	www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09
-	www.velocidex.com/golang/vfilter v0.0.0-20240417120216-f7fa24ce744e
+	www.velocidex.com/golang/vfilter v0.0.0-20240421183637-1454295e8546
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1344,7 +1344,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe h1:o9jQWSwK
 www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe/go.mod h1:R7IisRzDO7q5LVRJsCQf1xA50LrIavsPWzAjVE4THyY=
 www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09 h1:G1RWYBXP2lSzxKcrAU1YhiUlBetZ7hGIzIiWuuazvfo=
 www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09/go.mod h1:pxSECT5mWM3goJ4sxB4HCJNKnKqiAlpyT8XnvBwkLGU=
-www.velocidex.com/golang/vfilter v0.0.0-20240417120216-f7fa24ce744e h1:FhnWGS3SjGaUh4mGkVhJ/CakqQgWVAKwToRVB5s7dAM=
-www.velocidex.com/golang/vfilter v0.0.0-20240417120216-f7fa24ce744e/go.mod h1:P50KPQr2LpWVAu7ilGH8CBLBASGtOJ2971yA9YhR8rY=
+www.velocidex.com/golang/vfilter v0.0.0-20240421183637-1454295e8546 h1:XWhIhCSFt/qEgmrYiUSB5J4KaGmBK0R20P/jzenwV+E=
+www.velocidex.com/golang/vfilter v0.0.0-20240421183637-1454295e8546/go.mod h1:P50KPQr2LpWVAu7ilGH8CBLBASGtOJ2971yA9YhR8rY=
 www.velocidex.com/golang/vtypes v0.0.0-20240123105603-069d4a7f435c h1:rL/It+Ig+mvIhmy9vl5gg5b6CX2J12x0v2SXIT2RoWE=
 www.velocidex.com/golang/vtypes v0.0.0-20240123105603-069d4a7f435c/go.mod h1:tjaJNlBWbvH4cEMrEu678CFR2hrtcdyPINIpRxrOh4U=

--- a/gui/velociraptor/src/components/core/api-service.jsx
+++ b/gui/velociraptor/src/components/core/api-service.jsx
@@ -53,8 +53,24 @@ function retryDelay(retryNumber = 0) {
 }
 
 function isRetryableError(error) {
-    return error.code !== 'ECONNABORTED' && (!error.response || (
-        error.response.status >= 500 && error.response.status <= 599));
+    if (error.code === 'ECONNABORTED') {
+        return false;
+    }
+
+    if (!error.response) {
+        return true;
+    }
+
+    // This represents a real server error no need to retry it.
+    if (error.response.data && error.response.data.code) {
+        return false;
+    }
+
+    if (error.response.status >= 500 && error.response.status <= 599) {
+        return true;
+    }
+
+    return false;
 }
 
 function isNetworkError(error) {

--- a/gui/velociraptor/src/components/utils/json.jsx
+++ b/gui/velociraptor/src/components/utils/json.jsx
@@ -316,7 +316,7 @@ class RenderArray extends RenderObject {
             let abridged = this.props.value.slice(0, collapse_array_length-1);
             let indent = this.props.indent || 0;
             let buttons = [
-                <a className="json-expand-button"
+                <a className="json-expand-button" key="1"
                    onClick={x=>this.setState({showModal: true})}>
                   <span className="json-pad json-expand-button" style={{
                       paddingLeft: indent + 3 * scale}}>

--- a/services/notebook/calculate.go
+++ b/services/notebook/calculate.go
@@ -74,6 +74,7 @@ func (self *NotebookManager) UpdateNotebookCell(
 		Timestamp:         utils.GetTime().Now().Unix(),
 		CurrentlyEditing:  in.CurrentlyEditing,
 		Calculating:       true,
+		Output:            "Loading",
 		Env:               in.Env,
 		CurrentVersion:    in.Version,
 		AvailableVersions: in.AvailableVersions,

--- a/services/notebook/calculate_test.go
+++ b/services/notebook/calculate_test.go
@@ -13,6 +13,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/notebook"
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vtesting"
 )
@@ -42,6 +43,9 @@ func (self *NotebookManagerTestSuite) SetupTest() {
 	self.ConfigObj.Defaults.NotebookVersions = 3
 
 	self.LoadArtifactsIntoConfig(mock_definitions)
+
+	// Stop automatic syncing
+	notebook.DO_NOT_SYNC_NOTEBOOKS_FOR_TEST = true
 
 	self.TestSuite.SetupTest()
 

--- a/services/notebook/progress.go
+++ b/services/notebook/progress.go
@@ -41,7 +41,8 @@ func (self *progressReporter) Report(message string) {
                    params='{"notebook_id":"%s","cell_id":"%s","table_id":1,"cell_version": "%s", "message": "%s"}' />
 </div>
 `,
-		message, duration,
+		html.EscapeString(message),
+		html.EscapeString(duration.String()),
 		html.EscapeString(self.notebook_id),
 		html.EscapeString(self.notebook_cell.CellId),
 		html.EscapeString(self.version),

--- a/services/notebook/storage_test.go
+++ b/services/notebook/storage_test.go
@@ -1,0 +1,40 @@
+package notebook_test
+
+import (
+	"time"
+
+	"github.com/alecthomas/assert"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+func (self *NotebookManagerTestSuite) TestNotebookStorage() {
+	closer := utils.MockTime(utils.NewMockClock(time.Unix(10, 10)))
+	defer closer()
+
+	notebook_manager, err := services.GetNotebookManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	// Create a notebook the usual way.
+	global_notebook, err := notebook_manager.NewNotebook(
+		self.Ctx, "admin", &api_proto.NotebookMetadata{
+			Name: "Test Global Notebook",
+		})
+	assert.NoError(self.T(), err)
+
+	// Now create a flow notebook - these have pre-determined ID
+	_, err = notebook_manager.NewNotebook(
+		self.Ctx, "admin", &api_proto.NotebookMetadata{
+			Name:       "Test Flow Notebook",
+			NotebookId: "N.F.CODU1SDAMQ3CM-C.3ece159995d35b34",
+		})
+	assert.NoError(self.T(), err)
+
+	// Now list all notebooks - should only see the global one.
+	notebooks, err := notebook_manager.GetAllNotebooks()
+	assert.NoError(self.T(), err)
+
+	assert.Equal(self.T(), 1, len(notebooks))
+	assert.Equal(self.T(), global_notebook.NotebookId, notebooks[0].NotebookId)
+}

--- a/services/notebook/utils.go
+++ b/services/notebook/utils.go
@@ -1,6 +1,8 @@
 package notebook
 
 import (
+	"strings"
+
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
@@ -21,6 +23,16 @@ func GetNextVersion(version string) string {
 	return utils.NextId()
 }
 
+func isGlobalNotebooks(notebook_id string) bool {
+	if strings.HasPrefix(notebook_id, "N.F.") || // Flow Notebook
+		strings.HasPrefix(notebook_id, "N.H.") || // Hunt Notebook
+		strings.HasPrefix(notebook_id, "N.E.") { // Event Notebook
+		return false
+	}
+
+	return true
+}
+
 // Not all values from the real cell are stored in cell summaries.
 func SummarizeCell(cell_md *api_proto.NotebookCell) *api_proto.NotebookCell {
 	return &api_proto.NotebookCell{
@@ -29,5 +41,6 @@ func SummarizeCell(cell_md *api_proto.NotebookCell) *api_proto.NotebookCell {
 		Type:              cell_md.Type,
 		CurrentVersion:    cell_md.CurrentVersion,
 		AvailableVersions: cell_md.AvailableVersions,
+		Calculating:       cell_md.Calculating,
 	}
 }

--- a/services/notebook/worker.go
+++ b/services/notebook/worker.go
@@ -62,6 +62,7 @@ func (self *NotebookWorker) ProcessUpdateRequest(
 		Timestamp:         utils.GetTime().Now().Unix(),
 		CurrentlyEditing:  in.CurrentlyEditing,
 		Calculating:       true,
+		Output:            "Loading ...",
 		Env:               in.Env,
 		CurrentVersion:    in.Version,
 		AvailableVersions: in.AvailableVersions,
@@ -69,11 +70,6 @@ func (self *NotebookWorker) ProcessUpdateRequest(
 
 	notebook_path_manager := paths.NewNotebookPathManager(
 		notebook_metadata.NotebookId)
-
-	err := store.SetNotebook(notebook_metadata)
-	if err != nil {
-		return nil, err
-	}
 
 	// The query will run in a sub context of the main context to
 	// allow our notification to cancel it.  NOTE: The

--- a/vql/parsers/event_logs/watcher.go
+++ b/vql/parsers/event_logs/watcher.go
@@ -2,6 +2,7 @@ package event_logs
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -97,6 +98,9 @@ func (self *EventLogWatcherService) StartMonitoring(
 	if frequency == 0 {
 		frequency = 15
 	}
+
+	// Add some jitter to ensure evtx parsing is not synchronized.
+	frequency = uint64(rand.Intn(int(frequency)*2/10)) + frequency
 
 	// A resolver for messages
 	resolver, _ := evtx.GetNativeResolver()


### PR DESCRIPTION
Notebook updates were allowed to be done without locking the notebook. This resulted in the notebook being corrupted when updates were initiated during times where a cell was calculated, resulting in cell corruption.

This PR ensures the GUI does not attempt to edit the notebook while its state is not in sync with the server. As well as that the notebook manager ensures the notebook is updated under locks.

Also fixed memory leak regression with group by