### PR TITLE
Rate limit client event updates on artifact modification.

### DIFF
--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -501,6 +501,8 @@ func (self *ClientEventTable) load_from_file(
 			return nil, err
 		}
 
+		state.Version = uint64(self.Clock.Now().UnixNano())
+
 		return state, self.setClientMonitoringState(ctx, config_obj, "", state)
 	}
 

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -165,12 +165,12 @@ func (self *EventTable) Update(
 		return err
 	}
 
-	notifier, err := services.GetNotifier(config_obj)
-	if err == nil {
-		notifier.NotifyDirectListener(loadFileQueue(config_obj))
-	}
+	self.mu.Lock()
+	self.request = request
+	self.mu.Unlock()
 
-	return err
+	// Update the queries immediately
+	return self.StartQueries(config_obj)
 }
 
 // Compare a new set of queries with the current set to see if they


### PR DESCRIPTION
When artifacts are modified we need to recompile the client event tables - this takes time. If the user modifies a lot of artifacts very quickly (e.g. with a VQL query) this can overwhelm the server as it will try to recompile the event table for each artifact.

This PR adds debouncing via the notification service to limit the rate of event table compilation.