### PR TITLE
Bugfix: Make filestore accessor case insensitive.

### DIFF
--- a/accessors/file_store/accessor.go
+++ b/accessors/file_store/accessor.go
@@ -58,7 +58,15 @@ func (self FileStoreFileSystemAccessor) LstatWithOSPath(filename *accessors.OSPa
 	fullpath := path_specs.FromGenericComponentList(filename.Components)
 	lstat, err := self.file_store.StatFile(fullpath)
 	if err != nil {
-		return nil, err
+		// If it didnt work, we try case insensitive open
+		corrected_path, err := getCorrectCase(self.file_store, fullpath)
+		if err != nil {
+			return nil, err
+		}
+		lstat, err = self.file_store.StatFile(corrected_path)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return file_store_file_info.NewFileStoreFileInfoWithOSPath(
@@ -87,7 +95,16 @@ func (self FileStoreFileSystemAccessor) ReadDirWithOSPath(
 	fullpath := path_specs.FromGenericComponentList(filename.Components)
 	files, err := self.file_store.ListDirectory(fullpath)
 	if err != nil {
-		return nil, err
+		// If it didnt work, we try case insensitive
+		corrected_path, err := getCorrectCase(self.file_store, fullpath)
+		if err != nil {
+			return nil, err
+		}
+
+		files, err = self.file_store.ListDirectory(corrected_path)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var result []accessors.FileInfo
@@ -142,7 +159,16 @@ func (self FileStoreFileSystemAccessor) OpenWithOSPath(filename *accessors.OSPat
 		}
 
 		if err != nil {
-			return nil, err
+			// If it didnt work, we try case insensitive open
+			corrected_path, err := getCorrectCase(self.file_store, fullpath)
+			if err != nil {
+				return nil, err
+			}
+
+			file, err = self.file_store.ReadFile(corrected_path)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/accessors/file_store/accessor_test.go
+++ b/accessors/file_store/accessor_test.go
@@ -1,0 +1,71 @@
+package file_store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/directory"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
+	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+)
+
+var (
+	files = []string{
+		"fs:/Windows/System32/notepad.exe",
+		"fs:/Windows/System32/NotePad2.exe",
+	}
+)
+
+type FSAccessorTest struct {
+	test_utils.TestSuite
+
+	config_obj *config_proto.Config
+	file_store *directory.DirectoryFileStore
+}
+
+func (self *FSAccessorTest) TestCaseInsensitive() {
+	accessor := NewFileStoreFileSystemAccessor(self.ConfigObj)
+
+	file_store_factory := file_store.GetFileStore(self.ConfigObj)
+
+	buf := make([]byte, 100)
+
+	// Create some files with data
+	for _, f := range files {
+		pathspec, err := accessor.ParsePath(f)
+		assert.NoError(self.T(), err)
+
+		fullpath := path_specs.FromGenericComponentList(pathspec.Components)
+		w, err := file_store_factory.WriteFile(fullpath)
+		assert.NoError(self.T(), err)
+		w.Write([]byte("hello"))
+		w.Close()
+
+		// Use the accessor to open a file directly.
+		fd, err := accessor.Open(f)
+		assert.NoError(self.T(), err)
+
+		n, err := fd.Read(buf)
+		assert.NoError(self.T(), err)
+		assert.Equal(self.T(), n, 5)
+		assert.Equal(self.T(), string(buf[:n]), "hello")
+
+		// Now open the same file with the wrong casing.
+		fd, err = accessor.Open(strings.ToLower(f))
+		assert.NoError(self.T(), err)
+
+		n, err = fd.Read(buf)
+		assert.NoError(self.T(), err)
+		assert.Equal(self.T(), n, 5)
+		assert.Equal(self.T(), string(buf[:n]), "hello")
+	}
+
+}
+
+func TestFileStoreAccessor(t *testing.T) {
+	suite.Run(t, &FSAccessorTest{})
+}

--- a/accessors/file_store/casing.go
+++ b/accessors/file_store/casing.go
@@ -13,12 +13,8 @@ func getCorrectCase(
 	filename api.FSPathSpec) (api.FSPathSpec, error) {
 
 	// File is exactly fine.
-	s, err := file_store.StatFile(filename)
+	_, err := file_store.StatFile(filename)
 	if err == nil {
-		if !s.IsDir() {
-			return nil, utils.IsDirectoryError
-		}
-
 		return filename, nil
 	}
 

--- a/accessors/file_store/casing.go
+++ b/accessors/file_store/casing.go
@@ -1,0 +1,56 @@
+package file_store
+
+import (
+	"strings"
+
+	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+// Correct the filename to its correct casing.
+func getCorrectCase(
+	file_store api.FileStore,
+	filename api.FSPathSpec) (api.FSPathSpec, error) {
+
+	// File is exactly fine.
+	s, err := file_store.StatFile(filename)
+	if err == nil {
+		if !s.IsDir() {
+			return nil, utils.IsDirectoryError
+		}
+
+		return filename, nil
+	}
+
+	// File is not found, try to find the correct casing for the base
+	// component.
+	basename := filename.Base()
+	dirname := filename.Dir()
+
+	// For non root directories we need to look at the parents
+	if len(dirname.Components()) > 0 {
+		_, err := file_store.StatFile(dirname)
+		if err != nil {
+			// The parent directory can not be directly opened - it is
+			// possible that the parent directory casing is incorrect too.
+			dirname, err = getCorrectCase(file_store, dirname)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Try again with the correct case. It should work this time.
+	entries, err := file_store.ListDirectory(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if strings.EqualFold(e.Name(), basename) {
+			return dirname.AddChild(e.Name()), nil
+		}
+	}
+
+	return nil, utils.NotFoundError
+}

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -17,7 +17,6 @@ var (
 	NotImplementedError = errors.New("Not implemented")
 	InvalidConfigError  = errors.New("InvalidConfigError")
 	NotFoundError       = Wrap(os.ErrNotExist, "NotFoundError")
-	IsDirectoryError    = Wrap(NotFoundError, "IsDirectoryError")
 	InvalidArgError     = errors.New("InvalidArgError")
 	IOError             = errors.New("IOError")
 	NoAccessToOrgError  = errors.New("No access to org")

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -17,6 +17,7 @@ var (
 	NotImplementedError = errors.New("Not implemented")
 	InvalidConfigError  = errors.New("InvalidConfigError")
 	NotFoundError       = Wrap(os.ErrNotExist, "NotFoundError")
+	IsDirectoryError    = Wrap(NotFoundError, "IsDirectoryError")
 	InvalidArgError     = errors.New("InvalidArgError")
 	IOError             = errors.New("IOError")
 	NoAccessToOrgError  = errors.New("No access to org")


### PR DESCRIPTION
The filestore accessor is most commonly used in remapping for postprocessing (for example
https://docs.velociraptor.app/blog/2022/2022-08-04-post-processing/#automating-the-remapping). This usually comes from Windows systems and so it assumes case insensitivity.

This PR enables case insensitivity by default.