### PR TITLE
Bugfix: Actively reduce memory use in memcache filestore

### DIFF
--- a/artifacts/definitions/Server/Internal/Welcome.yaml
+++ b/artifacts/definitions/Server/Internal/Welcome.yaml
@@ -20,7 +20,7 @@ reports:
       <div class="card col-10">
       <img src="./velo.svg" height="150">
       <div class="card-body">
-      {{ Query "LET DebugLink <= link_to(type='debug')" | Expand }}
+      {{ $X := Query "LET DebugLink <= link_to(type='debug')" | Expand }}
 
       # Welcome to Velociraptor!
 


### PR DESCRIPTION
This PR forces synchronous writing when memory utilization is exceeded in the memcache filestore. By writing synchronously we can push back against writers to ensure that memory can be cleared before we take on new writes. Previously this flushing was asynchronous which means there was no guarantee that memory was properly flushed - leading to an uncontrolled increase in memory use.

Fixes: #3906 