### PR TITLE
Allows arbitrary length filenames in filestore.

### DIFF
--- a/artifacts/definitions/Server/Utils/StartHuntExample.yaml
+++ b/artifacts/definitions/Server/Utils/StartHuntExample.yaml
@@ -28,7 +28,7 @@ description: |
   ```
 
   This will allow users with the `COLLECT_BASIC` permission to also
-  collect it. Once collected the artifact specifies an impersonation
+  collect it. Once collected the artifact specifies the impersonate
   field to `admin` which will cause it to run under the `admin` user's
   permissions.
 
@@ -40,9 +40,9 @@ description: |
 type: SERVER
 
 # Collect this artifact under the admin user permissions.
-impersonation: admin
+impersonate: admin
 
-source:
+sources:
   - query: |
       -- This query will run with admin ACLs.
       SELECT hunt(

--- a/bin/hunts.go
+++ b/bin/hunts.go
@@ -95,7 +95,7 @@ func doHuntReconstruct() error {
 					return err
 				}
 				fmt.Printf("Rebuilding %v to %v\n", hunt.HuntId,
-					target.AsDatastoreFilename(config_obj))
+					target.String())
 			}
 		}
 	}

--- a/datastore/filebased_generic.go
+++ b/datastore/filebased_generic.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package datastore

--- a/datastore/filebased_utils.go
+++ b/datastore/filebased_utils.go
@@ -1,0 +1,184 @@
+package datastore
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+func AsFilestoreFilename(
+	db DataStore, config_obj *config_proto.Config, path api.FSPathSpec) string {
+	return AsFilestoreDirectory(db, config_obj, path) +
+		api.GetExtensionForFilestore(path)
+}
+
+func AsFilestoreDirectory(
+	db DataStore, config_obj *config_proto.Config,
+	path api.FSPathSpec) string {
+	data_store_root := ""
+	if config_obj != nil && config_obj.Datastore != nil {
+		data_store_root = config_obj.Datastore.FilestoreDirectory
+	}
+
+	if path.IsSafe() {
+		return asSafeDirWithRoot(config_obj,
+			path.AsDatastorePath(), data_store_root)
+	}
+	return asUnsafeDirWithRoot(db, config_obj,
+		path.AsDatastorePath(), data_store_root)
+}
+
+func AsDatastoreDirectory(
+	db DataStore, config_obj *config_proto.Config, path api.DSPathSpec) string {
+	location := ""
+	if config_obj.Datastore != nil {
+		location = config_obj.Datastore.Location
+	}
+
+	if path.IsSafe() {
+		return asSafeDirWithRoot(config_obj, path, location)
+	}
+	return asUnsafeDirWithRoot(db, config_obj, path, location)
+}
+
+// When we are unsafe we need to Sanitize components hitting the
+// filesystem.
+func asUnsafeDirWithRoot(
+	db DataStore,
+	config_obj *config_proto.Config,
+	path api.DSPathSpec, root string) string {
+	sep := string(filepath.Separator)
+	new_components := make([]string, 0, len(path.Components()))
+	for _, i := range path.Components() {
+		if i != "" {
+			new_components = append(new_components, CompressComponent(
+				db, config_obj, i))
+		}
+	}
+	result := sep + strings.Join(new_components, sep)
+
+	// This relies on the filepath starting with a drive letter
+	// and having \ as path separators. Main's
+	// validateServerConfig() ensures this is the case.
+	if runtime.GOOS == "windows" {
+		return "\\\\?\\" + root + result
+	}
+	return root + result
+}
+
+func AsDatastoreFilename(
+	db DataStore, config_obj *config_proto.Config, path api.DSPathSpec) string {
+	return AsDatastoreDirectory(db, config_obj, path) +
+		api.GetExtensionForDatastore(path)
+}
+
+// If the path spec is already safe we can shortcut it and not
+// sanitize.
+func asSafeDirWithRoot(
+	config_obj *config_proto.Config,
+	path api.DSPathSpec, root string) string {
+	// No need to sanitize here because the DSPathSpec is already
+	// safe.
+	sep := string(filepath.Separator)
+
+	// This relies on the filepath starting with a drive letter
+	// and having \ as path separators, and having a trailing
+	// \. Main's config.ValidateDatastoreConfig() ensures this is
+	// the case.
+	if runtime.GOOS == "windows" {
+		// Remove empty components which are broken on windows due to
+		// the long filename hack.
+		components := make([]string, 0, len(path.Components()))
+		for _, c := range path.Components() {
+			if c != "" {
+				components = append(components, c)
+			}
+		}
+		return WINDOWS_LFN_PREFIX + root + sep +
+			strings.Join(components, sep)
+	}
+
+	return root + sep + strings.Join(path.Components(), sep)
+}
+
+// This function is only really called when listing a directory - we
+// find the hash compressed member and need to reconstruct its full
+// name.
+func UncompressComponent(
+	db DataStore,
+	config_obj *config_proto.Config,
+	component string) string {
+	if len(component) == 0 || component[0] != '#' {
+		return utils.UnsanitizeComponent(component)
+	}
+
+	ds_pathspec := &api_proto.DSPathSpec{}
+	err := db.GetSubject(config_obj,
+		LFNCompressedHashPath(component), ds_pathspec)
+	if err != nil || len(ds_pathspec.Components) != 1 {
+		return component
+	}
+
+	return ds_pathspec.Components[0]
+}
+
+func CompressComponent(
+	db DataStore,
+	config_obj *config_proto.Config,
+	component string) string {
+	sanitized_component := utils.SanitizeString(component)
+	if len(sanitized_component) < 250 {
+		return sanitized_component
+	}
+
+	// Hash compress the original component
+	hash := sha1.Sum([]byte(component))
+	component_hash := fmt.Sprintf("#%x", hash)
+	db, err := GetDB(config_obj)
+	if err != nil {
+		return component_hash
+	}
+
+	ds_pathspec := &api_proto.DSPathSpec{
+		Components: []string{component},
+	}
+	_ = db.SetSubject(config_obj,
+		LFNCompressedHashPath(component_hash), ds_pathspec)
+	return component_hash
+}
+
+// Long file names are compressed into hashes and stored in the
+// datastore.
+func LFNCompressedHashPath(hash string) api.DSPathSpec {
+	res := path_specs.NewSafeDatastorePath("lfn_hashes").
+		SetType(api.PATH_TYPE_DATASTORE_JSON)
+
+	i := 0
+	var part []byte
+	for _, c := range []byte(hash) {
+		if c == '#' {
+			continue
+		}
+		part = append(part, c)
+		i++
+
+		if i == 3 || i == 12 {
+			res = res.AddChild(string(part))
+			part = nil
+		}
+	}
+
+	if len(part) > 0 {
+		res = res.AddChild(string(part))
+	}
+
+	return res
+}

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -76,7 +76,7 @@ func Walk(config_obj *config_proto.Config,
 	with_directories bool,
 	walkFn WalkFunc) error {
 
-	TraceDirectory(config_obj, "Walk", root)
+	TraceDirectory(datastore, config_obj, "Walk", root)
 	all_children, err := datastore.ListChildren(config_obj, root)
 	if err != nil {
 		return err

--- a/file_store/api/paths.go
+++ b/file_store/api/paths.go
@@ -1,9 +1,5 @@
 package api
 
-import (
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
-)
-
 /*
 
 # How paths are handled in Velociraptor.
@@ -117,12 +113,13 @@ type _PathSpec interface {
 	Type() PathType
 
 	String() string
+
+	// Does any of the components need escaping?
+	IsSafe() bool
 }
 
 type DSPathSpec interface {
 	_PathSpec
-	AsDatastoreDirectory(config_obj *config_proto.Config) string
-	AsDatastoreFilename(config_obj *config_proto.Config) string
 
 	Dir() DSPathSpec
 
@@ -147,8 +144,6 @@ type DSPathSpec interface {
 
 type FSPathSpec interface {
 	_PathSpec
-	AsFilestoreFilename(config_obj *config_proto.Config) string
-	AsFilestoreDirectory(config_obj *config_proto.Config) string
 
 	Dir() FSPathSpec
 

--- a/file_store/path_specs/fs_path_spec.go
+++ b/file_store/path_specs/fs_path_spec.go
@@ -3,7 +3,6 @@ package path_specs
 import (
 	"strconv"
 
-	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
@@ -70,25 +69,6 @@ func (self FSPathSpec) SetType(ext api.PathType) api.FSPathSpec {
 		path_type:  ext,
 		is_safe:    self.is_safe,
 	}}
-}
-
-func (self FSPathSpec) AsFilestoreFilename(
-	config_obj *config_proto.Config) string {
-	return self.AsFilestoreDirectory(config_obj) +
-		api.GetExtensionForFilestore(self)
-}
-
-func (self FSPathSpec) AsFilestoreDirectory(
-	config_obj *config_proto.Config) string {
-	data_store_root := ""
-	if config_obj != nil && config_obj.Datastore != nil {
-		data_store_root = config_obj.Datastore.FilestoreDirectory
-	}
-
-	if self.is_safe {
-		return self.asSafeDirWithRoot(data_store_root)
-	}
-	return self.asUnsafeDirWithRoot(data_store_root)
 }
 
 func (self FSPathSpec) AsClientPath() string {

--- a/file_store/tests/testsuite.go
+++ b/file_store/tests/testsuite.go
@@ -202,8 +202,7 @@ func (self *FileStoreTestSuite) TestListDirectory() {
 	names = nil
 	err = api.Walk(self.filestore, filename.AddChild("nonexistant"),
 		func(path api.FSPathSpec, info os.FileInfo) error {
-			names = append(names, path.AsFilestoreFilename(
-				self.config_obj))
+			names = append(names, path.String())
 			return nil
 		})
 	assert.NoError(self.T(), err)

--- a/paths/artifacts/paths_test.go
+++ b/paths/artifacts/paths_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Velocidex/ordereddict"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store/memory"
 	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
@@ -97,6 +98,9 @@ func (self *PathManageTestSuite) TestPathManager() {
 	closer := utils.MockTime(utils.NewMockClock(time.Unix(ts, 0)))
 	defer closer()
 
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
 	for _, testcase := range path_tests {
 		path_manager, err := artifacts.NewArtifactPathManager(
 			self.Ctx, self.ConfigObj,
@@ -108,7 +112,8 @@ func (self *PathManageTestSuite) TestPathManager() {
 		path, err := path_manager.GetPathForWriting()
 		assert.NoError(self.T(), err)
 		assert.Equal(self.T(),
-			cleanPath(path.AsFilestoreFilename(self.ConfigObj)),
+			cleanPath(datastore.AsFilestoreFilename(
+				db, self.ConfigObj, path)),
 			cleanPath(self.dirname+"/"+testcase.expected))
 
 		file_store := memory.NewMemoryFileStore(self.ConfigObj)

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -59,7 +59,7 @@ func (self *PathManagerTestSuite) getDatastorePath(path_spec api.DSPathSpec) str
 			continue
 		}
 		results = append(results, normalize_path(
-			k.AsDatastoreFilename(self.config_obj)))
+			datastore.AsDatastoreFilename(ds, self.config_obj, k)))
 	}
 	assert.Equal(self.T(), 1, len(results))
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -478,8 +478,11 @@ func (self *ServerTestSuite) RequiredFilestoreContains(
 
 	file_store_factory := test_utils.GetMemoryFileStore(self.T(), self.ConfigObj)
 
-	value, pres := file_store_factory.Get(filename.AsFilestoreFilename(
-		self.ConfigObj))
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	value, pres := file_store_factory.Get(datastore.AsFilestoreFilename(
+		db, self.ConfigObj, filename))
 	if !pres {
 		self.T().FailNow()
 	}

--- a/services/repository/manager_test.go
+++ b/services/repository/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	"www.velocidex.com/golang/velociraptor/paths/artifacts"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -62,8 +63,11 @@ name: TestArtifact
 		self.ConfigObj, "", "", "Server.Internal.ArtifactModification")
 	assert.NoError(self.T(), err)
 
+	db, err := datastore.GetDB(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
 	data, pres = file_store.Get(
-		path_manager.Path().AsFilestoreFilename(self.ConfigObj))
+		datastore.AsFilestoreFilename(db, self.ConfigObj, path_manager.Path()))
 	assert.True(self.T(), pres)
 
 	assert.Contains(self.T(), string(data), `"op":"set"`)

--- a/services/repository/plugin_test.go
+++ b/services/repository/plugin_test.go
@@ -1,23 +1,24 @@
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package repository_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -53,9 +54,15 @@ func (self *PluginTestSuite) TestArtifactsSyntax() {
 	manager, err := services.GetRepositoryManager(self.ConfigObj)
 	assert.NoError(self.T(), err)
 
+	logging.ClearMemoryLogs()
+
 	err = repository.LoadBuiltInArtifacts(
 		self.Ctx, self.ConfigObj, manager.(*repository.RepositoryManager))
 	assert.NoError(self.T(), err)
+
+	assert.NotContains(self.T(),
+		strings.Join(logging.GetMemoryLogs(), "\n"),
+		"Cant parse asset")
 
 	ConfigObj := self.ConfigObj
 	repository, err := manager.GetGlobalRepository(ConfigObj)

--- a/utils/sanitize.go
+++ b/utils/sanitize.go
@@ -50,6 +50,12 @@ func SanitizeString(component string) string {
 		return "%2E" + SanitizeString(component[1:])
 	}
 
+	// Escape components that start with # as the data store
+	// represents those as hashes.
+	if component[0] == '#' {
+		return "%23" + SanitizeString(component[1:])
+	}
+
 	// Windows can not have a trailing "." instead swallowing it
 	// completely.
 	if component[length-1] == '.' {


### PR DESCRIPTION
On Linux file names must be less then 255 bytes. The filestore attempts to preserve and sanitize the original filename of uploaded files, which means that in some cases the filestore filename can easily exceed the hard limit imposed by the OS.

This PR switches to a hash based compression when the filename exceeds 250 chars. This replaces the filestore filename with a hash, and the full component is stored in the datastore separately. This allows us to store arbitrary length filenames in the filestore.