### PR TITLE
Only use tempfiles when necessary in queue manager.

### DIFF
--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -168,7 +168,7 @@ class ColumnSort extends Component {
 }
 
 
-class ColumnToggle extends Component {
+export class ColumnToggle extends Component {
     static propTypes = {
         columns: PropTypes.array,
         toggles: PropTypes.object,
@@ -919,7 +919,8 @@ class VeloPagedTable extends Component {
     }
 
     renderRow = (row, idx)=>{
-        let selected_cls = this.props.selectRow && this.props.selectRow.classes;
+        let selected_cls = (this.props.selectRow &&
+                            this.props.selectRow.classes) || "row-selected";
         if(this.state.selected_row_idx !== idx) {
             selected_cls = "";
         }

--- a/gui/velociraptor/src/themes/veloci-dark.css
+++ b/gui/velociraptor/src/themes/veloci-dark.css
@@ -363,15 +363,6 @@ body.veloci-dark {
   border: none;
 }
 
-.veloci-dark .table-bordered thead th {
-  border: 1px solid var(--color-table-heading-background);
-  color: var(--color-foreground);
-  font-weight: 500;
-  vertical-align: middle;
-  text-shadow: none;
-  box-shadow: none;
-}
-
 .veloci-dark .table-bordered .notebook-filter td {
   border: none;
   text-shadow: none;


### PR DESCRIPTION
Previously we opened a temp file for each queue but there are many queues now and it is a bit unsightly. This PR only uses a tempfile only when it is necessary (i.e. the in memory queue is full and we need to fall back to disk backed buffer file).

Also refactored the timeline viewer to use better tables and column selector.