### PR TITLE
Correct Base64 regular expression

### DIFF
--- a/gui/velociraptor/src/components/utils/json.jsx
+++ b/gui/velociraptor/src/components/utils/json.jsx
@@ -11,7 +11,7 @@ const scale = 5;
 const collapse_string_length = 50;
 const collapse_array_length = 5;
 
-const base64regex = new RegExp("(^[-A-Za-z0-9+/=]$)|(={1,3}$)");
+const base64regex = new RegExp("(^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$)");
 
 
 class RenderString extends Component {


### PR DESCRIPTION
The current Base64 regular expression is incorrect:

- It fails to recognize Base64 strings longer than 1 character without padding (e.g., `TlZJU08h`)
- It recognizes invalid Base64 (e.g., `TlZJU0=`)

This PR corrects the Base64 regular expression, subsequently ensuring the UI correctly handles Base64 strings.