### PR TITLE
Added ListActiveHunts Function to Hunt Dispatcher Interface

### DIFF
--- a/services/hunt_dispatcher.go
+++ b/services/hunt_dispatcher.go
@@ -106,7 +106,10 @@ type IHuntDispatcher interface {
 		acl_manager vql_subsystem.ACLManager,
 		hunt *api_proto.Hunt) (*api_proto.Hunt, error)
 
-	// Deprecated - use GetHunts for paged access
+	ListActiveHunts(ctx context.Context,
+		config_obj *config_proto.Config,
+		in *api_proto.ListHuntsRequest) (*api_proto.ListHuntsResponse, error)
+
 	ListHunts(ctx context.Context,
 		config_obj *config_proto.Config,
 		in *api_proto.ListHuntsRequest) (*api_proto.ListHuntsResponse, error)

--- a/services/hunt_dispatcher/list.go
+++ b/services/hunt_dispatcher/list.go
@@ -38,6 +38,19 @@ func FindCollectedArtifacts(
 	}
 }
 
+func (self *HuntDispatcher) ListActiveHunts(
+	ctx context.Context, config_obj *config_proto.Config,
+	in *api_proto.ListHuntsRequest) (*api_proto.ListHuntsResponse, error) {
+	hunts, _ := self.ListHunts(ctx, config_obj, in)
+
+	for i, hunt := range hunts.GetItems() {
+		if hunt.State != api_proto.Hunt_RUNNING {
+			hunts.Items = append(hunts.Items[:i], hunts.Items[i+1:]...)
+		}
+	}
+	return hunts, nil
+}
+
 // This function is deprecated.
 func (self *HuntDispatcher) ListHunts(
 	ctx context.Context, config_obj *config_proto.Config,


### PR DESCRIPTION
Extended Hunt dispatcher interface to add a function that allows for only returning active hunts. This function will not necessarily be used in the base Velociraptor project but will allow for much more efficient hunt dispatching in the Cloudvelo layer since database queries are used when determining which hunts need to be dispatched.