### PR TITLE
Delay flow error until the flow is completed.

### DIFF
--- a/accessors/registry/registry_windows.go
+++ b/accessors/registry/registry_windows.go
@@ -312,14 +312,13 @@ func (self *RegValueInfo) materialize() error {
 		self.Type = "BINARY"
 
 	case registry.MULTI_SZ:
-		value_str, _ := value.(string)
-		self._binary_data = []byte(value_str)
+		self._binary_data, _ = json.Marshal(value)
 		self.Type = "MULTI_SZ"
 
 		if buf_size < MAX_EMBEDDED_REG_VALUE {
 			self._data = ordereddict.NewDict().
 				Set("type", "MULTI_SZ").
-				Set("value", strings.Split(value_str, "\n"))
+				Set("value", value)
 		}
 
 	case registry.SZ, registry.EXPAND_SZ:

--- a/artifacts/definitions/Generic/Client/Profile.yaml
+++ b/artifacts/definitions/Generic/Client/Profile.yaml
@@ -78,10 +78,9 @@ export: |
 
 sources:
   - query: |
-      SELECT Type,
-             if(condition=get(field="OSPath"),
-                then=upload(name=Type + ".bin", file=OSPath)) AS File,
-             get(member="Line") AS Line
+      LET X = scope()
+
+      SELECT *, X.OSPath && X.Type && upload(name=X.Type + ".bin", file=X.OSPath) AS File
       FROM profile(allocs=Allocs, block=Block, goroutine=Goroutine,
                    heap=Heap, mutex=Mutex, profile=Profile, trace=Trace,
                    logs=Logs, queries=QueryLogs, metrics=Metrics,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -127,8 +127,13 @@ func (self *ExecutorTestSuite) TestCancellation() {
 		received_messages := collector.Messages()
 
 		// Should be at least one stat message and several log messages
-		return len(received_messages) >= 3 &&
-			getFlowStat(received_messages) != nil
+		stats := getFlowStat(received_messages)
+		if stats == nil || stats.FlowStats == nil ||
+			len(stats.FlowStats.QueryStatus) == 0 {
+			return false
+		}
+
+		return stats.FlowStats.FlowComplete
 	})
 
 	received_messages := collector.Messages()

--- a/gui/velociraptor/src/components/flows/flow-overview.jsx
+++ b/gui/velociraptor/src/components/flows/flow-overview.jsx
@@ -163,9 +163,11 @@ export default class FlowOverview extends React.Component {
                         </dd>
 
                         <dt className="col-4">{T("State")}</dt>
-                        <dd className="col-8">{ T(flow.state) }</dd>
+                        <dd className="col-8">{ T(flow.state) }
+                          { flow.state !== "ERROR" && flow.status && T(" ( Error )")}
+                        </dd>
 
-                        { flow.state === "ERROR" &&
+                        { flow.status &&
                           <Fragment>
                             <dt className="col-4">{T("Error")}</dt>
                             <dd className="col-8">{ flow.status }</dd>

--- a/gui/velociraptor/src/components/flows/flows-list.jsx
+++ b/gui/velociraptor/src/components/flows/flows-list.jsx
@@ -696,7 +696,16 @@ const stateRenderer = (cell, row) => {
         result = <FontAwesomeIcon icon="hourglass"/>;
 
     } else if (cell === "IN_PROGRESS") {
-        result = <FontAwesomeIcon icon="person-running"/>;
+        // An error occured but the flow is still running.
+        if(row && row._Flow && row._Flow.status) {
+            result = <>
+                       <FontAwesomeIcon icon="person-running"/>&nbsp;
+                       <FontAwesomeIcon icon="exclamation"/>
+                     </>;
+        } else {
+
+            result = <FontAwesomeIcon icon="person-running"/>;
+        }
 
     } else if (cell === "UNRESPONSIVE") {
         result = <FontAwesomeIcon icon="question"/>;

--- a/responder/flow_context.go
+++ b/responder/flow_context.go
@@ -217,7 +217,7 @@ func (self *FlowContext) Cancel() {
 func (self *FlowContext) _Cancel() {
 	// Cancel all outstanding queries
 	for _, r := range self.responders {
-		r.RaiseError(self.ctx, "Cancelled")
+		r.Cancel(self.ctx)
 	}
 
 	self.addLogMessage("ERROR",
@@ -238,7 +238,7 @@ func (self *FlowContext) Close() {
 
 func (self *FlowContext) _Close() {
 	if self.owner != nil {
-		self.owner.removeFlowContext(self.flow_id)
+		self.owner.RemoveFlowContext(self.flow_id)
 	}
 	if self.checkpoint != "" {
 		os.Remove(self.checkpoint)

--- a/services/labels/labels.go
+++ b/services/labels/labels.go
@@ -75,15 +75,6 @@ func (self CachedLabels) Size() int {
 type Labeler struct {
 	mu  sync.Mutex
 	lru *ttlcache.Cache
-
-	Clock utils.Clock
-}
-
-func (self *Labeler) SetClock(c utils.Clock) {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-
-	self.Clock = c
 }
 
 // Assumption: We hold the lock entering this function.
@@ -214,7 +205,7 @@ func (self *Labeler) SetClientLabel(
 
 			client_info.Labels = append(client_info.Labels, new_label)
 			client_info.LabelsTimestamp = uint64(
-				self.Clock.Now().UnixNano())
+				utils.GetTime().Now().UnixNano())
 
 			return client_info, nil
 		})
@@ -276,7 +267,7 @@ func (self *Labeler) RemoveClientLabel(
 
 			client_info.Labels = new_labels
 			client_info.LabelsTimestamp = uint64(
-				self.Clock.Now().UnixNano())
+				utils.GetTime().Now().UnixNano())
 
 			return client_info, nil
 		})
@@ -405,8 +396,6 @@ func NewLabelerService(
 		return Dummy{}, nil
 	}
 
-	labeler := &Labeler{
-		Clock: &utils.RealClock{},
-	}
+	labeler := &Labeler{}
 	return labeler, labeler.Start(ctx, config_obj, wg)
 }

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -40,6 +40,7 @@ import (
 	// Load plugins (timestamp, parse_csv)
 	_ "www.velocidex.com/golang/velociraptor/accessors/data"
 	_ "www.velocidex.com/golang/velociraptor/result_sets/timed"
+	launcher_mod "www.velocidex.com/golang/velociraptor/services/launcher"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	_ "www.velocidex.com/golang/velociraptor/vql/functions"
 	_ "www.velocidex.com/golang/velociraptor/vql/parsers/csv"
@@ -1394,6 +1395,10 @@ func (self *LauncherTestSuite) _TestDelete(t *assert.R) {
 	// can not find it (The actual flow object is removed but the
 	// index is out of step).
 	vtesting.WaitUntil(10*time.Second, t, func() bool {
+		// Force the housekeep thread to run immediately.
+		launcher.Storage().(*launcher_mod.FlowStorageManager).
+			RemoveFlowsFromJournal(self.Ctx, self.ConfigObj)
+
 		datastore.FlushDatastore(self.ConfigObj)
 
 		res, err = launcher.GetFlows(self.Ctx, self.ConfigObj, "server",

--- a/utils/notebook_id.go
+++ b/utils/notebook_id.go
@@ -7,8 +7,8 @@ import (
 
 // A notebook id for clients flows
 var (
-	client_notebook_regex = regexp.MustCompile(`^N\.(F\.[^-]+?)-(C\..+|server)$`)
-	event_notebook_regex  = regexp.MustCompile(`^N\.E\.([^-]+?)-(C\..+|server)$`)
+	client_notebook_regex = regexp.MustCompile(`^N\.(F\.[^-]+?)-(.+|server)$`)
+	event_notebook_regex  = regexp.MustCompile(`^N\.E\.([^-]+?)-(.+|server)$`)
 )
 
 func ClientNotebookId(notebook_id string) (flow_id, client_id string, ok bool) {


### PR DESCRIPTION
Prevously the flow state was set to error as soon as a log was issued at level ERROR however the query continued running until the end. This caused the GUI to disable the cancel button so it was impossible to cancel the flow.

This PR Keeps the flow at the IN_PROGRESS state until completion while tagging the error message in the flow. This allows the flow to be cancelled after the error by the GUI. After completion the flow will be switched to the ERROR state.

Also:
1. Fix Registry accessor parsing of MULTI_SZ fields.
2. Fix Generic.Client.Profile artifact
3. Refactor tests to use the global mock clock