### PR TITLE
Special case offline collector copy collection.

### DIFF
--- a/api/flows.go
+++ b/api/flows.go
@@ -88,7 +88,7 @@ func (self *ApiServer) GetClientFlows(
 			json.AnyToString(flow.Request.Creator, vjson.DefaultEncOpts()),
 			json.AnyToString(flow.TotalUploadedBytes, vjson.DefaultEncOpts()),
 			json.AnyToString(flow.TotalCollectedRows, vjson.DefaultEncOpts()),
-			json.MustMarshalString(flow),
+			json.MustMarshalProtobufString(flow, vjson.DefaultEncOpts()),
 			json.AnyToString(flow.Request.Urgent, vjson.DefaultEncOpts()),
 			json.AnyToString(flow.ArtifactsWithResults, vjson.DefaultEncOpts()),
 		}

--- a/gui/velociraptor/src/components/flows/flows-list.jsx
+++ b/gui/velociraptor/src/components/flows/flows-list.jsx
@@ -327,7 +327,26 @@ class FlowsList extends React.Component {
         this.props.collapseToggle(SLIDE_STATES[next_slide].level);
     };
 
+    copyCollection = ()=> {
+        let selected_flows = this.props.selected_flow &&
+            this.props.selected_flow.artifacts_with_results;
 
+        // Special handling for offline collector
+        if (_.isEqual(selected_flows, ["Server.Utils.CreateCollector"])) {
+            let specs = this.props.selected_flow.request &&
+                this.props.selected_flow.request.specs;
+
+            if (!_.isArray(specs) || specs.length != 1) {
+                specs = [];
+            }
+
+            this.setState({
+                offlineSpecs: specs[0].parameters,
+                showOfflineWizard: true});
+        } else {
+            this.setState({showCopyWizard: true});
+        }
+    };
 
     render() {
         let tab = this.props.match && this.props.match.params &&
@@ -411,7 +430,7 @@ class FlowsList extends React.Component {
                   baseFlow={this.props.selected_flow}
                   onCancel={(e) => this.setState({showCopyWizard: false})}
                   onResolve={this.setCollectionRequest} />
-        }
+              }
 
               { this.state.showNewFromRouterWizard &&
                 <NewCollectionWizard
@@ -423,6 +442,7 @@ class FlowsList extends React.Component {
 
               { this.state.showOfflineWizard &&
                 <OfflineCollectorWizard
+                  collector_parameters={this.state.offlineSpecs}
                   onCancel={(e) => this.setState({showOfflineWizard: false})}
                   onResolve={this.setCollectionRequest} />
               }
@@ -483,7 +503,7 @@ class FlowsList extends React.Component {
                   <Button data-tooltip={T("Copy Collection")}
                           data-position="right"
                           className="btn-tooltip"
-                          onClick={() => this.setState({showCopyWizard: true})}
+                          onClick={this.copyCollection}
                           variant="default">
                     <FontAwesomeIcon icon="copy"/>
                     <span className="sr-only">{T("Copy Collection")}</span>

--- a/json/protobuf.go
+++ b/json/protobuf.go
@@ -8,6 +8,11 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+func MustMarshalProtobufString(v interface{}, opts *json.EncOpts) string {
+	res, _ := MarshalProtobuf(v, opts)
+	return string(res)
+}
+
 func MarshalProtobuf(v interface{}, opts *json.EncOpts) ([]byte, error) {
 	self, ok := v.(proto.Message)
 	if !ok {

--- a/services/frontend/frontend.go
+++ b/services/frontend/frontend.go
@@ -437,7 +437,7 @@ func NewFrontendService(ctx context.Context, wg *sync.WaitGroup,
 	}
 
 	// Sub orgs just use the same frontend manager
-	if config_obj.OrgId != "" {
+	if !utils.IsRootOrg(config_obj.OrgId) {
 		org_manager, err := services.GetOrgManager()
 		if err != nil {
 			return nil, err

--- a/services/hunt_manager/hunt_manager.go
+++ b/services/hunt_manager/hunt_manager.go
@@ -306,6 +306,8 @@ func (self *HuntManager) maybeDirectlyAssignFlow(
 				Set("ClientId", assignment.ClientId).
 				Set("FlowId", assignment.FlowId).
 				Set("Timestamp", utils.GetTime().Now().Unix()),
+		}, services.JournalOptions{
+			Sync: true,
 		})
 	if err != nil {
 		return err
@@ -425,7 +427,7 @@ func (self *HuntManager) ProcessFlowCompletion(
 			Set("StartTime", time.Unix(0, int64(flow.StartTime*1000))).
 			Set("EndTime", time.Unix(0, int64(flow.ActiveTime*1000))).
 			Set("Status", flow.State.String()).
-			Set("Error", flow.Status)})
+			Set("Error", flow.Status)}, services.JournalOptions{})
 }
 
 // When a label is changed we check all the active hunts to see if any
@@ -785,7 +787,8 @@ func scheduleHuntOnClient(
 
 	path_manager := paths.NewHuntPathManager(hunt_id)
 	err = journal.AppendToResultSet(config_obj,
-		path_manager.Clients(), []*ordereddict.Dict{row})
+		path_manager.Clients(), []*ordereddict.Dict{row},
+		services.JournalOptions{})
 	if err != nil {
 		return err
 	}

--- a/services/journal.go
+++ b/services/journal.go
@@ -22,6 +22,10 @@ import (
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 )
 
+type JournalOptions struct {
+	Sync bool
+}
+
 func GetJournal(config_obj *config_proto.Config) (JournalService, error) {
 	org_manager, err := GetOrgManager()
 	if err != nil {
@@ -48,7 +52,8 @@ type JournalService interface {
 	// Push the rows into the result set in the filestore. NOTE: This
 	// method synchronises access to the files within the process.
 	AppendToResultSet(config_obj *config_proto.Config,
-		path api.FSPathSpec, rows []*ordereddict.Dict) error
+		path api.FSPathSpec, rows []*ordereddict.Dict,
+		options JournalOptions) error
 
 	Broadcast(ctx context.Context, config_obj *config_proto.Config,
 		rows []*ordereddict.Dict, name, client_id, flows_id string) error

--- a/services/launcher/storage.go
+++ b/services/launcher/storage.go
@@ -61,7 +61,10 @@ func (self *FlowStorageManager) WriteFlowIndex(
 			Set("FlowId", flow.SessionId).
 			Set("Artifacts", flow.Request.Artifacts).
 			Set("Created", flow.CreateTime).
-			Set("Creator", flow.Request.Creator)})
+			Set("Creator", flow.Request.Creator)},
+		services.JournalOptions{
+			Sync: true,
+		})
 }
 
 func (self *FlowStorageManager) WriteTask(

--- a/services/orgs.go
+++ b/services/orgs.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	ROOT_ORG_ID = "root"
+	ROOT_ORG_ID   = "root"
+	ROOT_ORG_NAME = "<root>"
 )
 
 var (
@@ -83,7 +84,7 @@ type OrgManager interface {
 
 func GetOrgName(config_obj *config_proto.Config) string {
 	if config_obj.OrgId == "" {
-		return "Root Org"
+		return ROOT_ORG_NAME
 	}
 
 	return fmt.Sprintf("Org %v (%v)",

--- a/services/orgs/services.go
+++ b/services/orgs/services.go
@@ -293,6 +293,9 @@ func (self *ServiceContainer) ACLManager() (services.ACLManager, error) {
 // manager. This function is used both in the client and the server to
 // start all the needed services.
 func (self *OrgManager) startOrg(org_record *api_proto.OrgRecord) (err error) {
+
+	org_record.Id = utils.NormalizedOrgId(org_record.Id)
+
 	org_config := self.makeNewConfigObj(org_record)
 	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 	logger.Info("Starting services for %v", services.GetOrgName(org_config))
@@ -732,6 +735,8 @@ func maybeFlushFilesOnClose(
 func (self *OrgManager) Services(org_id string) services.ServiceContainer {
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	org_id = utils.NormalizedOrgId(org_id)
 
 	service_container, pres := self.orgs[org_id]
 	if !pres {

--- a/services/orgs/tests.go
+++ b/services/orgs/tests.go
@@ -38,7 +38,8 @@ func (self *TestOrgManager) Start(
 		service:    service_container,
 		sm:         services.NewServiceManager(ctx, org_config),
 	}
-	self.orgs[""] = org_context
+
+	self.orgs[services.ROOT_ORG_ID] = org_context
 	self.mu.Unlock()
 
 	return self.startOrgFromContext(org_context)

--- a/services/scheduler/minion_test.go
+++ b/services/scheduler/minion_test.go
@@ -71,7 +71,7 @@ func (self *MinionSchedulerTestSuite) TestNotebookMinionScheduler() {
 	org_manager, err := services.GetOrgManager()
 	assert.NoError(self.T(), err)
 
-	org_manager.Services("").(*orgs.ServiceContainer).MockFrontendManager(
+	org_manager.Services(services.ROOT_ORG_ID).(*orgs.ServiceContainer).MockFrontendManager(
 		frontend.NewMinionFrontendManager(self.ConfigObj, ""))
 
 	// Get a minion scheduler that will connect to the api server.

--- a/services/server_artifacts/server_uploader.go
+++ b/services/server_artifacts/server_uploader.go
@@ -86,6 +86,8 @@ func (self *ServerUploader) Upload(
 			Set("_Components", result.Components).
 			Set("file_size", result.Size).
 			Set("uploaded_size", result.Size),
+		}, services.JournalOptions{
+			Sync: true,
 		},
 	)
 	if err != nil {

--- a/services/users/set_user.go
+++ b/services/users/set_user.go
@@ -13,6 +13,7 @@ import (
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 var (
@@ -56,7 +57,7 @@ func (self *UserManager) SetUserPassword(
 	}
 
 	// Update the current org if needed
-	if current_org != "" {
+	if !utils.IsRootOrg(current_org) {
 		// Check if the current_org is in the list of user orgs
 		if !inUserOrgs(current_org, user_record) {
 			return fmt.Errorf("Error %v: Org %v does not include User %v",


### PR DESCRIPTION
The Offline Collector builder is a special GUI component used to build an offline collector. It creates an instance of the Server.Utils.CreateCollector artifact.

Previously when copying this collection, the default copy artifact widget was used which allowed the user to modify the raw artifact parameters to that artifact but this is not user friendly enough.

This PR opens the custom GUI component for editing allowing modification of the offline collector in a more natural way.