### PR TITLE
Update Lnk.yaml

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Lnk.yaml
+++ b/artifacts/definitions/Windows/Forensics/Lnk.yaml
@@ -655,7 +655,7 @@ export: |
             ["StringData", 2, "String", {
                 "encoding": "utf16",
                 "length": "x=>x.Size",
-                "max_length": 10000,
+                "max_length": 50000,
                 "term": "",
             }],
         ]],


### PR DESCRIPTION
Update LNK parser to use more characters by default. 10000 is only 5000 and I saw a sample recently with 5000+ spaces at the beginning to bypass parsers.