### PR TITLE
Truncate long lines in Artifact Description GUI

### DIFF
--- a/api/reflect.go
+++ b/api/reflect.go
@@ -1,19 +1,19 @@
 /*
-   Velociraptor - Dig Deeper
-   Copyright (C) 2019-2024 Rapid7 Inc.
+Velociraptor - Dig Deeper
+Copyright (C) 2019-2024 Rapid7 Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package api
 
@@ -119,6 +119,7 @@ func (self *ApiServer) GetKeywordCompletions(
 			{Name: "LIMIT", Type: "Keyword"},
 			{Name: "GROUP BY", Type: "Keyword"},
 			{Name: "ORDER BY", Type: "Keyword"},
+			{Name: "DESC", Type: "Keyword"},
 		},
 	}
 

--- a/artifacts/definitions/Server/Import/ArtifactExchange.yaml
+++ b/artifacts/definitions/Server/Import/ArtifactExchange.yaml
@@ -34,6 +34,8 @@ parameters:
    - name: Prefix
      description: Add artifacts with this prefix
      default: Exchange.
+   - name: ArchiveGlob
+     default: "/**/*.{yaml,yml}"
 
 sources:
   - query: |
@@ -45,7 +47,7 @@ sources:
         }, query={
           SELECT read_file(accessor="zip", filename=OSPath) AS Definition
           FROM glob(
-             globs='/**/*.{yaml,yml}',
+             globs=ArchiveGlob,
              root=pathspec(
                 DelegateAccessor="auto",
                 DelegatePath=Content),

--- a/artifacts/definitions/Server/Import/CuratedSigma.yaml
+++ b/artifacts/definitions/Server/Import/CuratedSigma.yaml
@@ -36,4 +36,5 @@ sources:
                             query={SELECT * FROM
                                 Artifact.Server.Import.ArtifactExchange(
                                 Prefix=Prefix,
+                                ArchiveGlob="*.yaml",
                                 ExchangeURL=get(item= URLlookup, member= _value))})

--- a/gui/velociraptor/src/components/artifacts/artifacts.jsx
+++ b/gui/velociraptor/src/components/artifacts/artifacts.jsx
@@ -176,6 +176,7 @@ class ArtifactInspector extends React.Component {
         this.setState({
             selectedDescriptor: row,
             fullSelectedDescriptor: {},
+            version: this.state.version+1,
         });
         this.props.history.push("/artifacts/" + row.name);
         e.preventDefault();
@@ -193,7 +194,6 @@ class ArtifactInspector extends React.Component {
             if (items.length > 0) {
                 this.setState({
                     fullSelectedDescriptor: items[0],
-                    version: this.state.version+1,
                 });
             };
         });
@@ -323,7 +323,10 @@ class ArtifactInspector extends React.Component {
                       this.fetchRows(this.state.current_filter,
                                      this.state.preset_filter);
                       this.getArtifactDescription(selected);
-                      this.setState({showEditedArtifactDialog: false});
+                      this.setState({
+                          showEditedArtifactDialog: false,
+                          version: this.state.version+1,
+                      });
                   }}
                 />
               }

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -293,14 +293,15 @@ export class TablePaginationControl extends React.Component {
 
         let total_pages = parseInt(total_size / this.props.page_size) + 1;
         let last_page = total_pages - 1;
-        if (last_page <= 0) {
-            last_page = 0;
-        }
 
         // Ensure the last page has some data - otherwise back up one
         // page.
         if (last_page * this.props.page_size===this.props.total_size) {
             last_page -= 1;
+        }
+
+        if (last_page <= 0) {
+            last_page = 0;
         }
 
         let pages = [];

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -297,6 +297,12 @@ export class TablePaginationControl extends React.Component {
             last_page = 0;
         }
 
+        // Ensure the last page has some data - otherwise back up one
+        // page.
+        if (last_page * this.props.page_size===this.props.total_size) {
+            last_page -= 1;
+        }
+
         let pages = [];
         let current_page = parseInt(this.props.start_row / this.props.page_size);
         let start_page = current_page - 4;
@@ -608,8 +614,12 @@ class VeloPagedTable extends Component {
 
         if (transform.filter_column) {
             result.push(
-                <ToolTip tooltip={T("Transformed")} key="1" >
-                  <Button disabled={true}
+                <ToolTip tooltip={T("Clear")} key="1" >
+                  <Button onClick={()=>{
+                      let new_transform = Object.assign({}, this.state.transform);
+                      new_transform.filter_column = undefined;
+                      this.setState({transform: new_transform});
+                  }}
                           className="table-transformed"
                           variant="outline-dark">
                     { transform.filter_column } ( {transform.filter_regex} )


### PR DESCRIPTION
This causes huge browser delays for certain large artifacts like Windows.Hayabusa.Rules which contain large blobs in the artifact definition.