### PR TITLE
Replace hard-coded timestamps with the vars. StartTime/EndTime

### DIFF
--- a/artifacts/definitions/Generic/Client/Stats.yaml
+++ b/artifacts/definitions/Generic/Client/Stats.yaml
@@ -30,12 +30,9 @@ sources:
           /*
           # Events from Generic.Client.Stats
           */
-          LET StartTime <= "2024-03-20T16:33:38Z"
-          LET EndTime <= "2024-03-20T20:01:37Z"
-
           LET resources = SELECT Timestamp, rate(x=CPU, y=Timestamp) * 100 As CPUPercent,
                RSS / 1000000 AS MemoryUse
-          FROM source()
+          FROM source(start_time=StartTime, end_time=EndTime)
           WHERE CPUPercent >= 0
           /*
             {{ Query "SELECT * FROM resources" | LineChart "xaxis_mode" "time" "RSS.yaxis" 2 }}


### PR DESCRIPTION
The Generic.Client.Stats plotting VQL suggestion uses two hard-coded timestamps and thus no longer works (especially since the timestamps are both a long time ago in the past). Instead, use the StartTime/EndTime variables.

It could be useful to keep two hard-coded timestamps in LET expressions, but as a comment, so that the user can easily override the time range after the notebook has been created.