### PR TITLE
Update MacOS and Linux Netstat Artifacts

### DIFF
--- a/artifacts/definitions/Linux/Network/Netstat.yaml
+++ b/artifacts/definitions/Linux/Network/Netstat.yaml
@@ -8,7 +8,7 @@ type: CLIENT
 parameters:
    - name: StateRegex
      type: regex
-     default: "Listening|Established"
+     default: "LISTEN|ESTAB"
      description: Only show these states
 
 sources:

--- a/artifacts/definitions/Linux/Network/NetstatEnriched.yaml
+++ b/artifacts/definitions/Linux/Network/NetstatEnriched.yaml
@@ -26,7 +26,7 @@ parameters:
     type: regex
   - name: ConnectionStatusRegex
     description: "regex search over connection status"
-    default: "LISTEN|ESTABLISHED"
+    default: "LISTEN|ESTAB"
     type: regex
   - name: ProcessPathRegex
     description: "regex search over source process path"

--- a/artifacts/definitions/MacOS/Network/Netstat.yaml
+++ b/artifacts/definitions/MacOS/Network/Netstat.yaml
@@ -26,7 +26,7 @@ parameters:
     type: regex
   - name: ConnectionStatusRegex
     description: "regex search over connection status"
-    default: "LISTEN|ESTABLISHED"
+    default: "LISTEN|ESTAB"
     type: regex
   - name: ProcessPathRegex
     description: "regex search over source process path"


### PR DESCRIPTION
I noticed that the Netstat artifact with default parameters returned a result set that seemed too short.  This was caused by the default status regex in the artifact using "ESTABLISHED" instead of "ESTAB".  Looks like all the OS's netstat plugins map the status to "ESTAB", so I updated the regex in these three artifacts that use it.  Now if the user runs with the default parameters they will return both Listening and Established connections as expected.