### PR TITLE
Update Windows.Forensics.CertUtil artifact

### DIFF
--- a/artifacts/definitions/Windows/Forensics/CertUtil.yaml
+++ b/artifacts/definitions/Windows/Forensics/CertUtil.yaml
@@ -99,7 +99,7 @@ sources:
                if(condition=AlsoUpload, then=upload(file=OSPath, accessor=Accessor)) AS _MetdataUpload,
                if(condition=AlsoUpload, then=upload(file=_ContentPath, accessor=Accessor)) AS _Upload,
                Header.URL AS URL,
-               url(parse=URL).Host AS UrlTLD,
+               url(parse=Header.URL).Host AS UrlTLD,
                Header.FileSize AS FileSize,
                regex_replace(re='"', replace="", source=Header.Hash) AS Hash,
                timestamp(winfiletime=Header.DownloadTime) AS DownloadTime,


### PR DESCRIPTION
Artifact had `Symbol URL not found.` error when run. This is the fix.