### PR TITLE
Backups should also include custom artifacts.

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -435,6 +435,13 @@
     type: string
     description: The name of the backup file.
     required: true
+  - name: prefix
+    type: string
+    description: Restore the backup from under this prefix in the zip file (defaults
+      to org id).
+  - name: providers
+    type: string
+    description: If provided only restore providers matching this regex.
   platforms:
   - darwin_amd64_cgo
   - darwin_arm64_cgo
@@ -4405,7 +4412,6 @@
            link_to(upload=Upload) AS Download
     FROM scope()
     ```
-
   type: Function
   args:
   - name: type
@@ -10807,3 +10813,4 @@
   platforms:
   - linux_amd64_cgo
   - windows_amd64_cgo
+

--- a/services/acl_manager/backup.go
+++ b/services/acl_manager/backup.go
@@ -26,8 +26,8 @@ func (self ACLBackupProvider) Name() []string {
 }
 
 func (self ACLBackupProvider) BackupResults(
-	ctx context.Context, wg *sync.WaitGroup) (
-	<-chan vfilter.Row, error) {
+	ctx context.Context, wg *sync.WaitGroup,
+	container services.BackupContainerWriter) (<-chan vfilter.Row, error) {
 
 	users_manager := services.GetUserManager()
 	user_list, err := users_manager.ListUsers(ctx,
@@ -70,6 +70,7 @@ func (self ACLBackupProvider) BackupResults(
 // because this may represent a security compromise but we want to
 // allow users to see the ACL permissions that were backed up.
 func (self ACLBackupProvider) Restore(ctx context.Context,
+	container services.BackupContainerReader,
 	in <-chan vfilter.Row) (stat services.BackupStat, err error) {
 
 	count := 0

--- a/services/backup.go
+++ b/services/backup.go
@@ -2,12 +2,31 @@ package services
 
 import (
 	"context"
+	"io"
+	"io/fs"
+	"regexp"
 	"sync"
+	"time"
 
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/vfilter"
 )
+
+// For writing.
+type BackupContainerWriter interface {
+	Create(name string, mtime time.Time) (io.WriteCloser, error)
+
+	WriteResultSet(
+		ctx context.Context,
+		config_obj *config_proto.Config,
+		dest string, in <-chan vfilter.Row) (total_rows int, err error)
+}
+
+// For reading.
+type BackupContainerReader interface {
+	Open(name string) (fs.File, error)
+}
 
 // Callers may register a backup provider to be included in the backup
 type BackupProvider interface {
@@ -22,13 +41,16 @@ type BackupProvider interface {
 	// can write the backup file (named in Name() above).
 	BackupResults(
 		ctx context.Context,
-		wg *sync.WaitGroup) (<-chan vfilter.Row, error)
+		wg *sync.WaitGroup,
+		container BackupContainerWriter) (<-chan vfilter.Row, error)
 
 	// This is the opposite of backup - it allows a provider to
 	// recover from an existing backup. Typcially providers need to
 	// clear their data and read new data from this channel. The
 	// provider may return stats about its operation.
-	Restore(ctx context.Context, in <-chan vfilter.Row) (BackupStat, error)
+	Restore(ctx context.Context,
+		container BackupContainerReader,
+		in <-chan vfilter.Row) (BackupStat, error)
 }
 
 // Alows each provider to report the stats of the most recent
@@ -38,11 +60,24 @@ type BackupStat struct {
 	Name    string
 	Error   error
 	Message string
+
+	// Which org owns this backup service.
+	OrgId string
+}
+
+type BackupRestoreOptions struct {
+	// By default the prefix in the zip is calculated based on the
+	// current org id. This allows this to be overriden.
+	Prefix string
+
+	// Only restore matching providers
+	ProviderRegex *regexp.Regexp
 }
 
 type BackupService interface {
 	Register(provider BackupProvider)
-	RestoreBackup(export_path api.FSPathSpec) ([]BackupStat, error)
+	RestoreBackup(export_path api.FSPathSpec,
+		opts BackupRestoreOptions) ([]BackupStat, error)
 	CreateBackup(export_path api.FSPathSpec) ([]BackupStat, error)
 }
 

--- a/services/backup/backup.go
+++ b/services/backup/backup.go
@@ -17,7 +17,6 @@ import (
 	"www.velocidex.com/golang/velociraptor/reporting"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
-	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 )
 
@@ -78,16 +77,57 @@ func (self *BackupService) CreateBackup(
 
 	defer container.Close()
 
+	org_container := &containerDelegate{
+		Container: container,
+	}
+
+	// The root org is responsible for dumping all child orgs as well.
+	if utils.IsRootOrg(self.config_obj.OrgId) {
+		org_manager, err := services.GetOrgManager()
+		if err != nil {
+			return stats, err
+		}
+
+		for _, org := range org_manager.ListOrgs() {
+			backup, err := org_manager.Services(org.Id).BackupService()
+			if err != nil {
+				continue
+			}
+
+			prefix := fmt.Sprintf("orgs/%v", org.Id)
+			org_container := &containerDelegate{
+				Container: container,
+				prefix:    prefix,
+			}
+			org_stats, _ := backup.(*BackupService).writeBackups(
+				org_container, prefix)
+			stats = append(stats, org_stats...)
+		}
+
+		// Not the root org, just backup this org only.
+	} else if !utils.IsRootOrg(self.config_obj.OrgId) {
+		prefix := fmt.Sprintf("orgs/%v", utils.GetOrgId(self.config_obj))
+		org_stats, _ := self.writeBackups(org_container, prefix)
+		stats = append(stats, org_stats...)
+	}
+
+	return stats, err
+}
+
+func (self *BackupService) writeBackups(
+	container services.BackupContainerWriter,
+	prefix string) (stats []services.BackupStat, err error) {
+
 	// Now we can dump all providers into the file.
-	scope := vql_subsystem.MakeScope()
+	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 
 	for _, provider := range self.registrations {
-		dest := strings.Join(provider.Name(), "/")
+		dest := strings.Join(append([]string{prefix}, provider.Name()...), "/")
 		stat := services.BackupStat{
 			Name: provider.ProviderName(),
 		}
 
-		rows, err := provider.BackupResults(self.ctx, self.wg)
+		rows, err := provider.BackupResults(self.ctx, self.wg, container)
 		if err != nil {
 			logger.Info("BackupService: <red>Error writing to %v: %v",
 				dest, err)
@@ -98,8 +138,8 @@ func (self *BackupService) CreateBackup(
 		}
 
 		// Write the results to the container now
-		total_rows, err := container.WriteResultSet(self.ctx, self.config_obj,
-			scope, reporting.ContainerFormatJson, dest, rows)
+		total_rows, err := container.WriteResultSet(
+			self.ctx, self.config_obj, dest, rows)
 		if err != nil {
 			logger.Info("BackupService: <red>Error writing to %v: %v",
 				dest, err)
@@ -117,7 +157,8 @@ func (self *BackupService) CreateBackup(
 
 // Opens a backup file and recovers all the data in it.
 func (self *BackupService) RestoreBackup(
-	export_path api.FSPathSpec) (stats []services.BackupStat, err error) {
+	export_path api.FSPathSpec,
+	opts services.BackupRestoreOptions) (stats []services.BackupStat, err error) {
 	// Create a container to hold the backup
 	file_store_factory := file_store.GetFileStore(self.config_obj)
 
@@ -141,8 +182,21 @@ func (self *BackupService) RestoreBackup(
 
 	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 
+	prefix := opts.Prefix
+	if prefix == "" {
+		prefix = fmt.Sprintf("orgs/%v", utils.GetOrgId(self.config_obj))
+	}
+
 	for _, provider := range self.registrations {
-		stat, err := self.feedProvider(provider, zip_reader)
+		if opts.ProviderRegex != nil && !opts.ProviderRegex.MatchString(
+			provider.ProviderName()) {
+			continue
+		}
+
+		stat, err := self.feedProvider(provider, zipDelegate{
+			Reader: zip_reader,
+			prefix: prefix,
+		})
 		if err != nil {
 			dest := strings.Join(provider.Name(), "/")
 			logger.Info("BackupService: <red>Error restoring to %v: %v",
@@ -158,7 +212,7 @@ func (self *BackupService) RestoreBackup(
 
 func (self *BackupService) feedProvider(
 	provider services.BackupProvider,
-	container *zip.Reader) (stat services.BackupStat, err error) {
+	container services.BackupContainerReader) (stat services.BackupStat, err error) {
 
 	dest := strings.Join(provider.Name(), "/")
 	member, err := container.Open(dest)
@@ -180,6 +234,8 @@ func (self *BackupService) feedProvider(
 		// Wait here until the provider is done.
 		stat = <-results
 		stat.Name = provider.ProviderName()
+		stat.OrgId = utils.GetOrgId(self.config_obj)
+
 		if stat.Error != nil {
 			err = stat.Error
 		}
@@ -198,7 +254,7 @@ func (self *BackupService) feedProvider(
 		defer close(results)
 
 		// Preserve the provider error as our return
-		stat, err := provider.Restore(sub_ctx, output)
+		stat, err := provider.Restore(sub_ctx, container, output)
 		if err != nil {
 			stat.Error = err
 		}

--- a/services/backup/backup_test.go
+++ b/services/backup/backup_test.go
@@ -136,11 +136,13 @@ func (self *BackupTestSuite) TestBackups() {
 		Set("TestProvider.json", test_provider).
 		Set("TestProvider Stats", filterStats(stats))
 
+	opts := services.BackupRestoreOptions{}
+
 	// Now restore the data from backup. NOTE: Each org restores only
 	// its own data from the zip file. This allows the same zip file
 	// to be shared between all the orgs.
 	stats, err = backup_service.(*backup.BackupService).
-		RestoreBackup(export_path)
+		RestoreBackup(export_path, opts)
 	assert.NoError(self.T(), err)
 
 	golden.Set("RestoredTestProvider", provider.restored).
@@ -151,7 +153,7 @@ func (self *BackupTestSuite) TestBackups() {
 	provider.restored = nil
 
 	stats, err = backup_service.(*backup.BackupService).
-		RestoreBackup(export_path)
+		RestoreBackup(export_path, opts)
 	assert.NoError(self.T(), err)
 
 	golden.Set("RestoredTestProvider With Error", provider.restored).

--- a/services/backup/delegates.go
+++ b/services/backup/delegates.go
@@ -1,0 +1,44 @@
+package backup
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"io/fs"
+	"time"
+
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/reporting"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
+)
+
+type containerDelegate struct {
+	*reporting.Container
+	prefix string
+}
+
+func (self *containerDelegate) Create(name string, mtime time.Time) (
+	io.WriteCloser, error) {
+	return self.Container.Create(self.prefix+"/"+name, mtime)
+}
+
+func (self *containerDelegate) WriteResultSet(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	dest string, in <-chan vfilter.Row) (total_rows int, err error) {
+
+	scope := vql_subsystem.MakeScope()
+
+	return self.Container.WriteResultSet(
+		ctx, config_obj, scope, reporting.ContainerFormatJson, dest, in)
+}
+
+type zipDelegate struct {
+	*zip.Reader
+	prefix string
+}
+
+func (self zipDelegate) Open(name string) (fs.File, error) {
+	return self.Reader.Open(self.prefix + "/" + name)
+}

--- a/services/backup/fixtures/TestBackups.golden
+++ b/services/backup/fixtures/TestBackups.golden
@@ -7,7 +7,8 @@
   {
    "Name": "TestProvider",
    "Error": null,
-   "Message": "Wrote 1 rows"
+   "Message": "Wrote 1 rows",
+   "OrgId": ""
   }
  ],
  "RestoredTestProvider": [
@@ -20,7 +21,8 @@
   {
    "Name": "TestProvider",
    "Error": null,
-   "Message": "All good!"
+   "Message": "All good!",
+   "OrgId": "root"
   }
  ],
  "RestoredTestProvider With Error": null,
@@ -28,7 +30,8 @@
   {
    "Name": "TestProvider",
    "Error": {},
-   "Message": "I have an error"
+   "Message": "I have an error",
+   "OrgId": "root"
   }
  ]
 }

--- a/services/client_info/backup.go
+++ b/services/client_info/backup.go
@@ -29,15 +29,14 @@ func (self ClientInfoBackupProvider) Name() []string {
 
 // The backup will just dump out the contents of the client info manager.
 func (self ClientInfoBackupProvider) BackupResults(
-	ctx context.Context, wg *sync.WaitGroup) (
-	<-chan vfilter.Row, error) {
+	ctx context.Context, wg *sync.WaitGroup,
+	container services.BackupContainerWriter) (<-chan vfilter.Row, error) {
 
 	return self.store.BackupResults(ctx, wg)
 }
 
 func (self *Store) BackupResults(
-	ctx context.Context, wg *sync.WaitGroup) (
-	<-chan vfilter.Row, error) {
+	ctx context.Context, wg *sync.WaitGroup) (<-chan vfilter.Row, error) {
 
 	// We dont lock the data so we can take as long as needed.
 	clients := self.Keys()
@@ -83,6 +82,7 @@ func (self *Store) BackupResults(
 }
 
 func (self ClientInfoBackupProvider) Restore(ctx context.Context,
+	container services.BackupContainerReader,
 	in <-chan vfilter.Row) (stat services.BackupStat, err error) {
 	return self.store.Restore(ctx, self.config_obj, in)
 }

--- a/services/hunt_dispatcher/backup.go
+++ b/services/hunt_dispatcher/backup.go
@@ -30,15 +30,14 @@ func (self HuntBackupProvider) Name() []string {
 
 // The backup will just dump out the contents of the hunt dispatcher.
 func (self HuntBackupProvider) BackupResults(
-	ctx context.Context, wg *sync.WaitGroup) (
-	<-chan vfilter.Row, error) {
+	ctx context.Context, wg *sync.WaitGroup,
+	container services.BackupContainerWriter) (<-chan vfilter.Row, error) {
 
 	return self.store.BackupResults(ctx, wg)
 }
 
 func (self *HuntStorageManagerImpl) BackupResults(
-	ctx context.Context, wg *sync.WaitGroup) (
-	<-chan vfilter.Row, error) {
+	ctx context.Context, wg *sync.WaitGroup) (<-chan vfilter.Row, error) {
 
 	// We dont lock the data so we can take as long as needed.
 	self.mu.Lock()
@@ -93,6 +92,7 @@ func (self *HuntStorageManagerImpl) BackupResults(
 }
 
 func (self HuntBackupProvider) Restore(ctx context.Context,
+	container services.BackupContainerReader,
 	in <-chan vfilter.Row) (stat services.BackupStat, err error) {
 	return self.store.Restore(ctx, self.config_obj, in)
 }

--- a/services/repository/backups.go
+++ b/services/repository/backups.go
@@ -1,0 +1,174 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sync"
+
+	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/vfilter"
+)
+
+type BackupRecord struct {
+	Artifact string                            `json:"artifact"`
+	Filename string                            `json:"filename"`
+	Metadata *artifacts_proto.ArtifactMetadata `json:"metadata"`
+}
+
+type RepositoryBackupProvider struct {
+	config_obj *config_proto.Config
+}
+
+func (self RepositoryBackupProvider) ProviderName() string {
+	return "RepositoryBackupProvider"
+}
+
+func (self RepositoryBackupProvider) Name() []string {
+	return []string{"custom_artifacts.json"}
+}
+
+// The backup will just dump out the contents of the hunt dispatcher.
+func (self RepositoryBackupProvider) BackupResults(
+	ctx context.Context, wg *sync.WaitGroup,
+	container services.BackupContainerWriter) (<-chan vfilter.Row, error) {
+
+	output_chan := make(chan vfilter.Row)
+
+	manager, err := services.GetRepositoryManager(self.config_obj)
+	if err != nil {
+		close(output_chan)
+		return output_chan, err
+	}
+
+	repository, err := manager.GetGlobalRepository(self.config_obj)
+	if err != nil {
+		close(output_chan)
+		return output_chan, err
+	}
+
+	all_artifacts, err := repository.List(ctx, self.config_obj)
+	if err != nil {
+		close(output_chan)
+		return output_chan, err
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(output_chan)
+
+		for _, name := range all_artifacts {
+			artifact, pres := repository.Get(ctx, self.config_obj, name)
+			if !pres {
+				continue
+			}
+
+			// Skip all these ones.
+			if artifact.IsInherited ||
+				artifact.BuiltIn ||
+				artifact.CompiledIn ||
+				artifact.IsAlias {
+				continue
+			}
+
+			name := fmt.Sprintf("artifacts/%v.yaml", artifact.Name)
+			writer, err := container.Create(name, utils.GetTime().Now())
+			if err != nil {
+				continue
+			}
+
+			writer.Write([]byte(artifact.Raw))
+			writer.Close()
+
+			record := &BackupRecord{
+				Artifact: artifact.Name,
+				Filename: name,
+			}
+
+			if artifact.Metadata != nil {
+				record.Metadata = artifact.Metadata
+			}
+
+			output_chan <- record
+		}
+	}()
+
+	return output_chan, nil
+}
+
+func (self RepositoryBackupProvider) Restore(ctx context.Context,
+	container services.BackupContainerReader,
+	in <-chan vfilter.Row) (stat services.BackupStat, err error) {
+
+	count := 0
+	defer func() {
+		if stat.Error == nil {
+			stat.Error = err
+		}
+		stat.Message += fmt.Sprintf("Restored %v custom artifacts\n", count)
+	}()
+
+	manager, err := services.GetRepositoryManager(self.config_obj)
+	if err != nil {
+		return stat, err
+	}
+
+	repository, err := manager.GetGlobalRepository(self.config_obj)
+	if err != nil {
+		return stat, err
+	}
+
+	options := services.ArtifactOptions{
+		ValidateArtifact: true,
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return stat, nil
+
+		case row, ok := <-in:
+			if !ok {
+				return stat, nil
+			}
+
+			serialized, err := json.MarshalWithOptions(
+				row, json.DefaultEncOpts())
+			if err != nil {
+				continue
+			}
+
+			record := &BackupRecord{}
+			err = json.Unmarshal(serialized, record)
+			if err != nil {
+				continue
+			}
+
+			fd, err := container.Open(record.Filename)
+			if err != nil {
+				continue
+			}
+
+			data, err := ioutil.ReadAll(fd)
+			if err != nil {
+				continue
+			}
+
+			_, err = repository.LoadYaml(string(data), options)
+			if err != nil {
+				stat.Message += fmt.Sprintf("Unable to load %v from %v: %v\n",
+					record.Artifact,
+					record.Filename, err)
+				continue
+			}
+			count++
+		}
+	}
+
+	return stat, nil
+}

--- a/services/repository/manager.go
+++ b/services/repository/manager.go
@@ -361,6 +361,16 @@ func NewRepositoryManager(ctx context.Context, wg *sync.WaitGroup,
 	// move on.
 	_ = self.metadata.loadMetadata(ctx, config_obj)
 
+	// Backup the custom artifacts - only for the Master node.
+	if services.IsMaster(config_obj) {
+		backup_service, err := services.GetBackupService(config_obj)
+		if err == nil {
+			backup_service.Register(&RepositoryBackupProvider{
+				config_obj: config_obj,
+			})
+		}
+	}
+
 	return self, self.StartWatchingForUpdates(ctx, wg, config_obj)
 }
 


### PR DESCRIPTION
* Root org will create a backup for all other orgs. The data for each org can be stored in the same zip file.
* It is now possible to restore only some providers selectively.