### PR TITLE
Table context menu allows annotation to timeline

### DIFF
--- a/gui/velociraptor/src/App.jsx
+++ b/gui/velociraptor/src/App.jsx
@@ -31,7 +31,6 @@ import LoginPage from './components/welcome/login.jsx';
 import LogoffPage from './components/welcome/logoff.jsx';
 import KeyboardHelp from './components/core/keyboard-help.jsx';
 import { UserSettings } from './components/core/user.jsx';
-import { ContextMenuPopup } from './components/utils/context.jsx';
 import { Switch, Route, withRouter } from "react-router-dom";
 import { Join } from './components/utils/paths.jsx';
 import SecretManager from './components/secrets/secrets.jsx';
@@ -249,7 +248,6 @@ class App extends Component {
                   </Switch>
                   <KeyboardHelp />
                 </SnackbarProvider>
-                <ContextMenuPopup/>
               </UserSettings>
             </div>
         );

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -621,7 +621,11 @@ class VeloPagedTable extends Component {
     }
 
     defaultFormatter = (cell, row, rowIndex) => {
-        return <VeloValueRenderer value={cell}/>;
+        let row_data = {};
+        _.each(this.activeColumns(), x=>{
+            row_data[x] = row[x];
+        });
+        return <VeloValueRenderer value={cell} row={row_data} />;
     }
 
     getColumnRenderer = column => {

--- a/gui/velociraptor/src/components/utils/annotations.jsx
+++ b/gui/velociraptor/src/components/utils/annotations.jsx
@@ -1,0 +1,213 @@
+import _ from 'lodash';
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Modal from 'react-bootstrap/Modal';
+import T from '../i8n/i8n.jsx';
+import {CancelToken} from 'axios';
+import VeloValueRenderer from '../utils/value.jsx';
+import Button from 'react-bootstrap/Button';
+import { sprintf } from 'sprintf-js';
+import api from '../core/api-service.jsx';
+import Select from 'react-select';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+
+const timestampRegex = /\d{4}-\d{2}-\d{2}[T ]\d{1,2}:\d{2}:\d{2}/;
+
+import { ToStandardTime } from '../utils/time.jsx';
+
+export default class AnnotateDialog extends Component {
+    static propTypes = {
+        row: PropTypes.object,
+        onClose: PropTypes.func.isRequired,
+    }
+
+    componentDidMount = () => {
+        this.source = CancelToken.source();
+        this.fetchGlobalTimelines();
+    }
+
+    state = {
+        collapsed: true,
+        global_timelines: [],
+        note: "",
+        notebook_id: "",
+        title: "",
+        name: "",
+        super_timeline: "",
+        time_column: "",
+        message_column: "",
+    }
+
+    fetchGlobalTimelines = ()=>{
+        api.get("v1/GetNotebooks", {
+            count: 100,
+            offset: 0,
+        }, this.source.token).then(response=>{
+            if (response.cancel) {
+                return;
+            }
+
+            if(response && response.data && response.data.items) {
+                let timelines = [];
+                _.each(response.data.items, x=>{
+                    _.each(x.timelines, y=>{
+                        timelines.push({notebook_id: x.notebook_id,
+                                        title: x.name,
+                                        name: y});
+                    });
+                });
+                this.setState({global_timelines: timelines});
+            }
+        });
+    }
+
+    isTimestamp = x=>{
+        if (timestampRegex.test(x)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    annotateRow = ()=>{
+        let timestamp = "";
+        if (this.state.time_column) {
+            timestamp = this.props.row[this.state.time_column];
+        }
+
+        let ts = ToStandardTime(timestamp || "1980-01-01T00:00:00Z");
+        let event = Object.assign({}, this.props.row);
+        if (this.state.message_column) {
+            event.Message = this.props.row[this.state.message_column];
+        }
+        api.post("v1/AnnotateTimeline", {
+            notebook_id: this.state.notebook_id,
+            super_timeline: this.state.super_timeline,
+            timestamp: ts.getTime() * 1000000,
+            note: this.state.note,
+            event_json: JSON.stringify(event),
+        }, this.source.token).then(response=>{
+            this.props.onClose();
+        });
+    }
+
+    render() {
+        let clsname = this.state.collapsed ? "compact": "";
+
+        let global_timeline_options = _.map(this.state.global_timelines, x=>{
+            return {value: x.name,
+                    label: sprintf(T("%s (notebook %s)"), x.name, x.title),
+                    notebook_id: x.notebook_id,
+                    isFixed: true,
+                    color: "#00B8D9"};
+        });
+
+        let time_column_options = [];
+        _.each(this.props.row, (v, k)=>{
+            if(this.isTimestamp(v)) {
+                time_column_options.push( {value: k, label: k, isFixed: true});
+            };
+        });
+
+        let message_column_options = _.map(this.props.row, (v, k)=>{
+            return {value: k, label: k, isFixed: true};
+        });
+
+        return <Modal show={true}
+                      enforceFocus={true}
+                      scrollable={false}
+                      size="lg"
+                      dialogClassName="modal-90w"
+                      onHide={this.props.onClose}>
+                 <Modal.Header closeButton>
+                   <Modal.Title>{T("Annotate Row")} </Modal.Title>
+                 </Modal.Header>
+                 <Modal.Body>
+                   <Form.Group as={Row}>
+                     <Form.Label column sm="3">
+                       {T("Global Timeline")}
+                     </Form.Label>
+                     <Col sm="8">
+                       <Select
+                         isClearable
+                         className="labels"
+                         classNamePrefix="velo"
+                         options={global_timeline_options}
+                         onChange={(e)=>this.setState({
+                             super_timeline: e && e.value,
+                             notebook_id: e && e.notebook_id,
+                         })}
+                         placeholder={T("Select timeline name from global notebook")}
+                         spellCheck="false"
+                       />
+
+                     </Col>
+                   </Form.Group>
+                   <Form.Group as={Row}>
+                     <Form.Label column sm="3">{T("Time column")}</Form.Label>
+                     <Col sm="8">
+                       <Select
+                         className="time-column"
+                         classNamePrefix="velo"
+                         options={time_column_options}
+                         onChange={(e)=>this.setState({time_column: e && e.value})}
+                         placeholder={T("Time Column")}
+                         spellCheck="false"
+                       />
+                     </Col>
+                   </Form.Group>
+                   <Form.Group as={Row}>
+                     <Form.Label column sm="3">{T("Message column")}</Form.Label>
+                     <Col sm="8">
+                       <Select
+                         className="time-column"
+                         classNamePrefix="velo"
+                         options={message_column_options}
+                         onChange={(e)=>this.setState({
+                             message_column: e && e.value})}
+                         placeholder={T("Message Column")}
+                         spellCheck="false"
+                       />
+                     </Col>
+                   </Form.Group>
+
+                   <Form.Group as={Row}>
+                     <Form.Label column sm="3">{T("Note")}</Form.Label>
+                     <Col sm="8">
+                       <Form.Control as="textarea" rows={1}
+                                     placeholder={T("Enter short annotation")}
+                                     spellCheck="true"
+                                     value={this.state.note || ""}
+                                     onChange={e => this.setState({note: e.target.value})}
+                       />
+                     </Col>
+                   </Form.Group>
+                   <Form.Group as={Row}>
+                     <Form.Label column sm="3">{T("Extra Data")}</Form.Label>
+                     <Col sm="8">
+                       <div className={clsname}
+                            onClick={()=>this.setState({
+                                collapsed: !this.state.collapsed})}>
+                         <VeloValueRenderer value={this.props.row}/>
+                       </div>
+                     </Col>
+                   </Form.Group>
+
+                 </Modal.Body>
+                 <Modal.Footer>
+                   <Button variant="secondary"
+                           onClick={this.props.onClose}>
+                     {T("Cancel")}
+                   </Button>
+                   <Button variant="primary"
+                           disabled={!this.state.notebook_id || !this.state.note}
+                           onClick={this.annotateRow}>
+                     {T("Submit")}
+                   </Button>
+                 </Modal.Footer>
+               </Modal>;
+    }
+}

--- a/gui/velociraptor/src/components/utils/value.jsx
+++ b/gui/velociraptor/src/components/utils/value.jsx
@@ -40,6 +40,7 @@ export default class VeloValueRenderer extends React.Component {
     static contextType = UserConfig;
     static propTypes = {
         value: PropTypes.any,
+        row: PropTypes.object,
         collapsed: PropTypes.bool,
     };
 
@@ -66,9 +67,11 @@ export default class VeloValueRenderer extends React.Component {
 
     render() {
         let v = this.props.value;
-
         if (_.isString(v)) {
-            return <ContextMenu value={v}>{this.maybeFormatTime(v)}</ContextMenu>;
+            return <ContextMenu value={v}
+                                row={this.props.row}>
+                     {this.maybeFormatTime(v)}
+                   </ContextMenu>;
         }
 
         if (_.isNumber(v)) {
@@ -87,7 +90,8 @@ export default class VeloValueRenderer extends React.Component {
                      </button>;
         }
 
-        return <ContextMenu value={this.props.value}>
+        return <ContextMenu value={this.props.value}
+                            row={this.props.row}>
                  {button && <div>{ button }</div> }
                  <JsonView value={v} indent={0} collapsed={this.props.collapsed}/>
                  { this.state.showDialog &&

--- a/gui/velociraptor/src/components/widgets/datetime.jsx
+++ b/gui/velociraptor/src/components/widgets/datetime.jsx
@@ -41,7 +41,8 @@ class Calendar extends Component {
     }
 
     componentDidUpdate = (prevProps, prevState, rootNode) => {
-        if (_.isUndefined(this.state.focus)) {
+        if (_.isUndefined(this.state.focus) ||
+            this.props.value !== prevProps.value) {
             let ts = this.parseDate(this.props.value);
             if(ts.isValid()) {
                 this.setState({focus: ts});

--- a/vql/server/hunts/info.go
+++ b/vql/server/hunts/info.go
@@ -1,0 +1,84 @@
+package hunts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/vql"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+)
+
+type HuntInfoFunctionArg struct {
+	HuntId string `vfilter:"optional,field=hunt_id,doc=Hunt Id to look up or a flow id created by that hunt (e.g. F.CRUU3KIE5D73G.H )."`
+}
+
+type HuntInfoFunction struct{}
+
+func (self *HuntInfoFunction) Call(ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) vfilter.Any {
+
+	err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
+	if err != nil {
+		scope.Log("hunt_info: %s", err)
+		return &vfilter.Null{}
+	}
+
+	arg := &HuntInfoFunctionArg{}
+	err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+	if err != nil {
+		scope.Log("hunt_info: %v", err)
+		return &vfilter.Null{}
+	}
+
+	err = services.RequireFrontend()
+	if err != nil {
+		scope.Log("hunt_info: %v", err)
+		return &vfilter.Null{}
+	}
+
+	config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		scope.Log("hunt_info: Command can only run on the server")
+		return &vfilter.Null{}
+	}
+
+	if strings.HasSuffix(arg.HuntId, ".H") &&
+		strings.HasPrefix(arg.HuntId, "F.") {
+		arg.HuntId = "H." + strings.TrimSuffix(
+			strings.TrimPrefix(arg.HuntId, "F."), ".H")
+	}
+
+	hunt_dispatcher_service, err := services.GetHuntDispatcher(config_obj)
+	if err != nil {
+		scope.Log("hunt_info: %v", err)
+		return &vfilter.Null{}
+	}
+
+	hunt_obj, pres := hunt_dispatcher_service.GetHunt(ctx, arg.HuntId)
+	if !pres {
+		return &vfilter.Null{}
+	}
+
+	return json.ConvertProtoToOrderedDict(hunt_obj)
+}
+
+func (self HuntInfoFunction) Info(scope vfilter.Scope,
+	type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
+	return &vfilter.FunctionInfo{
+		Name:     "hunt_info",
+		Doc:      "Retrieve the hunt information.",
+		ArgType:  type_map.AddType(scope, &HuntInfoFunctionArg{}),
+		Metadata: vql.VQLMetadata().Permissions(acls.READ_RESULTS).Build(),
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterFunction(&HuntInfoFunction{})
+}


### PR DESCRIPTION
This allows any row from any table to be annotated to a global timeline. This is allowed even if there is no natural time column in the row (the time is set to 1980 in that case).

This feature allows to selectively annotating noteworthy rows from any artifact/client/flow/hunt into a central place for reporting and analysis without first importing a time series.

The user simply right clicks on any row and selects "Annotate"