### PR TITLE
Bugfix: Reset column toggles when changing tables

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -142,7 +142,6 @@
 
     This works because the `.` operator on a list, creates another
     list with the `.` operator applying on each member.
-
   type: Function
   category: basic
 - name: artifact_definitions
@@ -3374,8 +3373,6 @@
     description: 'A SID to lookup using LookupAccountSid '
     required: true
   category: windows
-  metadata:
-    permissions: MACHINE_STATE
 - name: lowcase
   description: Returns the lowercase version of a string.
   type: Function
@@ -5211,6 +5208,11 @@
   - name: env
     type: ordereddict.Dict
     description: A dict of args to insert into the scope.
+  - name: copy_env
+    type: string
+    description: A list of variables in the current scope that will be copied into
+      the new scope.
+    repeated: true
   - name: cpu_limit
     type: float64
     description: Average CPU usage in percent of a core.
@@ -7270,7 +7272,6 @@
     ```vql
     SELECT winpmem(image_path='c:/test.dd', compression='s2') FROM scope()"
     ```
-
   type: Function
   args:
   - name: service
@@ -7551,3 +7552,4 @@
   category: plugin
   metadata:
     permissions: FILESYSTEM_READ
+

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -341,6 +341,13 @@ class VeloPagedTable extends Component {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
+        // If the table has changed we need to clear the state
+        // completely as it is a new table.
+        if (!_.isUndefined(this.props.name) &&
+            !_.isEqual(this.props.name, prevProps.name)) {
+            this.setState({toggles: {}, rows: [], columns: []});
+        }
+
         if (this.props.transform &&
             !_.isEqual(prevProps.transform, this.props.transform)) {
             this.setState({transform: this.props.transform});
@@ -440,7 +447,6 @@ class VeloPagedTable extends Component {
 
         return result;
     }
-
 
     fetchRows = () => {
         if (_.isEmpty(this.props.params)) {

--- a/gui/velociraptor/src/components/flows/flow-logs.jsx
+++ b/gui/velociraptor/src/components/flows/flow-logs.jsx
@@ -46,6 +46,8 @@ export default class FlowLogs extends React.Component {
     }
 
     render() {
+        let flow_id = this.props.flow && this.props.flow.session_id;
+
         let renderers = {
             client_time: (cell, row, rowIndex) => {
                 return (
@@ -95,6 +97,7 @@ export default class FlowLogs extends React.Component {
               setTransform={x=>{
                   this.setState({level_filter: "all"});
               }}
+              name={"FlowLogs" + flow_id}
             />
         );
     }

--- a/gui/velociraptor/src/components/flows/flow-results.jsx
+++ b/gui/velociraptor/src/components/flows/flow-results.jsx
@@ -75,6 +75,8 @@ export default class FlowResults extends React.Component {
                      No Data Available.
                    </div>;
         }
+        let flow_id = this.props.flow && this.props.flow.session_id;
+        let artifact = this.state.params && this.state.params.artifact;
 
         return (
             <>
@@ -88,9 +90,10 @@ export default class FlowResults extends React.Component {
               <VeloPagedTable
                 env={{
                     client_id: this.props.flow.client_id,
-                    flow_id: this.props.flow.session_id,
+                    flow_id: flow_id,
                 }}
                 className="col-12"
+                name={"FlowResults" + flow_id + artifact}
                 params={this.state.params}
                 version={getFlowState(this.props.flow)}
               />

--- a/gui/velociraptor/src/components/flows/flow-uploads.jsx
+++ b/gui/velociraptor/src/components/flows/flow-uploads.jsx
@@ -30,6 +30,8 @@ export default class FlowUploads extends React.Component {
     };
 
     render() {
+        let flow_id = this.props.flow && this.props.flow.session_id;
+
         let renderers = {
             Preview: (cell, row, rowIndex) => {
                 let client_id = this.props.flow && this.props.flow.client_id;
@@ -114,6 +116,7 @@ export default class FlowUploads extends React.Component {
                   flow_id: this.props.flow.session_id,
                   type: "uploads",
               }}
+              name={"FlowUploads" + flow_id}
             />
         );
     }

--- a/gui/velociraptor/src/components/flows/flows-list.jsx
+++ b/gui/velociraptor/src/components/flows/flows-list.jsx
@@ -629,6 +629,7 @@ class FlowsList extends React.Component {
                         this.setState({transform: x});
                     }}
                     no_toolbar={true}
+                    name={"GetClientFlows" + client_id}
                   />
                 </HotKeys>
               </div>

--- a/gui/velociraptor/src/components/hunts/hunt-clients.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-clients.jsx
@@ -54,6 +54,7 @@ export default class HuntClients extends React.Component {
               params={params}
               translate_column_headers={true}
               no_toolbar={true}
+              name={"HuntClients" + hunt_id}
             />
         );
     }

--- a/gui/velociraptor/src/components/hunts/hunt-list.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-list.jsx
@@ -612,6 +612,7 @@ class HuntList extends React.Component {
                         this.setState({transform: x, filter: ""});
                     }}
                     no_toolbar={true}
+                    name="HuntList"
                   />
                 </div>
             </>

--- a/gui/velociraptor/src/components/notebooks/notebook-report-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-report-renderer.jsx
@@ -109,6 +109,7 @@ export default class NotebookReportRenderer extends React.Component {
             return result;
         }
 
+        let cell_id = this.props.cell && this.props.cell.cell_id;
         let template = parseHTML(this.props.cell.output, {
             replace: (domNode) => {
                 // A table which contains the data inline.
@@ -170,6 +171,7 @@ export default class NotebookReportRenderer extends React.Component {
                               refresh={this.props.refresh}
                               params={parse_param(domNode)}
                               completion_reporter={this.props.completion_reporter}
+                              name={cell_id}
                             />
                         );
                     } catch(e) {

--- a/gui/velociraptor/src/components/notebooks/notebook-table-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-table-renderer.jsx
@@ -9,6 +9,7 @@ export default class NotebookTableRenderer extends React.Component {
         refresh: PropTypes.func,
         params: PropTypes.object,
         completion_reporter: PropTypes.func,
+        name: PropTypes.string,
     };
 
     render() {
@@ -18,6 +19,7 @@ export default class NotebookTableRenderer extends React.Component {
                  refresh={this.props.refresh}
                  params={this.props.params}
                  completion_reporter={this.props.completion_reporter}
+                 name={this.props.name}
                />;
     }
 }


### PR DESCRIPTION
When the user navigates to a different table the toggles set was retained in some cases causing it to ignore the calculating of default settings. This caused normally hidden columns to show up in some cases.

Also: Added the `copy_env` parameter to the `query()` plugin to allow functions to be carried into the query scope.