### PR TITLE
feat(SshPrivateKeys): add new parameter to artifact.

### DIFF
--- a/artifacts/definitions/Linux/Ssh/PrivateKeys.yaml
+++ b/artifacts/definitions/Linux/Ssh/PrivateKeys.yaml
@@ -37,6 +37,13 @@ parameters:
     default: "^/(proc|sys|run|snap)"
     type: regex
     description: If this regex matches the path of any directory we do not even descend inside of it.
+    
+  - name: LocalFilesystemOnly
+    default: Y
+    type: bool
+    description:  |
+      When set, we stay on local attached filesystems including loop, attached disk, cdrom, device mapper, and excluding proc, nfs etc.
+      When set, it can miss keys in some Linux distros. If not sure, or run accross multiple distros, it is recommended to not set it.
 
 sources:
   - query: |
@@ -58,8 +65,15 @@ sources:
           253, 7, 8, 9, 11, 65, 66, 67, 68, 69, 70,
           71, 128, 129, 130, 131, 132, 133, 134, 135, 202, 253, 254, 259)
 
-      // Only search local filesystems
-      LET RecursionCallback = "x=>x.Data.DevMajor IN LocalDeviceMajor"
+      -- By default set to 'True', to only search local filesystems.
+      LET RecursionCallback = if(
+       condition=LocalFilesystemOnly,
+         then=if(condition=ExcludePathRegex,
+                 then="x=>x.Data.DevMajor IN LocalDeviceMajor AND NOT x.OSPath =~ ExcludePathRegex",
+                 else="x=>x.Data.DevMajor IN LocalDeviceMajor"),
+         else=if(condition=ExcludePathRegex,
+                 then="x=>NOT x.OSPath =~ ExcludePathRegex",
+                 else=""))
 
       LET _Hits = SELECT OSPath,
            read_file(filename=OSPath, length=20240) AS Data


### PR DESCRIPTION
Depending on the Linux distro, the Linux SshPrivateKeys artifact does not find/return private key files.
To make it work out of the box and let users decide how to search for the keys, we propose to add this search parameter.
It works exactly the same as in the FileFinder artifact.