### PR TITLE
Bugfixes: Reg accessor dealing with keys and values of same name

### DIFF
--- a/accessors/raw_registry/raw_registry.go
+++ b/accessors/raw_registry/raw_registry.go
@@ -75,6 +75,8 @@ var (
 )
 
 type RawRegKeyInfo struct {
+	mu sync.Mutex
+
 	_full_path *accessors.OSPath
 	_data      *ordereddict.Dict
 	_modtime   time.Time
@@ -87,9 +89,13 @@ func (self *RawRegKeyInfo) IsDir() bool {
 }
 
 func (self *RawRegKeyInfo) Data() *ordereddict.Dict {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	if self._data == nil {
 		self._data = ordereddict.NewDict().Set("type", "Key")
 	}
+
 	return self._data
 }
 
@@ -198,6 +204,9 @@ func (self *RawRegValueInfo) Size() int64 {
 }
 
 func (self *RawRegValueInfo) Data() *ordereddict.Dict {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	if self._data != nil {
 		return self._data
 	}
@@ -223,6 +232,7 @@ func (self *RawRegValueInfo) Data() *ordereddict.Dict {
 			result.Set("value", value_data.Data)
 		}
 	}
+
 	self._data = result
 	return result
 }
@@ -363,42 +373,8 @@ func (self *RawRegFileSystemAccessor) ReadDir(key_path string) (
 	return self.ReadDirWithOSPath(full_path)
 }
 
-// Get the default value of a Registry Key if possible.
-func (self *RawRegFileSystemAccessor) getDefaultValue(
-	full_path *accessors.OSPath) (result *RawRegValueInfo, err error) {
-
-	// A Key has a default value if its parent directory contains a
-	// value with the same name as the key.
-	basename := full_path.Basename()
-	contents, _, err := self._readDirWithOSPath(full_path.Dirname())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, item := range contents {
-		value_item, ok := item.(*RawRegValueInfo)
-		if !ok {
-			continue
-		}
-
-		if strings.EqualFold(item.Name(), basename) {
-			item_copy := value_item.Copy()
-			item_copy._full_path = item_copy._full_path.Append("@")
-			return item_copy, nil
-		}
-	}
-
-	return nil, utils.NotFoundError
-}
-
 func (self *RawRegFileSystemAccessor) ReadDirWithOSPath(
 	full_path *accessors.OSPath) (result []accessors.FileInfo, err error) {
-
-	// Add the default value if the key has one
-	default_value, err := self.getDefaultValue(full_path)
-	if err == nil {
-		result = append(result, default_value)
-	}
 
 	contents, _, err := self._readDirWithOSPath(full_path)
 	return contents, err
@@ -407,6 +383,13 @@ func (self *RawRegFileSystemAccessor) ReadDirWithOSPath(
 // Return all the contents in the directory including all keys and all
 // values, even if some keys have a default value.
 // Additionally returns the CM_KEY_NODE for this actual directory.
+
+// This function is recursive! It ascends to the root cell recursively
+// and resolves all keys along the path to the required key. On each
+// level the function tries the LRU to avoid further recursion. This
+// means that in practice most of the time we wont actually be
+// recursing more than a few levels because top level keys will be
+// cached in the LRU.
 func (self *RawRegFileSystemAccessor) _readDirWithOSPath(
 	full_path *accessors.OSPath) (result []accessors.FileInfo, key *regparser.CM_KEY_NODE, err error) {
 
@@ -529,20 +512,24 @@ func (self *RawRegFileSystemAccessor) Open(path string) (
 
 func (self *RawRegFileSystemAccessor) OpenWithOSPath(path *accessors.OSPath) (
 	accessors.ReadSeekCloser, error) {
-	stat, err := self.LstatWithOSPath(path)
+	stats, err := self.multiLstat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	value_info, ok := stat.(*RawRegValueInfo)
-	if ok {
-		return NewValueBuffer(
-			value_info._value.ValueData().Data, stat), nil
+	// We are looking for a value to open try to find one but if now,
+	// just serialize the key data.
+	for _, stat := range stats {
+		value_info, ok := stat.(*RawRegValueInfo)
+		if ok {
+			return NewValueBuffer(
+				value_info._value.ValueData().Data, stat), nil
+		}
 	}
 
 	// Keys do not have any data.
-	serialized, _ := json.Marshal(stat.Data)
-	return NewValueBuffer(serialized, stat), nil
+	serialized, _ := json.Marshal(stats[0].Data)
+	return NewValueBuffer(serialized, stats[0]), nil
 }
 
 func (self *RawRegFileSystemAccessor) Lstat(filename string) (
@@ -559,6 +546,7 @@ func (self *RawRegFileSystemAccessor) LstatWithOSPath(
 	full_path *accessors.OSPath) (
 	accessors.FileInfo, error) {
 
+	// Top level stat
 	if len(full_path.Components) == 0 {
 		return &accessors.VirtualFileInfo{
 			Path:   full_path,
@@ -566,13 +554,28 @@ func (self *RawRegFileSystemAccessor) LstatWithOSPath(
 		}, nil
 	}
 
+	res, err := self.multiLstat(full_path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the first one.
+	return res[0], nil
+}
+
+// The registry can have keys and values named the same so an Lstat
+// can actually return two separate entities. This function returns
+// both.
+func (self *RawRegFileSystemAccessor) multiLstat(
+	full_path *accessors.OSPath) (res []accessors.FileInfo, err error) {
+
 	name := full_path.Basename()
 	container := full_path.Dirname()
 
 	// If the full_path refers to the default value of the key, return
 	// it.
 	if name == "@" {
-		return self.getDefaultValue(container)
+		name = ""
 	}
 
 	children, err := self.ReadDirWithOSPath(container)
@@ -582,11 +585,15 @@ func (self *RawRegFileSystemAccessor) LstatWithOSPath(
 
 	for _, child := range children {
 		if strings.EqualFold(child.Name(), name) {
-			return child, nil
+			res = append(res, child)
 		}
 	}
 
-	return nil, errors.New("Key not found")
+	if len(res) == 0 {
+		return nil, errors.New("Key not found")
+	}
+
+	return res, nil
 }
 
 func init() {

--- a/accessors/registry/registry_windows.go
+++ b/accessors/registry/registry_windows.go
@@ -521,18 +521,20 @@ func (self RegFileSystemAccessor) OpenWithOSPath(path *accessors.OSPath) (
 
 	metricsOpen.Inc()
 
-	stat, err := self.LstatWithOSPath(path)
+	// Try to open the key as a value
+	value_info, err := self.lstatValue(path)
+	if err == nil {
+		value_info.materialize()
+		return NewValueBuffer(value_info._binary_data, value_info), nil
+	}
+
+	// Did we just open a key?
+	stat, err := self.lstatKey(path)
 	if err != nil {
 		return nil, err
 	}
 
-	value_info, ok := stat.(*RegValueInfo)
-	if ok {
-		value_info.materialize()
-		return NewValueBuffer(value_info._binary_data, stat), nil
-	}
-
-	// Keys do not have any data.
+	// Keys do not have any data so just include the Data as a json blob.
 	serialized, _ := json.Marshal(stat.Data)
 	return NewValueBuffer(serialized, stat), nil
 }
@@ -564,6 +566,71 @@ func (self *RegFileSystemAccessor) Lstat(filename string) (
 	return self.LstatWithOSPath(full_path)
 }
 
+// Try to get the path as a key.
+func (self *RegFileSystemAccessor) lstatKey(
+	full_path *accessors.OSPath) (*RegKeyInfo, error) {
+
+	cached, ok := self.cache.Get(full_path.String())
+	if ok {
+		return cached, nil
+	}
+
+	hive, hive_key_path, err := getHiveAndKey(full_path)
+	if err != nil {
+		return nil, err
+	}
+
+	metricsOpenKey.Inc()
+	key, err := registry.OpenKey(hive, hive_key_path,
+		registry.READ|registry.QUERY_VALUE|registry.WOW64_64KEY)
+	if err != nil {
+		return nil, err
+	}
+	defer key.Close()
+
+	// We opened the full_path as a key - cache it for next time.
+	return self.buildAndCacheKeyInfo(key, full_path)
+}
+
+// Try to get the path as a key.
+func (self *RegFileSystemAccessor) lstatValue(
+	full_path *accessors.OSPath) (*RegValueInfo, error) {
+	// Try to open it as a value
+	if len(full_path.Components) == 0 {
+		return nil, utils.NotFoundError
+	}
+
+	// Maybe its a value then - open the containing key
+	// and return a valueInfo
+	containing_key := full_path.Dirname()
+
+	// We have the containing key in cache - use it.
+	cached, ok := self.cache.Get(containing_key.String())
+	if ok {
+		return getValueInfo(cached.ModTime(), full_path)
+	}
+
+	// We need to open the containing key
+	hive, hive_key_path, err := getHiveAndKey(containing_key)
+	if err != nil {
+		return nil, err
+	}
+
+	metricsOpenKey.Inc()
+	key, err := registry.OpenKey(hive, hive_key_path,
+		registry.READ|registry.QUERY_VALUE|registry.WOW64_64KEY)
+	if err != nil {
+		return nil, err
+	}
+	defer key.Close()
+
+	cached, err = self.buildAndCacheKeyInfo(key, containing_key)
+	if err != nil {
+		return nil, err
+	}
+	return getValueInfo(cached.ModTime(), full_path)
+}
+
 func (self *RegFileSystemAccessor) LstatWithOSPath(
 	full_path *accessors.OSPath) (accessors.FileInfo, error) {
 
@@ -576,56 +643,12 @@ func (self *RegFileSystemAccessor) LstatWithOSPath(
 	}
 
 	// No: Try to open it as a key
-	hive, hive_key_path, err := getHiveAndKey(full_path)
-	if err != nil {
-		return nil, err
+	res, err := self.lstatKey(full_path)
+	if err == nil {
+		return res, nil
 	}
 
-	metricsOpenKey.Inc()
-	key, err := registry.OpenKey(hive, hive_key_path,
-		registry.READ|registry.QUERY_VALUE|registry.WOW64_64KEY)
-
-	// We could not open it as a key - it could be a value
-	if err != nil && len(full_path.Components) > 1 {
-
-		// Maybe its a value then - open the containing key
-		// and return a valueInfo
-		containing_key := full_path.Dirname()
-
-		// We have the containing key in cache - use it.
-		cached, ok := self.cache.Get(containing_key.String())
-		if ok {
-			return getValueInfo(cached.ModTime(), full_path)
-		}
-
-		// We need to open the containing key
-		hive, hive_key_path, err := getHiveAndKey(containing_key)
-		if err != nil {
-			return nil, err
-		}
-
-		metricsOpenKey.Inc()
-		key, err := registry.OpenKey(hive, hive_key_path,
-			registry.READ|registry.QUERY_VALUE|registry.WOW64_64KEY)
-		if err != nil {
-			return nil, err
-		}
-		defer key.Close()
-
-		cached, err = self.buildAndCacheKeyInfo(key, containing_key)
-		if err != nil {
-			return nil, err
-		}
-		return getValueInfo(cached.ModTime(), full_path)
-	}
-	defer key.Close()
-
-	// We opened the full_path as a key - cache it for next time.
-	res, err := self.buildAndCacheKeyInfo(key, full_path)
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return self.lstatValue(full_path)
 }
 
 func (self *RegFileSystemAccessor) buildAndCacheKeyInfo(

--- a/accessors/registry/registry_windows.go
+++ b/accessors/registry/registry_windows.go
@@ -145,6 +145,12 @@ func (self *RegKeyInfo) Size() int64 {
 	return 0
 }
 
+func (self *RegKeyInfo) UniqueName() string {
+	// Key names can not have \ in them so it is safe to add this
+	// without risk of collisions.
+	return self._full_path.String() + "\\"
+}
+
 func (self *RegKeyInfo) FullPath() string {
 	return self._full_path.String()
 }
@@ -211,6 +217,10 @@ type RegValueInfo struct {
 
 func (self *RegValueInfo) IsDir() bool {
 	return false
+}
+
+func (self *RegValueInfo) UniqueName() string {
+	return self._full_path.String()
 }
 
 func (self *RegValueInfo) Mode() os.FileMode {

--- a/artifacts/definitions/Windows/Forensics/Shellbags.yaml
+++ b/artifacts/definitions/Windows/Forensics/Shellbags.yaml
@@ -41,7 +41,7 @@ sources:
               root=pathspec(DelegatePath=HivePath),
               globs=KeyGlob,
               accessor="raw_reg")
-           WHERE Data.type =~ "BINARY" AND OSPath.Path =~ "[0-9]\\\\@$"
+           WHERE Data.type =~ "BINARY" AND OSPath.Basename =~ "^[0-9]+$"
         })
 
       LET ParsedValues = SELECT

--- a/artifacts/testdata/server/testcases/raw_registry.in.yaml
+++ b/artifacts/testdata/server/testcases/raw_registry.in.yaml
@@ -2,33 +2,22 @@ Queries:
   - SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] )
     FROM scope()
 
-  # Test semantics around listing registry keys with default
-  # values. The 0 key actually has a default value. In the glob model
-  # it is a directory (since it is a Key) as well as a file (because
-  # it also is a value).  Velociraptor's glob model can not deal with
-  # directories which are also files (most artifacts test for IsDir to
-  # avoid reading directories.).
-
-  # Therefore we separate the value out into a default value called
-  # "@" within the key/directory. Globbing the parent directory will
-  # only show keys, while Globbing the keys will show the default
-  # value of the key as @.
-
-  # Just a regular key
-  - SELECT OSPath.Path AS Key, Data FROM glob(globs="*", accessor="raw_reg", root=pathspec(
+  # Test listing a direcctory with Key named the same as a value. This
+  # should show both key and value as separate entities with the same
+  # name. Glob should be able to handle this because raw registry
+  # accessor presents the UniqueName() interface to allow Globs to see
+  # them as different entities.
+  - SELECT OSPath.Path AS Key, Data, Data.type AS Type
+    FROM glob(globs="*", accessor="raw_reg", root=pathspec(
        Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU",
        DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat"))
     WHERE OSPath.Basename =~ "0"
+    ORDER BY Type
 
-  # A value with name @
-  - SELECT OSPath.Path AS Key, Data FROM glob(globs="*", accessor="raw_reg", root=pathspec(
-       Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0",
-       DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat"))
-    WHERE OSPath.Basename =~ "@"
-
-  # Now test read_file on values
+  # Now test read_file on values. If there is a value and a key of the
+  # same name an Open() will prefer the value.
   - SELECT format(format="%02x", args=read_file(accessor='raw_reg', filename=pathspec(
-       Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0/@",
+       Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0",
        DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat"))) AS ValueContent
     FROM scope()
 

--- a/artifacts/testdata/server/testcases/raw_registry.out.yaml
+++ b/artifacts/testdata/server/testcases/raw_registry.out.yaml
@@ -2,23 +2,24 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')])": null
  }
-]SELECT OSPath.Path AS Key, Data FROM glob(globs="*", accessor="raw_reg", root=pathspec( Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU", DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat")) WHERE OSPath.Basename =~ "0"[
+]SELECT OSPath.Path AS Key, Data, Data.type AS Type FROM glob(globs="*", accessor="raw_reg", root=pathspec( Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU", DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat")) WHERE OSPath.Basename =~ "0" ORDER BY Type[
  {
   "Key": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\0",
   "Data": {
    "type": "Key"
-  }
- }
-]SELECT OSPath.Path AS Key, Data FROM glob(globs="*", accessor="raw_reg", root=pathspec( Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0", DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat")) WHERE OSPath.Basename =~ "@"[
+  },
+  "Type": "Key"
+ },
  {
-  "Key": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\0\\@",
+  "Key": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\0",
   "Data": {
    "type": "REG_BINARY",
    "data_len": 22,
    "value": "FAAfgMuFn2cgAoBAsptVQMwFqrYAAA=="
-  }
+  },
+  "Type": "REG_BINARY"
  }
-]SELECT format(format="%02x", args=read_file(accessor='raw_reg', filename=pathspec( Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0/@", DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat"))) AS ValueContent FROM scope()[
+]SELECT format(format="%02x", args=read_file(accessor='raw_reg', filename=pathspec( Path="/Local Settings/Software/Microsoft/Windows/Shell/BagMRU/0", DelegatePath=srcDir+"/artifacts/testdata/files/UsrClass.dat"))) AS ValueContent FROM scope()[
  {
   "ValueContent": "14001f80cb859f6720028040b29b5540cc05aab60000"
  }
@@ -72,7 +73,7 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:28:19Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
   "Description": {
    "ShortName": "My Computer",
    "Type": "Root"
@@ -94,7 +95,51 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:28:19Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\1",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+  "Description": {
+   "ShortName": "My Computer",
+   "Type": "Root"
+  },
+  "Path": "My Computer",
+  "_Parsed": {
+   "ItemIDSize": 20,
+   "Offset": 0,
+   "Type": 1,
+   "Subtype": 1,
+   "ShellBag": {
+    "Description": {
+     "ShortName": "My Computer",
+     "Type": "Root"
+    }
+   }
+  }
+ },
+ {
+  "ModTime": "2021-06-01T06:28:19Z",
+  "basename(path=Hive)": "UsrClass.dat",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+  "Description": {
+   "ShortName": "My Computer",
+   "Type": "Root"
+  },
+  "Path": "My Computer",
+  "_Parsed": {
+   "ItemIDSize": 85,
+   "Offset": 0,
+   "Type": 1,
+   "Subtype": 1,
+   "ShellBag": {
+    "Description": {
+     "ShortName": "My Computer",
+     "Type": "Root"
+    }
+   }
+  }
+ },
+ {
+  "ModTime": "2021-06-01T06:28:19Z",
+  "basename(path=Hive)": "UsrClass.dat",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
   "Description": {
    "ShortName": "My Computer",
    "Type": "Root"
@@ -116,7 +161,7 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:27:57Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\1\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\1",
   "Description": {
    "LongName": "",
    "ShortName": "",
@@ -139,53 +184,9 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
   }
  },
  {
-  "ModTime": "2021-06-01T06:28:19Z",
-  "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\2",
-  "Description": {
-   "ShortName": "My Computer",
-   "Type": "Root"
-  },
-  "Path": "My Computer",
-  "_Parsed": {
-   "ItemIDSize": 85,
-   "Offset": 0,
-   "Type": 1,
-   "Subtype": 1,
-   "ShellBag": {
-    "Description": {
-     "ShortName": "My Computer",
-     "Type": "Root"
-    }
-   }
-  }
- },
- {
-  "ModTime": "2021-06-01T06:28:19Z",
-  "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3",
-  "Description": {
-   "ShortName": "My Computer",
-   "Type": "Root"
-  },
-  "Path": "My Computer",
-  "_Parsed": {
-   "ItemIDSize": 20,
-   "Offset": 0,
-   "Type": 1,
-   "Subtype": 1,
-   "ShellBag": {
-    "Description": {
-     "ShortName": "My Computer",
-     "Type": "Root"
-    }
-   }
-  }
- },
- {
   "ModTime": "2021-06-01T06:28:10Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3",
   "Description": null,
   "Path": "My Computer -\u003e ?",
   "_Parsed": {
@@ -199,7 +200,7 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:28:10Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0",
   "Description": {
    "Type": "NetworkLocation",
    "ShortName": "\\\\vmware-host\\Shared Folders"
@@ -222,7 +223,7 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:28:12Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0\\0\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0\\0",
   "Description": {
    "Type": [
     "Directory",
@@ -282,7 +283,7 @@ SELECT mock(plugin='info', results=[dict(OS='windows'), dict(OS='windows')] ) FR
  {
   "ModTime": "2021-06-01T06:28:19Z",
   "basename(path=Hive)": "UsrClass.dat",
-  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0\\0\\0\\0",
+  "KeyPath": "\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\\3\\0\\0\\0",
   "Description": {
    "Type": [
     "Directory",

--- a/artifacts/testdata/windows/init.reg
+++ b/artifacts/testdata/windows/init.reg
@@ -18,3 +18,10 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Test]
 @="Test Data"
+
+[HKEY_CURRENT_USER\Software\Test]
+"KeyWithValue"="Test Data"
+
+[HKEY_CURRENT_USER\Software\Test\KeyWithValue]
+@="Default Value Data"
+"Value"="Value content"

--- a/artifacts/testdata/windows/registry.in.yaml
+++ b/artifacts/testdata/windows/registry.in.yaml
@@ -65,5 +65,9 @@ Queries:
   # Test default value handling - The key itself looks like a regular directory
   - SELECT OSPath.Path AS Key, Data FROM glob(globs='Test', root='HKEY_CURRENT_USER/Software', accessor='registry')
 
-  # Listing the key shows a single value with name @
-  - SELECT OSPath.Path AS Key, Data FROM glob(globs='Test/*', root='HKEY_CURRENT_USER/Software', accessor='registry')
+  # Listing the key shows a value with name @ as well as one subkey
+  # with name KeyWithValue and a value with name KeyWithValue. We can
+  # have key and values with the same name.
+  # Reading such a path with read_file() will open the value in preference to the key.
+  - SELECT OSPath.Path AS Key, Data, read_file(accessor='registry', filename=OSPath) AS Content
+    FROM glob(globs='Test/*', root='HKEY_CURRENT_USER/Software', accessor='registry')

--- a/artifacts/testdata/windows/registry.out.yaml
+++ b/artifacts/testdata/windows/registry.out.yaml
@@ -132,12 +132,28 @@ SELECT OSPath FROM glob(globs="/*", accessor="registry")[
    "type": "key"
   }
  }
-]SELECT OSPath.Path AS Key, Data FROM glob(globs='Test/*', root='HKEY_CURRENT_USER/Software', accessor='registry')[
+]SELECT OSPath.Path AS Key, Data, read_file(accessor='registry', filename=OSPath) AS Content FROM glob(globs='Test/*', root='HKEY_CURRENT_USER/Software', accessor='registry')[
  {
   "Key": "HKEY_CURRENT_USER\\Software\\Test\\@",
   "Data": {
    "type": "SZ",
    "value": "Test Data"
-  }
+  },
+  "Content": "Test Data"
+ },
+ {
+  "Key": "HKEY_CURRENT_USER\\Software\\Test\\KeyWithValue",
+  "Data": {
+   "type": "key"
+  },
+  "Content": "Test Data"
+ },
+ {
+  "Key": "HKEY_CURRENT_USER\\Software\\Test\\KeyWithValue",
+  "Data": {
+   "type": "SZ",
+   "value": "Test Data"
+  },
+  "Content": "Test Data"
  }
 ]

--- a/gui/velociraptor/src/components/flows/new-collection.jsx
+++ b/gui/velociraptor/src/components/flows/new-collection.jsx
@@ -43,6 +43,7 @@ class PaginationBuilder {
         }
     }
 
+    active = false
     title = ""
     name = ""
     shouldFocused = (isFocused, step) => isFocused;
@@ -55,6 +56,7 @@ class PaginationBuilder {
     // navigators are disabled.
     makePaginator = (spec) => {
         let {props, onBlur, isFocused} = spec;
+        this.active = this.name === this.PaginationSteps[props.currentStep-1];
         return <Col md="12">
                  <Pagination>
                    { _.map(this.PaginationSteps, (step, i) => {
@@ -97,6 +99,8 @@ const remove_artifact = (artifacts, name) => {
 
 
 class NewCollectionSelectArtifacts extends React.Component {
+    inputRef = React.createRef(null);
+
     static propTypes = {
         // A list of artifact descriptors that are selected.
         artifacts: PropTypes.array,
@@ -125,10 +129,13 @@ class NewCollectionSelectArtifacts extends React.Component {
         showFavoriteSelector: false,
 
         current_favorite: null,
+
+        active: false,
     }
 
     componentDidMount = () => {
         this.source = CancelToken.source();
+        this.focusSearch();
 
         // Prepare the debounced function in advance.
         this._doSearch = _.debounce((value)=>{
@@ -156,6 +163,24 @@ class NewCollectionSelectArtifacts extends React.Component {
         if(_.isEmpty(prevProps.artifacts) && !_.isEmpty(this.props.artifacts)) {
             this.onSelect(this.props.artifacts[0], true);
         }
+
+        if(this.props.paginator.active && !this.state.active) {
+            this.focusSearch();
+            this.setState({active: true});
+        }
+
+        if(!this.props.paginator.active && this.state.active) {
+            this.setState({active: false});
+        }
+    }
+
+    focusSearch() {
+        const input = this.inputRef.current;
+
+        // Focus the input box once all the form is rendered.
+        setTimeout(function() {
+            input.select();
+        }, 400);
     }
 
     onSelect = (row, isSelect) => {
@@ -322,10 +347,15 @@ class NewCollectionSelectArtifacts extends React.Component {
                       <thead>
                         <tr>
                           <th>
-                            <Form>
-                              <Form.Control type="text"
-                                            onChange={e=>this.doSearch(e.target.value)}
-                                            placeholder={T("Search for artifacts...")}
+                            <Form onSubmit={e=>{
+                                e.preventDefault();
+                                return false;
+                            }}>
+                              <Form.Control
+                                type="text"
+                                ref={this.inputRef}
+                                onChange={e=>this.doSearch(e.target.value)}
+                                placeholder={T("Search for artifacts...")}
                               />
                             </Form>
                           </th>

--- a/gui/velociraptor/src/components/timeline/timeline.jsx
+++ b/gui/velociraptor/src/components/timeline/timeline.jsx
@@ -99,7 +99,7 @@ class AnnotationDialog extends Component {
                          <Form.Control as="textarea" rows={1}
                                        placeholder={T("Enter short annotation")}
                                        spellCheck="true"
-                                       value={this.state.note}
+                                       value={this.state.note || ""}
                                        onChange={e => this.setState({note: e.target.value})}
                          />
                          </Col>
@@ -149,7 +149,7 @@ class TimelineTableRow extends Component {
             notebook_id: this.props.notebook_id,
             super_timeline: this.props.super_timeline,
             event_json: JSON.stringify({
-                AnnotationID: this.props.row.AnnotationID,
+                _AnnotationID: this.props.row._AnnotationID,
             }),
         }, this.source.token).then(response=>{
             this.props.onUpdate();

--- a/gui/velociraptor/src/components/utils/url.jsx
+++ b/gui/velociraptor/src/components/utils/url.jsx
@@ -47,7 +47,7 @@ export default class URLViewer extends Component {
                      className="url-link"
                      size="sm"
                      variant="outline-info"
-                     href={api.href(url, {
+                     href={api.href(url, {}, {
                          internal: this.props.internal,
                      })} target="_blank">
                      <FontAwesomeIcon icon="external-link-alt"/>

--- a/gui/velociraptor/src/components/vfs/file-list.jsx
+++ b/gui/velociraptor/src/components/vfs/file-list.jsx
@@ -692,6 +692,7 @@ class VeloFileList extends Component {
                   params={{
                       client_id: this.props.client.client_id,
                       flow_id: this.props.node.flow_id,
+                      artifact: "System.VFS.ListDirectory/Listing",
                       vfs_components: this.props.node.path,
                   }}
                   selectRow={ selectRow }

--- a/gui/velociraptor/src/index.html
+++ b/gui/velociraptor/src/index.html
@@ -17,6 +17,12 @@
           window.base_path = "";
       }
 
+      // Set the OrgId from the URL if possible.
+      let url = new URL(window.location.href)
+      if (url.searchParams.get("org_id")) {
+          window.globals.OrgId = url.searchParams.get("org_id");
+      }
+
     </script>
     <script type="text/javascript">
       // Used to launch the application in an error state - allows the

--- a/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
@@ -48,9 +48,9 @@
    "OriginalEventField": "Extra field 1",
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
-   "AnnotatedBy": "admin",
-   "AnnotatedAt": "2024-05-15T12:19:47Z",
-   "AnnotationID": "TdAAAAAAAAA=",
+   "_AnnotatedBy": "admin",
+   "_AnnotatedAt": "2024-05-15T12:19:47Z",
+   "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   }
  ],
@@ -62,9 +62,9 @@
    "OriginalEventField": "Extra field 2",
    "Foo": "Older Bar 2",
    "Notes": "An Earlier Foo is suspicious at being Older Bar!",
-   "AnnotatedBy": "mike",
-   "AnnotatedAt": "2024-05-15T12:19:47Z",
-   "AnnotationID": "TtAAAAAAAAA=",
+   "_AnnotatedBy": "mike",
+   "_AnnotatedAt": "2024-05-15T12:19:47Z",
+   "_AnnotationID": "TtAAAAAAAAA=",
    "_Source": "Annotation"
   },
   {
@@ -74,9 +74,9 @@
    "OriginalEventField": "Extra field 1",
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
-   "AnnotatedBy": "admin",
-   "AnnotatedAt": "2024-05-15T12:19:47Z",
-   "AnnotationID": "TdAAAAAAAAA=",
+   "_AnnotatedBy": "admin",
+   "_AnnotatedAt": "2024-05-15T12:19:47Z",
+   "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   }
  ],
@@ -102,9 +102,9 @@
   "Foo": "Older Bar 2",
   "_Source": "Annotation",
   "Notes": "Updated First Annotation - all other fields remain",
-  "AnnotatedBy": "admin",
-  "AnnotatedAt": "2024-05-15T12:19:47Z",
-  "AnnotationID": "TtAAAAAAAAA="
+  "_AnnotatedBy": "admin",
+  "_AnnotatedAt": "2024-05-15T12:19:47Z",
+  "_AnnotationID": "TtAAAAAAAAA="
  },
  "Updated Annotations": [
   {
@@ -114,9 +114,9 @@
    "OriginalEventField": "Extra field 1",
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
-   "AnnotatedBy": "admin",
-   "AnnotatedAt": "2024-05-15T12:19:47Z",
-   "AnnotationID": "TdAAAAAAAAA=",
+   "_AnnotatedBy": "admin",
+   "_AnnotatedAt": "2024-05-15T12:19:47Z",
+   "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   },
   {
@@ -126,9 +126,9 @@
    "OriginalEventField": "Extra field 2",
    "Foo": "Older Bar 2",
    "Notes": "Updated First Annotation - all other fields remain",
-   "AnnotatedBy": "admin",
-   "AnnotatedAt": "2024-05-15T12:19:47Z",
-   "AnnotationID": "TtAAAAAAAAA=",
+   "_AnnotatedBy": "admin",
+   "_AnnotatedAt": "2024-05-15T12:19:47Z",
+   "_AnnotationID": "TtAAAAAAAAA=",
    "_Source": "Annotation"
   }
  ]

--- a/services/notebook/timelines.go
+++ b/services/notebook/timelines.go
@@ -27,7 +27,10 @@ import (
 )
 
 const (
-	AnnotationID = "AnnotationID"
+	// Annotation fields are hidden by default.
+	AnnotationID = "_AnnotationID"
+	AnnotatedBy  = "_AnnotatedBy"
+	AnnotatedAt  = "_AnnotatedAt"
 )
 
 var (
@@ -422,8 +425,8 @@ func (self *NotebookStoreImpl) AnnotateTimeline(
 	if timestamp.After(epoch) {
 		row := event.Update(constants.TIMELINE_DEFAULT_KEY, timestamp).
 			Set("Notes", message).
-			Set("AnnotatedBy", principal).
-			Set("AnnotatedAt", utils.GetTime().Now()).
+			Set(AnnotatedBy, principal).
+			Set(AnnotatedAt, utils.GetTime().Now()).
 			Set(AnnotationID, guid)
 
 		// Push it into the sorter


### PR DESCRIPTION
Sometime keys and values have the same name in the registry. This requires the registry accessor to expose the UniqueName() API to allow glob to handle different entitied with the same name.

Also GUI fixes:

* Restore focus on artifact search textbox when the wizard step appears.
* Proper URL handling in the "url" column type - only replace org_id if it is not already set.
* Fix CSV/JSON download in VFS file list tables.