### PR TITLE
Add option to override collector filename to CreateCollector.yaml

### DIFF
--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -1,3 +1,4 @@
+name: Server.Utils.CreateCollector
 description: |
   A utility artifact to create a stand alone collector.
 

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -103,6 +103,12 @@ parameters:
       The filename to use. You can expand environment variables as
       well as the following %FQDN% and %TIMESTAMP%.
 
+  - name: opt_collector_filename_prefix
+    default: ""
+    type: string
+    description: |
+      If used, this option adds a prefix to the filename of the collector being built.
+
   - name: opt_cpu_limit
     default: "0"
     type: int
@@ -389,8 +395,8 @@ sources:
 
       // This is what we will call it.
       LET CollectorName <= format(
-          format='Collector_%v',
-          args=inventory_get(tool=Target).Definition.filename)
+          format='%sCollector_%v',
+          args=[opt_collector_filename_prefix, inventory_get(tool=Target).Definition.filename])
 
       LET CollectionArtifact <= SELECT Value FROM switch(
         a = { SELECT CommonCollections + StandardCollection AS Value

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -459,6 +459,7 @@ sources:
                     dict(name="Format", default=opt_format),
                     dict(name="OutputPrefix", default=opt_output_directory),
                     dict(name="FilenameTemplate", default=opt_filename_template),
+                    dict(name="CollectorFilenamePrefix", default=opt_collector_filename_prefix),
                     dict(name="CpuLimit", type="int",
                          default=opt_cpu_limit),
                     dict(name="ProgressTimeout", type="int",

--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -1,4 +1,3 @@
-name: Server.Utils.CreateCollector
 description: |
   A utility artifact to create a stand alone collector.
 
@@ -103,11 +102,10 @@ parameters:
       The filename to use. You can expand environment variables as
       well as the following %FQDN% and %TIMESTAMP%.
 
-  - name: opt_collector_filename_prefix
-    default: ""
+  - name: opt_collector_filename
     type: string
     description: |
-      If used, this option adds a prefix to the filename of the collector being built.
+      If used, this option overrides the default filename of the collector being built.
 
   - name: opt_cpu_limit
     default: "0"
@@ -392,11 +390,11 @@ sources:
       )
 
       LET Target <= tool_name[0].Type
-
+      
       // This is what we will call it.
-      LET CollectorName <= format(
-          format='%sCollector_%v',
-          args=[opt_collector_filename_prefix, inventory_get(tool=Target).Definition.filename])
+      LET CollectorName <= if(condition=opt_collector_filename, 
+       then=opt_collector_filename, 
+       else=format(format='Collector_%v', args=inventory_get(tool=Target).Definition.filename))
 
       LET CollectionArtifact <= SELECT Value FROM switch(
         a = { SELECT CommonCollections + StandardCollection AS Value
@@ -459,7 +457,7 @@ sources:
                     dict(name="Format", default=opt_format),
                     dict(name="OutputPrefix", default=opt_output_directory),
                     dict(name="FilenameTemplate", default=opt_filename_template),
-                    dict(name="CollectorFilenamePrefix", default=opt_collector_filename_prefix),
+                    dict(name="CollectorFilename", default=opt_collector_filename),
                     dict(name="CpuLimit", type="int",
                          default=opt_cpu_limit),
                     dict(name="ProgressTimeout", type="int",


### PR DESCRIPTION
Added a parameter to add a prefix to the filename of the collector being built. This allows the artifact to be run multiple times in a single notebook, with different configurations, and not overwrite the previously created executables.