### PR TITLE
Add Xattr fetch to MacOS.Search.Filefinder

### DIFF
--- a/artifacts/definitions/MacOS/Search/FileFinder.yaml
+++ b/artifacts/definitions/MacOS/Search/FileFinder.yaml
@@ -50,6 +50,10 @@ parameters:
     default:
     description: A yara rule to search for matching files.
 
+  - name: Fetch_Xattr
+    default: N
+    type: bool
+    
   - name: Upload_File
     default: N
     type: bool
@@ -127,6 +131,9 @@ sources:
                if(condition=Upload_File and Mode.IsRegular,
                   then=upload(file=OSPath,
                               accessor="file")) AS Upload,
+               if(condition=Fetch_Xattr,
+                  then=xattr(filename=OSPath,
+                              accessor="file")) AS XAttr,
                if(condition=Calculate_Hash and Mode.IsRegular,
                   then=hash(path=OSPath,
                             accessor="file")) AS Hash


### PR DESCRIPTION
Just a tiny change to enable retrieving of Extended Attributes (xattr).