### PR TITLE
Clean up VQL reference

### DIFF
--- a/accessors/data/scope.go
+++ b/accessors/data/scope.go
@@ -112,5 +112,5 @@ func (self ScopeFilesystemAccessor) Open(path string) (
 
 func init() {
 	accessors.Register("scope", &ScopeFilesystemAccessor{},
-		`Similar to the "data" accessor, this makes a string appears as a file. However, instead of the Filename containing the file content itself, the Filename refers to the name of a variable in the current scope that contains the data. This is useful when the binary data is not unicode safe and can not be properly represented by JSON.`)
+		`Present the content of a scope variable as a file.`)
 }

--- a/accessors/ewf/ewf.go
+++ b/accessors/ewf/ewf.go
@@ -93,32 +93,5 @@ func GetEWFImage(full_path *accessors.OSPath, scope vfilter.Scope) (
 func init() {
 	accessors.Register("ewf", zip.NewGzipFileSystemAccessor(
 		accessors.MustNewLinuxOSPath(""), GetEWFImage),
-		`Allow reading an ewf file.
-
-Note that usually EWF files form a set of files with extensions
-like .E01, .E02 etc. This accessor will automatically try to find
-all parts of the same volume set if the file name ends with a '.E01'.
-
-For Example
-
-SELECT * FROM glob(
-  globs="*", accessor="raw_ntfs", root=pathspec(
-    Path="/",
-    DelegateAccessor="ewf",
-    DelegatePath="C:/test.ntfs.dd.E01"))
-
-The next example reads a FAT partition through the offset
-accessor (32256 is the byte offset of the first FAT partition).
-
-    SELECT OSPath.Path AS OSPath, Size, Mode.String
-    FROM glob(
-       globs="*", accessor="fat", root=pathspec(
-          Path="/",
-          DelegateAccessor="offset",
-          DelegatePath=pathspec(
-            Path="/32256",
-            DelegateAccessor="ewf",
-            DelegatePath="/tmp/ubnist1.gen3.E01")))
-
-`)
+		`Allow reading an EWF file.`)
 }

--- a/accessors/ext4/ext4_accessor.go
+++ b/accessors/ext4/ext4_accessor.go
@@ -302,26 +302,7 @@ func (self *Ext4FileSystemAccessor) LstatWithOSPath(
 
 func init() {
 	accessors.Register("raw_ext4", &Ext4FileSystemAccessor{},
-		`Access the Ext4 filesystem inside an image by parsing the image.
-
-This accessor is designed to operate on images directly. It requires a
-delegate accessor to get the raw image and will open files using the
-FAT full path rooted at the top of the filesystem.
-
-## Example
-
-The following query will glob all the files under the directory 'a'
-inside a Ext4 image file
-
-SELECT *
-FROM glob(globs='/**',
-  accessor="raw_ext4",
-  root=pathspec(
-    Path="a",
-    DelegateAccessor="file",
-    DelegatePath='ext4.dd'))
-
-`)
+		`Access the Ext4 filesystem inside an image by parsing the image.`)
 
 	json.RegisterCustomEncoder(&Ext4FileInfo{}, accessors.MarshalGlobFileInfo)
 }

--- a/accessors/ext4/ext4_accessor_linux.go
+++ b/accessors/ext4/ext4_accessor_linux.go
@@ -93,21 +93,5 @@ func (self LinuxExt4FileSystemAccessor) New(scope vfilter.Scope) (
 
 func init() {
 	accessors.Register("ext4", &LinuxExt4FileSystemAccessor{},
-		`Access files by parsing the raw ext4 filesystems.
-
-This accessor is designed to operate on a live system. It
-automatically enumerates the mount points and attaches a raw ext4
-mount to each mounted device.
-
-Users can use the same path as is presented on the real system, but
-the raw ext4 partitions will be parsed instead.
-
-This accessor is only available under linux.
-
-## Example
-
-SELECT *
-FROM glob(globs='/boot/*', accessor="ext4")
-
-`)
+		`Access files by parsing the raw ext4 filesystems.`)
 }

--- a/accessors/fat/fat_accessor.go
+++ b/accessors/fat/fat_accessor.go
@@ -330,26 +330,7 @@ func (self *FATFileSystemAccessor) LstatWithOSPath(
 
 func init() {
 	accessors.Register("fat", &FATFileSystemAccessor{},
-		`Access the FAT filesystem inside an image by parsing FAT.
-
-This accessor is designed to operate on images directly. It requires a
-delegate accessor to get the raw image and will open files using the
-FAT full path rooted at the top of the filesystem.
-
-## Example
-
-The following query will glob all the files under the directory 'a'
-inside a FAT image file
-
-SELECT *
-FROM glob(globs='/**',
-  accessor="fat",
-  root=pathspec(
-    Path="a",
-    DelegateAccessor="file",
-    DelegatePath='fat.dd'))
-
-`)
+		`Access the FAT filesystem inside an image by parsing FAT.`)
 
 	json.RegisterCustomEncoder(&FATFileInfo{}, accessors.MarshalGlobFileInfo)
 }

--- a/accessors/mscfb/mscfb_accessor.go
+++ b/accessors/mscfb/mscfb_accessor.go
@@ -250,8 +250,7 @@ func (self *MscfbFileSystemAccessor) LstatWithOSPath(
 
 func init() {
 	accessors.Register("mscfb", &MscfbFileSystemAccessor{},
-		`Parse a MSCFB file as an archive.
-`)
+		`Parse a MSCFB file as an archive.`)
 
 	json.RegisterCustomEncoder(&MscfbFileInfo{}, accessors.MarshalGlobFileInfo)
 }

--- a/accessors/ntfs/mft.go
+++ b/accessors/ntfs/mft.go
@@ -210,15 +210,5 @@ func (self *MFTFileSystemAccessor) LstatWithOSPath(full_path *accessors.OSPath) 
 
 func init() {
 	accessors.Register("mft", &MFTFileSystemAccessor{},
-		`Access arbitrary MFT streams as files.
-
-The filename is taken as an MFT inode number in the
-form <entry_id>-<stream_type>-<id>, e.g. 203-128-0
-
-An example of using this artifact:
-
-SELECT upload(accessor="mft", filename="C:/203-128-0")
-FROM scope()
-
-`)
+		`Access arbitrary MFT streams as files.`)
 }

--- a/accessors/ntfs/ntfs_accessor.go
+++ b/accessors/ntfs/ntfs_accessor.go
@@ -577,25 +577,7 @@ func Open(scope vfilter.Scope, self *ntfs.MFT_ENTRY,
 
 func init() {
 	accessors.Register("raw_ntfs", &NTFSFileSystemAccessor{},
-		`Access the NTFS filesystem inside an image by parsing NTFS.
-
-This accessor is designed to operate on images directly. It requires a
-delegate accessor to get the raw image and will open files using the
-NTFS full path rooted at the top of the filesystem.
-
-## Example
-
-The following query will open the $MFT file from the raw image file
-that will be accessed using the file accessor.
-
-SELECT * FROM parse_mft(
-  filename=pathspec(
-    Path="$MFT",
-    DelegateAccessor="file",
-    DelegatePath='ntfs.dd'),
-  accessor="raw_ntfs")
-
-`)
+		`Access the NTFS filesystem inside an image by parsing NTFS.`)
 
 	json.RegisterCustomEncoder(&NTFSFileInfo{}, accessors.MarshalGlobFileInfo)
 }

--- a/accessors/offset/offset.go
+++ b/accessors/offset/offset.go
@@ -139,13 +139,5 @@ func GetOffsetFile(full_path *accessors.OSPath, scope vfilter.Scope) (
 func init() {
 	accessors.Register("offset", zip.NewGzipFileSystemAccessor(
 		accessors.MustNewLinuxOSPath(""), GetOffsetFile),
-		`Allow reading another file from a specific offset.
-
-For Example
-
-FileName = pathspec(
-      DelegateAccessor="data",
-      DelegatePath=MyData,
-      Path="/5")
-`)
+		`Allow reading another file from a specific offset.`)
 }

--- a/accessors/pipe/pipe.go
+++ b/accessors/pipe/pipe.go
@@ -205,18 +205,6 @@ func (self PipeFilesystemAccessor) OpenWithOSPath(
 
 func init() {
 	accessors.Register("pipe", &PipeFilesystemAccessor{},
-		`Read from a VQL pipe.
-
-A VQL pipe allows data to be generated from a VQL query, as the pipe is read, the query proceeds to feed more data to it.
-
-Example:
-
-  LET MyPipe = pipe(query={
-        SELECT _value FROM range(start=0, end=10, step=1)
-  }, sep="\n")
-
-  SELECT read_file(filename="MyPipe", accessor="pipe")
-  FROM scope()
-`)
+		`Read from a VQL pipe.`)
 	vql_subsystem.RegisterFunction(&PipeFunction{})
 }

--- a/accessors/s3/s3.go
+++ b/accessors/s3/s3.go
@@ -258,28 +258,7 @@ func (self RawS3SystemAccessor) LstatWithOSPath(
 
 func init() {
 	accessors.Register("s3", &RawS3SystemAccessor{},
-		`Access S3 Buckets.
-
-This artifact allows access to S3 buckets:
-
-1. The first component is interpreted as the bucket name.
-
-2. Provide credentials through the VQL environment
-   variable S3_CREDENTIALS. This should be a dict with
-   a key of the bucket name and the value being the credentials.
-
-Example:
-
-LET S3_CREDENTIALS<=dict(endpoint='http://127.0.0.1:4566/',
-  credentials_key='admin',
-  credentials_secret='password',
-  no_verify_cert=1)
-
-SELECT *, read_file(filename=OSPath,
-   length=10, accessor='s3') AS Data
-FROM glob(globs='/velociraptor/orgs/root/clients/C.39a107c4c58c5efa/collections/*/uploads/auto/*', accessor='s3')
-
-`)
+		`Allows access to S3 buckets.`)
 }
 
 // Set the page size for tests. Normally we dont need to adjust this

--- a/accessors/smb/smb.go
+++ b/accessors/smb/smb.go
@@ -266,5 +266,5 @@ func init() {
 	}
 	accessors.Register("smb", &SMBFileSystemAccessor{
 		root: root_path,
-	}, `Access smb shares.`)
+	}, `Allows access SMB shares.`)
 }

--- a/accessors/smb/smb.go
+++ b/accessors/smb/smb.go
@@ -266,5 +266,5 @@ func init() {
 	}
 	accessors.Register("smb", &SMBFileSystemAccessor{
 		root: root_path,
-	}, `Allows access SMB shares.`)
+	}, `Allows access to SMB shares.`)
 }

--- a/accessors/sparse/sparse.go
+++ b/accessors/sparse/sparse.go
@@ -247,14 +247,5 @@ func GetSparseFile(full_path *accessors.OSPath, scope vfilter.Scope) (
 func init() {
 	accessors.Register("sparse", zip.NewGzipFileSystemAccessor(
 		accessors.MustNewPathspecOSPath(""), GetSparseFile),
-		`Allow reading another file by overlaying a sparse map on top of it.
-
-The map excludes reading from certain areas which are considered sparse.
-
-The resulting file is sparse (and therefore uploading it excludes the masked out regions). The filename is taken as a list of ranges. For example:
-
-FileName = pathspec(
-      DelegateAccessor="data", DelegatePath=MyData,
-      Path=[dict(Offset=0,Length=5), dict(Offset=10,Length=5)])
-`)
+		`Allows reading another file by overlaying a sparse map on top of it.`)
 }

--- a/accessors/ssh/ssh.go
+++ b/accessors/ssh/ssh.go
@@ -129,28 +129,6 @@ func (self SSHFileSystemAccessor) OpenWithOSPath(filename *accessors.OSPath) (
 }
 
 func init() {
-	accessors.Register("ssh", &SSHFileSystemAccessor{}, `
-Access a remote system's filesystem via SSH/SFTP.
-
-This accessor allows accessing remote systems via SFTP/SSH.
-This is useful for being able to search remote systems where it is not possible
-to run a Velociraptor client directly on the endpoint. For example, on embedded
-edge devices such as routers/firewalls/VPNs etc.
-
-To use this accessor you will need to provide credentials via the SSH_CONFIG
-scope variable:
-
-`+"```"+`vql
-LET SSH_CONFIG <= dict(hostname='localhost:22',
-    username='mic',
-    private_key=read_file(filename='/home/mic/.ssh/id_rsa'))
-`+"```"+`
-
-NOTES:
-
-1. hostname must have a port after the column.
-2. You can provide a password via the password parameter
-3. The private_key parameter must contain an unencrypted PEM encoded SSH private key pair.
-
-`)
+	accessors.Register("ssh", &SSHFileSystemAccessor{},
+	`Access a remote system's filesystem via SSH/SFTP.`)
 }

--- a/accessors/vhdx/vhdx.go
+++ b/accessors/vhdx/vhdx.go
@@ -98,24 +98,5 @@ func GetVHDXImage(full_path *accessors.OSPath, scope vfilter.Scope) (
 func init() {
 	accessors.Register("vhdx", zip.NewGzipFileSystemAccessor(
 		accessors.MustNewLinuxOSPath(""), GetVHDXImage),
-		`Allow reading a vhdx file.
-
-This accessor allows access to the content of VHDX files. Note that usually
-VHDX files are disk images with a partition table and an NTFS volume. You
-will usually need to wrap this accessor with a suitable Offset (to account
-for the parition) and parse it with the the "raw_ntfs" accessor.
-
-For Example
-
-    SELECT OSPath.Path AS OSPath, Size, Mode.String
-    FROM glob(
-       globs="*", accessor="raw_ntfs", root=pathspec(
-          Path="/",
-          DelegateAccessor="offset",
-          DelegatePath=pathspec(
-            Path="/65536",
-            DelegateAccessor="vhdx",
-            DelegatePath="/tmp/test.vhdx")))
-
-`)
+		`Allow reading a VHDX file.`)
 }

--- a/accessors/vmdk/vmdk.go
+++ b/accessors/vmdk/vmdk.go
@@ -98,28 +98,5 @@ func GetVMDKImage(full_path *accessors.OSPath, scope vfilter.Scope) (
 func init() {
 	accessors.Register("vmdk", zip.NewGzipFileSystemAccessor(
 		accessors.MustNewLinuxOSPath(""), GetVMDKImage),
-		`Allow reading a vmdk file.
-
-This accessor allows access to the content of VMDK files. Note that usually
-VMDK files are disk images with a partition table and an NTFS volume. You
-will usually need to wrap this accessor with a suitable Offset (to account
-for the parition) and parse it with the the "raw_ntfs" accessor.
-
-The VMDK file should be the metadata file (i.e. not the extent files).
-The extent files are expected to be in the same directory as the
-metadata file and this accessor will open them separately.
-
-For Example
-
-    SELECT OSPath.Path AS OSPath, Size, Mode.String
-    FROM glob(
-       globs="*", accessor="raw_ntfs", root=pathspec(
-          Path="/",
-          DelegateAccessor="offset",
-          DelegatePath=pathspec(
-            Path="/65536",
-            DelegateAccessor="vmdk",
-            DelegatePath="/tmp/test.vmdk")))
-
-`)
+		`Allow reading a VMDK file.`)
 }

--- a/accessors/zip/zip.go
+++ b/accessors/zip/zip.go
@@ -691,24 +691,10 @@ func init() {
 	accessors.Register("zip", &ZipFileSystemAccessor{
 		nocase: false,
 	},
-		`Open a zip file as if it was a directory.
-
-Filename is a pathspec with a delegate accessor opening the Zip file,
-and the Path representing the file within the zip file.
-
-Example:
-
-       select FullPath, Mtime, Size from glob(
-         globs='/**/*.txt',
-         root=pathspec(DelegateAccessor='file',
-              DelegatePath="File.zip",
-              Path='/'),
-         accessor='zip')
-
-`)
+		`Open a zip file as if it was a directory.`)
 	accessors.Register("zip_nocase", &ZipFileSystemAccessor{
 		nocase: true,
-	}, `Open a zip file as if it was a directory. Although zip files are case sensitive, this accessor behaves case insensitive`)
+	}, `Open a zip file as if it was a directory. Although zip files are case-sensitive, this accessor behaves case-insensitive`)
 
 	json.RegisterCustomEncoder(&ZipFileInfo{}, accessors.MarshalGlobFileInfo)
 

--- a/bin/vql.go
+++ b/bin/vql.go
@@ -189,7 +189,7 @@ func doVQLList() error {
 	if description != nil {
 		for _, k := range keys {
 			v, _ := description.Get(k)
-			fmt.Printf("%s: %s\n", k, v)
+			fmt.Printf("**%s**: %s\n\n", k, v)
 		}
 	}
 

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -562,7 +562,7 @@
     therefore only really useful for opening the file for reading - or for
     chaining with another accessor.
 
-    ```sql
+    ```vql
     SELECT read_file(accessor="bzip2", filename="F:/hello.txt.bz2", length=10)
     FROM scope()
     ```
@@ -3025,7 +3025,7 @@
     each backslash into 8 backslashes (once for regular expressions
     and twice for nested strings).
 
-    ```sql
+    ```vql
     SELECT * FROM glob(
       globs="C:/Users/*/*",
       recursion_callback="x=> NOT x.OSPath =~ 'C:\\\\\\\\Users\\\\\\\\Admini'")
@@ -3033,7 +3033,7 @@
 
     It is a bit easier to use variables and raw strings
 
-    ```sql
+    ```vql
     LET Exclude <= '''C:\\Users\\Admin'''
 
     SELECT * FROM glob(
@@ -3176,7 +3176,7 @@
     therefore only really useful for opening the file for reading - or for
     chaining with another accessor.
 
-    ```sql
+    ```vql
     SELECT read_file(accessor="gzip", filename="F:/hello.txt.gz", length=10)
     FROM scope()
     ```
@@ -3985,7 +3985,7 @@
 
     ### Example - Parse IPv4-mapped IPv6 addresses
 
-    ```sql
+    ```vql
     SELECT ip(parse='0:0:0:0:0:FFFF:129.144.52.38') FROM scope()
     ```
 
@@ -4003,7 +4003,7 @@
     - IsMulticast
     - IsPrivate
 
-    ```sql
+    ```vql
     SELECT ip(parse='192.168.1.2').IsPrivate FROM scope()
     ```
 
@@ -5307,7 +5307,7 @@
 
     ### Example
 
-    ```sql
+    ```vql
     SELECT read_file(accessor="offset", filename=pathspec(
     DelegateAccessor="data",
     DelegatePath="Hello world",
@@ -7083,7 +7083,7 @@
     `Artifact` plugin, for example the following accesses the
     `Custom.VQL` artifact:
 
-    ```sql
+    ```vql
     SELECT * FROM Artifact.Custom.VQL()
     ```
 
@@ -7091,7 +7091,7 @@
     isolated. If you want to use the `Artifact` plugin in the new
     scope you need to pass it through the `env` variable:
 
-    ```sql
+    ```vql
     SELECT * FROM query(query={
           SELECT * FROM Artifact.Custom.VQL()
     }, env=dict(artifact=Artifact))
@@ -7116,7 +7116,7 @@
     statement it is no possible to use a LET expression (since LET is
     a separate statement). So this is not valid VQL syntax:
 
-    ```sql
+    ```vql
     SELECT * FROM query(query={
       LET Foo(X) = ....
       SELECT * FROM Foo(X=1)
@@ -7124,7 +7124,7 @@
     ```
 
     You can define the LET statements outside the query block and pass them in:
-    ```sql
+    ```vql
     LET Foo(X) = ....
 
     SELECT * FROM query(query={
@@ -7393,7 +7393,7 @@
 
     For example we can search the raw registry for the System hive:
 
-    ```sql
+    ```vql
     SELECT OSPath
     FROM glob(globs='*',
         accessor="raw_reg",
@@ -7866,7 +7866,7 @@
 
     ### Example
 
-    ```sql
+    ```vql
     LET MyData <= "This is a test string"
 
     SELECT read_file(accessor="scope", filename="MyData") FROM scope()
@@ -9052,7 +9052,7 @@
     following calculates the time exactly one day (24 hours) before
     the stated time:
 
-    ```sql
+    ```vql
     SELECT timestamp(epoch=timestamp(epoch="2024-03-26T06:53:37Z").Unix - 86400)
     FROM scope()
     ```

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -12,7 +12,7 @@
     description: A dict of artifact parameters
   - name: label
     type: string
-    description: Add this artifact to this label group (default all)
+    description: Add the artifact to this label group (default all)
   category: server
   metadata:
     permissions: COLLECT_CLIENT
@@ -490,6 +490,7 @@
     Return the basename of the path.
 
     ### Example
+
     ```vql
     basename(path="/foo/bar") -> "bar"
     ```
@@ -657,7 +658,7 @@
 
     This plugin can take a long time!
 
-    Example:
+    ### Example
 
     ```vql
     SELECT * FROM carve_usn(device='''\\.\C:''')
@@ -826,7 +827,7 @@
     database so it is very fast and suitable to be called frequently
     on each row.
 
-    # Example - enriching hostnames
+    ### Example - enriching hostnames
 
     Internally, Velociraptor uses client id to uniquely identify the
     client. But often we want to provide a hostname as well. In the
@@ -1084,7 +1085,7 @@
     you will often need to specify a field name containing full
     stop. You can escape this using the backticks like the example above.
 
-    # Example - conditional collections
+    ### Example - conditional collections
 
     In this example we wish to create an artifact with check buttons
     for selecting groups of artifacts to launch. Assume `Do1` and
@@ -1250,6 +1251,7 @@
     conventions.
 
     ### Example
+
     ```vql
     SELECT
       commandline_split(command='''"C:\Program Files\Velociraptor\Velociraptor.exe" service run'''),
@@ -1317,7 +1319,7 @@
     accessor into a file on disk.
 
     This function can also be used to create new files with prescribed
-    content - for example:
+    content, for example:
 
     ```vql
     SELECT copy(filename="Hello world", accessor="data", dest="C:/hi.txt")
@@ -1721,6 +1723,7 @@
     Return the directory path.
 
     ### Example
+
     ```vql
     dirname(path="/usr/bin/ls") -> "/usr/bin"
     ```
@@ -2012,7 +2015,7 @@
     Note that when eval calls the function, the current scope will be
     passed as the first parameter to the lambda.
 
-    Example:
+    ### Example
 
     ```vql
     LET AddTwo(x) = x + 2
@@ -2034,13 +2037,13 @@
   - windows_amd64_cgo
 - name: ewf
   description: |
-    Allow reading an `EWF` file.
+    Allow reading an EWF file.
 
     Note that usually EWF files form a set of files with extensions
     like .E01, .E02 etc. This accessor will automatically try to find
     all parts of the same volume set if the file name ends with a '.E01'.
 
-    ## Example
+    ### Example
 
     ```vql
     SELECT * FROM glob(
@@ -2198,7 +2201,7 @@
 
     This accessor is only available under linux.
 
-    ## Example
+    ### Example
 
     ```vql
     SELECT *
@@ -2215,7 +2218,7 @@
     delegate accessor to get the raw image and will open files using the
     FAT full path rooted at the top of the filesystem.
 
-    ## Example
+    ### Example
 
     The following query will glob all the files under the directory 'a'
     inside a FAT image file
@@ -2413,7 +2416,7 @@
     information about clients etc. The VFS path is a path into the file
     store. Of course ultimately (at least in the current implementation)
     the file store is storing files on disk, but the disk filename is not
-    necessarily the same as the VFS path (for example non representable
+    necessarily the same as the VFS path (for example non-representable
     characters are escaped).
 
     You can use the `file_store()` function to return the real file path
@@ -2472,6 +2475,7 @@
     the condition is applied.
 
     ### Examples
+
     ```vql
     filter(list=["AA", "AB", "BA", "BB"], regex="^A") -> ["AA", "AB"]
 
@@ -2818,7 +2822,7 @@
   description: |
     Gets the member field from item.
 
-    This is useful to index an item from an array. For example:
+    This is useful to index an item from an array.
 
     ### Example
 
@@ -2977,7 +2981,7 @@
     parameter.  The `root` parameter is useful if the directory name
     itself may contain glob characters.
 
-    ## Following symlinks
+    ### Following symlinks
 
     On Unix like operating systems symlinks are used
     extensively. Symlinks complicate the job of the glob() plugin
@@ -2989,7 +2993,7 @@
     checking that a target of a symlink has not been seen before. You
     can disable this behavior with `nosymlink=TRUE`
 
-    ## Setting a recursion callback
+    ### Setting a recursion callback
 
     Sometimes it is useful to prevent glob() from recursing into a
     directory. For example, if we know a directory can not possibly
@@ -3011,7 +3015,7 @@
         recursion_callback="x=>NOT x.OSPath =~ '^/(proc|sys|snap)'")
     ```
 
-    ## A note about escaping.
+    ### A note about escaping.
 
     Windows paths often contain backslashes which are difficult to
     work with because they need to be escaped both by regular
@@ -3144,6 +3148,7 @@
     Uncompress a gzip-compressed block of data.
 
     ### Example
+
     ```vql
     gunzip(string=base64decode(string="H4sIAAAAAAACA3N0pC4AAKAb0QxQAAAA")) -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     ```
@@ -3244,7 +3249,9 @@
     NOTE: No caching is currently provided so this may generate a lot
     of load on DNS servers when scanning many rows.
 
-    Example: The first query resolves through an external DNS server
+    ### Example
+
+    The first query resolves through an external DNS server
     while the second uses the local resolver.
 
     ```
@@ -3334,7 +3341,7 @@
     `Content` being the name of the file. The file will be
     automatically removed when the query ends.
 
-    ### Example: Uploading files
+    ### Example - Uploading files
 
     Many API handlers support uploading files via POST messages. This
     is supported using the `files` parameter for this plugin. The
@@ -3553,7 +3560,7 @@
     a specific label and then just assign the label to specific
     clients.
 
-    ## Adding an existing flow to a hunt.
+    ### Adding an existing flow to a hunt.
 
     If a flow_id is specified, this function will just immediately add
     the collection to the hunt, without scheduling a new
@@ -3976,7 +3983,7 @@
     (https://pkg.go.dev/net#IP ). This makes it easy to deal with
     various IP address notations. Some use cases:
 
-    ## Example - Parse IPv4-mapped IPv6 addresses
+    ### Example - Parse IPv4-mapped IPv6 addresses
 
     ```sql
     SELECT ip(parse='0:0:0:0:0:FFFF:129.144.52.38') FROM scope()
@@ -3984,7 +3991,7 @@
 
     Will return the string "129.144.52.38"
 
-    ## Example - Get information about IP addresses
+    ### Example - Get information about IP addresses
 
     VQL will also expose the following attributes of the IP address:
 
@@ -4001,7 +4008,6 @@
     ```
 
     Return "true" since this is a private address block.
-
   type: Function
   args:
   - name: parse
@@ -4350,7 +4356,7 @@
     WHERE log(message="Value of OSPath is %v", args=OSPath)
     ```
 
-    ## Deduplication
+    ### Deduplication
 
     Log messages will be deduped according to the `dedup`
     parameter - each distinct format string will not be emitted more
@@ -4841,7 +4847,7 @@
     This accessor does not support directories and so can not be used
     in `glob()`
 
-    An example of using this artifact:
+    ### Example
 
     ```vql
     SELECT upload(accessor="mft", filename="C:/203-128-0")
@@ -5299,7 +5305,7 @@
 
     The filename is taken as an offset into the delegate.
 
-    ## Example
+    ### Example
 
     ```sql
     SELECT read_file(accessor="offset", filename=pathspec(
@@ -5437,7 +5443,7 @@
     - each client's result set will be filtered in parallel on a
     different core.
 
-    ### Example:
+    ### Example
 
     ```vql
     SELECT * FROM parallelize(hunt_id=HuntId, artifact=ArtifactName, query={
@@ -5920,7 +5926,7 @@
     It can either operate on an image file or the raw device (on
     windows), or alternatively you can provide a raw $MFT file.
 
-    ### Example:
+    ### Example
 
     ```vql
     SELECT parse_ntfs(
@@ -5932,7 +5938,7 @@
     You can get the MFT entry number from `parse_mft()` or from the
     Data attribute of a `glob()` using the `ntfs` accessor.
 
-    ### Example 2: Using a raw $MFT file
+    ### Example - Using a raw $MFT file
 
     If you have previously collected the $MFT file (e.g. using the
     `Windows.KapeFiles.Targets` artifact, you can use `parse_ntfs()`
@@ -6384,6 +6390,7 @@
     ```vql
     SELECT get_client_monitoring() FROM scope()
     ```
+
     ```json
     [
       {
@@ -6414,14 +6421,14 @@
   args:
   - name: item
     type: Any
-    description: The item to path
+    description: The item to patch
     required: true
   - name: patch
     type: Any
-    description: A JSON Patch to apply
+    description: A JSON patch to apply
   - name: merge
     type: Any
-    description: A merge-patch to apply
+    description: A merge patch to apply
   category: server
   platforms:
   - darwin_amd64_cgo
@@ -6534,7 +6541,7 @@
     A VQL pipe allows data to be generated from a VQL query, as the
     pipe is read, the query proceeds to feed more data to it.
 
-    ## Example
+    ### Example
 
     ```vql
     LET MyPipe = pipe(query={
@@ -7069,7 +7076,7 @@
     Below we describe a few quirks that users might encounter with
     this plugin.
 
-    ## Custom artifacts
+    ### Custom artifacts
 
     The isolated scope does not contain any artifacts by
     default. Usually artifacts are accessible from VQL using the
@@ -7090,7 +7097,7 @@
     }, env=dict(artifact=Artifact))
     ```
 
-    ## Remapping rules
+    ### Remapping rules
 
     When using the `remap()` function to install a new remapping
     configuration, the remapping applies on the current scope and
@@ -7102,7 +7109,7 @@
     inside an isolated `query()` scope. This way the remapping will
     only apply for the like of the `query()` plugin invocation.
 
-    ## Using LET statements inside the query
+    ### Using LET statements inside the query
 
     The `query` parameter can specify a VQL statement or a string
     which will be parsed into a VQL statement. If you use a VQL
@@ -7132,7 +7139,7 @@
     ''')
     ```
 
-    ## Running a query in a different org
+    ### Running a query in a different org
 
     Normally a VQL query runs in the org context in which it was
     started. However sometimes it is useful to run in different
@@ -7156,7 +7163,7 @@
     })
     ```
 
-    ## Running as a different user
+    ### Running as a different user
 
     You can specify a different user to run the VQL. This will load
     the other user's ACL token and username (basically this acts like
@@ -7287,10 +7294,10 @@
     delegate accessor to get the raw image and will open files using the
     FAT full path rooted at the top of the filesystem.
 
-    ## Example
+    ### Example
 
     The following query will glob all the files under the directory 'a'
-    inside a Ext4 image file
+    inside a Ext4 image file:
 
     ```vql
     SELECT *
@@ -7334,7 +7341,7 @@
     delegate accessor to get the raw image and will open files using the
     NTFS full path rooted at the top of the filesystem.
 
-    ## Example
+    ### Example
 
     The following query will open the $MFT file from the raw image file
     that will be accessed using the file accessor.
@@ -7748,7 +7755,7 @@
     required: true
   - name: label
     type: string
-    description: Remove this artifact from this label group (default the 'all'  group)
+    description: Remove the artifact from this label group (default the 'all'  group)
   category: server
   metadata:
     permissions: COLLECT_CLIENT
@@ -7790,17 +7797,15 @@
   - windows_amd64_cgo
 - name: s3
   description: |
-    Access S3 Buckets.
-
-    This artifact allows access to S3 buckets:
+    Allows access to S3 buckets.
 
     1. The first component is interpreted as the bucket name.
 
     2. Provide credentials through the VQL environment
-       variable S3_CREDENTIALS. This should be a dict with
+       variable `S3_CREDENTIALS`. This should be a dict with
        a key of the bucket name and the value being the credentials.
 
-    ## Example
+    ### Example
 
     ```vql
     LET S3_CREDENTIALS<=dict(endpoint='http://127.0.0.1:4566/',
@@ -7816,8 +7821,8 @@
     ```
 
     NOTE: It is more convenient to use the [secrets support]({{< ref
-    "/blog/2024/2024-03-10-release-notes-0.72/#secret-management" >}}) in
-    0.72 to manage these credentials.
+    "/blog/2024/2024-03-10-release-notes-0.72/#secret-management" >}})
+    introduced in version 0.72 to manage these credentials.
   type: Accessor
   platforms:
   - linux_amd64_cgo
@@ -7859,7 +7864,7 @@
     echoed in various log messages and with the `data` accessor this
     will echo some binary data into the logs.
 
-    ## Example
+    ### Example
 
     ```sql
     LET MyData <= "This is a test string"
@@ -7939,6 +7944,7 @@
     network event closely followed by a process event.
 
     ### Example
+
     ```vql
     SELECT * FROM sequence(
     network={
@@ -8217,7 +8223,7 @@
     credentials from the `SMB_CREDENTIALS` dict. This allows multiple
     servers and multiple credentials to be defined at the same time.
 
-    ## Example:
+    ### Example
 
     ```
     LET SMB_CREDENTIALS <= dict(ServerName="Username:Password")
@@ -8304,7 +8310,7 @@
   - windows_amd64_cgo
 - name: sparse
   description: |
-    Allow reading another file by overlaying a sparse map on top of
+    Allows reading another file by overlaying a sparse map on top of
     it.
 
     The map excludes reading from certain areas which are considered
@@ -8689,6 +8695,7 @@
     ```vql
     strip(string=">>  lorem ipsum  <<", prefix=">>", suffix="<<") -> "  lorem ipsum  "
     ```
+
     ```vql
     strip(string="   lorem ipsum   ") -> "lorem ipsum"
     ```
@@ -8953,7 +8960,7 @@
     ```
 
     You can also provide a string, and `timestamp()` will try to parse
-    it by guessing what it represents. For example
+    it by guessing what it represents. For example:
 
     ```vql
     SELECT timestamp(string='March 3 2019'),
@@ -8994,7 +9001,7 @@
     `PARSE_TZ` is `local` then we use the local timezone on the
     endpoint.
 
-    For example:
+    ### Example
 
     ```vql
     LET PARSE_TZ <= "local"
@@ -9086,7 +9093,7 @@
     The output timezone is UTC by default but can be changed using the
     `TZ` VQL variable.
 
-    Example:
+    ### Example
 
     ```vql
     LET TZ="Europe/Berlin"
@@ -9800,9 +9807,11 @@
   description: |
     Update and read the user GUI options
 
-    Example: The following will set the user language to french, dark
+    ### Example
+
+    The following will set the user language to French, dark
     theme and add a sidebar link named Foobar. The default password
-    for Zip exports will also be set to `foorbar`.
+    for zip exports will also be set to `foobar`.
 
     ```vql
     SELECT user_options(user=whoami(),
@@ -9857,6 +9866,7 @@
     Parse input from utf16.
 
     ### Example
+
     ```vql
     utf16(string='A\x00B\x00C\x00D\x00') -> "ABCD"
     ```
@@ -9878,6 +9888,7 @@
     Encode a string to utf16 bytes.
 
     ### Example
+
     ```vql
     utf16_encode(string="ABCD") -> "A\u0000B\u0000C\u0000D\u0000"
     ```
@@ -9918,8 +9929,7 @@
   - windows_386_cgo
   - windows_amd64_cgo
 - name: version
-  description: |2
-
+  description: |
     Gets the version of a VQL plugin or function.
 
     This is useful when writing portable VQL which can work with
@@ -9930,6 +9940,7 @@
 
     For example the following can chose from a legacy query or a
     modern query based on the plugin version:
+
     ```vql
      SELECT * FROM if(
       condition=version(plugin="glob") >= 1,
@@ -10010,14 +10021,14 @@
   - windows_amd64_cgo
 - name: vhdx
   description: |+
-    Allow reading a vhdx file.
+    Allow reading a VHDX file.
 
     This accessor allows access to the content of VHDX files. Note that usually
     VHDX files are disk images with a partition table and an NTFS volume. You
     will usually need to wrap this accessor with a suitable Offset (to account
     for the parition) and parse it with the the "raw_ntfs" accessor.
 
-    ## Example
+    ### Example
 
     ```vql
     SELECT OSPath.Path AS OSPath, Size, Mode.String
@@ -10037,7 +10048,7 @@
   - windows_amd64_cgo
 - name: vmdk
   description: |+
-    Allow reading a vmdk file.
+    Allow reading a VMDK file.
 
     This accessor allows access to the content of VMDK files. Note
     that usually VMDK files are disk images with a partition table and
@@ -10049,7 +10060,7 @@
     files).  The extent files are expected to be in the same directory
     as the metadata file and this accessor will open them separately.
 
-    ## Example
+    ### Example
 
     ```vql
     SELECT OSPath.Path AS OSPath, Size, Mode.String
@@ -10362,7 +10373,7 @@
        as there will be too much smear.
 
 
-    # Example
+    ### Example
 
     ```vql
     SELECT winpmem(image_path='c:/test.dd', compression='s2') FROM scope()"
@@ -10642,7 +10653,7 @@
     Filename is a pathspec with a delegate accessor opening the Zip file,
     and the Path representing the file within the zip file.
 
-    ## Example
+    ### Example
 
     ```vql
     SELECT OSPath, Mtime, Size from glob(
@@ -10660,11 +10671,12 @@
   description: |
     Open a zip file as if it was a directory.
 
-    Although zip files are case sensitive, this accessor treats file
-    names inside the zip file as case insensitive. This is useful when
+    Although zip files are case-sensitive, this accessor treats file
+    names inside the zip file as case-insensitive. This is useful when
     remapping an offline collector from a Windows system for post
     processing.
   type: Accessor
   platforms:
   - linux_amd64_cgo
   - windows_amd64_cgo
+

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2478,7 +2478,9 @@
 
     ```vql
     filter(list=["AA", "AB", "BA", "BB"], regex="^A") -> ["AA", "AB"]
+    ```
 
+    ```vql
     filter(list=[1, 2, 3, 4, 5, 6], condition="x=>x > 3") -> [4, 5, 6]
     ```
   type: Function

--- a/vql/server/monitoring/add_monitoring.go
+++ b/vql/server/monitoring/add_monitoring.go
@@ -18,7 +18,7 @@ import (
 type AddClientMonitoringFunctionArgs struct {
 	Artifact   string           `vfilter:"required,field=artifact,doc=The name of the artifact to add"`
 	Parameters vfilter.LazyExpr `vfilter:"optional,field=parameters,doc=A dict of artifact parameters"`
-	Label      string           `vfilter:"optional,field=label,doc=Add this artifact to this label group (default all)"`
+	Label      string           `vfilter:"optional,field=label,doc=Add the artifact to this label group (default all)"`
 }
 
 type AddClientMonitoringFunction struct{}

--- a/vql/server/monitoring/rm_monitoring.go
+++ b/vql/server/monitoring/rm_monitoring.go
@@ -14,7 +14,7 @@ import (
 
 type RemoveClientMonitoringFunctionArgs struct {
 	Artifact string `vfilter:"required,field=artifact,doc=The name of the artifact to remove from the event table"`
-	Label    string `vfilter:"optional,field=label,doc=Remove this artifact from this label group (default the 'all'  group)"`
+	Label    string `vfilter:"optional,field=label,doc=Remove the artifact from this label group (default the 'all'  group)"`
 }
 
 type RemoveClientMonitoringFunction struct{}


### PR DESCRIPTION
- Reduced inline accessor descriptions to basic descriptions since the full descriptions, including examples, are now represented in vql.yaml (which I double-checked).
- Standardized the markdown headings in vql.yaml descriptions so that they will look consistent on the documentation site.
- Fixed some minor issues in vql.yaml descriptions.
- Slightly changed formatting for accessors in `vql list` command so that they render prettier when piped through [glow](https://github.com/charmbracelet/glow).
![Screenshot from 2024-09-14 18-29-44](https://github.com/user-attachments/assets/ff5f3b76-1f68-4bb9-8c33-7666330c7fb2)
Maybe in future we could do direct markdown rendering using [Charm's Glamour](https://github.com/charmbracelet/glamour) package?
