### PR TITLE
Bugfix: Report access denied to org errors.

### DIFF
--- a/api/authenticators/basic.go
+++ b/api/authenticators/basic.go
@@ -110,12 +110,15 @@ func (self *BasicAuthenticator) AuthenticateUserHandler(
 		err = CheckOrgAccess(self.config_obj, r, user_record)
 		if err != nil {
 			services.LogAudit(r.Context(),
-				self.config_obj, user_record.Name, "Unauthorized username",
+				self.config_obj, user_record.Name, "User Unauthorized for Org",
 				ordereddict.NewDict().
+					Set("err", err.Error()).
 					Set("remote", r.RemoteAddr).
 					Set("status", http.StatusUnauthorized))
 
-			http.Error(w, "authorization failed", http.StatusUnauthorized)
+			// Return status forbidden because we dont want the user
+			// to reauthenticate
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 

--- a/api/download.go
+++ b/api/download.go
@@ -128,8 +128,6 @@ func vfsFileDownloadHandler() http.Handler {
 
 		org_id = utils.NormalizedOrgId(org_id)
 
-		utils.Debug(org_id)
-
 		org_manager, err := services.GetOrgManager()
 		if err != nil {
 			returnError(w, 404, err.Error())

--- a/api/static.go
+++ b/api/static.go
@@ -93,14 +93,14 @@ func (self *CachedFilesystem) Open(name string) (http.File, error) {
 	// We do not support gz files at all - it is either brotli or
 	// uncompressed.
 	if strings.HasSuffix(name, ".gz") {
-		return nil, services.NotFoundError
+		return nil, services.OrgNotFoundError
 	}
 
 	fd, err := self.FileSystem.Open(name)
 	if err != nil {
 		// If there is not brotli file, it is just not there.
 		if strings.HasSuffix(name, ".br") {
-			return nil, services.NotFoundError
+			return nil, services.OrgNotFoundError
 		}
 
 		// Check if a compressed .br file exists

--- a/gui/velociraptor/src/components/artifacts/reporting.jsx
+++ b/gui/velociraptor/src/components/artifacts/reporting.jsx
@@ -121,9 +121,9 @@ export default class VeloReportViewer extends React.Component {
             }
             this.setState(new_state);
         }).catch((err) => {
-            let response = err.response && err.response.data;
+            let response = err.response && (err.response.data || err.response.message);
             if (response) {
-                let templ = "<div class='no-content'>" + response.message + "</div>";
+                let templ = "<div class='no-content'>" + response + "</div>";
                 this.setState({"template": templ,loading: false});
             } else {
                 this.setState({"template": "Error " + err.message, loading: false});

--- a/gui/velociraptor/src/components/utils/time.jsx
+++ b/gui/velociraptor/src/components/utils/time.jsx
@@ -103,12 +103,26 @@ class VeloTimestamp extends Component {
         }
 
         let timezone = this.context.traits.timezone || "UTC";
-        var when = moment(ts);
+        let when = moment(ts);
+        let when_tz = moment.tz(when, timezone);
+        let formatted_ts = when_tz.format("YYYY-MM-DDTHH:mm:ss");
+
+        let fractional_part = when_tz.format(".SSS");
+        if (fractional_part === ".000") {
+            fractional_part = "";
+        }
+        formatted_ts += fractional_part;
+        if (when_tz.isUtc()) {
+            formatted_ts += "Z";
+        } else {
+            formatted_ts += when_tz.format("Z");
+        }
+
         return <OverlayTrigger
                  delay={{show: 250, hide: 400}}
                  overlay={(props)=>renderToolTip(props, ts)}>
                  <div className="timestamp">
-                   {moment.tz(when, timezone).format()}
+                   {formatted_ts}
                  </div>
                </OverlayTrigger>;
     };

--- a/services/orgs.go
+++ b/services/orgs.go
@@ -19,7 +19,7 @@ var (
 	mu          sync.Mutex
 	org_manager OrgManager
 
-	NotFoundError = errors.New("Org not found")
+	OrgNotFoundError = errors.New("Org not found")
 )
 
 // Currently the org manager is the only binary wide global - all

--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -99,7 +99,7 @@ func (self *OrgManager) GetOrgConfig(org_id string) (*config_proto.Config, error
 
 	result, pres := self.orgs[org_id]
 	if !pres {
-		return nil, services.NotFoundError
+		return nil, services.OrgNotFoundError
 	}
 	return result.config_obj, nil
 }
@@ -112,7 +112,7 @@ func (self *OrgManager) GetOrg(org_id string) (*api_proto.OrgRecord, error) {
 
 	result, pres := self.orgs[org_id]
 	if !pres {
-		return nil, services.NotFoundError
+		return nil, services.OrgNotFoundError
 	}
 	return result.record, nil
 }
@@ -129,7 +129,7 @@ func (self *OrgManager) OrgIdByNonce(nonce string) (string, error) {
 
 	result, pres := self.org_id_by_nonce[nonce]
 	if !pres {
-		return "", services.NotFoundError
+		return "", services.OrgNotFoundError
 	}
 	return result, nil
 }

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -19,6 +19,7 @@ var (
 	NotFoundError       = Wrap(os.ErrNotExist, "NotFoundError")
 	InvalidArgError     = errors.New("InvalidArgError")
 	IOError             = errors.New("IOError")
+	NoAccessToOrgError  = errors.New("No access to org")
 )
 
 // This is a custom error type that wraps an inner error but does not

--- a/vql/functions/humanize.go
+++ b/vql/functions/humanize.go
@@ -61,7 +61,7 @@ func (self *HumanizeFunction) Call(ctx context.Context,
 		return humanize.Bytes(uint64(arg.Bytes))
 	}
 
-	return humanize.IBytes(uint64(arg.Bytes))
+	return humanize.IBytes(uint64(arg.IBytes))
 }
 
 func (self HumanizeFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {


### PR DESCRIPTION
Previously the org was just automatically switched to another valid org when a user had no access to that org. This caused a problem when the user was an org admin so could switch to any org, but didnt have permission in the new org. This caused the app to switch to another org but the org selector still had the old org shown.

This resulted in a confusing UI when the org selector was showing an org but the application was actually communicating with a different org.

This change propagates the access denied error to ensure the user is aware they can not connect to the org they wanted rather than automatically switch to another org.

Also fixed a GUI bug where fractional timestamps were not properly shown.