### PR TITLE
Only load notebook cell when it is visible

### DIFF
--- a/executor/nanny.go
+++ b/executor/nanny.go
@@ -191,16 +191,13 @@ func (self *NannyService) Start(
 
 func NewNanny(
 	config_obj *config_proto.Config) *NannyService {
-	if config_obj.Client.NannyMaxConnectionDelay > 0 {
-		return &NannyService{
-			MaxMemoryHardLimit: config_obj.Client.MaxMemoryHardLimit,
-			last_check_time:    utils.GetTime().Now(),
-			MaxConnectionDelay: time.Duration(
-				config_obj.Client.NannyMaxConnectionDelay) * time.Second,
-			Logger: logging.GetLogger(config_obj, &logging.ClientComponent),
-		}
+	return &NannyService{
+		MaxMemoryHardLimit: config_obj.Client.MaxMemoryHardLimit,
+		last_check_time:    utils.GetTime().Now(),
+		MaxConnectionDelay: time.Duration(
+			config_obj.Client.NannyMaxConnectionDelay) * time.Second,
+		Logger: logging.GetLogger(config_obj, &logging.ClientComponent),
 	}
-	return nil
 }
 
 func StartNannyService(
@@ -212,7 +209,7 @@ func StartNannyService(
 	}
 
 	Nanny = NewNanny(config_obj)
-	if Nanny != nil {
+	if config_obj.Client.NannyMaxConnectionDelay > 0 {
 		Nanny.Start(ctx, wg)
 	}
 	return nil

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -50,7 +50,7 @@
                 "react-simple-snackbar": "^1.1.11",
                 "react-split-pane": "^0.1.92",
                 "react-step-wizard": "^5.3.11",
-                "recharts": "^2.14.1",
+                "recharts": "^2.15.0",
                 "sprintf-js": "1.1.3",
                 "url-parse": "^1.5.10",
                 "webpack": "5.97.1"
@@ -8173,9 +8173,9 @@
             }
         },
         "node_modules/recharts": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.14.1.tgz",
-            "integrity": "sha512-xtWulflkA+/xu4/QClBdtZYN30dbvTHjxjkh5XTMrH/CQ3WGDDPHHa/LLKCbgoqz0z3UaSH2/blV1i6VNMeh1g==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
+            "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
             "license": "MIT",
             "dependencies": {
                 "clsx": "^2.0.0",
@@ -8191,8 +8191,8 @@
                 "node": ">=14"
             },
             "peerDependencies": {
-                "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+                "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/recharts-scale": {
@@ -15289,9 +15289,9 @@
             }
         },
         "recharts": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.14.1.tgz",
-            "integrity": "sha512-xtWulflkA+/xu4/QClBdtZYN30dbvTHjxjkh5XTMrH/CQ3WGDDPHHa/LLKCbgoqz0z3UaSH2/blV1i6VNMeh1g==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
+            "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
             "requires": {
                 "clsx": "^2.0.0",
                 "eventemitter3": "^4.0.1",

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
-                "@fortawesome/fontawesome-svg-core": "6.7.1",
+                "@fortawesome/fontawesome-svg-core": "^6.7.2",
                 "@fortawesome/free-regular-svg-icons": "6.7.1",
                 "@fortawesome/free-solid-svg-icons": "^6.7.1",
                 "@fortawesome/react-fontawesome": "0.2.2",
@@ -2671,13 +2671,22 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.1.tgz",
-            "integrity": "sha512-8dBIHbfsKlCk2jHQ9PoRBg2Z+4TwyE3vZICSnoDlnsHA6SiMlTwfmW6yX0lHsRmWJugkeb92sA0hZdkXJhuz+g==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+            "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "license": "MIT",
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.7.1"
+                "@fortawesome/fontawesome-common-types": "6.7.2"
             },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -11203,11 +11212,18 @@
             "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ=="
         },
         "@fortawesome/fontawesome-svg-core": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.1.tgz",
-            "integrity": "sha512-8dBIHbfsKlCk2jHQ9PoRBg2Z+4TwyE3vZICSnoDlnsHA6SiMlTwfmW6yX0lHsRmWJugkeb92sA0hZdkXJhuz+g==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+            "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "6.7.1"
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": {
+                    "version": "6.7.2",
+                    "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+                    "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg=="
+                }
             }
         },
         "@fortawesome/free-regular-svg-icons": {

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.7.1",
                 "@fortawesome/react-fontawesome": "0.2.2",
                 "@popperjs/core": "^2.11.8",
-                "ace-builds": "1.36.5",
+                "ace-builds": "^1.37.1",
                 "axios": ">=1.7.9",
                 "axios-retry": "3.9.1",
                 "bootstrap": "5.3.3",
@@ -3723,9 +3723,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "node_modules/ace-builds": {
-            "version": "1.36.5",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.5.tgz",
-            "integrity": "sha512-mZ5KVanRT6nLRDLqtG/1YQQLX/gZVC/v526cm1Ru/MTSlrbweSmqv2ZT0d2GaHpJq035MwCMIrj+LgDAUnDXrg==",
+            "version": "1.37.1",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.1.tgz",
+            "integrity": "sha512-6/jxFucA1z1C3hgLlVkTE5/znZ+iYvD301vfwtybiMc3k76IDykliCD0xh/eYZMJUfsJtaOQHZ2AJO5ey0PHWw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/acorn": {
@@ -12018,9 +12018,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ace-builds": {
-            "version": "1.36.5",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.5.tgz",
-            "integrity": "sha512-mZ5KVanRT6nLRDLqtG/1YQQLX/gZVC/v526cm1Ru/MTSlrbweSmqv2ZT0d2GaHpJq035MwCMIrj+LgDAUnDXrg=="
+            "version": "1.37.1",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.1.tgz",
+            "integrity": "sha512-6/jxFucA1z1C3hgLlVkTE5/znZ+iYvD301vfwtybiMc3k76IDykliCD0xh/eYZMJUfsJtaOQHZ2AJO5ey0PHWw=="
         },
         "acorn": {
             "version": "8.14.0",

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -16,13 +16,13 @@
                 "@fortawesome/react-fontawesome": "0.2.2",
                 "@popperjs/core": "^2.11.8",
                 "ace-builds": "1.36.5",
-                "axios": "^1.7.9",
+                "axios": ">=1.7.9",
                 "axios-retry": "3.9.1",
                 "bootstrap": "5.3.3",
                 "classnames": "^2.5.1",
                 "csv-parse": "4.16.3",
                 "csv-stringify": "5.6.5",
-                "dompurify": "^3.2.2",
+                "dompurify": "3.2.2",
                 "env-cmd": "^10.1.0",
                 "hosted-git-info": "^2.8.9",
                 "html-react-parser": "^0.14.3",
@@ -53,7 +53,7 @@
                 "recharts": "^2.14.1",
                 "sprintf-js": "1.1.3",
                 "url-parse": "^1.5.10",
-                "webpack": "^5.97.1"
+                "webpack": "5.97.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.25.2",
@@ -69,7 +69,7 @@
                 "eslint-plugin-import": "^2.27.5",
                 "eslint-plugin-jsx-a11y": "^6.7.1",
                 "eslint-plugin-react": "^7.32.2",
-                "vite": "^4.5.5",
+                "vite": "^4.5.9",
                 "vite-plugin-compression": "^0.5.1",
                 "vite-plugin-eslint": "1.8.1"
             }
@@ -9162,10 +9162,11 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-            "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+            "version": "4.5.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+            "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.18.10",
                 "postcss": "^8.4.27",
@@ -15997,9 +15998,9 @@
             }
         },
         "vite": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-            "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+            "version": "4.5.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+            "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.18.10",

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -22,7 +22,7 @@
                 "classnames": "^2.5.1",
                 "csv-parse": "4.16.3",
                 "csv-stringify": "5.6.5",
-                "dompurify": "3.2.2",
+                "dompurify": "^3.2.3",
                 "env-cmd": "^10.1.0",
                 "hosted-git-info": "^2.8.9",
                 "html-react-parser": "^0.14.3",
@@ -4748,9 +4748,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.2.tgz",
-            "integrity": "sha512-YMM+erhdZ2nkZ4fTNRTSI94mb7VG7uVF5vj5Zde7tImgnhZE3R6YW/IACGIHb2ux+QkEXMhe591N+5jWOmL4Zw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+            "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -12779,9 +12779,9 @@
             }
         },
         "dompurify": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.2.tgz",
-            "integrity": "sha512-YMM+erhdZ2nkZ4fTNRTSI94mb7VG7uVF5vj5Zde7tImgnhZE3R6YW/IACGIHb2ux+QkEXMhe591N+5jWOmL4Zw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+            "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
             "requires": {
                 "@types/trusted-types": "^2.0.7"
             }

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -39,7 +39,7 @@
                 "react": "^16.14.0",
                 "react-ace": "^9.5.0",
                 "react-autosuggest": "^10.1.0",
-                "react-bootstrap": "2.10.6",
+                "react-bootstrap": "^2.10.7",
                 "react-calendar-timeline": "^0.28.0",
                 "react-contexify": "5.0.0",
                 "react-dom": "^16.14.0",
@@ -3225,9 +3225,10 @@
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.5",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+            "version": "15.7.14",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+            "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "17.0.53",
@@ -7857,14 +7858,15 @@
             }
         },
         "node_modules/react-bootstrap": {
-            "version": "2.10.6",
-            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.6.tgz",
-            "integrity": "sha512-fNvKytSp0nHts1WRnRBJeBEt+I9/ZdrnhIjWOucEduRNvFRU1IXjZueDdWnBiqsTSJ7MckQJi9i/hxGolaRq+g==",
+            "version": "2.10.7",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
+            "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.24.7",
                 "@restart/hooks": "^0.4.9",
-                "@restart/ui": "^1.9.0",
+                "@restart/ui": "^1.9.2",
+                "@types/prop-types": "^15.7.12",
                 "@types/react-transition-group": "^4.4.6",
                 "classnames": "^2.3.2",
                 "dom-helpers": "^5.2.1",
@@ -11660,9 +11662,9 @@
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/prop-types": {
-            "version": "15.7.5",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+            "version": "15.7.14",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+            "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
         },
         "@types/react": {
             "version": "17.0.53",
@@ -15048,13 +15050,14 @@
             }
         },
         "react-bootstrap": {
-            "version": "2.10.6",
-            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.6.tgz",
-            "integrity": "sha512-fNvKytSp0nHts1WRnRBJeBEt+I9/ZdrnhIjWOucEduRNvFRU1IXjZueDdWnBiqsTSJ7MckQJi9i/hxGolaRq+g==",
+            "version": "2.10.7",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
+            "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
             "requires": {
                 "@babel/runtime": "^7.24.7",
                 "@restart/hooks": "^0.4.9",
-                "@restart/ui": "^1.9.0",
+                "@restart/ui": "^1.9.2",
+                "@types/prop-types": "^15.7.12",
                 "@types/react-transition-group": "^4.4.6",
                 "classnames": "^2.3.2",
                 "dom-helpers": "^5.2.1",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -45,7 +45,7 @@
         "react-simple-snackbar": "^1.1.11",
         "react-split-pane": "^0.1.92",
         "react-step-wizard": "^5.3.11",
-        "recharts": "^2.14.1",
+        "recharts": "^2.15.0",
         "sprintf-js": "1.1.3",
         "url-parse": "^1.5.10",
         "webpack": "5.97.1"

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -10,7 +10,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@popperjs/core": "^2.11.8",
-        "ace-builds": "1.36.5",
+        "ace-builds": "1.37.1",
         "axios": ">=1.7.9",
         "axios-retry": "3.9.1",
         "bootstrap": "5.3.3",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -34,7 +34,7 @@
         "react": "^16.14.0",
         "react-ace": "^9.5.0",
         "react-autosuggest": "^10.1.0",
-        "react-bootstrap": "2.10.6",
+        "react-bootstrap": "2.10.7",
         "react-calendar-timeline": "^0.28.0",
         "react-contexify": "5.0.0",
         "react-dom": "^16.14.0",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -17,7 +17,7 @@
         "classnames": "^2.5.1",
         "csv-parse": "4.16.3",
         "csv-stringify": "5.6.5",
-        "dompurify": "3.2.2",
+        "dompurify": "3.2.3",
         "env-cmd": "^10.1.0",
         "hosted-git-info": "^2.8.9",
         "html-react-parser": "^0.14.3",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@fortawesome/fontawesome-svg-core": "6.7.1",
+        "@fortawesome/fontawesome-svg-core": "6.7.2",
         "@fortawesome/free-regular-svg-icons": "6.7.1",
         "@fortawesome/free-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "0.2.2",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -95,7 +95,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
-        "vite": "^4.5.5",
+        "vite": "^4.5.9",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-eslint": "1.8.1"
     }

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.css
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.css
@@ -25,3 +25,7 @@
 .report-viewer .panel {
     overflow-x: auto;
 }
+
+.cell-placeholder {
+    height: 100px;
+}

--- a/services/notebook/calculate_test.go
+++ b/services/notebook/calculate_test.go
@@ -102,7 +102,7 @@ func (self *NotebookManagerTestSuite) TearDownTest() {
 }
 
 func (self *NotebookManagerTestSuite) TestNotebookManagerUpdateCell() {
-	assert.Retry(self.T(), 3, time.Second, self._TestNotebookManagerUpdateCell)
+	assert.Retry(self.T(), 5, time.Second, self._TestNotebookManagerUpdateCell)
 }
 
 func (self *NotebookManagerTestSuite) _TestNotebookManagerUpdateCell(r *assert.R) {

--- a/vql/tools/query.go
+++ b/vql/tools/query.go
@@ -61,7 +61,7 @@ func (self QueryPlugin) Call(
 
 		config_obj, ok := vql_subsystem.GetServerConfig(scope)
 		if !ok {
-			config_obj, err = org_manager.GetOrgConfig("")
+			config_obj, err = org_manager.GetOrgConfig(services.ROOT_ORG_ID)
 			if err != nil {
 				scope.Log("query: %v", err)
 				return


### PR DESCRIPTION
This helps for very large notebooks with many cells. Previous behavior was to load all the cells immediately but this can increase load on the server and cause the connections to timeout.

This change allows cells to be loaded only when they are scrolled into the view port.