### PR TITLE
Bugfix: Add a stat before opening devices to try to guess their size

### DIFF
--- a/accessors/file/os_windows.go
+++ b/accessors/file/os_windows.go
@@ -305,8 +305,8 @@ func (self OSFileSystemAccessor) OpenWithOSPath(full_path *accessors.OSPath) (
 
 		// Try to figure out the size - not necessary but in case we
 		// can we can limit readers to this size.
-		stat, err := os.Lstat(device_name)
-		if err == nil {
+		stat, err1 := os.Lstat(device_name)
+		if err1 == nil {
 			res.SetSize(stat.Size())
 		}
 

--- a/accessors/file/os_windows.go
+++ b/accessors/file/os_windows.go
@@ -300,7 +300,17 @@ func (self OSFileSystemAccessor) OpenWithOSPath(full_path *accessors.OSPath) (
 		if err != nil {
 			return nil, err
 		}
-		return utils.NewReadSeekReaderAdapter(reader), err
+
+		res := utils.NewReadSeekReaderAdapter(reader)
+
+		// Try to figure out the size - not necessary but in case we
+		// can we can limit readers to this size.
+		stat, err := os.Lstat(device_name)
+		if err == nil {
+			res.SetSize(stat.Size())
+		}
+
+		return res, err
 	}
 
 	filename := full_path.String()

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	howett.net/plist v1.0.0
 	www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377
 	www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2
-	www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c
+	www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215044736-81b32bb0b4d2
 	www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b
 	www.velocidex.com/golang/go-prefetch v0.0.0-20240910051453-2385582c1c22
 	www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	howett.net/plist v1.0.0
 	www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377
 	www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2
-	www.velocidex.com/golang/go-ntfs v0.2.1-0.20241123135758-e6f7e1f1c474
+	www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c
 	www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b
 	www.velocidex.com/golang/go-prefetch v0.0.0-20240910051453-2385582c1c22
 	www.velocidex.com/golang/oleparse v0.0.0-20230217092320-383a0121aafe

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,8 @@ www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377 h1:dJn+CMhWi5
 www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377/go.mod h1:JDMB7j3uBFgww0+PzsQUGvnOywFEHkbynzAPyNvhiAg=
 www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2 h1:f7nj4NsyeMSrwiFd9XO/VfsZYt6o6FH1KJmmqlBZDgM=
 www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2/go.mod h1:YKxCStqE15c6F/P81oCG0Y5oelDBah2hCdO6P+VPUIQ=
-www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c h1:t0coUgN42dBFBkPDytkunIQPIEHM8pyL/I2tnCyoaTs=
-www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
+www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215044736-81b32bb0b4d2 h1:lMxVWF28O+6dcPD6BbBlopfGE9eVy+cyFV96Sop8+xY=
+www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215044736-81b32bb0b4d2/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
 www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b h1:hOxQYDyETh4wdnCbM9Il4X+6LwonGdLnsoznqvzw48A=
 www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b/go.mod h1:agYwYzeeytVtdwkRrvxZAjgIA8SCeM/Tg7Ym2/jBwmA=
 www.velocidex.com/golang/go-prefetch v0.0.0-20240910051453-2385582c1c22 h1:Re+YlRCwkHESCIopk0WNLKXMnlnhALvoT4RiunT2qJE=

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,8 @@ www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377 h1:dJn+CMhWi5
 www.velocidex.com/golang/evtx v0.2.1-0.20250117005955-e5cd153ed377/go.mod h1:JDMB7j3uBFgww0+PzsQUGvnOywFEHkbynzAPyNvhiAg=
 www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2 h1:f7nj4NsyeMSrwiFd9XO/VfsZYt6o6FH1KJmmqlBZDgM=
 www.velocidex.com/golang/go-ese v0.2.1-0.20240919031214-2aa005106db2/go.mod h1:YKxCStqE15c6F/P81oCG0Y5oelDBah2hCdO6P+VPUIQ=
-www.velocidex.com/golang/go-ntfs v0.2.1-0.20241123135758-e6f7e1f1c474 h1:iaV0M55ZTdVU9nIqcHkQKwUfQOOoswC0eBZsKvlPN/0=
-www.velocidex.com/golang/go-ntfs v0.2.1-0.20241123135758-e6f7e1f1c474/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
+www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c h1:t0coUgN42dBFBkPDytkunIQPIEHM8pyL/I2tnCyoaTs=
+www.velocidex.com/golang/go-ntfs v0.2.1-0.20250215000145-a92b5c3f8b5c/go.mod h1:itvbHQcnLdTVIDY6fI3lR0zeBwXwBYBdUFtswE0x1vc=
 www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b h1:hOxQYDyETh4wdnCbM9Il4X+6LwonGdLnsoznqvzw48A=
 www.velocidex.com/golang/go-pe v0.1.1-0.20250101153735-7a925ba8334b/go.mod h1:agYwYzeeytVtdwkRrvxZAjgIA8SCeM/Tg7Ym2/jBwmA=
 www.velocidex.com/golang/go-prefetch v0.0.0-20240910051453-2385582c1c22 h1:Re+YlRCwkHESCIopk0WNLKXMnlnhALvoT4RiunT2qJE=

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -1334,7 +1334,7 @@ func getReqName(in *actions_proto.VQLCollectorArgs) string {
 }
 
 func (self *LauncherTestSuite) TestDelete() {
-	assert.Retry(self.T(), 3, time.Second, self._TestDelete)
+	assert.Retry(self.T(), 10, time.Second, self._TestDelete)
 }
 
 func (self *LauncherTestSuite) _TestDelete(t *assert.R) {

--- a/utils/read_seek_reader_adapter.go
+++ b/utils/read_seek_reader_adapter.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -45,13 +44,10 @@ func (self *ReadSeekReaderAdapter) Read(buf []byte) (int, error) {
 	}
 
 	n, err := self.reader.ReadAt(buf, self.offset)
-	fmt.Printf("Read from %#v %T %v: %v, %v\n", self.reader, self.reader,
-		self.offset, n, err)
-
-	self.offset += int64(n)
 	if errors.Is(err, io.EOF) {
 		self.eof = true
 	}
+	self.offset += int64(n)
 
 	return n, err
 }

--- a/vql/readers/paged_reader_test.go
+++ b/vql/readers/paged_reader_test.go
@@ -2,9 +2,7 @@ package readers
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"testing"
 	"time"
@@ -83,7 +81,7 @@ func (self *TestSuite) TestPagedReader() {
 			self.scope, "file", self.filenames[i], 100)
 		assert.NoError(self.T(), err)
 		_, err = reader.ReadAt(buff, 0)
-		assert.True(self.T(), errors.Is(err, io.EOF))
+		assert.NoError(self.T(), err)
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(i))
 		readers = append(readers, reader)
 	}
@@ -92,7 +90,7 @@ func (self *TestSuite) TestPagedReader() {
 		reader, err := NewAccessorReader(self.scope, "file", self.filenames[i], 100)
 		assert.NoError(self.T(), err)
 		_, err = reader.ReadAt(buff, 0)
-		assert.True(self.T(), errors.Is(err, io.EOF))
+		assert.NoError(self.T(), err)
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(i))
 	}
 
@@ -102,7 +100,7 @@ func (self *TestSuite) TestPagedReader() {
 		assert.NoError(self.T(), err)
 
 		_, err = reader.ReadAt(buff, 0)
-		assert.True(self.T(), errors.Is(err, io.EOF))
+		assert.NoError(self.T(), err)
 
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 	}
@@ -115,7 +113,7 @@ func (self *TestSuite) TestPagedReader() {
 	for i := 0; i < 10; i++ {
 		reader.Close()
 		_, err = reader.ReadAt(buff, 0)
-		assert.True(self.T(), errors.Is(err, io.EOF))
+		assert.NoError(self.T(), err)
 
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 	}
@@ -124,7 +122,7 @@ func (self *TestSuite) TestPagedReader() {
 	reader.SetLifetime(10 * time.Millisecond)
 	reader.Close()
 	_, err = reader.ReadAt(buff, 0)
-	assert.True(self.T(), errors.Is(err, io.EOF))
+	assert.NoError(self.T(), err)
 	assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 
 	// Wait here until the reader closes itself by itself.
@@ -137,7 +135,7 @@ func (self *TestSuite) TestPagedReader() {
 
 	// Next read still works.
 	_, err = reader.ReadAt(buff, 0)
-	assert.True(self.T(), errors.Is(err, io.EOF))
+	assert.NoError(self.T(), err)
 	assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 
 	// Close the scope - this should close all the pool

--- a/vql/readers/paged_reader_test.go
+++ b/vql/readers/paged_reader_test.go
@@ -2,7 +2,9 @@ package readers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -81,7 +83,7 @@ func (self *TestSuite) TestPagedReader() {
 			self.scope, "file", self.filenames[i], 100)
 		assert.NoError(self.T(), err)
 		_, err = reader.ReadAt(buff, 0)
-		assert.NoError(self.T(), err)
+		assert.True(self.T(), errors.Is(err, io.EOF))
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(i))
 		readers = append(readers, reader)
 	}
@@ -90,7 +92,7 @@ func (self *TestSuite) TestPagedReader() {
 		reader, err := NewAccessorReader(self.scope, "file", self.filenames[i], 100)
 		assert.NoError(self.T(), err)
 		_, err = reader.ReadAt(buff, 0)
-		assert.NoError(self.T(), err)
+		assert.True(self.T(), errors.Is(err, io.EOF))
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(i))
 	}
 
@@ -100,7 +102,7 @@ func (self *TestSuite) TestPagedReader() {
 		assert.NoError(self.T(), err)
 
 		_, err = reader.ReadAt(buff, 0)
-		assert.NoError(self.T(), err)
+		assert.True(self.T(), errors.Is(err, io.EOF))
 
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 	}
@@ -113,7 +115,7 @@ func (self *TestSuite) TestPagedReader() {
 	for i := 0; i < 10; i++ {
 		reader.Close()
 		_, err = reader.ReadAt(buff, 0)
-		assert.NoError(self.T(), err)
+		assert.True(self.T(), errors.Is(err, io.EOF))
 
 		assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 	}
@@ -122,7 +124,7 @@ func (self *TestSuite) TestPagedReader() {
 	reader.SetLifetime(10 * time.Millisecond)
 	reader.Close()
 	_, err = reader.ReadAt(buff, 0)
-	assert.NoError(self.T(), err)
+	assert.True(self.T(), errors.Is(err, io.EOF))
 	assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 
 	// Wait here until the reader closes itself by itself.
@@ -135,7 +137,7 @@ func (self *TestSuite) TestPagedReader() {
 
 	// Next read still works.
 	_, err = reader.ReadAt(buff, 0)
-	assert.NoError(self.T(), err)
+	assert.True(self.T(), errors.Is(err, io.EOF))
 	assert.Equal(self.T(), binary.LittleEndian.Uint32(buff), uint32(1))
 
 	// Close the scope - this should close all the pool


### PR DESCRIPTION
Without this, a `raw_file` accessor of a real file will never complete because there is no end to the paged reader.