### PR TITLE
Bugfix: Seekable Zip failed to create a temp file with zip_nocase

### DIFF
--- a/accessors/zip/zip.go
+++ b/accessors/zip/zip.go
@@ -468,7 +468,7 @@ loop:
 			// A directory has no member file
 		} else {
 			seen[member_name] = &ZipFileInfo{
-				_full_path: cd_cache.full_path.Append(member_name),
+				_full_path: full_path.Append(member_name),
 			}
 		}
 	}

--- a/accessors/zip/zip.go
+++ b/accessors/zip/zip.go
@@ -367,9 +367,11 @@ func (self *ZipFileCache) Open(full_path *accessors.OSPath, nocase bool) (
 	self.refs++
 	zipAccessorCurrentReferences.Inc()
 	return &SeekableZip{
-		delegate:  fd,
-		info:      info,
-		full_path: full_path,
+		delegate: fd,
+		info:     info,
+
+		// Use the correct path
+		full_path: info.OSPath(),
 
 		// We will be closed when done - Leak a reference.
 		zip_file: self,
@@ -466,7 +468,7 @@ loop:
 			// A directory has no member file
 		} else {
 			seen[member_name] = &ZipFileInfo{
-				_full_path: full_path.Append(member_name),
+				_full_path: cd_cache.full_path.Append(member_name),
 			}
 		}
 	}
@@ -610,7 +612,7 @@ func (self *SeekableZip) createTmpBackup() (err error) {
 	// start of it.
 	reader, err := self.zip_file.Open(self.full_path, false)
 	if err != nil {
-		return err
+		return utils.Wrap(io.EOF, err.Error())
 	}
 	defer reader.Close()
 

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -8,10 +8,10 @@
             "name": "velociraptor",
             "version": "0.72",
             "dependencies": {
-                "@babel/core": "^7.24.9",
+                "@babel/core": "^7.25.2",
                 "@babel/plugin-syntax-flow": "^7.24.7",
-                "@babel/plugin-transform-react-jsx": "^7.24.7",
-                "@babel/runtime": "^7.24.8",
+                "@babel/plugin-transform-react-jsx": "^7.25.2",
+                "@babel/runtime": "^7.25.0",
                 "@fortawesome/fontawesome-svg-core": "6.6.0",
                 "@fortawesome/free-regular-svg-icons": "6.6.0",
                 "@fortawesome/free-solid-svg-icons": "^6.6.0",
@@ -120,21 +120,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-            "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.9",
-                "@babel/helper-compilation-targets": "^7.24.8",
-                "@babel/helper-module-transforms": "^7.24.9",
-                "@babel/helpers": "^7.24.8",
-                "@babel/parser": "^7.24.8",
-                "@babel/template": "^7.24.7",
-                "@babel/traverse": "^7.24.8",
-                "@babel/types": "^7.24.9",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -459,13 +459,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-            "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+            "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.8"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1636,16 +1636,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+            "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
                 "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/plugin-syntax-jsx": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2081,9 +2081,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-            "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+            "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -13438,20 +13438,20 @@
             "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ=="
         },
         "@babel/core": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-            "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.9",
-                "@babel/helper-compilation-targets": "^7.24.8",
-                "@babel/helper-module-transforms": "^7.24.9",
-                "@babel/helpers": "^7.24.8",
-                "@babel/parser": "^7.24.8",
-                "@babel/template": "^7.24.7",
-                "@babel/traverse": "^7.24.8",
-                "@babel/types": "^7.24.9",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -13681,12 +13681,12 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-            "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+            "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
             "requires": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.8"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.0"
             }
         },
         "@babel/highlight": {
@@ -14430,15 +14430,15 @@
             }
         },
         "@babel/plugin-transform-react-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+            "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.24.7",
                 "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
                 "@babel/plugin-syntax-jsx": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.25.2"
             }
         },
         "@babel/plugin-transform-react-jsx-development": {
@@ -14745,9 +14745,9 @@
             "dev": true
         },
         "@babel/runtime": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-            "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+            "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
             "requires": {
                 "regenerator-runtime": "^0.14.0"
             }

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -37,7 +37,7 @@
                 "moment-timezone": "0.5.45",
                 "npm-watch": "^0.13.0",
                 "prop-types": "^15.8.1",
-                "qs": "6.12.3",
+                "qs": "^6.13.0",
                 "query-string": "^6.14.1",
                 "react": "^16.14.0",
                 "react-ace": "^9.5.0",
@@ -9833,9 +9833,10 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
-            "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.0.6"
             },
@@ -20747,9 +20748,9 @@
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         },
         "qs": {
-            "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
-            "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "requires": {
                 "side-channel": "^1.0.6"
             }

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -33,7 +33,7 @@
         "moment-timezone": "0.5.45",
         "npm-watch": "^0.13.0",
         "prop-types": "^15.8.1",
-        "qs": "6.12.3",
+        "qs": "6.13.0",
         "query-string": "^6.14.1",
         "react": "^16.14.0",
         "react-ace": "^9.5.0",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -4,10 +4,10 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "@babel/core": "^7.24.9",
+        "@babel/core": "^7.25.2",
         "@babel/plugin-syntax-flow": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.24.7",
-        "@babel/runtime": "^7.24.8",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/runtime": "^7.25.0",
         "@fortawesome/fontawesome-svg-core": "6.6.0",
         "@fortawesome/free-regular-svg-icons": "6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/vql/remapping/install.go
+++ b/vql/remapping/install.go
@@ -147,6 +147,9 @@ func getTypedOSPath(path_type string, path string) (*accessors.OSPath, error) {
 	case "ntfs":
 		return accessors.NewWindowsNTFSPath(path)
 
+	case "zip":
+		return accessors.NewZipFilePath(path)
+
 	default:
 		return accessors.NewGenericOSPath(path)
 	}


### PR DESCRIPTION
This falied to read files like EVTX which require a lot of seeking
when directly applying remapping rules like:

```
remappings:
- type: permissions
  permissions:
  - FILESYSTEM_READ

- type: mount
  from:
    accessor: zip_nocase
    prefix: |-
      {
        "Path": "/uploads/auto/",
        "DelegateAccessor": "file",
        "DelegatePath": "/tmp/Collection-WIN-A6VLA77KD6P-2024-08-26T13_39_38Z.zip"
      }
    path_type: zip
  "on":
    accessor: auto
    path_type: windows
```

And query like

```sql
SELECT * FROM parse_evtx(filename='C:/Windows/System32/winevt/logs/Security.evtx')
```