### PR TITLE
Clean up some trailing quotes from VQL reference

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -5315,7 +5315,7 @@
     description: Start reading the result set from this row
   - name: count
     type: int64
-    description: Maximum number of clients to fetch (default unlimited)'
+    description: Maximum number of clients to fetch (default unlimited)
   category: server
   metadata:
     permissions: READ_RESULTS
@@ -8735,10 +8735,10 @@
     description: Start reading the result set from this row
   - name: count
     type: int64
-    description: Maximum number of clients to fetch (default unlimited)'
+    description: Maximum number of clients to fetch (default unlimited)
   - name: orgs
     type: string
-    description: Run the query over these orgs. If empty use the current org.'
+    description: Run the query over these orgs. If empty use the current org.
     repeated: true
   category: server
   metadata:
@@ -10784,7 +10784,6 @@
        },
     }
     ```
-
   type: Plugin
   args:
   - name: name
@@ -11027,7 +11026,7 @@
     ### Example
 
     ```vql
-    SELECT winpmem(image_path='c:/test.dd', compression='s2') FROM scope()"
+    SELECT winpmem(image_path='c:/test.dd', compression='s2') FROM scope()
     ```
   type: Function
   args:
@@ -11371,3 +11370,4 @@
   - linux_amd64_cgo
   - windows_386_cgo
   - windows_amd64_cgo
+

--- a/vql/server/flows/monitoring.go
+++ b/vql/server/flows/monitoring.go
@@ -45,7 +45,7 @@ type MonitoringPluginArgs struct {
 	EndTime   vfilter.Any `vfilter:"optional,field=end_time,doc=Stop end events reach this time (event sources)."`
 
 	StartRow int64 `vfilter:"optional,field=start_row,doc=Start reading the result set from this row"`
-	Limit    int64 `vfilter:"optional,field=count,doc=Maximum number of clients to fetch (default unlimited)'"`
+	Limit    int64 `vfilter:"optional,field=count,doc=Maximum number of clients to fetch (default unlimited)"`
 }
 
 type MonitoringPlugin struct{}

--- a/vql/server/flows/results.go
+++ b/vql/server/flows/results.go
@@ -84,9 +84,9 @@ type SourcePluginArgs struct {
 	NotebookCellTable   int64  `vfilter:"optional,field=notebook_cell_table,doc=A notebook cell can have multiple tables.)"`
 
 	StartRow int64 `vfilter:"optional,field=start_row,doc=Start reading the result set from this row"`
-	Limit    int64 `vfilter:"optional,field=count,doc=Maximum number of clients to fetch (default unlimited)'"`
+	Limit    int64 `vfilter:"optional,field=count,doc=Maximum number of clients to fetch (default unlimited)"`
 
-	OrgIds []string `vfilter:"optional,field=orgs,doc=Run the query over these orgs. If empty use the current org.'"`
+	OrgIds []string `vfilter:"optional,field=orgs,doc=Run the query over these orgs. If empty use the current org."`
 }
 
 type SourcePlugin struct{}


### PR DESCRIPTION
Not sure if this was valid YAML syntax, but the trailing quotes disturbed syntax highlighting of vql.yaml in some editors.