### PR TITLE
Keep record of finished flows in client's flow manager.

### DIFF
--- a/responder/responder.go
+++ b/responder/responder.go
@@ -105,13 +105,16 @@ func (self *FlowResponder) IsComplete() bool {
 
 func (self *FlowResponder) GetStatus() *crypto_proto.VeloStatus {
 	self.mu.Lock()
+
+	if !self.completed {
+		self.status.LastActive = uint64(utils.GetTime().Now().UnixNano() / 1000)
+
+		// Duration is in milli seconds
+		self.status.Duration = int64(self.status.LastActive-self.status.FirstActive) * 1000
+	}
+
 	status := proto.Clone(&self.status).(*crypto_proto.VeloStatus)
 	self.mu.Unlock()
-
-	status.LastActive = uint64(utils.GetTime().Now().UnixNano() / 1000)
-
-	// Duration is in milli seconds
-	status.Duration = int64(status.LastActive-status.FirstActive) * 1000
 
 	return status
 }
@@ -202,6 +205,10 @@ func (self *FlowResponder) Return(ctx context.Context) {
 
 	// Only when the query is completed, we call Return()
 	self.completed = true
+	self.status.LastActive = uint64(utils.GetTime().Now().UnixNano() / 1000)
+
+	// Duration is in milli seconds
+	self.status.Duration = int64(self.status.LastActive-self.status.FirstActive) * 1000
 }
 
 // Send a log message to the server. We do not actually send the log

--- a/result_sets/simple/simple.go
+++ b/result_sets/simple/simple.go
@@ -512,6 +512,10 @@ func (self ResultSetFactory) NewResultSetReader(
 	file_store_factory api.FileStore,
 	log_path api.FSPathSpec) (result_sets.ResultSetReader, error) {
 
+	if file_store_factory == nil {
+		return nil, errors.New("No filestore")
+	}
+
 	fd, err := file_store_factory.ReadFile(log_path)
 	if errors.Is(err, io.EOF) || errors.Is(err, os.ErrNotExist) {
 		fd = &NullReader{

--- a/services/launcher/dummy.go
+++ b/services/launcher/dummy.go
@@ -1,1 +1,77 @@
 package launcher
+
+import (
+	"context"
+
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
+	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+	"www.velocidex.com/golang/velociraptor/result_sets"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+var (
+	notAvailableError = utils.Wrap(utils.InvalidConfigError,
+		"FlowStorer not available without a filestore")
+)
+
+type DummyStorer struct{}
+
+func (self *DummyStorer) WriteFlow(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	flow *flows_proto.ArtifactCollectorContext,
+	completion func()) error {
+	return notAvailableError
+}
+
+func (self *DummyStorer) WriteFlowIndex(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	flow *flows_proto.ArtifactCollectorContext) error {
+	return notAvailableError
+}
+
+func (self *DummyStorer) WriteTask(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	client_id string,
+	msg *crypto_proto.VeloMessage) error {
+	return notAvailableError
+}
+
+func (self *DummyStorer) DeleteFlow(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	client_id string, flow_id string, principal string,
+	options services.DeleteFlowOptions) ([]*services.DeleteFlowResponse, error) {
+	return nil, notAvailableError
+}
+
+func (self *DummyStorer) LoadCollectionContext(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	client_id, flow_id string) (*flows_proto.ArtifactCollectorContext, error) {
+	return nil, notAvailableError
+}
+
+func (self *DummyStorer) ListFlows(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	client_id string,
+	options result_sets.ResultSetOptions,
+	offset, length int64) ([]*services.FlowSummary, int64, error) {
+	return nil, 0, notAvailableError
+}
+
+// Get the exact requests that were sent for this collection (for
+// provenance).
+func (self *DummyStorer) GetFlowRequests(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	client_id string, flow_id string,
+	offset uint64, count uint64) (*api_proto.ApiFlowRequestDetails, error) {
+	return nil, notAvailableError
+}

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -777,6 +777,15 @@ func NewLauncherService(
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) (services.Launcher, error) {
 
+	// The laucher service is also created on the client to ensure it
+	// can compile artifacts etc. But it does not make sense to
+	// actually store any of the flows on the client. We therefore
+	// install a dummy storer which just returns errors for any
+	// attempts to store flows.
+	if config_obj.Datastore == nil {
+		return &Launcher{Storage_: &DummyStorer{}}, nil
+	}
+
 	res := &Launcher{
 		Storage_: NewFlowStorageManager(ctx, config_obj, wg),
 	}

--- a/services/launcher/storage.go
+++ b/services/launcher/storage.go
@@ -318,6 +318,7 @@ func NewFlowStorageManager(
 	res := &FlowStorageManager{
 		indexBuilders: make(map[string]*flowIndexBuilder),
 	}
+
 	wg.Add(1)
 	go res.houseKeeping(ctx, config_obj, wg)
 


### PR DESCRIPTION
This allows profiles to see the status of recent flows that have completed. It also addresses the issue of the in flight checks checking the flow status after it has completed. The client will keep records of past flows and simply return the exit status of those flows when asked.