### PR TITLE
DeleteFlow: Do not always rebuild flow index from scratch

### DIFF
--- a/artifacts/definitions/Server/Utils/DeleteFlow.yaml
+++ b/artifacts/definitions/Server/Utils/DeleteFlow.yaml
@@ -22,8 +22,12 @@ parameters:
   - name: ReallyDoIt
     description: If you really want to delete the collection, check this.
     type: bool
+  - name: Sync
+    description: If specified we ensure delete happens immediately
+    type: bool
 
 sources:
   - query: |
        SELECT Type, Data.VFSPath AS VFSPath, Error
-       FROM delete_flow(flow_id=FlowId, client_id=ClientId, really_do_it=ReallyDoIt)
+       FROM delete_flow(flow_id=FlowId,
+          client_id=ClientId, really_do_it=ReallyDoIt, sync=Sync)

--- a/gui/velociraptor/src/components/flows/flows-list.jsx
+++ b/gui/velociraptor/src/components/flows/flows-list.jsx
@@ -74,6 +74,7 @@ export class DeleteFlowDialog extends React.PureComponent {
                         "Server.Utils.DeleteFlow",
                         {FlowId: flow_id,
                          ClientId: client_id,
+                         Sync: "Y",
                          ReallyDoIt: "Y"}, ()=>{
                              this.props.onClose();
                              this.setState({loading: false});

--- a/services/launcher.go
+++ b/services/launcher.go
@@ -62,11 +62,13 @@ const (
 	// When the principal is set to this below we avoid audit logging
 	// the call.
 	NoAuditLogging = ""
-	DryRunOnly     = false
 )
 
 var (
 	FlowNotFoundError = utils.Wrap(os.ErrNotExist, "Flow not found")
+	DryRunOnly        = DeleteFlowOptions{
+		ReallyDoIt: false,
+	}
 )
 
 type DeleteFlowResponse struct {
@@ -91,6 +93,19 @@ type GetFlowOptions struct {
 
 	// Include the flow downloads (ZIP exports of the flow).
 	Downloads bool
+}
+
+type DeleteFlowOptions struct {
+	// If this is not set, we do a dry run to indicate which files
+	// will be deleted within the flow but do not actually delete the
+	// files.
+	ReallyDoIt bool
+
+	// If this is set the delete will be synchronous and index updated
+	// immediately. This is much slower but it is necessary when
+	// results need to be available immediately. When False, we delete
+	// asynchronously and update the index at a later time.
+	Sync bool
 }
 
 type CompilerOptions struct {
@@ -136,7 +151,7 @@ type FlowStorer interface {
 		ctx context.Context,
 		config_obj *config_proto.Config,
 		client_id string, flow_id string, principal string,
-		really_do_it bool) ([]*DeleteFlowResponse, error)
+		options DeleteFlowOptions) ([]*DeleteFlowResponse, error)
 
 	LoadCollectionContext(
 		ctx context.Context,
@@ -246,5 +261,5 @@ type Launcher interface {
 		config_obj *config_proto.Config,
 		principal, artifact, client_id string,
 		start_time, end_time time.Time,
-		really_do_it bool) ([]*DeleteFlowResponse, error)
+		options DeleteFlowOptions) ([]*DeleteFlowResponse, error)
 }

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -27,7 +27,8 @@ func (self *FlowStorageManager) DeleteFlow(
 	ctx context.Context,
 	config_obj *config_proto.Config,
 	client_id string, flow_id string, principal string,
-	really_do_it bool) ([]*services.DeleteFlowResponse, error) {
+	options services.DeleteFlowOptions) (
+	[]*services.DeleteFlowResponse, error) {
 
 	launcher, err := services.GetLauncher(config_obj)
 	if err != nil {
@@ -46,7 +47,7 @@ func (self *FlowStorageManager) DeleteFlow(
 		return nil, nil
 	}
 
-	if really_do_it && principal != "" {
+	if options.ReallyDoIt && principal != "" {
 		services.LogAudit(ctx,
 			config_obj, principal, "delete_flow",
 			ordereddict.NewDict().
@@ -60,7 +61,7 @@ func (self *FlowStorageManager) DeleteFlow(
 	upload_metadata_path := flow_path_manager.UploadMetadata()
 
 	r := &reporter{
-		really_do_it: really_do_it,
+		really_do_it: options.ReallyDoIt,
 		ctx:          ctx,
 		config_obj:   config_obj,
 		seen:         make(map[string]bool),
@@ -151,8 +152,16 @@ func (self *FlowStorageManager) DeleteFlow(
 			r.emit_fs("NotebookItem", path)
 			return nil
 		})
-	if really_do_it {
-		err = self.removeFlowFromIndex(ctx, config_obj, client_id, flow_id)
+	if options.ReallyDoIt {
+		// User specified the flow must be removed immediately.
+		if options.Sync {
+			err = self.removeFlowFromIndex(ctx, config_obj, client_id, flow_id)
+		} else {
+			// Otherwise we just mark the index as pending a rebuild and move on.
+			self.mu.Lock()
+			self.pendingIndexes = append(self.pendingIndexes, client_id)
+			self.mu.Unlock()
+		}
 	}
 	r.pool.StopAndWait()
 
@@ -265,7 +274,8 @@ func (self *Launcher) DeleteEvents(
 	config_obj *config_proto.Config,
 	principal, artifact, client_id string,
 	start_time, end_time time.Time,
-	really_do_it bool) ([]*services.DeleteFlowResponse, error) {
+	options services.DeleteFlowOptions) (
+	[]*services.DeleteFlowResponse, error) {
 
 	path_manager, err := artifacts.NewArtifactPathManager(ctx,
 		config_obj, client_id, "", artifact)
@@ -284,7 +294,7 @@ func (self *Launcher) DeleteEvents(
 			f.StartTime.Before(end_time) {
 			var error_message string
 
-			if really_do_it {
+			if options.ReallyDoIt {
 				err := file_store_factory.Delete(f.Path)
 				if err != nil {
 					error_message = fmt.Sprintf(
@@ -320,7 +330,7 @@ func (self *Launcher) DeleteEvents(
 			f.StartTime.Before(end_time) {
 			var error_message string
 
-			if really_do_it {
+			if options.ReallyDoIt {
 				err := file_store_factory.Delete(f.Path)
 				if err != nil {
 					error_message = fmt.Sprintf(
@@ -347,7 +357,7 @@ func (self *Launcher) DeleteEvents(
 	}
 
 	// Log into the audit log
-	if really_do_it {
+	if options.ReallyDoIt {
 		return result, services.LogAudit(ctx, config_obj, principal, "DeleteEvents",
 			ordereddict.NewDict().
 				Set("artifact", artifact).

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -151,11 +151,8 @@ func (self *FlowStorageManager) DeleteFlow(
 			r.emit_fs("NotebookItem", path)
 			return nil
 		})
-	// Rebuild the flow index to ensure GUI paging works
-	// properly. This is pretty slow but we do not expect to delete
-	// flows that often.
 	if really_do_it {
-		err = self.buildFlowIndexFromLegacy(ctx, config_obj, client_id)
+		err = self.removeFlowFromIndex(ctx, config_obj, client_id, flow_id)
 	}
 	r.pool.StopAndWait()
 

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -761,7 +761,8 @@ func NewLauncherService(
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) (services.Launcher, error) {
 
-	return &Launcher{
-		Storage_: &FlowStorageManager{},
-	}, nil
+	res := &Launcher{
+		Storage_: NewFlowStorageManager(ctx, config_obj, wg),
+	}
+	return res, nil
 }

--- a/vql/server/flows/delete.go
+++ b/vql/server/flows/delete.go
@@ -16,6 +16,7 @@ type DeleteFlowPluginArgs struct {
 	FlowId     string `vfilter:"required,field=flow_id"`
 	ClientId   string `vfilter:"required,field=client_id"`
 	ReallyDoIt bool   `vfilter:"optional,field=really_do_it"`
+	Sync       bool   `vfilter:"optional,field=sync,doc=If specified we ensure data is available immediately"`
 }
 
 type DeleteFlowPlugin struct{}
@@ -63,7 +64,10 @@ func (self DeleteFlowPlugin) Call(
 
 		principal := vql_subsystem.GetPrincipal(scope)
 		responses, err := launcher.Storage().DeleteFlow(ctx, config_obj,
-			arg.ClientId, arg.FlowId, principal, arg.ReallyDoIt)
+			arg.ClientId, arg.FlowId, principal, services.DeleteFlowOptions{
+				ReallyDoIt: arg.ReallyDoIt,
+				Sync:       arg.Sync,
+			})
 		if err != nil {
 			scope.Log("delete_flow: %v", err)
 			return

--- a/vql/server/hunts/delete.go
+++ b/vql/server/hunts/delete.go
@@ -98,7 +98,9 @@ func (self DeleteHuntPlugin) Call(ctx context.Context,
 			results, err := launcher.Storage().DeleteFlow(ctx, config_obj,
 				flow_details.Context.ClientId,
 				flow_details.Context.SessionId,
-				services.NoAuditLogging, arg.ReallyDoIt)
+				services.NoAuditLogging, services.DeleteFlowOptions{
+					ReallyDoIt: arg.ReallyDoIt,
+				})
 			if err != nil {
 				scope.Log("hunt_delete: %s: %v", arg.HuntId, err)
 				continue

--- a/vql/server/monitoring/delete.go
+++ b/vql/server/monitoring/delete.go
@@ -82,7 +82,9 @@ func (self DeleteEventsPlugin) Call(
 
 		responses, err := launcher.DeleteEvents(ctx, config_obj,
 			principal, arg.Artifact, arg.ClientId,
-			arg.StartTime, arg.EndTime, arg.ReallyDoIt)
+			arg.StartTime, arg.EndTime, services.DeleteFlowOptions{
+				ReallyDoIt: arg.ReallyDoIt,
+			})
 		if err != nil {
 			scope.Log("delete_events: %v", err)
 			return


### PR DESCRIPTION
Filter out the deleted flow id, write index back to storage.

(If the index can't be opened, still rebuild from scratch.)

Close #4015