### PR TITLE
Set the user avatar in the datastore

### DIFF
--- a/api/authenticators/google.go
+++ b/api/authenticators/google.go
@@ -190,12 +190,16 @@ func (self *GoogleAuthenticator) oauthGoogleCallback() http.Handler {
 				return
 			}
 
+			// Update the user picture in the datastore if we can - it
+			// will be populated from there for each GetUserUITraits
+			// call. This keeps our cookie smaller.
+			setUserPicture(r.Context(), user_info.Email, user_info.Picture)
+
 			// Sign and get the complete encoded token as a string using the secret
 			cookie, err := getSignedJWTTokenCookie(
 				self.config_obj, self.authenticator,
 				&Claims{
 					Username: user_info.Email,
-					Picture:  user_info.Picture,
 				})
 			if err != nil {
 				logging.GetLogger(self.config_obj, &logging.GUIComponent).
@@ -316,8 +320,7 @@ func authenticateUserHandle(
 			// build a token to pass to the underlying GRPC
 			// service with metadata about the user.
 			user_info := &api_proto.VelociraptorUser{
-				Name:    user_record.Name,
-				Picture: claims.Picture,
+				Name: user_record.Name,
 			}
 
 			// NOTE: This context is NOT the same context that is received

--- a/api/authenticators/users.go
+++ b/api/authenticators/users.go
@@ -1,0 +1,18 @@
+package authenticators
+
+import (
+	"context"
+
+	"www.velocidex.com/golang/velociraptor/services"
+)
+
+// Try to store the picture URL in the datastore to avoid making the
+// cookie too large. Not critical if it fails, just move on.
+func setUserPicture(ctx context.Context, username, url string) {
+	user_manager := services.GetUserManager()
+	user_record, err := user_manager.GetUserWithHashes(ctx, username, username)
+	if err == nil && user_record.Picture != url {
+		user_record.Picture = url
+		user_manager.SetUser(ctx, user_record)
+	}
+}

--- a/api/fixtures/TestMultiAuthenticator.golden
+++ b/api/fixtures/TestMultiAuthenticator.golden
@@ -72,10 +72,6 @@
    "authenticators.IpFilter",
    " authenticators.(*AzureAuthenticator).oauthAzureLogin"
   ],
-  "/velociraptor/auth/azure/picture": [
-   "authenticators.IpFilter",
-   " authenticators.(*AzureAuthenticator).oauthAzurePicture"
-  ],
   "/velociraptor/auth/github/callback": [
    "authenticators.IpFilter",
    " authenticators.(*GitHubAuthenticator).oauthGithubCallback"


### PR DESCRIPTION
Previously we added the token in the cookie which would make the cookie too large. This PR sets the user avatar in the datastore during the oauth step so it can be retrieved from there instead of the cookie each time. This keeps the cookie smaller.

Fixes: #4177