### PR TITLE
Bugfix: Retry removing tempfile in scope destructor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	www.velocidex.com/golang/go-prefetch v0.0.0-20220801101854-338dbe61982a
 	www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe
 	www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09
-	www.velocidex.com/golang/vfilter v0.0.0-20240618023104-cd2ef63ee978
+	www.velocidex.com/golang/vfilter v0.0.0-20240725055846-2a1740af9bab
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1371,7 +1371,7 @@ www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe h1:o9jQWSwK
 www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe/go.mod h1:R7IisRzDO7q5LVRJsCQf1xA50LrIavsPWzAjVE4THyY=
 www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09 h1:G1RWYBXP2lSzxKcrAU1YhiUlBetZ7hGIzIiWuuazvfo=
 www.velocidex.com/golang/regparser v0.0.0-20240404115756-2169ac0e3c09/go.mod h1:pxSECT5mWM3goJ4sxB4HCJNKnKqiAlpyT8XnvBwkLGU=
-www.velocidex.com/golang/vfilter v0.0.0-20240618023104-cd2ef63ee978 h1:4OsjvVgF4L4B9lzLjHFaxBLk4c6V7IK4uohb4z1qsGI=
-www.velocidex.com/golang/vfilter v0.0.0-20240618023104-cd2ef63ee978/go.mod h1:P50KPQr2LpWVAu7ilGH8CBLBASGtOJ2971yA9YhR8rY=
+www.velocidex.com/golang/vfilter v0.0.0-20240725055846-2a1740af9bab h1:vbxheOyXsbkW9lmG3hz4TTYFAUDTqO5lEtR1ZtI4iAs=
+www.velocidex.com/golang/vfilter v0.0.0-20240725055846-2a1740af9bab/go.mod h1:P50KPQr2LpWVAu7ilGH8CBLBASGtOJ2971yA9YhR8rY=
 www.velocidex.com/golang/vtypes v0.0.0-20240123105603-069d4a7f435c h1:rL/It+Ig+mvIhmy9vl5gg5b6CX2J12x0v2SXIT2RoWE=
 www.velocidex.com/golang/vtypes v0.0.0-20240123105603-069d4a7f435c/go.mod h1:tjaJNlBWbvH4cEMrEu678CFR2hrtcdyPINIpRxrOh4U=

--- a/vql/materializer/materialize.go
+++ b/vql/materializer/materialize.go
@@ -43,8 +43,10 @@ func NewTempFileMatrializer(
 	if err != nil {
 		return nil, err
 	}
-	vql_subsystem.GetRootScope(scope).AddDestructor(
-		func() { filesystem.RemoveFile(scope, tmpfile.Name()) })
+	root_scope := vql_subsystem.GetRootScope(scope)
+	root_scope.AddDestructor(func() {
+		filesystem.RemoveFile(0, tmpfile.Name(), root_scope)
+	})
 
 	result := &TempFileMatrializer{
 		filename: tmpfile.Name(),

--- a/vql/parsers/pe_dump.go
+++ b/vql/parsers/pe_dump.go
@@ -109,10 +109,10 @@ func (self _PEDumpFunction) Call(
 			return false
 		}
 		defer tmpfile.Close()
-		_ = vql_subsystem.GetRootScope(scope).
-			AddDestructor(func() {
-				filesystem.RemoveFile(scope, tmpfile.Name())
-			})
+		root_scope := vql_subsystem.GetRootScope(scope)
+		_ = root_scope.AddDestructor(func() {
+			filesystem.RemoveFile(0, tmpfile.Name(), root_scope)
+		})
 
 		writer = tmpfile
 

--- a/vql/vql.go
+++ b/vql/vql.go
@@ -195,7 +195,8 @@ func MakeNewScope() vfilter.Scope {
 	return result
 }
 
-// Used in tests to flush the global scope - needed **after** .
+// Used in tests to flush the global scope - needed **after**
+// overriding plugins with OverridePlugin, OverrideFunction etc.
 func ResetGlobalScopeCache() {
 	mu.Lock()
 	defer mu.Unlock()

--- a/vql/windows/winpmem.go
+++ b/vql/windows/winpmem.go
@@ -93,10 +93,11 @@ func (self WinpmemFunction) Call(
 		}
 
 		// Driver will only be uninstalled when then root scope is destroyed.
-		vql_subsystem.GetRootScope(scope).AddDestructor(func() {
+		root_scope := vql_subsystem.GetRootScope(scope)
+		root_scope.AddDestructor(func() {
 			err := winpmem.UninstallDriver(tmpfile.Name(), arg.ServiceName, logger)
 			if err == nil {
-				filesystem.RemoveFile(scope, tmpfile.Name())
+				filesystem.RemoveFile(0, tmpfile.Name(), root_scope)
 			}
 		})
 


### PR DESCRIPTION
On windows, we can not remove a file that is still opened. This PR allows the removal routine to be re-scheduled in the destructor list for the root scope in order to retry removing it after the file is closed by another destructor.