### PR TITLE
Giving default folder Read & Traverse permissions in Darwin installer

### DIFF
--- a/bin/installer_darwin.go
+++ b/bin/installer_darwin.go
@@ -94,7 +94,7 @@ func doInstall() error {
 		dirname := filepath.Dir(target_path)
 		logger.Info("Attempting to create intermediate directory %s.",
 			dirname)
-		err = os.MkdirAll(dirname, 0700)
+		err = os.MkdirAll(dirname, 0755)
 		if err != nil {
 			return fmt.Errorf("Create intermediate directories: %w", err)
 		}


### PR DESCRIPTION
# Background
The default folder for Darwin installers is `/usr/local/sbin` as per https://github.com/Velocidex/velociraptor/blob/a5abaee504234366a0ebe2eb114d0e02019f38d5/docs/references/server.config.yaml#L278.
This folder does not exist by default on MacOS. 
Currently the installer will create it with if it is not present upon installation, with 0700 permissions (=only root can read, write and traverse; everyone else can't do anything).

As per [best practices](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s16.html):
>  Locally-installed system administration programs should be placed into `/usr/local/sbin`.
> (...)
> We recommend that users have read and execute permission for everything in `/sbin` except, perhaps, certain setuid and setgid programs. 
> The division between `/bin` and `/sbin` was not created for security reasons or to prevent users from seeing the operating system, but to provide a good partition between binaries that everyone uses and ones that are primarily used for administration tasks. 
> There is no inherent security advantage in making `/sbin` off-limits for users. 

# Proposed solution
Change the permissions to 0755, which preserves the current rights for root, but allows other users to traverse and read without obstruction. 

This is in line with best practices and ensures it doesn't interfere with other tools interacting with this folder.