### PR TITLE
Bugfix: Correlation rules should report their details and enrichment

### DIFF
--- a/vql/sigma/details.go
+++ b/vql/sigma/details.go
@@ -2,10 +2,10 @@ package sigma
 
 import (
 	"context"
-	"encoding/json"
 	"regexp"
 
 	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/sigma/evaluator"
 	"www.velocidex.com/golang/vfilter"
@@ -71,5 +71,5 @@ func (self *SigmaContext) AddDetail(
 		})
 	}
 
-	return row.Copy().Set("Details", details)
+	return row.Set("Details", details)
 }

--- a/vql/sigma/evaluator/checks.go
+++ b/vql/sigma/evaluator/checks.go
@@ -11,7 +11,8 @@ import (
 
 func (self *VQLRuleEvaluator) CheckRule() error {
 	// Rule has no condition - just and all the selections
-	if len(self.Detection.Conditions) == 0 {
+	if self.Correlation == nil &&
+		len(self.Detection.Conditions) == 0 {
 		fields := []string{}
 		for k := range self.Detection.Searches {
 			fields = append(fields, k)

--- a/vql/sigma/evaluator/correlation.go
+++ b/vql/sigma/evaluator/correlation.go
@@ -441,7 +441,7 @@ func getCmp(scope vfilter.Scope,
 
 // One correlator per correlation rule
 type SigmaCorrelator struct {
-	sigma.Rule
+	*VQLRuleEvaluator
 
 	mu     sync.Mutex
 	lookup map[string]*SigmaCorrelatorGroup
@@ -491,9 +491,18 @@ func (self *SigmaCorrelator) Match(
 }
 
 // One correlator per rule.
-func NewSigmaCorrelator(rule sigma.Rule) *SigmaCorrelator {
-	return &SigmaCorrelator{
-		Rule:   rule,
-		lookup: make(map[string]*SigmaCorrelatorGroup),
+func NewSigmaCorrelator(
+	scope types.Scope,
+	rule sigma.Rule,
+	fieldmappings *FieldMappingResolver) (*SigmaCorrelator, error) {
+	evaluator := NewVQLRuleEvaluator(scope, rule, fieldmappings)
+	err := evaluator.CheckRule()
+	if err != nil {
+		return nil, err
 	}
+
+	return &SigmaCorrelator{
+		VQLRuleEvaluator: evaluator,
+		lookup:           make(map[string]*SigmaCorrelatorGroup),
+	}, nil
 }

--- a/vql/sigma/fixtures/TestSigma.golden
+++ b/vql/sigma/fixtures/TestSigma.golden
@@ -13,7 +13,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -52,7 +51,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Rule With Details": [
@@ -69,7 +69,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": "This is column Foo=Bar Int=4 List=[1,2,3] Dict={\"X\":1,\"Y\":2}",
    "_Match": {
     "match": true,
     "search_results": {
@@ -117,7 +116,8 @@
     "AdditionalFields": {
      "details": "This is column Foo=%Foo% Int=%Integer% List=%List% Dict=%Dict%"
     }
-   }
+   },
+   "Details": "This is column Foo=Bar Int=4 List=[1,2,3] Dict={\"X\":1,\"Y\":2}"
   }
  ],
  "Default Details in callback": [
@@ -134,7 +134,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": "I'm a scope var:Default Detail Foo=Bar",
    "_Match": {
     "match": true,
     "search_results": {
@@ -173,7 +172,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": "I'm a scope var:Default Detail Foo=Bar"
   }
  ],
  "Match field with regex": [
@@ -190,7 +190,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -232,7 +231,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match field with logical operators": [
@@ -249,7 +249,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -312,7 +311,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match field with logical or operator": [
@@ -329,7 +329,6 @@
     "Y": 2
    },
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -392,7 +391,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match simple logsource": [
@@ -400,7 +400,6 @@
    "System": {
     "EventID": 2
    },
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -439,14 +438,14 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match field with vql operator": [
   {
    "Foo": "Bar",
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -491,12 +490,12 @@
     "AdditionalFields": {
      "custom_field": "Some Custom Field"
     }
-   }
+   },
+   "Details": null
   },
   {
    "Foo": "Baz",
    "Baz": "Bye",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -541,14 +540,14 @@
     "AdditionalFields": {
      "custom_field": "Some Custom Field"
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match with no condition": [
   {
    "Foo": "bar",
    "Baz": "Hello",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -587,13 +586,13 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match with NULL": [
   {
    "Bar": 1,
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -638,14 +637,14 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Unknown modifiers": [],
  "All modifier": [
   {
    "Foo": "Bar",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -731,7 +730,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Test Modifiers": [
@@ -743,7 +743,6 @@
    "fieldname_int": 15,
    "CommandLine": "ping /f ―g —h ",
    "CommandLineWide": "cABpAG4AZwAgAA==",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1144,7 +1143,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Match single base64offset field": [
@@ -1152,7 +1152,6 @@
    "Match": "Should match selection1 and selection2 contains single element (Shift 1)",
    "Decoded": "ejfjefhellorfriufirtestkdkdg",
    "Foo": "ZWpmamVmaGVsbG9yZnJpdWZpcnRlc3RrZGtkZw==",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1262,13 +1261,13 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   },
   {
    "Match": "Should match selection1 and selection2 contains single element (Shift 2)",
    "Decoded": "jfjefhellorfriufirtestkdkdg",
    "Foo": "amZqZWZoZWxsb3Jmcml1ZmlydGVzdGtka2Rn",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1378,13 +1377,13 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   },
   {
    "Match": "Should match selection1 and selection2 contains single element",
    "Decoded": "jejfjefhellorfriufirtestkdkdg",
    "Foo": "amVqZmplZmhlbGxvcmZyaXVmaXJ0ZXN0a2RrZGc=",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1494,13 +1493,13 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   },
   {
    "Match": "Should match selection3 with all",
    "Decoded": "kgkrpepsigrgspriteefjefe",
    "Foo": "a2drcnBlcHNpZ3Jnc3ByaXRlZWZqZWZl",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1610,13 +1609,13 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   },
   {
    "Match": "Should match selection4 with contains one of members",
    "Decoded": "kgkrgrgveloefjefe",
    "Foo": "a2drcmdyZ3ZlbG9lZmplZmU=",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1726,14 +1725,14 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Test VQL Events": [
   {
    "Foo": 1,
    "Bar": "Baz",
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1796,7 +1795,8 @@
     "AdditionalFields": {
      "vql": "x=\u003edict(Foo=1, Bar=\"Baz\")"
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Test Conditions": [
@@ -1804,7 +1804,6 @@
    "Foo": 1,
    "Bar": "Baz",
    "Proc": 1,
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1882,7 +1881,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Automatic Field Mappings": [
@@ -1892,7 +1892,6 @@
      "Baz": "Hello world"
     }
    },
-   "Details": null,
    "_Match": {
     "match": true,
     "search_results": {
@@ -1934,7 +1933,8 @@
       }
      ]
     }
-   }
+   },
+   "Details": null
   }
  ]
 }

--- a/vql/sigma/fixtures/TestSigmaCorrelation.golden
+++ b/vql/sigma/fixtures/TestSigmaCorrelation.golden
@@ -6,25 +6,28 @@
    "EventID": 4625,
    "TargetDomainName": "Domain",
    "TargetUserName": "A",
-   "Details": null,
+   "_MatchingRule": "Failed logon",
    "_Correlations": [
     {
      "Timestamp": "2024-10-10T12:22:00+10",
      "EventID": 4625,
      "TargetDomainName": "Domain",
-     "TargetUserName": "A"
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
     },
     {
      "Timestamp": "2024-10-10T12:24:00+10",
      "EventID": 4625,
      "TargetDomainName": "Domain",
-     "TargetUserName": "A"
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
     },
     {
      "Timestamp": "2024-10-10T12:25:00+10",
      "EventID": 4625,
      "TargetDomainName": "Domain",
-     "TargetUserName": "A"
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
     }
    ],
    "_Rule": {
@@ -42,8 +45,36 @@
      "condition": {
       "gte": 3
      }
+    },
+    "AdditionalFields": {
+     "details": "Detected Multiple Failed Logins",
+     "enrichment": "x=\u003ex._Correlations"
     }
-   }
+   },
+   "Details": "Detected Multiple Failed Logins",
+   "Enrichment": [
+    {
+     "Timestamp": "2024-10-10T12:22:00+10",
+     "EventID": 4625,
+     "TargetDomainName": "Domain",
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
+    },
+    {
+     "Timestamp": "2024-10-10T12:24:00+10",
+     "EventID": 4625,
+     "TargetDomainName": "Domain",
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
+    },
+    {
+     "Timestamp": "2024-10-10T12:25:00+10",
+     "EventID": 4625,
+     "TargetDomainName": "Domain",
+     "TargetUserName": "A",
+     "_MatchingRule": "Failed logon"
+    }
+   ]
   }
  ],
  "Correlation Test VALUE_COUNT": [
@@ -52,31 +83,35 @@
    "EventID": 4799,
    "SubjectUserName": "admin",
    "TargetUserName": "Distributed COM Users",
-   "Details": null,
+   "_MatchingRule": "High-privilege group enumeration",
    "_Correlations": [
     {
      "Timestamp": "2024-10-10T12:22:00+10",
      "EventID": 4799,
      "SubjectUserName": "admin",
-     "TargetUserName": "Administrators"
+     "TargetUserName": "Administrators",
+     "_MatchingRule": "High-privilege group enumeration"
     },
     {
      "Timestamp": "2024-10-10T12:23:00+10",
      "EventID": 4799,
      "SubjectUserName": "admin",
-     "TargetUserName": "Remote Desktop Users"
+     "TargetUserName": "Remote Desktop Users",
+     "_MatchingRule": "High-privilege group enumeration"
     },
     {
      "Timestamp": "2024-10-10T12:24:00+10",
      "EventID": 4799,
      "SubjectUserName": "admin",
-     "TargetUserName": "Remote Management Users"
+     "TargetUserName": "Remote Management Users",
+     "_MatchingRule": "High-privilege group enumeration"
     },
     {
      "Timestamp": "2024-10-10T12:25:00+10",
      "EventID": 4799,
      "SubjectUserName": "admin",
-     "TargetUserName": "Distributed COM Users"
+     "TargetUserName": "Distributed COM Users",
+     "_MatchingRule": "High-privilege group enumeration"
     }
    ],
    "_Rule": {
@@ -103,7 +138,8 @@
       "Directory assessment tools"
      ]
     }
-   }
+   },
+   "Details": null
   }
  ],
  "Correlation Test TEMPORAL": [
@@ -112,20 +148,22 @@
    "cs-method": "POST",
    "cs-uri-query": "/app//json/setup-restore-local.action",
    "sc-status": 200,
-   "Details": null,
+   "_MatchingRule": "CVE-2023-22518 Exploitation Attempt - Vulnerable Endpoint Connection (Webserver)",
    "_Correlations": [
     {
      "Timestamp": "2024-10-10T12:22:00+10",
      "ParentImage": "C:\\Windows\\tomcat9.exe",
      "ParentCommandLine": "confluence",
      "Image": "C:\\Windows\\cmd.exe",
-     "OriginalFileName": "Cmd.Exe"
+     "OriginalFileName": "Cmd.Exe",
+     "_MatchingRule": "CVE-2023-22518 Exploitation Attempt - Suspicious Confluence Child Process (Windows)"
     },
     {
      "Timestamp": "2024-10-10T12:23:00+10",
      "cs-method": "POST",
      "cs-uri-query": "/app//json/setup-restore-local.action",
-     "sc-status": 200
+     "sc-status": 200,
+     "_MatchingRule": "CVE-2023-22518 Exploitation Attempt - Vulnerable Endpoint Connection (Webserver)"
     }
    ],
    "_Rule": {
@@ -139,7 +177,8 @@
      "timespan": "10m"
     },
     "Level": "high"
-   }
+   },
+   "Details": null
   }
  ]
 }

--- a/vql/sigma/sigma_test.go
+++ b/vql/sigma/sigma_test.go
@@ -761,6 +761,10 @@ correlation:
     timespan: 5m
     condition:
         gte: 3
+
+# Make sure the details and enrichment comes from the correlation rule.
+details: Detected Multiple Failed Logins
+enrichment: x=>x._Correlations
 `,
 			fieldmappings: loginEvents_field_mappings,
 


### PR DESCRIPTION
Previously the details and enrichment field were filled from the matching rule.

The PR also tags each matching event in the correlator with the rule that actually matched it. This makes it easier to see why the rule was selected into the correlator.