### PR TITLE
Fallback SID resolving functionality

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
+++ b/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
@@ -85,6 +85,13 @@ sources:
         FROM glob(globs=expand(path=EvtxGlob), accessor=Accessor)
         WHERE OSPath =~ PathRegex
 
+      -- Cache function for lookupSID
+      LET LookupSIDCache(SID) = cache(name="SID1", key=SID, func=lookupSID(sid=SID))
+
+      -- resolve usernames via registry if lookupSID is not available or yields no results
+      LET ResolveSIDCache(SID) = cache(name="SID2", key=SID, func=pathspec(parse=stat(accessor="registry",
+              filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename)
+
       -- function returning IOC hits
       LET evtxsearch(PathList) = SELECT * FROM foreach(
             row=PathList,
@@ -97,7 +104,7 @@ sources:
                     System.EventID.Value as EventID,
                     System.EventRecordID as EventRecordID,
                     System.Security.UserID as UserSID,
-                    lookupSID(sid=System.Security.UserID) as Username,
+                    LookupSIDCache(SID=System.Security.UserID) || ResolveSIDCache(SID=System.Security.UserID) || "" as Username,
                     get(field="EventData") as EventData,
                     get(field="UserData") as UserData,
                     get(field="Message") as Message,

--- a/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
+++ b/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
@@ -69,6 +69,9 @@ parameters:
     type: timestamp
     description: "search for events before this date. YYYY-MM-DDTmm:hh:ssZ"
 
+imports:
+  - Windows.Sys.AllUsers
+
 sources:
   - query: |
       LET VSS_MAX_AGE_DAYS <= VSSAnalysisAge
@@ -85,13 +88,6 @@ sources:
         FROM glob(globs=expand(path=EvtxGlob), accessor=Accessor)
         WHERE OSPath =~ PathRegex
 
-      -- Cache function for lookupSID
-      LET LookupSIDCache(SID) = cache(name="SID1", key=SID, func=lookupSID(sid=SID))
-
-      -- resolve usernames via registry if lookupSID is not available or yields no results
-      LET ResolveSIDCache(SID) = cache(name="SID2", key=SID, func=pathspec(parse=stat(accessor="registry",
-              filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename)
-
       -- function returning IOC hits
       LET evtxsearch(PathList) = SELECT * FROM foreach(
             row=PathList,
@@ -104,7 +100,7 @@ sources:
                     System.EventID.Value as EventID,
                     System.EventRecordID as EventRecordID,
                     System.Security.UserID as UserSID,
-                    LookupSIDCache(SID=System.Security.UserID) || ResolveSIDCache(SID=System.Security.UserID) || "" as Username,
+                    LookupSIDCache(SID=System.Security.UserID || "") AS Username,
                     get(field="EventData") as EventData,
                     get(field="UserData") as UserData,
                     get(field="Message") as Message,

--- a/artifacts/definitions/Windows/Forensics/SRUM.yaml
+++ b/artifacts/definitions/Windows/Forensics/SRUM.yaml
@@ -32,14 +32,20 @@ parameters:
     type: bool
 
 export: |
-  LET resolveESEId(OSPath, Accessor, Id) = cache(
+  LET ResolveESEId(OSPath, Accessor, Id) = cache(
       name="ESE",
       func=srum_lookup_id(file=OSPath, accessor=Accessor, id=Id),
       key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
 
-  LET lookupSIDCache(OSPath, Accessor, Id) = cache(
-      name="SID",
+  LET LookupSIDCache(OSPath, Accessor, Id) = cache(
+      name="SID1",
       func=lookupSID(sid=srum_lookup_id(file=OSPath, accessor=Accessor, id=Id)),
+      key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
+
+  LET ResolveSIDCache(OSPath, Accessor, Id) = cache(
+      name="SID2",
+      func=pathspec(parse=stat(accessor="registry",
+                  filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + srum_lookup_id(file=OSPath, accessor=Accessor, id=Id) + "/ProfileImagePath").Data.value).Basename,
       key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
 
 sources:
@@ -56,12 +62,12 @@ sources:
 
         SELECT  AutoIncId AS ID,
                 TimeStamp,
-                resolveESEId(OSPath=SRUMFiles.OSPath,
+                ResolveESEId(OSPath=SRUMFiles.OSPath,
                              Accessor=accessor, Id=AppId) AS App,
-                resolveESEId(OSPath=SRUMFiles.OSPath,
+                ResolveESEId(OSPath=SRUMFiles.OSPath,
                              Accessor=accessor, Id=UserId) AS UserSid,
-                lookupSIDCache(OSPath=SRUMFiles.OSPath,
-                          Accessor=accessor, Id=UserId) AS User,
+                LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
+                ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
                 timestamp(winfiletime=EndTime) AS EndTime,
                 DurationMS,
                 NetworkBytesRaw
@@ -75,12 +81,12 @@ sources:
 
         SELECT AutoIncId as SRUMId,
                TimeStamp,
-               resolveESEId(OSPath=SRUMFiles.OSPath,
+               ResolveESEId(OSPath=SRUMFiles.OSPath,
                             Accessor=accessor, Id=AppId) AS App,
-               resolveESEId(OSPath=SRUMFiles.OSPath,
+               ResolveESEId(OSPath=SRUMFiles.OSPath,
                             Accessor=accessor, Id=UserId) AS UserSid,
-               lookupSIDCache(OSPath=SRUMFiles.OSPath,
-                         Accessor=accessor, Id=UserId) AS User,
+               LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
+               ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
                ForegroundCycleTime,
                BackgroundCycleTime,
                FaceTime,
@@ -106,12 +112,12 @@ sources:
 
         SELECT AutoIncId as SRUMId,
              TimeStamp,
-             resolveESEId(OSPath=SRUMFiles.OSPath,
+             ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=AppId) AS App,
-             resolveESEId(OSPath=SRUMFiles.OSPath,
+             ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=UserId) AS UserSid,
-             lookupSIDCache(OSPath=SRUMFiles.OSPath,
-                       Accessor=accessor, Id=UserId) AS User,
+             LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
+             ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
              InterfaceLuid,
              ConnectedTime,
              timestamp(winfiletime=ConnectStartTime) AS StartTime
@@ -125,12 +131,12 @@ sources:
 
         SELECT AutoIncId as SRUMId,
              TimeStamp,
-             resolveESEId(OSPath=SRUMFiles.OSPath,
+             ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=AppId) AS App,
-             resolveESEId(OSPath=SRUMFiles.OSPath,
+             ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=UserId) AS UserSid,
-             lookupSID(OSPath=SRUMFiles.OSPath,
-                       Accessor=accessor, Id=UserId) AS User,
+             LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
+             ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
              UserId,
              BytesSent,
              BytesRecvd,

--- a/artifacts/definitions/Windows/Forensics/SRUM.yaml
+++ b/artifacts/definitions/Windows/Forensics/SRUM.yaml
@@ -37,16 +37,8 @@ export: |
       func=srum_lookup_id(file=OSPath, accessor=Accessor, id=Id),
       key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
 
-  LET LookupSIDCache(OSPath, Accessor, Id) = cache(
-      name="SID1",
-      func=lookupSID(sid=srum_lookup_id(file=OSPath, accessor=Accessor, id=Id)),
-      key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
-
-  LET ResolveSIDCache(OSPath, Accessor, Id) = cache(
-      name="SID2",
-      func=pathspec(parse=stat(accessor="registry",
-                  filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + srum_lookup_id(file=OSPath, accessor=Accessor, id=Id) + "/ProfileImagePath").Data.value).Basename,
-      key=format(format="%v-%v-%v", args=[OSPath, Accessor, Id]))
+imports:
+  - Windows.Sys.AllUsers
 
 sources:
   - name: Upload
@@ -66,8 +58,8 @@ sources:
                              Accessor=accessor, Id=AppId) AS App,
                 ResolveESEId(OSPath=SRUMFiles.OSPath,
                              Accessor=accessor, Id=UserId) AS UserSid,
-                LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
-                ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
+                LookupSIDCache(SID=srum_lookup_id(
+                    file=SRUMFiles, accessor=accessor, id=UserId) || "") AS User,
                 timestamp(winfiletime=EndTime) AS EndTime,
                 DurationMS,
                 NetworkBytesRaw
@@ -85,8 +77,8 @@ sources:
                             Accessor=accessor, Id=AppId) AS App,
                ResolveESEId(OSPath=SRUMFiles.OSPath,
                             Accessor=accessor, Id=UserId) AS UserSid,
-               LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
-               ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
+               LookupSIDCache(SID=srum_lookup_id(
+                    file=SRUMFiles, accessor=accessor, id=UserId) || "") AS User,
                ForegroundCycleTime,
                BackgroundCycleTime,
                FaceTime,
@@ -116,8 +108,8 @@ sources:
                           Accessor=accessor, Id=AppId) AS App,
              ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=UserId) AS UserSid,
-             LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
-             ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
+             LookupSIDCache(SID=srum_lookup_id(
+                    file=SRUMFiles, accessor=accessor, id=UserId) || "") AS User,
              InterfaceLuid,
              ConnectedTime,
              timestamp(winfiletime=ConnectStartTime) AS StartTime
@@ -135,8 +127,8 @@ sources:
                           Accessor=accessor, Id=AppId) AS App,
              ResolveESEId(OSPath=SRUMFiles.OSPath,
                           Accessor=accessor, Id=UserId) AS UserSid,
-             LookupSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) ||
-             ResolveSIDCache(OSPath=SRUMFiles.OSPath, Accessor=accessor, Id=UserId) AS User,
+             LookupSIDCache(SID=srum_lookup_id(
+                    file=SRUMFiles, accessor=accessor, id=UserId) || "") AS User,
              UserId,
              BytesSent,
              BytesRecvd,

--- a/artifacts/definitions/Windows/Sys/AllUsers.yaml
+++ b/artifacts/definitions/Windows/Sys/AllUsers.yaml
@@ -27,12 +27,15 @@ sources:
         LET GetTimestamp(High, Low) = if(condition=High,
                 then=timestamp(winfiletime=High * 4294967296 + Low))
 
+        LET ResolveSID(SID) = pathspec(parse=stat(accessor="registry",
+            filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename
+
         -- lookupSID() may not be available on deaddisk analysis
         LET roaming_users <=
           SELECT
              split(string=Key.OSPath.Basename, sep="-")[-1] as Uid,
              "" AS Gid,
-             lookupSID(sid=Key.OSPath.Basename) || "" AS Name,
+             lookupSID(sid=Key.OSPath.Basename) || ResolveSID(SID=Key.OSPath.Basename) || "" AS Name,
              Key.OSPath as Description,
              ProfileImagePath as Directory,
              Key.OSPath.Basename as UUID,

--- a/artifacts/definitions/Windows/Sys/AllUsers.yaml
+++ b/artifacts/definitions/Windows/Sys/AllUsers.yaml
@@ -20,6 +20,18 @@ parameters:
   - name: remoteRegKey
     default: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*
 
+export: |
+  -- Cache function for lookupSID
+  LET LookupSIDCache(SID) = cache(name="SID", key=SID,
+     func=lookupSID(sid=SID) ||
+
+     -- resolve usernames via registry if lookupSID is not available
+     -- or yields no results
+
+          pathspec(parse=stat(accessor="registry",
+               filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" +
+                      SID + "/ProfileImagePath").Data.value).Basename || "")
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
@@ -27,15 +39,12 @@ sources:
         LET GetTimestamp(High, Low) = if(condition=High,
                 then=timestamp(winfiletime=High * 4294967296 + Low))
 
-        LET ResolveSID(SID) = pathspec(parse=stat(accessor="registry",
-            filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename
-
         -- lookupSID() may not be available on deaddisk analysis
         LET roaming_users <=
           SELECT
              split(string=Key.OSPath.Basename, sep="-")[-1] as Uid,
              "" AS Gid,
-             lookupSID(sid=Key.OSPath.Basename) || ResolveSID(SID=Key.OSPath.Basename) || "" AS Name,
+             LookupSIDCache(SID=Key.OSPath.Basename || "") AS Name,
              Key.OSPath as Description,
              ProfileImagePath as Directory,
              Key.OSPath.Basename as UUID,

--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -20,10 +20,13 @@ sources:
         LET GetTimestamp(High, Low) = if(condition=High,
                 then=timestamp(winfiletime=High * 4294967296 + Low))
 
+        LET ResolveSID(SID) = pathspec(parse=stat(accessor="registry",
+            filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename
+
         -- lookupSID() may not be available on deaddisk analysis
         SELECT split(string=Key.OSPath.Basename, sep="-")[-1] as Uid,
            "" AS Gid,
-           lookupSID(sid=Key.OSPath.Basename) || "" AS Name,
+           lookupSID(sid=Key.OSPath.Basename) || ResolveSID(SID=Key.OSPath.Basename) || "" AS Name,
            Key.OSPath as Description,
            ProfileImagePath as Directory,
            Key.OSPath.Basename as UUID,

--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -12,6 +12,9 @@ parameters:
   - name: remoteRegKey
     default: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*
 
+imports:
+  - Windows.Sys.AllUsers
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows'
@@ -20,13 +23,10 @@ sources:
         LET GetTimestamp(High, Low) = if(condition=High,
                 then=timestamp(winfiletime=High * 4294967296 + Low))
 
-        LET ResolveSID(SID) = pathspec(parse=stat(accessor="registry",
-            filename="HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList/" + SID + "/ProfileImagePath").Data.value).Basename
-
         -- lookupSID() may not be available on deaddisk analysis
         SELECT split(string=Key.OSPath.Basename, sep="-")[-1] as Uid,
            "" AS Gid,
-           lookupSID(sid=Key.OSPath.Basename) || ResolveSID(SID=Key.OSPath.Basename) || "" AS Name,
+           LookupSIDCache(SID=Key.OSPath.Basename || "") AS Name,
            Key.OSPath as Description,
            ProfileImagePath as Directory,
            Key.OSPath.Basename as UUID,


### PR DESCRIPTION
Added fallback sid resolving functionality in vql via `HKEY_LOCAL_MACHINE/Software/Microsoft/Windows NT/CurrentVersion/ProfileList` in artifacts for cases when:
- lookupSid does not yield results
- lookupSid is not available (in deaddisk mode)

This resolves the issue described in https://github.com/Velocidex/velociraptor/issues/3601

Also added caching mechanisms to `Windows.EventLogs.EvtxHunter` (as I suspect that one will do a lot of resolving)

Note that I tested `Windows.Sys.Users`, `Windows.Sys.AllUsers` and `Windows.EventLogs.EvtxHunter` but was not able to test `Windows.Forensics.SRUM` via the collects I currently have.