### PR TITLE
Bugfix: Parameter type artifactset should serialize to CSV

### DIFF
--- a/gui/velociraptor/src/components/core/paged-table.css
+++ b/gui/velociraptor/src/components/core/paged-table.css
@@ -95,8 +95,7 @@ td.column-resizer {
 }
 
 .paged-table tbody tr td.compact {
-    mask-image: -webkit-gradient(linear, left top, left bottom,
-                                 from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
+    mask-image: -webkit-linear-gradient(top,rgba(0,0,0,1) 50%,rgba(0,0,0,0));
 }
 
 .column-name {
@@ -119,4 +118,13 @@ td.column-resizer {
 
 th.paged-table-header {
     white-space: nowrap;
+}
+
+.draggable {
+    cursor: move;
+    cursor: grab;
+}
+
+.draggable:active {
+    cursor: grabbing;
 }

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -226,6 +226,7 @@ export class ColumnToggle extends Component {
             return <Dropdown.Item
                      key={ column }
                      eventKey={column}
+                     className="draggable"
                      active={!hidden}
                      draggable="true"
                      onDragStart={e=>{
@@ -981,7 +982,7 @@ class VeloPagedTable extends Component {
             this.props.prevent_transformations[column]) {
             return <React.Fragment key={idx}>
                      <th style={styles}
-                         className={transformed_class + " paged-table-header"}
+                         className={transformed_class + " draggable paged-table-header"}
                          onDragStart={e=>{
                              e.dataTransfer.setData("column", column);
                          }}
@@ -1014,7 +1015,7 @@ class VeloPagedTable extends Component {
         return (
             <React.Fragment key={idx}>
               <th style={styles}
-                  className={transformed_class + " paged-table-header"}
+                  className={transformed_class + " draggable paged-table-header"}
                   onDragStart={e=>{
                       e.dataTransfer.setData("column", column);
                   }}
@@ -1198,12 +1199,24 @@ class VeloPagedTable extends Component {
     // Insert the to_col right before the from_col
     swapColumns = (from_col, to_col)=>{
         let new_columns = [];
+        let from_seen = false;
+
         _.each(this.state.columns, x=>{
             if(x === to_col) {
-                new_columns.push(from_col);
+                if (from_seen) {
+                    new_columns.push(to_col);
+                    new_columns.push(from_col);
+                } else {
+                    new_columns.push(from_col);
+                    new_columns.push(to_col);
+                }
             }
 
-            if(x !== from_col) {
+            if(x === from_col) {
+                from_seen = true;
+            }
+
+            if(x !== from_col && x !== to_col) {
                 new_columns.push(x);
             }
         });

--- a/gui/velociraptor/src/components/forms/form.jsx
+++ b/gui/velociraptor/src/components/forms/form.jsx
@@ -492,8 +492,11 @@ export default class VeloForm extends React.Component {
                       isMulti
                       defaultValue={a_defaults}
                       onChange={e=>{
-                          let data = _.map(e, x=>x.value);
-                          this.props.setValue(JSON.stringify(data));
+                          let data = _.map(e, x=>{
+                              return {Artifact: x.value};
+                          });
+                          // artifact sets require csv style output.
+                          this.props.setValue(serializeCSV(data, ["Artifact"]));
                       }}
                       options={a_options}
                       />


### PR DESCRIPTION
The artifactset GUI was redesigned to use a multi-select which serializes to a json array. However, artifactset expects to serialize to a CSV type parameter.

This made it impossible to specify any artifacts in the GUI correctly.