### PR TITLE
Use consistent data type in Users memoisation

### DIFF
--- a/artifacts/definitions/Linux/Events/TrackProcesses.yaml
+++ b/artifacts/definitions/Linux/Events/TrackProcesses.yaml
@@ -149,8 +149,7 @@ sources:
      LET Users <= memoize(
          query={
            SELECT 
-                  int(
-                    int=Uid) AS UID,
+                  Uid AS UID,
                   User
            FROM Artifact.Linux.Sys.Users()
          },


### PR DESCRIPTION
The Sys.Users() data was memoised in order for efficient lookup of usernames. This was done by using UIDs as integer keys instead of string keys. However, I forgot to convert the input data type, which was a string, to an integer, when using it, resulting in no usernames ever being mapped in process tracker sync. updates. This simple fix should resolve that.

I did not notice this during testing because it was not obvious to me when fields were supposed to be NULL or not in the output of process_tracker_updates(). However, recently I noticed missing Username in the results from process_tracker_pslist().