### PR TITLE
Delete notebook now deletes the files from data store

### DIFF
--- a/gui/velociraptor/src/components/notebooks/notebooks-list.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebooks-list.jsx
@@ -40,7 +40,7 @@ class DeleteNotebook extends React.Component {
     deleteNotebook = () => {
         let notebook = Object.assign({}, this.props.notebook);
         notebook.hidden = true;
-        api.post("v1/UpdateNotebook", notebook, this.source.token).then(
+        api.post("v1/DeleteNotebook", notebook, this.source.token).then(
             this.props.updateNotebooks);
     }
 
@@ -51,24 +51,23 @@ class DeleteNotebook extends React.Component {
                    onHide={this.props.closeDialog} >
               <Modal.Header closeButton>
                 <Modal.Title>
-                  Archive notebook {this.props.notebook.notebook_id}
+                  {T("Delete notebook")} {this.props.notebook.notebook_id}
                 </Modal.Title>
               </Modal.Header>
 
               <Modal.Body>
                 <Alert variant="danger" className="text-center">
-                  You are about to archive notebook {this.props.notebook.notebook_id}!
-                  You can always recover this notebook from the filestore later.
+                  {T("You are about to delete this notebook permanently!")}
                 </Alert>
               </Modal.Body>
               <Modal.Footer>
                 <Button variant="secondary"
                         onClick={this.props.closeDialog}>
-                  Cancel
+                  {T("Cancel")}
                 </Button>
                 <Button variant="primary"
                         onClick={this.deleteNotebook}>
-                  Do It!!!
+                  {T("Do It!!!")}
                 </Button>
               </Modal.Footer>
             </Modal>

--- a/paths/notebooks.go
+++ b/paths/notebooks.go
@@ -56,6 +56,14 @@ func (self *NotebookPathManager) Path() api.DSPathSpec {
 	return self.root.AddChild(self.notebook_id).SetTag("Notebook")
 }
 
+// Stored the cached copy of the psuedo artifact we calculated when
+// the artifact was first created. This is used even if the original
+// artifact is deleted or modified.
+func (self *NotebookPathManager) Artifact() api.DSPathSpec {
+	return self.root.AddChild(self.notebook_id, "artifact").
+		SetTag("Artifact")
+}
+
 // Support versioned cells by appending the version to the cell id.
 func (self *NotebookPathManager) Cell(
 	cell_id, version string) *NotebookCellPathManager {

--- a/services/notebook/fixtures/TestInitialNotebook.golden
+++ b/services/notebook/fixtures/TestInitialNotebook.golden
@@ -96,7 +96,7 @@
   "artifacts": [
    "Custom.Generic.Client.Info"
   ],
-  "notebook_id": "N.F.1234-C.1235"
+  "notebook_id": "N.F.1235-C.1235"
  },
  "Custom.Generic.Client.Info Response": {
   "name": "PrivateNotebook",
@@ -113,7 +113,7 @@
    },
    {
     "name": "FlowId",
-    "default": "F.1234",
+    "default": "F.1235",
     "description": "Implied flow id from notebook"
    }
   ],

--- a/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
@@ -26,7 +26,6 @@
    }
   ],
   "created_time": 1715775587,
-  "modified_time": 1715775587,
   "notebook_id": "N.01",
   "cell_metadata": [
    {
@@ -67,7 +66,6 @@
    }
   ],
   "created_time": 1715775587,
-  "modified_time": 1715775588,
   "notebook_id": "N.01",
   "cell_metadata": [
    {
@@ -95,7 +93,6 @@
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
    "_AnnotatedBy": "admin",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   },
@@ -107,7 +104,6 @@
    "Foo": "Older Bar 2",
    "Notes": "Updated First Annotation - all other fields remain",
    "_AnnotatedBy": "admin",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TtAAAAAAAAA=",
    "_Source": "Annotation"
   }
@@ -121,7 +117,6 @@
    "Foo": "Older Bar 2",
    "Notes": "An Earlier Foo is suspicious at being Older Bar!",
    "_AnnotatedBy": "mike",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TtAAAAAAAAA=",
    "_Source": "Annotation"
   },
@@ -133,7 +128,6 @@
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
    "_AnnotatedBy": "admin",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   }
@@ -161,7 +155,6 @@
   "_Source": "Annotation",
   "Notes": "Updated First Annotation - all other fields remain",
   "_AnnotatedBy": "admin",
-  "_AnnotatedAt": "2024-05-15T12:19:48Z",
   "_AnnotationID": "TtAAAAAAAAA="
  },
  "Updated Annotations": [
@@ -173,7 +166,6 @@
    "Foo": "Bar 1",
    "Notes": "Foo is suspicious at being Bar!",
    "_AnnotatedBy": "admin",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TdAAAAAAAAA=",
    "_Source": "Annotation"
   },
@@ -185,7 +177,6 @@
    "Foo": "Older Bar 2",
    "Notes": "Updated First Annotation - all other fields remain",
    "_AnnotatedBy": "admin",
-   "_AnnotatedAt": "2024-05-15T12:19:48Z",
    "_AnnotationID": "TtAAAAAAAAA=",
    "_Source": "Annotation"
   }

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -168,6 +168,11 @@ func CalculateNotebookArtifact(
 
 	out := proto.Clone(in).(*api_proto.NotebookMetadata)
 
+	// No notebook Id will allocate a global ID.
+	if out.NotebookId == "" {
+		out.NotebookId = NewNotebookId()
+	}
+
 	manager, err := services.GetRepositoryManager(config_obj)
 	if err != nil {
 		return nil, nil, err
@@ -199,7 +204,7 @@ func CalculateNotebookArtifact(
 		return nil, nil, err
 	}
 
-	notebook_path_manager := paths.NewNotebookPathManager(in.NotebookId)
+	notebook_path_manager := paths.NewNotebookPathManager(out.NotebookId)
 	err = db.GetSubject(config_obj,
 		notebook_path_manager.Artifact(),
 		res)

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -75,6 +75,7 @@ import (
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/datastore"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -190,9 +191,29 @@ func CalculateNotebookArtifact(
 	}
 
 	// This is a psuedo artifact used to build the notebook.
-	res := &artifacts_proto.Artifact{
-		Name: "PrivateNotebook",
+	res := &artifacts_proto.Artifact{}
+
+	// Check if the psuedo artifact is already cached.
+	db, err := datastore.GetDB(config_obj)
+	if err != nil {
+		return nil, nil, err
 	}
+
+	notebook_path_manager := paths.NewNotebookPathManager(in.NotebookId)
+	err = db.GetSubject(config_obj,
+		notebook_path_manager.Artifact(),
+		res)
+	if err == nil {
+		// Artifact is cached, lets return that
+		out.Parameters = res.Parameters
+		return res, out, nil
+	}
+
+	// Cache it for next time.
+	defer db.SetSubject(config_obj, notebook_path_manager.Artifact(), res)
+
+	// Now build the psuedo artifact.
+	res.Name = "PrivateNotebook"
 
 	seen := make(map[string]bool)
 	seen_tools := make(map[string]bool)

--- a/services/notebook/timelines_test.go
+++ b/services/notebook/timelines_test.go
@@ -207,6 +207,7 @@ func (self *NotebookManagerTestSuite) _TestNotebookManagerTimelineAnnotations(
 	golden.Set("Updated Annotations", read_all_events())
 
 	goldie.Retry(t, self.T(), "TestNotebookManagerTimelineAnnotations",
-		json.MustMarshalIndent(golden))
+		goldie.RemoveLines("_AnnotatedAt|modified_time",
+			json.MustMarshalIndent(golden)))
 
 }


### PR DESCRIPTION
Previously we only archived the notebook but kept the files on disk.

Also this PR caches the psuedo artifact that we calculated when initially creating the notebook in the datastore. This means the original artifact can be deleted or modified without affecting the notebook.