### PR TITLE
Bugfix: Removed global filestore flush

### DIFF
--- a/accessors/smb/cache.go
+++ b/accessors/smb/cache.go
@@ -163,11 +163,12 @@ func NewSMBMountCache(scope vfilter.Scope) *SMBMountCache {
 	}
 	result.lru.SetTTL(time.Hour)
 	result.lru.SetExpirationCallback(
-		func(key string, value interface{}) {
+		func(key string, value interface{}) error {
 			ctx, ok := value.(*SMBConnectionContext)
 			if ok {
 				ctx.Close()
 			}
+			return nil
 		})
 
 	vql_subsystem.GetRootScope(scope).AddDestructor(func() {

--- a/file_store/directory/directory.go
+++ b/file_store/directory/directory.go
@@ -180,7 +180,7 @@ func (self *DirectoryFileStore) StatFile(
 
 func (self *DirectoryFileStore) WriteFile(
 	filename api.FSPathSpec) (api.FileWriter, error) {
-	return self.WriteFileWithCompletion(filename, nil)
+	return self.WriteFileWithCompletion(filename, utils.SyncCompleter)
 }
 
 func (self *DirectoryFileStore) WriteFileWithCompletion(

--- a/file_store/memcache/memcache_test.go
+++ b/file_store/memcache/memcache_test.go
@@ -144,6 +144,9 @@ func (self *MemcacheTestSuite) TestDelayedWrites() {
 		}
 		file_store.Flush()
 
+		mu.Lock()
+		defer mu.Unlock()
+
 		return write_times
 	}
 

--- a/file_store/memory/memory.go
+++ b/file_store/memory/memory.go
@@ -274,7 +274,7 @@ func (self *MemoryFileStore) ReadFile(path api.FSPathSpec) (api.FileReader, erro
 }
 
 func (self *MemoryFileStore) WriteFile(path api.FSPathSpec) (api.FileWriter, error) {
-	return self.WriteFileWithCompletion(path, nil)
+	return self.WriteFileWithCompletion(path, utils.SyncCompleter)
 }
 
 func (self *MemoryFileStore) WriteFileWithCompletion(

--- a/flows/artifacts_test.go
+++ b/flows/artifacts_test.go
@@ -596,6 +596,7 @@ func (self *TestSuite) testCollectionCompletion(
 		"System.Flow.Completion", "", func(ctx context.Context,
 			config_obj *config_proto.Config,
 			row *ordereddict.Dict) error {
+
 			mu.Lock()
 			defer mu.Unlock()
 
@@ -609,7 +610,7 @@ func (self *TestSuite) testCollectionCompletion(
 	}
 	runner.Close(self.Ctx)
 
-	vtesting.WaitUntil(time.Second, self.T(), func() bool {
+	vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Velocidex/json v0.0.0-20220224052537-92f3c0326e5a
 	github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a
 	github.com/Velocidex/sflags v0.3.1-0.20231011011525-620ab7ca8617
-	github.com/Velocidex/ttlcache/v2 v2.9.1-0.20230724083715-1eb048b1f6d6
+	github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130
 	github.com/Velocidex/yaml/v2 v2.2.8
 	github.com/Velocidex/zip v0.0.0-20210101070220-e7ecefb7aad7
 	github.com/alecthomas/assert v1.0.0
@@ -233,7 +233,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/Velocidex/sflags v0.3.1-0.20231011011525-620ab7ca8617 h1:pxAOaYTYwbWh
 github.com/Velocidex/sflags v0.3.1-0.20231011011525-620ab7ca8617/go.mod h1:TTYBEgQFkjJvyBOC2s7G1+mNPZ3IHuqLZmVFRzyPfq4=
 github.com/Velocidex/sigma-go v0.0.0-20240505024531-e8ce54ec3aed h1:zqhuWeg6oqO3jNabjKJaGO7DreiGhbVfeyqleICMAZk=
 github.com/Velocidex/sigma-go v0.0.0-20240505024531-e8ce54ec3aed/go.mod h1:fHCN8y8cC1l5CYY7oOhPIznHmj/yeGxUvU+vAV7alr4=
-github.com/Velocidex/ttlcache/v2 v2.9.1-0.20230724083715-1eb048b1f6d6 h1:3HSrLwAt64gM7FNTPRXYMszpS5bRijQ6xaPVq2vsbuI=
-github.com/Velocidex/ttlcache/v2 v2.9.1-0.20230724083715-1eb048b1f6d6/go.mod h1:3/pI9BBAF7gydBWvMVtV7W1qRwshEG9lBwed/d8xfFg=
+github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130 h1:+QujZ0D7KSy3WJVchkOhMkvAUab6/CIisO5LCoN48q4=
+github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130/go.mod h1:3/pI9BBAF7gydBWvMVtV7W1qRwshEG9lBwed/d8xfFg=
 github.com/Velocidex/yaml/v2 v2.2.8 h1:GUrSy4SBJ6RjGt43k6MeBKtw2z/27gh4A3hfFmFY3No=
 github.com/Velocidex/yaml/v2 v2.2.8/go.mod h1:PlXIg/Pxmoja48C1vMHo7C5pauAZvLq/UEPOQ3DsjS4=
 github.com/Velocidex/zip v0.0.0-20210101070220-e7ecefb7aad7 h1:IAry9WUMrVYA+XPvMF5UMN56ya5II/hoUOtqaHKOHrs=
@@ -907,8 +907,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
-golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/gui/velociraptor/src/components/artifacts/reporting.jsx
+++ b/gui/velociraptor/src/components/artifacts/reporting.jsx
@@ -18,10 +18,11 @@ import { NotebookLineChart, NotebookTimeChart,
        } from '../notebooks/notebook-chart-renderer.jsx';
 
 import VeloValueRenderer from '../utils/value.jsx';
+import { JSONparse } from '../utils/json_parse.jsx';
 
 // Renders a report in the DOM.
-const parse_param = domNode=>JSON.parse(decodeURIComponent(
-    domNode.attribs.params || "{}"));
+const parse_param = domNode=>JSONparse(decodeURIComponent(
+    domNode.attribs.params, {}));
 
 // NOTE: The server sanitizes reports using the bluemonday
 // sanitization. We therefore trust the output and are allowed to
@@ -111,7 +112,7 @@ export default class VeloReportViewer extends React.Component {
             let new_state  = {
                 template: response.data.template || "No Reports",
                 messages: response.data.messages || [],
-                data: JSON.parse(response.data.data),
+                data: JSONparse(response.data.data),
                 loading: false,
                 version: this.state.version + 1,
             };
@@ -155,7 +156,7 @@ export default class VeloReportViewer extends React.Component {
                         let data = this.state.data;
                         let value = decodeURIComponent(domNode.attribs.value || "");
                         let response = data[value] || {};
-                        let rows = JSON.parse(response.Response);
+                        let rows = JSONparse(response.Response, []);
                         return (
                             <VeloTable
                               rows={rows}
@@ -172,7 +173,7 @@ export default class VeloReportViewer extends React.Component {
                     if (value) {
                         let match = re.exec(value);
                         let data = this.state.data[match[1]];
-                        let rows = JSON.parse(data.Response);
+                        let rows = JSONparse(data.Response, []);
 
                         return (
                             <VeloTable rows={rows} columns={data.Columns} />
@@ -223,8 +224,8 @@ export default class VeloReportViewer extends React.Component {
                     let match = re.exec(value);
                     let data = this.state.data[match[1]];
                     try {
-                        let rows = JSON.parse(data.Response);
-                        let params = JSON.parse(decodeURIComponent(domNode.attribs.params));
+                        let rows = JSONparse(data.Response, []);
+                        let params = JSONparse(decodeURIComponent(domNode.attribs.params), {});
                         return (
                             <VeloLineChart data={rows}
                                            columns={data.Columns}
@@ -244,8 +245,9 @@ export default class VeloReportViewer extends React.Component {
                     let match = re.exec(value);
                     let data = this.state.data[match[1]];
                     try {
-                        let rows = JSON.parse(data.Response);
-                        let params = JSON.parse(decodeURIComponent(domNode.attribs.params));
+                        let rows = JSONparse(data.Response, []);
+                        let params = JSONparse(
+                            decodeURIComponent(domNode.attribs.params), {});
                         return (
                             <VeloTimeChart data={rows}
                                            columns={data.Columns}

--- a/gui/velociraptor/src/components/clients/shell-viewer.jsx
+++ b/gui/velociraptor/src/components/clients/shell-viewer.jsx
@@ -19,6 +19,7 @@ import Completer from '../artifacts/syntax.jsx';
 import { DeleteFlowDialog } from "../flows/flows-list.jsx";
 import Button from 'react-bootstrap/Button';
 import { withRouter }  from "react-router-dom";
+import { JSONparse } from '../utils/json_parse.jsx';
 
 // Refresh every 5 seconds
 const SHELL_POLL_TIME = 5000;
@@ -620,11 +621,7 @@ class ShellViewer extends Component {
                        // Column 8 is the _Flow column;
                        let flow_json = rows[i] && rows[i].cell &&
                            rows[i].cell[column_idx];
-                       try {
-                           var flow = JSON.parse(flow_json);
-                       } catch(e) {
-                           continue;
-                       }
+                       let flow = JSONparse(flow_json);
                        if (!flow || !flow.request) {
                            continue;
                        }

--- a/gui/velociraptor/src/components/core/ace.jsx
+++ b/gui/velociraptor/src/components/core/ace.jsx
@@ -93,7 +93,7 @@ import UserConfig from './user.jsx';
 
 import api from '../core/api-service.jsx';
 import {CancelToken} from 'axios';
-
+import { JSONparse } from '../utils/json_parse.jsx';
 
 export class SettingsButton extends Component {
     static propTypes = {
@@ -168,7 +168,7 @@ export default class VeloAce extends Component {
 
     getUserOptions = () => {
         let user_options = this.normalizeOptions(
-            JSON.parse(this.context.traits.ui_settings || "{}"));
+            JSONparse(this.context.traits.ui_settings, {}));
         return Object.assign(user_options, this.props.options || {});
     }
 

--- a/gui/velociraptor/src/components/core/table.jsx
+++ b/gui/velociraptor/src/components/core/table.jsx
@@ -32,7 +32,7 @@ import TreeCell from './tree-cell.jsx';
 import ContextMenu from '../utils/context.jsx';
 import PreviewUpload from '../widgets/preview_uploads.jsx';
 import filterFactory from 'react-bootstrap-table2-filter';
-
+import { JSONparse } from '../utils/json_parse.jsx';
 import Download from "../widgets/download.jsx";
 
 // Shows the InspectRawJson modal dialog UI.
@@ -422,9 +422,9 @@ export function PrepareData(value) {
 
             // A bit of a hack for now, this represents an object.
             if (cell === null || cell === "null")  {
-                cell = null
+                cell = null;
             } else if (cell[0] === "{" || cell[0] === "[") {
-                cell = JSON.parse(cell);
+                cell = JSONparse(cell);
             } else if(cell.match(int_regex)) {
                 cell = parseInt(cell);
             } else if(cell[0] === " ") {

--- a/gui/velociraptor/src/components/core/user.jsx
+++ b/gui/velociraptor/src/components/core/user.jsx
@@ -5,6 +5,7 @@ import {CancelToken} from 'axios';
 import PropTypes from 'prop-types';
 import qs from "qs";
 import { withRouter }  from "react-router-dom";
+import { JSONparse } from '../utils/json_parse.jsx';
 
 const UserConfig = React.createContext({
     traits: {},
@@ -87,7 +88,7 @@ class _UserSettings extends React.Component {
     }
 
     getUserOptions = (traits) => {
-        return JSON.parse(traits.ui_settings || "{}");
+        return JSONparse(traits.ui_settings, {});
     }
 
     render() {

--- a/gui/velociraptor/src/components/forms/form.jsx
+++ b/gui/velociraptor/src/components/forms/form.jsx
@@ -20,6 +20,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import CSVForm from './csv.jsx';
 import Select from 'react-select';
 import T from '../i8n/i8n.jsx';
+import { JSONparse } from '../utils/json_parse.jsx';
 
 import BootstrapTable from 'react-bootstrap-table-next';
 import cellEditFactory, { Type } from 'react-bootstrap-table2-editor';
@@ -428,10 +429,8 @@ export default class VeloForm extends React.Component {
                 options.push({value: x, label: x});
             });
 
-            let defaults = [];
-            try {
-                defaults = _.map(JSON.parse(this.props.value), x=>{return {value: x, label: x};});
-            } catch(e){};
+            let defaults = _.map(JSONparse(this.props.value, []),
+                                 x=>{return {value: x, label: x};});
 
             return (
                 <Form.Group as={Row}>

--- a/gui/velociraptor/src/components/forms/regex_array.jsx
+++ b/gui/velociraptor/src/components/forms/regex_array.jsx
@@ -5,6 +5,8 @@ import RegEx from './regex.jsx';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Button from 'react-bootstrap/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { JSONparse } from '../utils/json_parse.jsx';
+
 
 export default class RegExArray extends Component {
     static propTypes = {
@@ -32,12 +34,7 @@ export default class RegExArray extends Component {
         this.props.setValue(JSON.stringify(regex_array));
     }
 
-    getRegexArray = ()=>{
-        try {
-            return JSON.parse(this.props.value || '[]');
-        } catch(e){};
-        return [];
-    }
+    getRegexArray = ()=>JSONparse(this.props.value, []);
 
     render() {
         return (

--- a/gui/velociraptor/src/components/notebooks/notebook-report-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-report-renderer.jsx
@@ -19,9 +19,11 @@ import { NotebookLineChart, NotebookTimeChart,
 import NotebookTableRenderer from './notebook-table-renderer.jsx';
 
 import VeloValueRenderer from '../utils/value.jsx';
+import { JSONparse } from '../utils/json_parse.jsx';
 
-const parse_param = domNode=>JSON.parse(decodeURIComponent(
-    domNode.attribs.params || "{}"));
+
+const parse_param = domNode=>JSONparse(decodeURIComponent(
+    domNode.attribs.params, {}));
 
 export default class NotebookReportRenderer extends React.Component {
     static propTypes = {
@@ -69,7 +71,7 @@ export default class NotebookReportRenderer extends React.Component {
         let value = decodeURIComponent(domNode.attribs.value || "");
         let match = re.exec(value);
         let data = this.state.data[match[1]];
-        let rows = JSON.parse(data.Response);
+        let rows = JSONparse(data.Response, []);
 
         switch  (domNode.name) {
         case "grr-line-chart":
@@ -108,10 +110,10 @@ export default class NotebookReportRenderer extends React.Component {
                 // A table which contains the data inline.
                 if (domNode.name === "inline-table-viewer") {
                     try {
-                        let data = JSON.parse(this.props.cell.data || '{}');
+                        let data = JSONparse(this.props.cell.data, {});
                         let value = decodeURIComponent(domNode.attribs.value || "");
                         let response = data[value] || {};
-                        let rows = JSON.parse(response.Response);
+                        let rows = JSONparse(response.Response, []);
                         if(this.props.completion_reporter) {
                             this.props.completion_reporter(response.Columns);
                         }

--- a/gui/velociraptor/src/components/notebooks/timelines.jsx
+++ b/gui/velociraptor/src/components/notebooks/timelines.jsx
@@ -17,6 +17,7 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ToStandardTime } from '../utils/time.jsx';
+import { JSONparse } from '../utils/json_parse.jsx';
 
 import T from '../i8n/i8n.jsx';
 
@@ -120,9 +121,9 @@ export class AddVQLCellToTimeline extends React.Component {
         parseHTML(this.props.cell.output, {
             replace: (domNode) => {
                 if (domNode.name === "grr-csv-viewer") {
-                    try {
-                        tags.push(JSON.parse(decodeURIComponent(domNode.attribs.params)));
-                    } catch(e) { }
+                    let value = JSONparse(
+                        decodeURIComponent(domNode.attribs.params), "");
+                    tags.push(value);
                 };
                 return domNode;
             }

--- a/gui/velociraptor/src/components/timeline/timeline.jsx
+++ b/gui/velociraptor/src/components/timeline/timeline.jsx
@@ -13,6 +13,7 @@ import { PrepareData } from '../core/table.jsx';
 import VeloTimestamp from "../utils/time.jsx";
 import VeloValueRenderer from '../utils/value.jsx';
 import Form from 'react-bootstrap/Form';
+import { JSONparse } from '../utils/json_parse.jsx';
 
 // make sure you include the timeline stylesheet or the timeline will not be styled
 import 'react-calendar-timeline/lib/Timeline.css';
@@ -284,9 +285,8 @@ export default class TimelineRenderer extends React.Component {
     render() {
         let super_timeline = {timelines:[]};
         if (_.isString(this.props.params)) {
-            try {
-                super_timeline = JSON.parse(this.props.params);
-            } catch(e) {
+            super_timeline = JSONparse(this.props.params);
+            if(!super_timeline) {
                 return <></>;
             }
         } else if(_.isObject(this.props.params)) {

--- a/gui/velociraptor/src/components/users/user-label.jsx
+++ b/gui/velociraptor/src/components/users/user-label.jsx
@@ -27,6 +27,7 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import InputGroup from 'react-bootstrap/InputGroup';
 import Select from 'react-select';
 
+import { JSONparse } from '../utils/json_parse.jsx';
 
 class _PasswordChange extends React.Component {
     static propTypes = {
@@ -412,7 +413,7 @@ export default class UserLabel extends React.Component {
 
     setSettings = (options) => {
         // Set the ACE theme according to the theme so they match.
-        let ace_options = JSON.parse(this.context.traits.ui_settings || "{}");
+        let ace_options = JSONparse(this.context.traits.ui_settings, {});
         if (options.theme === "no-theme") {
             ace_options.theme = "ace/theme/xcode";
             ace_options.fontFamily = "Iosevka Term";

--- a/gui/velociraptor/src/components/utils/json_parse.jsx
+++ b/gui/velociraptor/src/components/utils/json_parse.jsx
@@ -1,0 +1,15 @@
+import _ from 'lodash';
+
+
+// JSON.parse is unsafe because it raises an exception - this
+// function wraps it with a possible default value but does not raise.
+export function JSONparse(x, default_value) {
+    try {
+        return JSON.parse(x);
+    } catch(e) {
+        if (!_.isUndefined(default_value)) {
+            return default_value;
+        }
+        return x;
+    };
+}

--- a/gui/velociraptor/src/components/vfs/file-tree.jsx
+++ b/gui/velociraptor/src/components/vfs/file-tree.jsx
@@ -11,6 +11,8 @@ import { EncodePathInURL, DecodePathInURL, SplitPathComponents, Join } from '../
 
 import api from '../core/api-service.jsx';
 import { withRouter }  from "react-router-dom";
+import { JSONparse } from '../utils/json_parse.jsx';
+
 
 class VeloFileTree extends Component {
     static contextType = UserConfig;
@@ -174,7 +176,7 @@ class VeloFileTree extends Component {
 
                 if (response && response.data) {
                     // Hold on to the raw data.
-                    node.raw_data = JSON.parse(response.data.Response || '[]');
+                    node.raw_data = JSONparse(response.data.Response,  []);
                     node.flow_id = response.data.flow_id;
                     node.start_idx = response.data.start_idx;
                     node.end_idx = response.data.end_idx;

--- a/result_sets/simple/simple.go
+++ b/result_sets/simple/simple.go
@@ -199,14 +199,18 @@ func (self ResultSetFactory) NewResultSetWriter(
 		return &NullResultSetWriter{}, nil
 	}
 
+	// Call the completion when both files are done.
+	completer := utils.NewCompleter(completion)
+
 	fd, err := file_store_factory.WriteFileWithCompletion(
-		log_path, completion)
+		log_path, completer.GetCompletionFunc())
 	if err != nil {
 		return nil, err
 	}
 
-	idx_fd, err := file_store_factory.WriteFile(log_path.
-		SetType(api.PATH_TYPE_FILESTORE_JSON_INDEX))
+	idx_fd, err := file_store_factory.WriteFileWithCompletion(
+		log_path.SetType(api.PATH_TYPE_FILESTORE_JSON_INDEX),
+		completer.GetCompletionFunc())
 	if err != nil {
 		fd.Close()
 		return nil, err

--- a/services/hunt_dispatcher/index.go
+++ b/services/hunt_dispatcher/index.go
@@ -35,18 +35,17 @@ func (self *HuntStorageManagerImpl) FlushIndex(
 	// Debounce the flushing a bit so we dont overload the system for
 	// fast events. Note that flushes occur periodically anyway so if
 	// we skip a flush we will get it later.
-	now := utils.GetTime().Now()
-	if now.Sub(self.last_flush_time) < 5*time.Second {
+	start := utils.GetTime().Now()
+	if start.Sub(self.last_flush_time) < 5*time.Second {
 		return nil
 	}
-	self.last_flush_time = now
+	self.last_flush_time = start
 
 	hunt_ids := make([]string, 0, len(self.hunts))
 	for hunt_id := range self.hunts {
 		hunt_ids = append(hunt_ids, hunt_id)
 	}
 
-	start := utils.GetTime().Now()
 	defer func() {
 		now := utils.GetTime().Now()
 
@@ -60,7 +59,7 @@ func (self *HuntStorageManagerImpl) FlushIndex(
 	file_store_factory := file_store.GetFileStore(self.config_obj)
 	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
 		hunt_path_manager.HuntIndex(),
-		json.DefaultEncOpts(), utils.SyncCompleter, result_sets.TruncateMode)
+		json.DefaultEncOpts(), utils.BackgroundWriter, result_sets.TruncateMode)
 	if err != nil {
 		return err
 	}

--- a/services/labels/labels.go
+++ b/services/labels/labels.go
@@ -343,12 +343,16 @@ func (self *Labeler) Start(ctx context.Context,
 
 	self.lru = ttlcache.NewCache()
 	self.lru.SetCacheSizeLimit(int(expected_clients))
-	self.lru.SetNewItemCallback(func(key string, value interface{}) {
-		metricLabelLRU.Inc()
-	})
-	self.lru.SetExpirationCallback(func(key string, value interface{}) {
-		metricLabelLRU.Dec()
-	})
+	self.lru.SetNewItemCallback(
+		func(key string, value interface{}) error {
+			metricLabelLRU.Inc()
+			return nil
+		})
+	self.lru.SetExpirationCallback(
+		func(key string, value interface{}) error {
+			metricLabelLRU.Dec()
+			return nil
+		})
 
 	journal, err := services.GetJournal(config_obj)
 	if err != nil {

--- a/timelines/writer.go
+++ b/timelines/writer.go
@@ -11,6 +11,7 @@ import (
 	vjson "www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/result_sets"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 const (
@@ -113,14 +114,17 @@ func NewTimelineWriter(
 
 	result := &TimelineWriter{}
 
+	// Call the completer when both index and file are done.
+	completer := utils.NewCompleter(completion)
+
 	fd, err := file_store_factory.WriteFileWithCompletion(
-		path_manager.Path(), completion)
+		path_manager.Path(), completer.GetCompletionFunc())
 	if err != nil {
 		return nil, err
 	}
 
-	index_fd, err := file_store_factory.WriteFile(
-		path_manager.Index())
+	index_fd, err := file_store_factory.WriteFileWithCompletion(
+		path_manager.Index(), completer.GetCompletionFunc())
 	if err != nil {
 		fd.Close()
 		return nil, err

--- a/utils/completer.go
+++ b/utils/completer.go
@@ -26,7 +26,7 @@ const (
 
 /*
   The Completer is a helper that is used to ensure a completion
-  funciton is called when several asynchronous operations are
+  function is called when several asynchronous operations are
   finished. Only when all operations are done, the completion function
   will be called.
 
@@ -48,8 +48,7 @@ const (
   }
 
   NOTE: As a special case, if the completer is created with
-  SyncCompleter it meands all completion functions will be
-  synchronous.
+  SyncCompleter it means all completion functions will be synchronous.
 */
 
 type Completer struct {

--- a/vql/readers/paged.go
+++ b/vql/readers/paged.go
@@ -257,11 +257,12 @@ func GetReaderPool(scope vfilter.Scope, lru_size int64) *ReaderPool {
 
 		// Close the item on expiration
 		pool.lru.SetExpirationReasonCallback(
-			func(key string, reason ttlcache.EvictionReason, value interface{}) {
+			func(key string, reason ttlcache.EvictionReason, value interface{}) error {
 				accessor, ok := value.(*AccessorReader)
 				if ok {
 					accessor.Close()
 				}
+				return nil
 			})
 
 		// When the item expires from the cache we need to close it.

--- a/vql/server/downloads/downloads.go
+++ b/vql/server/downloads/downloads.go
@@ -198,8 +198,14 @@ func createDownloadFile(
 		"download_file": download_file,
 	}).Info("CreateDownload")
 
+	completion := utils.BackgroundWriter
+	if wait {
+		completion = utils.SyncCompleter
+	}
+
 	file_store_factory := file_store.GetFileStore(config_obj)
-	fd, err := file_store_factory.WriteFile(download_file)
+	fd, err := file_store_factory.WriteFileWithCompletion(
+		download_file, completion)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +263,6 @@ func createDownloadFile(
 
 	if wait {
 		wg.Wait()
-
-		file_store.FlushFilestore(config_obj)
 	}
 
 	return download_file, nil
@@ -707,8 +711,14 @@ func createHuntDownloadFile(
 	}).Info("CreateHuntDownload")
 
 	// Write the download file
+	completion := utils.BackgroundWriter
+	if wait {
+		completion = utils.SyncCompleter
+	}
+
 	file_store_factory := file_store.GetFileStore(config_obj)
-	fd, err := file_store_factory.WriteFile(download_file)
+	fd, err := file_store_factory.WriteFileWithCompletion(
+		download_file, completion)
 	if err != nil {
 		return nil, err
 	}
@@ -831,8 +841,6 @@ func createHuntDownloadFile(
 
 	if wait {
 		wg.Wait()
-
-		file_store.FlushFilestore(config_obj)
 	}
 
 	return download_file, nil

--- a/vql/server/downloads/pool.go
+++ b/vql/server/downloads/pool.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/vfilter"
@@ -68,9 +67,6 @@ func (self *pool) Close() {
 	self.wg.Wait()
 
 	self.cancel()
-
-	// Wait here until the filestore is fully flushed.
-	file_store.FlushFilestore(self.config_obj)
 }
 
 func (self *pool) copyFile(

--- a/vql/server/notebooks/download.go
+++ b/vql/server/notebooks/download.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/acls"
-	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/vql"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
@@ -54,7 +53,6 @@ func (self *CreateNotebookDownload) Call(ctx context.Context,
 
 	// Wait here until the notebook is fully exported.
 	wg.Wait()
-	file_store.FlushFilestore(config_obj)
 
 	return path
 }

--- a/vql/server/notebooks/export.go
+++ b/vql/server/notebooks/export.go
@@ -77,10 +77,6 @@ func (self ExportNotebookFunction) Call(ctx context.Context,
 	defer func() {
 		// Wait here until the export is done.
 		wg.Wait()
-
-		// Make sure the data is flushed to disk so the VQL can get
-		// it.
-		file_store.FlushFilestore(config_obj)
 	}()
 
 	principal := vql_subsystem.GetPrincipal(scope)
@@ -341,7 +337,8 @@ func ExportNotebookToZip(
 	}
 
 	file_store_factory := file_store.GetFileStore(config_obj)
-	fd, err := file_store_factory.WriteFile(output_filename)
+	fd, err := file_store_factory.WriteFileWithCompletion(
+		output_filename, utils.SyncCompleter)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +490,8 @@ func ExportNotebookToHTML(
 
 		file_store_factory := file_store.GetFileStore(config_obj)
 
-		output, err := file_store_factory.WriteFile(output_filename)
+		output, err := file_store_factory.WriteFileWithCompletion(
+			output_filename, utils.SyncCompleter)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The memcache filestore delays writes in order to batch them. This can cause race conditions in some cases. In particular when creating a download export zip, the GUI tries to access the file immediately. However if the writes are still in flight then it will not be able to find it.

Previously this order was ensured by using FlushFilestore which is a global flush of all inflight writes. However, for memcache filestore on EFS this global flush is a performance killer since the filestore is locked for the duration of the flush. This appears as a deadlock where the entire process is blocked while an export is underway.

This PR improves things in a number of ways:
1. The flushes are gone in the background - ensuring the filestore is not locked too long.

2. We avoid calling the global FlushFilestore by installing appropriate completion functions in the export functions.

3. The TTL cache is updated to allow for overriding the expiry behavior. This makes it simpler to avoid expiring files that are still open.

Also this PR fixes a GUI issue where JSON parsing raises an exception for invalid data. Now the GUI handles it with a suitable default object.