### PR TITLE
add base64 extraction improvement

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Lnk.yaml
+++ b/artifacts/definitions/Windows/Forensics/Lnk.yaml
@@ -1462,11 +1462,12 @@ sources:
         FROM if(condition=data, 
             then={
                 SELECT Base64,  len(list=Base64) as Length 
-                FROM parse_records_with_regex(accessor='data',file=data, regex='''(?P<Base64>[A-Za-z0-9+/]{10,}={0,2})''')
-                ORDER BY Length DESC LIMIT 1
+                FROM parse_records_with_regex(accessor='data',file=data, regex='''(?P<Base64>(https?://[^\s]+/)*[A-Za-z0-9+/]{10,}={0,2})''')
+                WHERE NOT Base64 =~ '^http' -- Implementing negative regex match: We exclude b64 strings with http prefix.
+                ORDER BY Length DESC 
+                LIMIT 1
             },
-            else=null )
-    
+            else=null )    
       
       LET add_suspicious = SELECT *, dict(
                 `Large Size` = SourceFile.Size > SusSize,


### PR DESCRIPTION
Updated extraction function to exclude any base64 blobs in a URL as large scale testing I observed base64 characters extracted from URLs was always a misfire and often above the minimum character threshold.