### PR TITLE
Add a Journal notebook suggestion: Simple syslog-like view

### DIFF
--- a/artifacts/definitions/Linux/Forensics/Journal.yaml
+++ b/artifacts/definitions/Linux/Forensics/Journal.yaml
@@ -38,3 +38,19 @@ sources:
       FROM parse_journald(filename=OSPath,
           start_time=DateAfter, end_time=DateBefore)
     })
+
+  notebook:
+    - type: vql_suggestion
+      name: Simplified syslog-like view
+      template: |
+        /*
+        # Simplified log view
+        */
+        LET ColumnTypes<=dict(`_ClientId`='client')
+
+        SELECT System.Timestamp AS Timestamp,
+               ClientId AS _ClientId,
+               client_info(client_id=ClientId).os_info.hostname AS Hostname,
+               EventData.SYSLOG_IDENTIFIER AS Unit,
+               EventData.MESSAGE AS Message
+        FROM source()


### PR DESCRIPTION
Add a notebook suggestion that creates a simple table that looks very much like the default output from journalctl. I find myself studying the identifier/unit and message exclusively most of the time. Having this simplification as a VQL suggestion would be very handy for day-to-day use.