### PR TITLE
Do not self-reference artifact name when not necessary

### DIFF
--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -103,7 +103,7 @@ sources:
                 `Computer Info`.DomainRole AS DomainRole
               FROM source(client_id=client_id,
                   flow_id=last_interrogate_flow_id,
-                  artifact="Generic.Client.Info/WindowsInfo")
+                  source="WindowsInfo")
           })
           -- WHERE DomainRole =~ "Controller"
 
@@ -141,7 +141,7 @@ reports:
 
       {{ define "computerinfo" }}
       LET X <= SELECT *
-        FROM source(artifact='Generic.Client.Info/LinuxInfo')
+        FROM source(source="LinuxInfo')
         LIMIT 1
 
       SELECT humanize(bytes=TotalPhysicalMemory) AS  TotalPhysicalMemory,
@@ -162,8 +162,8 @@ reports:
         {{ $windows_info | Table }}
       {{ end }}
 
-      {{ $linux_info := Query "LET X <= SELECT * FROM source(artifact='Generic.Client.Info/LinuxInfo') LIMIT 1 SELECT * FROM X" }}
-      {{ if Query "SELECT * FROM source(artifact='Generic.Client.Info/LinuxInfo')" | Expand }}
+      {{ $linux_info := Query "LET X <= SELECT * FROM source(source='LinuxInfo') LIMIT 1 SELECT * FROM X" }}
+      {{ if Query "SELECT * FROM source(source='LinuxInfo')" | Expand }}
       # Linux agent information
 
       ### Network Info


### PR DESCRIPTION
This commit allows for interrogation artifact to be overridden without errors.