### PR TITLE
Added a notebook template initialized with VQL cells

### DIFF
--- a/artifacts/definitions/Notebooks/VQLx2.yaml
+++ b/artifacts/definitions/Notebooks/VQLx2.yaml
@@ -1,0 +1,20 @@
+name: Notebooks.VQLx2
+description: |
+  A notebook initialized with 2 VQL cells
+
+type: NOTEBOOK
+
+sources:
+  - notebook:
+    - type: vql
+      template: |
+        /*
+        *<< 1st cell: Click here to edit >>*
+        */
+        SELECT * FROM orgs()
+    - type: vql
+      template: |
+        /*
+        *<< 2nd cell: Click here to edit >>*
+        */
+        SELECT * FROM gui_users() WHERE name = whoami()

--- a/artifacts/definitions/Notebooks/VQLx2.yaml
+++ b/artifacts/definitions/Notebooks/VQLx2.yaml
@@ -7,14 +7,12 @@ type: NOTEBOOK
 sources:
   - notebook:
     - type: vql
+      output: |
+        << 1st cell: Click here to edit >>
       template: |
-        /*
-        *<< 1st cell: Click here to edit >>*
-        */
         SELECT * FROM orgs()
     - type: vql
+      output: |
+        << 2nd cell: Click here to edit >>
       template: |
-        /*
-        *<< 2nd cell: Click here to edit >>*
-        */
         SELECT * FROM gui_users() WHERE name = whoami()


### PR DESCRIPTION
This notebook template just provides an alternative with no initial markdown cells. So it reduces the annoyance of having to switch cell type for people who like to see VQL first.