### PR TITLE
Avoid I/O after deleting client flows

### DIFF
--- a/paths/constants.go
+++ b/paths/constants.go
@@ -17,6 +17,9 @@ var (
 				SetType(api.PATH_TYPE_DATASTORE_PROTO).
 				SetTag("ClientIndex")
 
+	FLOWS_JOUNRNAL = path_specs.NewSafeFilestorePath("flows_journal").
+			SetType(api.PATH_TYPE_FILESTORE_JSON)
+
 	// An index of all the hunts and clients.
 	HUNT_INDEX = path_specs.NewSafeDatastorePath("hunt_index").
 			SetType(api.PATH_TYPE_DATASTORE_PROTO)

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -158,9 +158,7 @@ func (self *FlowStorageManager) DeleteFlow(
 			err = self.removeFlowsFromIndex(ctx, config_obj, client_id, flow_id)
 		} else {
 			// Otherwise we just mark the index as pending a rebuild and move on.
-			self.mu.Lock()
-			self.pendingIndexes = append(self.pendingIndexes, client_id)
-			self.mu.Unlock()
+			self.removeFlowFromIndexAsync(client_id, flow_id)
 		}
 	}
 	r.pool.StopAndWait()

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -155,7 +155,7 @@ func (self *FlowStorageManager) DeleteFlow(
 	if options.ReallyDoIt {
 		// User specified the flow must be removed immediately.
 		if options.Sync {
-			err = self.removeFlowFromIndex(ctx, config_obj, client_id, flow_id)
+			err = self.removeFlowsFromIndex(ctx, config_obj, client_id, flow_id)
 		} else {
 			// Otherwise we just mark the index as pending a rebuild and move on.
 			self.mu.Lock()

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -156,7 +156,7 @@ func (self *FlowStorageManager) DeleteFlow(
 	if options.ReallyDoIt {
 		// User specified the flow must be removed immediately.
 		if options.Sync {
-			err = self.removeClientFlowsFromIndex(
+			err = self.RemoveClientFlowsFromIndex(
 				ctx, config_obj, client_id, map[string]bool{
 					flow_id: true,
 				})

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -152,13 +152,18 @@ func (self *FlowStorageManager) DeleteFlow(
 			r.emit_fs("NotebookItem", path)
 			return nil
 		})
+
 	if options.ReallyDoIt {
 		// User specified the flow must be removed immediately.
 		if options.Sync {
-			err = self.removeFlowsFromIndex(ctx, config_obj, client_id, flow_id)
+			err = self.removeClientFlowsFromIndex(
+				ctx, config_obj, client_id, map[string]bool{
+					flow_id: true,
+				})
 		} else {
-			// Otherwise we just mark the index as pending a rebuild and move on.
-			self.removeFlowFromIndexAsync(client_id, flow_id)
+			// Otherwise we just mark the index as pending a rebuild
+			// and move on.
+			self.writeFlowJournal(config_obj, client_id, flow_id)
 		}
 	}
 	r.pool.StopAndWait()

--- a/services/launcher/index.go
+++ b/services/launcher/index.go
@@ -25,14 +25,21 @@ type flowIndexBuilder struct {
 
 // Rebuild the flow index from individual flow context files. This can
 // be very slow on slow filesystems as it does a lot of IO.
-func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
+func (self *flowIndexBuilder) BuildFlowIndexFromDatastore(
 	ctx context.Context,
 	config_obj *config_proto.Config,
-	storage_manager services.FlowStorer,
-	client_id string) error {
+	storage_manager services.FlowStorer) error {
 
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	return self.buildFlowIndexFromDatastore(ctx, config_obj, storage_manager)
+}
+
+func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	storage_manager services.FlowStorer) error {
 
 	// Ignore rebuilds more frequent than a second - this is probably
 	// fresh enough.
@@ -49,7 +56,7 @@ func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
 		return err
 	}
 
-	flow_path_manager := paths.NewFlowPathManager(client_id, "")
+	flow_path_manager := paths.NewFlowPathManager(self.client_id, "")
 	all_flow_urns, err := db.ListChildren(
 		config_obj, flow_path_manager.ContainerPath())
 	if err != nil {
@@ -70,7 +77,7 @@ func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
 	}
 
 	flow_reader := NewFlowReader(
-		ctx, config_obj, storage_manager, client_id)
+		ctx, config_obj, storage_manager, self.client_id)
 
 	go func() {
 		defer flow_reader.Close()
@@ -80,7 +87,7 @@ func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
 		}
 	}()
 
-	client_path_manager := paths.NewClientPathManager(client_id)
+	client_path_manager := paths.NewClientPathManager(self.client_id)
 	file_store_factory := file_store.GetFileStore(config_obj)
 
 	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
@@ -97,6 +104,45 @@ func (self *flowIndexBuilder) buildFlowIndexFromDatastore(
 			Set("Artifacts", flow.Request.Artifacts).
 			Set("Created", flow.CreateTime).
 			Set("Creator", flow.Request.Creator))
+	}
+
+	return nil
+}
+
+// Filter the index through the journal.
+func (self *flowIndexBuilder) RemoveClientFlowsFromIndex(
+	ctx context.Context, config_obj *config_proto.Config,
+	storage_manager services.FlowStorer,
+	flows map[string]bool) error {
+
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	client_path_manager := paths.NewClientPathManager(self.client_id)
+	file_store_factory := file_store.GetFileStore(config_obj)
+	rs_reader, err := result_sets.NewResultSetReader(file_store_factory,
+		client_path_manager.FlowIndex())
+	if err != nil {
+		// No existing result set, build from scratch.
+		return self.buildFlowIndexFromDatastore(ctx, config_obj, storage_manager)
+	}
+	defer rs_reader.Close()
+
+	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
+		client_path_manager.FlowIndex(),
+		json.DefaultEncOpts(), utils.SyncCompleter, result_sets.TruncateMode)
+	if err != nil {
+		return err
+	}
+	defer rs_writer.Close()
+
+	for r := range rs_reader.Rows(ctx) {
+		flow_id, _ := r.GetString("FlowId")
+		_, ok := flows[flow_id]
+		if ok {
+			continue
+		}
+		rs_writer.Write(r)
 	}
 
 	return nil

--- a/services/launcher/journal.go
+++ b/services/launcher/journal.go
@@ -1,0 +1,206 @@
+package launcher
+
+import (
+	"context"
+
+	"github.com/Velocidex/ordereddict"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/paths"
+	"www.velocidex.com/golang/velociraptor/result_sets"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+/*
+  For fast access in the GUI we keep a flows index. The index has flow
+  summaries in sorted order stores as a regular result set. The GUI
+  can then access the summaries index and apply transformations like
+  sorting and filtering in the same way as any other result set.
+
+  The flow index summary only contains flow metadata which does not
+  change over time. The full records are retrieved as individual
+  records from the datastore.
+
+  For example, say there are 1000 flows in a client. There will be
+  1000 separate flow context records:
+
+  - clients/C.123/collections/F.CRFRQ7GTMH9DC.json.db
+  - clients/C.123/collections/F.CRMITU9T2MQN8.json.db
+  ....
+
+  There is also a summary index as a regular result set:
+  - clients/C.123/flow_index.json
+
+  The GUI asks to see the first page which retrieves 10 records from
+  the summary, the server then reads the first 10 full records based
+  on the Flow Ids returned from the index.
+
+  This speeds up filtering, sorting etc of the flow objects because we
+  always deal with the index in an efficient way.
+
+  How to keep the index in sync with the flows?
+
+  When adding a new flow, the new summary is appended to the end of
+  the index. This means that the next time the GUI requests a
+  transformation of the index (e.g. sorted by timestamp or filtered)
+  the server will automatically rebuild the transformed index. There
+  is nothing more we need to do - this is the simple case as the new
+  flow will natually fall at the end of the index (the index is sorted
+  by creation time).
+
+  When a flow is deleted this is more complicated:
+  1. The collection object is removed from the data store.
+  2. The deletion is written in the flow journal file by appending it to the end.
+
+  Eventually we need to remove the deleted flow from the index result
+  set completely, but we can not do this immediately because if the
+  user deletes many flows quickly, the extra overheads of rebuilding
+  the index for each deletion is not reasonable for IO performance on
+  slow filesystems.
+
+  Therefore we delay the index rebuild into a housekeeping thread
+  which runs periodically:
+
+  1. Read all deletions from the journal file
+  2. Read all flow summary objects from the index
+  3. Write them out into a new index file, if they are not in the deleted set.
+
+  Immediately after deleted the flow, the flow will not appear as part
+  of the GUI listing (because the full object is still missing). So
+  before the house keeping thread runs the GUI will show e.g. 9 or 8
+  rows in the same page when requested 10 rows, until the next
+  housekeeping job fixes the index. This is considered an acceptable
+  tradeoff.
+
+*/
+
+// The journal keeps a list of deleted flows to be removed from the
+// main index.
+func (self *FlowStorageManager) writeFlowJournal(
+	config_obj *config_proto.Config, client_id, flow_id string) error {
+	// Serialize access to the journal with the housekeeping thread.
+	self.flow_journal_mu.Lock()
+	defer self.flow_journal_mu.Unlock()
+
+	journal, err := services.GetJournal(config_obj)
+	if err != nil {
+		return err
+	}
+
+	return journal.AppendToResultSet(config_obj,
+		paths.FLOWS_JOUNRNAL,
+		[]*ordereddict.Dict{ordereddict.NewDict().
+			Set("Type", "delete").
+			Set("ClientId", client_id).
+			Set("FlowId", flow_id)},
+		services.JournalOptions{
+			Sync: true,
+		})
+}
+
+func (self *FlowStorageManager) clearJournal(
+	config_obj *config_proto.Config) error {
+
+	file_store_factory := file_store.GetFileStore(config_obj)
+	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
+		paths.FLOWS_JOUNRNAL, json.DefaultEncOpts(),
+		utils.SyncCompleter, result_sets.TruncateMode)
+	if err != nil {
+		return err
+	}
+	rs_writer.Close()
+
+	return nil
+}
+
+func (self *FlowStorageManager) removeFlowsFromJournal(
+	ctx context.Context, config_obj *config_proto.Config) error {
+
+	self.flow_journal_mu.Lock()
+	defer self.flow_journal_mu.Unlock()
+
+	file_store_factory := file_store.GetFileStore(config_obj)
+
+	// ClientId: Set(FlowId)
+	id_map := make(map[string]map[string]bool)
+
+	journal_reader, err := result_sets.NewResultSetReader(
+		file_store_factory, paths.FLOWS_JOUNRNAL)
+
+	// No journal there is nothing to do.
+	if err != nil {
+		return nil
+	}
+	for row := range journal_reader.Rows(ctx) {
+		client_id, _ := row.GetString("ClientId")
+		if client_id == "" {
+			continue
+		}
+
+		flow_id, _ := row.GetString("FlowId")
+		if flow_id == "" {
+			continue
+		}
+
+		client_set, pres := id_map[client_id]
+		if !pres {
+			client_set = make(map[string]bool)
+			id_map[client_id] = client_set
+		}
+
+		client_set[flow_id] = true
+	}
+	journal_reader.Close()
+
+	var r_err error
+	for client_id, flows := range id_map {
+		err := self.removeClientFlowsFromIndex(ctx, config_obj, client_id, flows)
+		if err != nil {
+			r_err = err
+		}
+	}
+
+	// Only clear the journal if all reindex operations are successful.
+	if r_err == nil {
+		self.clearJournal(config_obj)
+	}
+
+	return r_err
+}
+
+// Filter the index through the journal.
+func (self *FlowStorageManager) removeClientFlowsFromIndex(
+	ctx context.Context, config_obj *config_proto.Config,
+	client_id string, flows map[string]bool) error {
+
+	client_path_manager := paths.NewClientPathManager(client_id)
+	file_store_factory := file_store.GetFileStore(config_obj)
+	rs_reader, err := result_sets.NewResultSetReader(file_store_factory,
+		client_path_manager.FlowIndex())
+	if err != nil {
+		// No existing result set, build from scratch.
+		return self.buildFlowIndexFromDatastore(ctx, config_obj, client_id)
+	}
+	defer rs_reader.Close()
+
+	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
+		client_path_manager.FlowIndex(),
+		json.DefaultEncOpts(), utils.SyncCompleter, result_sets.TruncateMode)
+	if err != nil {
+		return err
+	}
+	defer rs_writer.Close()
+
+	for r := range rs_reader.Rows(ctx) {
+		flow_id, _ := r.GetString("FlowId")
+		_, ok := flows[flow_id]
+		if ok {
+			continue
+		}
+		rs_writer.Write(r)
+	}
+
+	return nil
+}

--- a/services/launcher/journal.go
+++ b/services/launcher/journal.go
@@ -115,7 +115,7 @@ func (self *FlowStorageManager) clearJournal(
 	return nil
 }
 
-func (self *FlowStorageManager) removeFlowsFromJournal(
+func (self *FlowStorageManager) RemoveFlowsFromJournal(
 	ctx context.Context, config_obj *config_proto.Config) error {
 
 	self.flow_journal_mu.Lock()
@@ -156,7 +156,7 @@ func (self *FlowStorageManager) removeFlowsFromJournal(
 
 	var r_err error
 	for client_id, flows := range id_map {
-		err := self.removeClientFlowsFromIndex(ctx, config_obj, client_id, flows)
+		err := self.RemoveClientFlowsFromIndex(ctx, config_obj, client_id, flows)
 		if err != nil {
 			r_err = err
 		}
@@ -168,27 +168,4 @@ func (self *FlowStorageManager) removeFlowsFromJournal(
 	}
 
 	return r_err
-}
-
-func (self *FlowStorageManager) removeClientFlowsFromIndex(
-	ctx context.Context, config_obj *config_proto.Config,
-	client_id string, flows map[string]bool) error {
-
-	// Do not hold the lock while we build different clients.
-	self.mu.Lock()
-	builder, pres := self.indexBuilders[client_id]
-	if !pres {
-		builder = &flowIndexBuilder{
-			client_id: client_id,
-		}
-	}
-	self.mu.Unlock()
-
-	err := builder.RemoveClientFlowsFromIndex(ctx, config_obj, self, flows)
-	self.mu.Lock()
-	delete(self.indexBuilders, client_id)
-	self.mu.Unlock()
-
-	return err
-
 }

--- a/services/launcher/storage.go
+++ b/services/launcher/storage.go
@@ -154,14 +154,18 @@ func (self *FlowStorageManager) ListFlows(
 	return result, rs_reader.TotalRows(), nil
 }
 
-func (self *FlowStorageManager) removeFlowFromIndex(
+func (self *FlowStorageManager) removeFlowsFromIndex(
 	ctx context.Context,
 	config_obj *config_proto.Config,
 	client_id string,
-	flow_id string) error {
+	flow_ids ...string) error {
 
 	client_path_manager := paths.NewClientPathManager(client_id)
 	file_store_factory := file_store.GetFileStore(config_obj)
+	id_map := make(map[string]struct{})
+	for _, id := range flow_ids {
+		id_map[id] = struct{}{}
+	}
 
 	rs_reader, err := result_sets.NewResultSetReader(file_store_factory,
 		client_path_manager.FlowIndex())
@@ -180,7 +184,7 @@ func (self *FlowStorageManager) removeFlowFromIndex(
 
 	for r := range rs_reader.Rows(ctx) {
 		flow_id, _ := r.GetString("FlowId")
-		if flow_id == flow_id {
+		if _, ok := id_map[flow_id]; ok {
 			continue
 		}
 		rs_writer.Write(r)

--- a/services/launcher/storage.go
+++ b/services/launcher/storage.go
@@ -202,7 +202,7 @@ func (self *FlowStorageManager) buildFlowIndexFromDatastore(
 	}
 	self.mu.Unlock()
 
-	err := builder.buildFlowIndexFromDatastore(ctx, config_obj, self, client_id)
+	err := builder.BuildFlowIndexFromDatastore(ctx, config_obj, self)
 	self.mu.Lock()
 	delete(self.indexBuilders, client_id)
 	self.mu.Unlock()


### PR DESCRIPTION
Commit 786e65604260c7ad880874cc3d43d7dcb95a8ff9 introduced a background job for updating client flow indices after deleting flows.
This background job always constructed indices from scratch, leading to slow I/O in a master/minion setup backed by Amazon EFS.

This PR allows individual flow IDs to be passed to the background job so it can simply filter them out from the index files, similar to the path taken when  `delete_flow( … , sync = true )` is called.