### PR TITLE
Rewrite InstallDeb util, fixing issues and adding improvements

### DIFF
--- a/artifacts/definitions/Linux/Utils/InstallDeb.yaml
+++ b/artifacts/definitions/Linux/Utils/InstallDeb.yaml
@@ -2,8 +2,30 @@ name: Linux.Utils.InstallDeb
 author: Andreas Misje – @misje
 description: |
    Install a deb package and configure it with debconf answers. The package
-   may either be specified by name or be an uploaded file. If the package
-   already exists, it may be optionally reconfigured with debconf answers.
+   may either be specified by name, as an uploaded file or as a "tool". If the
+   package already exists, it may be optionally reconfigured with debconf
+   answers.
+
+   There are three ways to specify a package (listed in order of preference if
+   all are set):
+
+     - DebFile: An uploaded deb package. Limited to about 4 MB in size.
+
+     - DebTool: A deb package provided as a tool, specified by tool name. Since
+       this is a utility artifact meant to be called by other artifacts, the
+       tool should be specified in the artifact calling this artifact.
+       Alternatively, configure the tool using
+       [VQL](https://docs.velociraptor.app/vql_reference/server/inventory_add/).
+
+     - DebName: The name of the package to install, or an absolute path to a deb
+       file to install. Each word is considered as a package name or file name.
+       `apt-get` interprets the package name, and allows you to specify a
+       specific version, architecture, or even install and remove packages in
+       the same go:
+
+       - "foo": installs foo
+       - "foo bar- baz=1.0.0-1 qux:arm64": installs foo, removes bar, installs
+         a specific version of baz and a specific architecture of qux
 
 type: CLIENT
 
@@ -16,15 +38,30 @@ reference:
 parameters:
    - name: DebName
      description: |
-        Package to install (by name). Ignored if DebFile is set. An absolute path
-        to a deb file that already exists on the system is also accepted.
+        Package to install (by name). Ignored if DebFile or DebTool is set. An
+        absolute path to a deb file that already exists on the system is also
+        accepted.
 
    - name: DebFile
      description: |
         Package to install (by file). Remember to click "Upload"! When set,
-        DebName is ignored. Use DebName with an absolute file path if the
-        file already exists on the system and does not need to be uploaded.
+        DebName and DebTool is ignored. Use DebName with an absolute file path
+        if the file already exists on the system and does not need to be
+        uploaded.
      type: upload
+
+   - name: DebTool
+     description: |
+        Package to install as a tool (tool name). The tool must be configured
+        manually by using VQL or in another artifact (calling this artifact).
+        Ignored if DebFile is set.
+
+   - name: ToolSleepDuration
+     description: |
+        Maximum number of seconds to sleep before downloading the package. Only
+        relevant if DebTool is set.
+     type: int
+     default: 20
 
    - name: UpdateSources
      description: |
@@ -39,6 +76,18 @@ parameters:
      description: |
         Use the configuration delivered by the package instead of keeping the
         local changes.
+
+   - name: Reinstall
+     type: bool
+     description: |
+        Reinstall the package if it is already installed. This is only useful
+        if you know or suspect that the package installation is broken. This
+        also reconfigures the package.
+
+   - name: UpgradeOnly
+     type: bool
+     description: |
+        Do not install the package; only upgrade it if it is already installed.
 
    - name: ReconfigureIfInstalled
      type: bool
@@ -69,110 +118,131 @@ sources:
       SELECT OS From info() where OS = 'linux'
 
     query: |
-     LET Package <= if(
-         condition=DebFile,
-         then=tempfile(data=DebFile, extension='_amd64.deb'),
-         else=DebName)
-
-     /* The file name is lost from the uploaded file, so extract it from the
-        package instead: */
-     LET PackageInfo = SELECT Stdout
-       FROM execve(argv=['/usr/bin/dpkg-deb', '--field', Package, 'Package'])
-
-     LET PackageName = if(
-         condition=DebFile,
-         then=PackageInfo[0].Stdout[:-1], // remove "\n"
-         else=DebName)
-
-     /* The file format is "package_name question type answer": */
-     LET PreSeedLines = SELECT
-                               join(
-                                 sep=' ',
-                                 array=(PackageName, Key, Type, Value, )) AS Line
-       FROM DebConfValues
-
-     LET PreSeedFile <= tempfile(data=join(sep='\n', array=PreSeedLines.Line))
-
-     LET AptOpts <= ('-f', '-y', '-o', 'Debug::pkgProblemResolver=yes', '--no-install-recommends', ) + if(
-         condition=ForceConfNew,
-         then=('-o', 'Dpkg::Options::="--force-confnew"', ),
-         else=[])
-
-     LET PreSeed = SELECT
-                          'Pre-seed debconf' AS Step,
-                          *
-       FROM if(
-         condition=DebConfValues,
-         then={
-           SELECT *
-           FROM execve(argv=['/usr/bin/debconf-set-selections', PreSeedFile, ])
-           WHERE log(
-             message=format(
-               format='Pre-seeding %v',
-               args=[PackageName, ]),
-             level='INFO')
-         })
-
-     LET Install = SELECT *
+       LET Tool = SELECT OSPath
+         FROM Artifact.Generic.Utils.FetchBinary(ToolName=DebTool,
+                                                 TemporaryOnly=true,
+                                                 SleepDuration=ToolSleepDuration)
+       LET Package <= if(
+           condition=DebTool,
+           then=Tool[0].OSPath,
+           else=if(
+             condition=DebFile,
+             then=tempfile(data=DebFile, extension='_amd64.deb'),
+             else=DebName))
+       /* The file name is lost from the uploaded file, so extract it from the
+          package instead (apt has certain requirements for the file name): */
+       LET PackageInfo = SELECT 
+                                Stdout
+         FROM execve(argv=['/usr/bin/dpkg-deb', '--field', Package, 'Package'])
+       LET PackageName = if(
+           condition=DebTool OR DebFile,
+           // remove "\n":
+           then=PackageInfo[0].Stdout[:-1],
+           else=DebName)
+       /* The file format is "package_name question type answer": */
+       LET PreSeedLines = SELECT 
+                                 join(
+                                   sep=' ',
+                                   array=(PackageName, Key, Type, Value, )) AS Line
+         FROM DebConfValues
+       LET PreSeedFile <= tempfile(
+           data=join(
+             sep='\n',
+             array=PreSeedLines.Line))
+       LET AptEnv = dict(
+           DEBIAN_FRONTEND='noninteractive',
+           DEBCONF_NOWARNINGS='yes')
+       LET AptOpts <= ('-f', '-y', '-o', 'Debug::pkgProblemResolver=yes', '--no-install-recommends', ) + if(
+           condition=ForceConfNew,
+           then=('-o', 'Dpkg::Options::=--force-confnew', ),
+           else=[]) + if(
+           condition=Reinstall,
+           then=('--reinstall', ),
+           else=[]) + if(
+           condition=UpgradeOnly,
+           then=('--only-upgrade', ),
+           else=[])
+       LET PreSeed = SELECT 
+                            'Pre-seed debconf' AS Step,
+                            *
+         FROM if(
+           condition=DebConfValues,
+           then={
+             SELECT *
+             FROM execve(argv=['/usr/bin/debconf-set-selections', PreSeedFile, ])
+             WHERE log(
+               message=format(
+                 format='Pre-seeding %v',
+                 args=(PackageName, )),
+               level='INFO')
+              AND (NOT ReturnCode OR log(
+                      level='ERROR',
+                      message='%v failed: %v',
+                      args=(Step, Stderr)))
+           })
+       /* Install regardless of whether package is installed or not, handing all
+          the (arch-specific) version comparison logic to apt: */
+       LET Install <= SELECT *
+         FROM chain(
+           a_update={
+             SELECT 
+                    'Updating index' AS Step,
+                    *
+             FROM if(
+               condition=UpdateSources,
+               then={
+                 SELECT *
+                 FROM execve(argv=['/usr/bin/apt-get', '-y', 'update'])
+                 WHERE log(
+                   message='Updating package index before installing',
+                   level='INFO')
+               })
+           },
+           b_debconf=PreSeed,
+           c_install={
+             SELECT 
+                    'Installing package' AS Step,
+                    *
+             FROM execve(
+               argv=('/usr/bin/apt-get', ) + AptOpts + if(
+                 condition=Package = DebName,
+                 then=('install', ) + split(
+                   sep='''\s+''',
+                   string=Package),
+                 else=('install', Package, )),
+               env=AptEnv)
+             WHERE log(
+               message=format(
+                 format='Installing deb package %v',
+                 args=(PackageName, )),
+               level='INFO')
+           })
+         WHERE NOT ReturnCode OR log(
+           level='ERROR',
+           message='%v failed: %v',
+           args=(Step, Stderr))
+       SELECT *
        FROM chain(
-         a_update={
-           SELECT
-                  'Update index' AS Step,
-                  *
-           FROM if(
-             condition=UpdateSources,
-             then={
-               SELECT *
-               FROM execve(argv=['/usr/bin/apt-get', '-y', 'update'])
-               WHERE log(
-                 message='Updating package index before installing',
-                 level='INFO')
-             })
-         },
-         b_debconf=PreSeed,
-         c_install={
-           SELECT
-                  'Installing package' AS Step,
-                  *
-           FROM execve(argv=('/usr/bin/apt-get', 'install', ) + AptOpts + (Package, ))
-           WHERE log(
-             message=format(
-               format='Installing deb package %v',
-               args=[PackageName, ]),
-             level='INFO')
-         })
-
-     LET IsInstalled = SELECT *
-       FROM stat(
-         filename=path_join(
-           components=('/var/lib/dpkg/info', PackageName + '.list')))
-       WHERE log(
-         message=format(
-           format='Package %v is already installed',
-           args=[PackageName, ]),
-         level='INFO')
-
-     SELECT *
-     FROM if(
-       condition=IsInstalled,
-       then=if(
-         condition=ReconfigureIfInstalled,
-         then={
+         a_install=Install,
+         b_reconfigure={
            SELECT *
-           FROM chain(
-             a_debconf=PreSeed,
-             b_reconfigure={
-               SELECT
+           FROM if(
+             condition=ReconfigureIfInstalled
+              AND (Reinstall OR Install.Stdout =~ 'Skipping|already the newest version'),
+             then={
+               SELECT 
                       'Reconfiguring package' AS Step,
                       *
                FROM execve(argv=['/usr/sbin/dpkg-reconfigure', PackageName, ],
-                           env=dict(
-                             DEBIAN_FRONTEND='noninteractive'))
+                           env=AptEnv)
                WHERE log(
                  message=format(
                    format='Reconfiguring deb package %v',
-                   args=[PackageName, ]),
+                   args=(PackageName, )),
                  level='INFO')
+                AND (NOT ReturnCode OR log(
+                        level='ERROR',
+                        message='%v failed: %v',
+                        args=(Step, Stderr)))
              })
-         }),
-       else=Install)
+         })

--- a/artifacts/definitions/Linux/Utils/InstallDeb.yaml
+++ b/artifacts/definitions/Linux/Utils/InstallDeb.yaml
@@ -130,125 +130,98 @@ sources:
              /* apt requires file names to end in an architecture name, so
                 create a copy ending in "_amd64.deb". The architecture chosen
                 here, amd64, does not need to match the architecture of neither
-                the package or the system: */
-             then=copy(
-               dest=tempdir() + '/package_amd64.deb',
-               filename=DebFile),
-             else=DebName))
+                the package or the system:
+             */
+             then=copy(dest=tempdir() + '/package_amd64.deb',
+                       filename=DebFile),
+                       else=DebName))
+
        /* The file name is lost from the uploaded file, so extract it from the
-          package instead (apt has certain requirements for the file name): */
-       LET PackageInfo = SELECT 
-                                Stdout
+          package instead (apt has certain requirements for the file name):
+       */
+       LET PackageInfo = SELECT Stdout
          FROM execve(argv=['/usr/bin/dpkg-deb', '--field', Package, 'Package'])
-       LET PackageName = if(
-           condition=DebTool OR DebFile,
-           // remove "\n":
-           then=PackageInfo[0].Stdout[:-1],
-           else=DebName)
+
+       LET PackageName = if(condition=DebTool OR DebFile,
+                            // remove "\n":
+                            then=PackageInfo[0].Stdout[:-1], else=DebName)
+
        /* The file format is "package_name question type answer": */
-       LET PreSeedLines = SELECT 
-                                 join(
-                                   sep=' ',
-                                   array=(PackageName, Key, Type, Value, )) AS Line
+       LET PreSeedLines = SELECT join(sep=' ',
+           array=(PackageName, Key, Type, Value)) AS Line
          FROM DebConfValues
-       LET PreSeedFile <= tempfile(
-           data=join(
-             sep='\n',
-             array=PreSeedLines.Line))
+
+       LET PreSeedFile <= tempfile(data=join(sep='\n', array=PreSeedLines.Line))
+
        LET AptEnv = dict(
            DEBIAN_FRONTEND='noninteractive',
            DEBCONF_NOWARNINGS='yes')
-       LET AptOpts <= ('-f', '-y', '-o', 'Debug::pkgProblemResolver=yes', '--no-install-recommends', ) + if(
-           condition=ForceConfNew,
-           then=('-o', 'Dpkg::Options::=--force-confnew', ),
-           else=[]) + if(
-           condition=Reinstall,
-           then=('--reinstall', ),
-           else=[]) + if(
-           condition=UpgradeOnly,
-           then=('--only-upgrade', ),
-           else=[])
-       LET PreSeed = SELECT 
-                            'Pre-seed debconf' AS Step,
-                            *
-         FROM if(
-           condition=DebConfValues,
-           then={
+
+       LET AptOpts <= ('-f', '-y', '-o', 'Debug::pkgProblemResolver=yes',
+                       '--no-install-recommends') +
+           if(condition=ForceConfNew,
+              then=('-o', 'Dpkg::Options::=--force-confnew'), else=[]) +
+           if(condition=Reinstall, then=('--reinstall', ), else=[]) +
+           if(condition=UpgradeOnly, then=('--only-upgrade', ), else=[])
+
+       LET PreSeed = SELECT 'Pre-seed debconf' AS Step, *
+         FROM if(condition=DebConfValues, then={
              SELECT *
              FROM execve(argv=['/usr/bin/debconf-set-selections', PreSeedFile, ])
-             WHERE log(
-               message=format(
-                 format='Pre-seeding %v',
-                 args=(PackageName, )),
-               level='INFO')
-              AND (NOT ReturnCode OR log(
-                      level='ERROR',
-                      message='%v failed: %v',
-                      args=(Step, Stderr)))
+             WHERE log(message='Pre-seeding %v', dedup= -1,
+                       args=PackageName,
+                       level='INFO')
+              AND (NOT ReturnCode OR log(level='ERROR',
+                      message='%v failed: %v', args=(Step, Stderr)))
            })
+
        /* Install regardless of whether package is installed or not, handing all
-          the (arch-specific) version comparison logic to apt: */
-       LET Install <= SELECT *
-         FROM chain(
+          the (arch-specific) version comparison logic to apt:
+        */
+       LET Install <= SELECT * FROM chain(
            a_update={
-             SELECT 
-                    'Updating index' AS Step,
-                    *
-             FROM if(
-               condition=UpdateSources,
-               then={
+             SELECT 'Updating index' AS Step, *
+             FROM if(condition=UpdateSources, then={
                  SELECT *
                  FROM execve(argv=['/usr/bin/apt-get', '-y', 'update'])
-                 WHERE log(
-                   message='Updating package index before installing',
-                   level='INFO')
+                 WHERE log(message='Updating package index before installing',
+                           level='INFO')
                })
            },
            b_debconf=PreSeed,
            c_install={
-             SELECT 
-                    'Installing package' AS Step,
-                    *
+             SELECT 'Installing package' AS Step, *
              FROM execve(
-               argv=('/usr/bin/apt-get', ) + AptOpts + if(
-                 condition=Package = DebName,
-                 then=('install', ) + split(
-                   sep='''\s+''',
-                   string=Package),
-                 else=('install', Package, )),
+               argv=('/usr/bin/apt-get', ) + AptOpts +
+               if(condition=Package = DebName,
+                  then=('install', ) + split(sep='''\s+''', string=Package),
+                  else=('install', Package)),
                env=AptEnv)
-             WHERE log(
-               message=format(
-                 format='Installing deb package %v',
-                 args=(PackageName, )),
-               level='INFO')
+             WHERE log(message='Installing deb package %v',
+                       args=PackageName,
+                       dedup= -1,
+                       level='INFO')
            })
-         WHERE NOT ReturnCode OR log(
-           level='ERROR',
-           message='%v failed: %v',
-           args=(Step, Stderr))
-       SELECT *
-       FROM chain(
+         WHERE NOT ReturnCode OR log(level='ERROR',
+                                     message='%v failed: %v',
+                                     args=(Step, Stderr))
+
+       SELECT * FROM chain(
          a_install=Install,
          b_reconfigure={
-           SELECT *
-           FROM if(
-             condition=ReconfigureIfInstalled
-              AND (Reinstall OR Install.Stdout =~ 'Skipping|already the newest version'),
+           SELECT * FROM if(
+             condition=ReconfigureIfInstalled AND (
+                Reinstall OR Install.Stdout =~ 'Skipping|already the newest version'),
              then={
-               SELECT 
-                      'Reconfiguring package' AS Step,
-                      *
+               SELECT 'Reconfiguring package' AS Step, *
                FROM execve(argv=['/usr/sbin/dpkg-reconfigure', PackageName, ],
                            env=AptEnv)
-               WHERE log(
-                 message=format(
-                   format='Reconfiguring deb package %v',
-                   args=(PackageName, )),
-                 level='INFO')
-                AND (NOT ReturnCode OR log(
-                        level='ERROR',
-                        message='%v failed: %v',
-                        args=(Step, Stderr)))
+               WHERE log(message='Reconfiguring deb package %v',
+                         args=PackageName,
+                         dedup= -1,
+                         level='INFO')
+                AND (NOT ReturnCode OR log(level='ERROR',
+                                       message='%v failed: %v',
+                                       args=(Step, Stderr)))
              })
          })

--- a/artifacts/definitions/Linux/Utils/InstallDeb.yaml
+++ b/artifacts/definitions/Linux/Utils/InstallDeb.yaml
@@ -9,7 +9,7 @@ description: |
    There are three ways to specify a package (listed in order of preference if
    all are set):
 
-     - DebFile: An uploaded deb package. Limited to about 4 MB in size.
+     - DebFile: An uploaded deb package.
 
      - DebTool: A deb package provided as a tool, specified by tool name. Since
        this is a utility artifact meant to be called by other artifacts, the
@@ -48,7 +48,7 @@ parameters:
         DebName and DebTool is ignored. Use DebName with an absolute file path
         if the file already exists on the system and does not need to be
         uploaded.
-     type: upload
+     type: upload_file
 
    - name: DebTool
      description: |
@@ -127,7 +127,13 @@ sources:
            then=Tool[0].OSPath,
            else=if(
              condition=DebFile,
-             then=tempfile(data=DebFile, extension='_amd64.deb'),
+             /* apt requires file names to end in an architecture name, so
+                create a copy ending in "_amd64.deb". The architecture chosen
+                here, amd64, does not need to match the architecture of neither
+                the package or the system: */
+             then=copy(
+               dest=tempdir() + '/package_amd64.deb',
+               filename=DebFile),
              else=DebName))
        /* The file name is lost from the uploaded file, so extract it from the
           package instead (apt has certain requirements for the file name): */

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -40,7 +40,7 @@
                 "react": "^16.14.0",
                 "react-ace": "^9.5.0",
                 "react-autosuggest": "^10.1.0",
-                "react-bootstrap": "2.10.7",
+                "react-bootstrap": "^2.10.9",
                 "react-calendar-timeline": "^0.28.0",
                 "react-contexify": "5.0.0",
                 "react-dom": "^16.14.0",
@@ -2923,9 +2923,9 @@
             }
         },
         "node_modules/@restart/ui": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.2.tgz",
-            "integrity": "sha512-MWWqJqSyqUWWPBOOiRQrX57CBc/9CoYONg7sE+uag72GCAuYrHGU5c49vU5s4BUSBgiKNY6rL7TULqGDrouUaA==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+            "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
@@ -2944,9 +2944,9 @@
             }
         },
         "node_modules/@restart/ui/node_modules/@restart/hooks": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.0.tgz",
-            "integrity": "sha512-wS+h6IusJCPjTkmOOrRZxIPICD/mtFA3PRZviutoM23/b7akyDGfZF/WS+nIFk27u7JDhPE2+0GBdZxjSqHZkg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+            "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
             "license": "MIT",
             "dependencies": {
                 "dequal": "^2.0.3"
@@ -7918,14 +7918,14 @@
             }
         },
         "node_modules/react-bootstrap": {
-            "version": "2.10.7",
-            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
-            "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
+            "version": "2.10.9",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
+            "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.24.7",
                 "@restart/hooks": "^0.4.9",
-                "@restart/ui": "^1.9.2",
+                "@restart/ui": "^1.9.4",
                 "@types/prop-types": "^15.7.12",
                 "@types/react-transition-group": "^4.4.6",
                 "classnames": "^2.3.2",
@@ -11468,9 +11468,9 @@
             }
         },
         "@restart/ui": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.2.tgz",
-            "integrity": "sha512-MWWqJqSyqUWWPBOOiRQrX57CBc/9CoYONg7sE+uag72GCAuYrHGU5c49vU5s4BUSBgiKNY6rL7TULqGDrouUaA==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+            "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
             "requires": {
                 "@babel/runtime": "^7.26.0",
                 "@popperjs/core": "^2.11.8",
@@ -11484,9 +11484,9 @@
             },
             "dependencies": {
                 "@restart/hooks": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.0.tgz",
-                    "integrity": "sha512-wS+h6IusJCPjTkmOOrRZxIPICD/mtFA3PRZviutoM23/b7akyDGfZF/WS+nIFk27u7JDhPE2+0GBdZxjSqHZkg==",
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+                    "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
                     "requires": {
                         "dequal": "^2.0.3"
                     }
@@ -15162,13 +15162,13 @@
             }
         },
         "react-bootstrap": {
-            "version": "2.10.7",
-            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
-            "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
+            "version": "2.10.9",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
+            "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
             "requires": {
                 "@babel/runtime": "^7.24.7",
                 "@restart/hooks": "^0.4.9",
-                "@restart/ui": "^1.9.2",
+                "@restart/ui": "^1.9.4",
                 "@types/prop-types": "^15.7.12",
                 "@types/react-transition-group": "^4.4.6",
                 "classnames": "^2.3.2",

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.73",
             "hasInstallScript": true,
             "dependencies": {
-                "@babel/runtime": "^7.26.0",
+                "@babel/runtime": "^7.26.7",
                 "@fortawesome/fontawesome-svg-core": "6.7.2",
                 "@fortawesome/free-regular-svg-icons": "6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
@@ -2085,9 +2085,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+            "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -10934,9 +10934,9 @@
             "dev": true
         },
         "@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+            "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
             "requires": {
                 "regenerator-runtime": "^0.14.0"
             }

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -31,7 +31,7 @@
                 "lodash": "^4.17.21",
                 "markdown-it": "14.1.0",
                 "moment": "^2.30.1",
-                "moment-timezone": "0.5.46",
+                "moment-timezone": "^0.5.47",
                 "npm-watch": "^0.13.0",
                 "patch-package": "8.0.0",
                 "path-browserify": "1.0.1",
@@ -7102,9 +7102,9 @@
             }
         },
         "node_modules/moment-timezone": {
-            "version": "0.5.46",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-            "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+            "version": "0.5.47",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
+            "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
             "license": "MIT",
             "dependencies": {
                 "moment": "^2.29.4"
@@ -14593,9 +14593,9 @@
             "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
         },
         "moment-timezone": {
-            "version": "0.5.46",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-            "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+            "version": "0.5.47",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
+            "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
             "requires": {
                 "moment": "^2.29.4"
             }

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/react-fontawesome": "0.2.2",
                 "@popperjs/core": "^2.11.8",
-                "ace-builds": "^1.37.4",
+                "ace-builds": "1.37.4",
                 "axios": ">=1.7.9",
                 "axios-retry": "3.9.1",
                 "bootstrap": "5.3.3",
@@ -51,7 +51,7 @@
                 "react-simple-snackbar": "^1.1.11",
                 "react-split-pane": "^0.1.92",
                 "react-step-wizard": "^5.3.11",
-                "recharts": "^2.15.0",
+                "recharts": "^2.15.1",
                 "sprintf-js": "1.1.3",
                 "url-parse": "^1.5.10",
                 "webpack": "5.97.1"
@@ -5658,9 +5658,10 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-equals": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
-            "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+            "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -8135,17 +8136,18 @@
             }
         },
         "node_modules/react-smooth": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.0.tgz",
-            "integrity": "sha512-2NMXOBY1uVUQx1jBeENGA497HK20y6CPGYL1ZnJLeoQ8rrc3UfmOM82sRxtzpcoCkUMy4CS0RGylfuVhuFjBgg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+            "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+            "license": "MIT",
             "dependencies": {
                 "fast-equals": "^5.0.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react-split-pane": {
@@ -8234,16 +8236,16 @@
             }
         },
         "node_modules/recharts": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
-            "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+            "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
             "license": "MIT",
             "dependencies": {
                 "clsx": "^2.0.0",
                 "eventemitter3": "^4.0.1",
                 "lodash": "^4.17.21",
                 "react-is": "^18.3.1",
-                "react-smooth": "^4.0.0",
+                "react-smooth": "^4.0.4",
                 "recharts-scale": "^0.4.4",
                 "tiny-invariant": "^1.3.1",
                 "victory-vendor": "^36.6.8"
@@ -13536,9 +13538,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-equals": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
-            "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ=="
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+            "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="
         },
         "fast-glob": {
             "version": "3.3.2",
@@ -15324,9 +15326,9 @@
             }
         },
         "react-smooth": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.0.tgz",
-            "integrity": "sha512-2NMXOBY1uVUQx1jBeENGA497HK20y6CPGYL1ZnJLeoQ8rrc3UfmOM82sRxtzpcoCkUMy4CS0RGylfuVhuFjBgg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+            "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
             "requires": {
                 "fast-equals": "^5.0.1",
                 "prop-types": "^15.8.1",
@@ -15402,15 +15404,15 @@
             }
         },
         "recharts": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
-            "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+            "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
             "requires": {
                 "clsx": "^2.0.0",
                 "eventemitter3": "^4.0.1",
                 "lodash": "^4.17.21",
                 "react-is": "^18.3.1",
-                "react-smooth": "^4.0.0",
+                "react-smooth": "^4.0.4",
                 "recharts-scale": "^0.4.4",
                 "tiny-invariant": "^1.3.1",
                 "victory-vendor": "^36.6.8"

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/react-fontawesome": "0.2.2",
                 "@popperjs/core": "^2.11.8",
-                "ace-builds": "1.37.4",
+                "ace-builds": "^1.37.5",
                 "axios": ">=1.7.9",
                 "axios-retry": "3.9.1",
                 "bootstrap": "5.3.3",
@@ -3736,9 +3736,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "node_modules/ace-builds": {
-            "version": "1.37.4",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.4.tgz",
-            "integrity": "sha512-niaXM/b7Nm6l/GKpc/jtG0jjExBOkqRN1pZbyV/ngb3GrQQF5fCB2032n5qaaAr7hWSGbc+PGfZ3C0LsmYQptA==",
+            "version": "1.37.5",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.5.tgz",
+            "integrity": "sha512-VMJ4Cnhq6L9dwvOCyuyyvQuiVTSwdZC7zDKJBBBJJax0wGQ7MvzQZFoi0gMmCm2I4Zuv/ZbtwU/dlglIhCNLhw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/acorn": {
@@ -12095,9 +12095,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ace-builds": {
-            "version": "1.37.4",
-            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.4.tgz",
-            "integrity": "sha512-niaXM/b7Nm6l/GKpc/jtG0jjExBOkqRN1pZbyV/ngb3GrQQF5fCB2032n5qaaAr7hWSGbc+PGfZ3C0LsmYQptA=="
+            "version": "1.37.5",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.5.tgz",
+            "integrity": "sha512-VMJ4Cnhq6L9dwvOCyuyyvQuiVTSwdZC7zDKJBBBJJax0wGQ7MvzQZFoi0gMmCm2I4Zuv/ZbtwU/dlglIhCNLhw=="
         },
         "acorn": {
             "version": "8.14.0",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -46,7 +46,7 @@
         "react-simple-snackbar": "^1.1.11",
         "react-split-pane": "^0.1.92",
         "react-step-wizard": "^5.3.11",
-        "recharts": "^2.15.0",
+        "recharts": "^2.15.1",
         "sprintf-js": "1.1.3",
         "url-parse": "^1.5.10",
         "webpack": "5.97.1"

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -26,7 +26,7 @@
         "lodash": "^4.17.21",
         "markdown-it": "14.1.0",
         "moment": "^2.30.1",
-        "moment-timezone": "0.5.46",
+        "moment-timezone": "0.5.47",
         "npm-watch": "^0.13.0",
         "patch-package": "8.0.0",
         "path-browserify": "1.0.1",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -10,7 +10,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@popperjs/core": "^2.11.8",
-        "ace-builds": "1.37.4",
+        "ace-builds": "1.37.5",
         "axios": ">=1.7.9",
         "axios-retry": "3.9.1",
         "bootstrap": "5.3.3",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "@babel/runtime": "^7.26.0",
+        "@babel/runtime": "^7.26.7",
         "@fortawesome/fontawesome-svg-core": "6.7.2",
         "@fortawesome/free-regular-svg-icons": "6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -35,7 +35,7 @@
         "react": "^16.14.0",
         "react-ace": "^9.5.0",
         "react-autosuggest": "^10.1.0",
-        "react-bootstrap": "2.10.7",
+        "react-bootstrap": "2.10.9",
         "react-calendar-timeline": "^0.28.0",
         "react-contexify": "5.0.0",
         "react-dom": "^16.14.0",


### PR DESCRIPTION
The existing version of this artifact had flawed logic, making it impossible to upgrade a package. Instead of skipping installation altogether if the packages is already installed, run the installation and let apt-get handle all the (architecture-specific) version comparison logic, then check stdout. Complete list of changes:

- Always attempt to install the package, allowing for upgrades.
- Allow multiple packages to be installed by name, and document some of the package name syntax accepted by apt (like specifying version/architecture, and allowing for removal by suffixing "-").
- Support package removal as well as installation, allowing for installation of packages that would otherwise fail due to "conflicts" relationship: A conflicting package can now be removed during installation.
- Add support for installation a package by file using "tools". This allows for larger deb file sizes.
- Add an option for reinstalling packages (useful for fixing broken packages or tampered installations).
- Add an option for upgrade-only: Do not install the packages if an earlier version is not already installed, allowing for upgrades without installing packages where they are not needed.
- Add more helpful logging
- Fail the collection if any execve() return codes are non-zero (except for `apt-get update`). Updating the cache will sometime fail, and this should not prevent installation.