### PR TITLE
Changed hardcoded PID of 9604 used in the VAD plugin to Pid variable

### DIFF
--- a/artifacts/definitions/Windows/Memory/PEDump.yaml
+++ b/artifacts/definitions/Windows/Memory/PEDump.yaml
@@ -41,5 +41,5 @@ sources:
               length=10) AS Header,
             upload(file=pe_dump(pid=Pid, base_offset=Address),
                    name=GetFilename(MappingName=MappingName, BaseOffset=Address)) AS Upload
-     FROM vad(pid=9604)
+     FROM vad(pid=Pid)
      WHERE Header =~ "^MZ" AND MappingName =~ FilenameRegex


### PR DESCRIPTION
The artifact contained a hardcoded PID equal to 9604 that prevented the artifact from working correctly. 

The following error can be seen in the Log when attempting to run the artifact:
- vad: OpenProcess for pid 9604 : The parameter is incorrect.

Modifying the harcoded PID of 9604 to Pid addresses the issue.