### PR TITLE
Revert "Bump path-to-regexp and react-router-dom in /gui/velociraptor…

### DIFF
--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -56,7 +56,7 @@
                 "react-dom": "^16.14.0",
                 "react-hotkeys": "^2.0.0",
                 "react-overlays": "5.2.1",
-                "react-router-dom": "^6.26.2",
+                "react-router-dom": "^5.3.4",
                 "react-select": "^3.2.0",
                 "react-simple-snackbar": "^1.1.11",
                 "react-split-grid": "^1.0.4",
@@ -2908,14 +2908,6 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@remix-run/router": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
-            "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@restart/hooks": {
@@ -6316,6 +6308,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/history": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+            "dependencies": {
+                "@babel/runtime": "^7.1.2",
+                "loose-envify": "^1.2.0",
+                "resolve-pathname": "^3.0.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0",
+                "value-equal": "^1.0.1"
+            }
+        },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -7571,6 +7576,19 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
+        "node_modules/path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
+        "node_modules/path-to-regexp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -8236,34 +8254,45 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
-            "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
             "dependencies": {
-                "@remix-run/router": "1.19.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "hoist-non-react-statics": "^3.1.0",
+                "loose-envify": "^1.3.1",
+                "path-to-regexp": "^1.7.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=15"
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
-            "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
             "dependencies": {
-                "@remix-run/router": "1.19.2",
-                "react-router": "6.26.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-router": "5.3.4",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": ">=15"
             }
+        },
+        "node_modules/react-router/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-select": {
             "version": "3.2.0",
@@ -8600,6 +8629,11 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/resolve-pathname": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "node_modules/reusify": {
             "version": "1.0.4",
@@ -9503,6 +9537,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "node_modules/value-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "node_modules/victory-vendor": {
             "version": "36.6.8",
@@ -11740,11 +11779,6 @@
             "requires": {
                 "@swc/helpers": "^0.5.0"
             }
-        },
-        "@remix-run/router": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
-            "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA=="
         },
         "@restart/hooks": {
             "version": "0.4.9",
@@ -14314,6 +14348,19 @@
                 "function-bind": "^1.1.2"
             }
         },
+        "history": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+            "requires": {
+                "@babel/runtime": "^7.1.2",
+                "loose-envify": "^1.2.0",
+                "resolve-pathname": "^3.0.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0",
+                "value-equal": "^1.0.1"
+            }
+        },
         "hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -15229,6 +15276,21 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+                }
+            }
+        },
         "path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -15695,20 +15757,40 @@
             "dev": true
         },
         "react-router": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
-            "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
             "requires": {
-                "@remix-run/router": "1.19.2"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "hoist-non-react-statics": "^3.1.0",
+                "loose-envify": "^1.3.1",
+                "path-to-regexp": "^1.7.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
             }
         },
         "react-router-dom": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
-            "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
             "requires": {
-                "@remix-run/router": "1.19.2",
-                "react-router": "6.26.2"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-router": "5.3.4",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
             }
         },
         "react-select": {
@@ -15967,6 +16049,11 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "resolve-pathname": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "reusify": {
             "version": "1.0.4",
@@ -16612,6 +16699,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "value-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "victory-vendor": {
             "version": "36.6.8",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -52,7 +52,7 @@
         "react-dom": "^16.14.0",
         "react-hotkeys": "^2.0.0",
         "react-overlays": "5.2.1",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^5.3.4",
         "react-select": "^3.2.0",
         "react-simple-snackbar": "^1.1.11",
         "react-split-grid": "^1.0.4",


### PR DESCRIPTION
… (#3742)"

This reverts commit 43450881533d2c2ad1ae2fa6c0ee8d946ddf4c10.

Major refactor required to switch to react-router-dom v6. This is not a dependabot appropriate change.