### PR TITLE
Added LNK file condition check

### DIFF
--- a/artifacts/definitions/Windows/Memory/PEDump.yaml
+++ b/artifacts/definitions/Windows/Memory/PEDump.yaml
@@ -41,5 +41,5 @@ sources:
               length=10) AS Header,
             upload(file=pe_dump(pid=Pid, base_offset=Address),
                    name=GetFilename(MappingName=MappingName, BaseOffset=Address)) AS Upload
-     FROM vad(pid=9604)
+     FROM vad(pid=Pid)
      WHERE Header =~ "^MZ" AND MappingName =~ FilenameRegex

--- a/artifacts/definitions/Windows/Sys/StartupItems.yaml
+++ b/artifacts/definitions/Windows/Sys/StartupItems.yaml
@@ -73,6 +73,7 @@ sources:
                   FROM Artifact.Windows.Forensics.Lnk(TargetGlob=OSPath)
                 } as Details
             FROM scope()
+            WHERE OSPath.Basename =~ ".lnk$"
         }, default={
             SELECT hash(path=OSPath) AS Details
             FROM scope()


### PR DESCRIPTION
There was no condition check if a file was ending a .lnk extension.

This led to the Artifact.Windows.Forensics.Lnk attempting to parse other files such as executables.