### PR TITLE
Bugfix: Glob plugin was only cancellable when a hit was reported.

### DIFF
--- a/glob/glob.go
+++ b/glob/glob.go
@@ -307,7 +307,7 @@ func (self *Globber) ExpandWithContext(
 		defer close(output_chan)
 
 		// Nothing to do here
-		if len(self.filters) == 0 {
+		if len(self.filters) == 0 || utils.IsCtxDone(ctx) {
 			return
 		}
 

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -91,3 +91,12 @@ func DebugLogWhenCtxDone(ctx context.Context, name string) {
 		fmt.Printf(name + ": Ctx done!\n")
 	}()
 }
+
+func IsCtxDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/vql/common/batch.go
+++ b/vql/common/batch.go
@@ -28,7 +28,7 @@ func (self BatchPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("batch", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "batch", args)()
 
 		arg := &BatchPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/chain.go
+++ b/vql/common/chain.go
@@ -39,7 +39,7 @@ func (self _ChainPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("chain", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "chain", args)()
 
 		var async bool
 

--- a/vql/common/clock.go
+++ b/vql/common/clock.go
@@ -45,7 +45,7 @@ func (self ClockPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("clock", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "clock", args)()
 
 		arg := &ClockPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/columns.go
+++ b/vql/common/columns.go
@@ -26,7 +26,7 @@ func (self ColumnFilter) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("column_filter", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "column_filter", args)()
 
 		arg := &ColumnFilterArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/dedup.go
+++ b/vql/common/dedup.go
@@ -29,7 +29,7 @@ func (self DedupPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("dedup", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "dedup", args)()
 
 		arg := &DedupPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/diff.go
+++ b/vql/common/diff.go
@@ -169,7 +169,7 @@ func (self _DiffPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("diff", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "diff", args)()
 
 		arg := &_DiffPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/fifo.go
+++ b/vql/common/fifo.go
@@ -190,7 +190,7 @@ func (self _FIFOPlugin) Call(ctx context.Context,
 	wg.Add(1)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("fifo", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "fifo", args)()
 
 		arg := &_FIFOPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/items.go
+++ b/vql/common/items.go
@@ -24,7 +24,7 @@ func (self ItemsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("items", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "items", args)()
 
 		arg := &ItemsPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/sampler.go
+++ b/vql/common/sampler.go
@@ -23,7 +23,7 @@ func (self _SamplerPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("sample", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "sample", args)()
 
 		arg := &_SamplerPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/common/sequence.go
+++ b/vql/common/sequence.go
@@ -91,7 +91,7 @@ func (self _SequencePlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("sequence", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "sequence", args)()
 
 		query_any, pres := args.Get("query")
 		if !pres {

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -62,7 +62,7 @@ func (self ShellPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("execve", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "execve", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.EXECVE)
 		if err != nil {

--- a/vql/common/switch.go
+++ b/vql/common/switch.go
@@ -18,7 +18,7 @@ func (self _SwitchPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("switch", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "switch", args)()
 
 		queries := []vfilter.StoredQuery{}
 		members := scope.GetMembers(args)

--- a/vql/common/yara.go
+++ b/vql/common/yara.go
@@ -87,7 +87,7 @@ func (self YaraScanPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("yara", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "yara", args)()
 
 		arg := &YaraScanPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -598,7 +598,7 @@ func (self YaraProcPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("proc_yara", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "proc_yara", args)()
 
 		arg := &YaraProcPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/darwin/vad.go
+++ b/vql/darwin/vad.go
@@ -66,7 +66,7 @@ func (self VADPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer vql_subsystem.CheckForPanic(scope, "vad")
-		defer vql_subsystem.RegisterMonitor("vad", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "vad", args)()
 
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 		if err != nil {

--- a/vql/darwin/xattr.go
+++ b/vql/darwin/xattr.go
@@ -28,7 +28,7 @@ func (self XAttrFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("xattr", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "xattr", args)()
 	defer vql_subsystem.CheckForPanic(scope, "xattr")
 
 	arg := &XAttrArgs{}

--- a/vql/filesystem/copy.go
+++ b/vql/filesystem/copy.go
@@ -49,7 +49,7 @@ type CopyFunction struct{}
 func (self *CopyFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("copy", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "copy", args)()
 
 	select {
 	case <-ctx.Done():

--- a/vql/filesystem/filesystem.go
+++ b/vql/filesystem/filesystem.go
@@ -56,7 +56,7 @@ func (self GlobPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("glob", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "glob", args)()
 
 		config_obj, ok := vql_subsystem.GetServerConfig(scope)
 		if !ok {
@@ -260,7 +260,7 @@ func (self ReadFilePlugin) Call(
 	args *ordereddict.Dict) <-chan vfilter.Row {
 	output_chan := make(chan vfilter.Row)
 
-	defer vql_subsystem.RegisterMonitor("read_file", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "read_file", args)()
 
 	arg := &ReadFileArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -276,7 +276,7 @@ func (self ReadFilePlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("read_file", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "read_file", args)()
 
 		err := vql_subsystem.CheckFilesystemAccess(scope, arg.Accessor)
 		if err != nil {
@@ -327,7 +327,7 @@ func (self *ReadFileFunction) Call(ctx context.Context,
 	args *ordereddict.Dict) vfilter.Any {
 	arg := &ReadFileFunctionArgs{}
 
-	defer vql_subsystem.RegisterMonitor("read_file", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "read_file", args)()
 
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -399,7 +399,7 @@ func (self *StatPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("stat", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "stat", args)()
 
 		arg := &StatArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -455,7 +455,7 @@ func (self *StatFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("stat", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "stat", args)()
 
 	arg := &StatArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/filesystem/pathspec.go
+++ b/vql/filesystem/pathspec.go
@@ -27,7 +27,7 @@ func (self PathSpecFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("pathspec", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "pathspec", args)()
 
 	arg := &PathSpecArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/filesystem/raw_registry.go
+++ b/vql/filesystem/raw_registry.go
@@ -29,7 +29,7 @@ func (self ReadKeyValues) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("read_reg_key", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "read_reg_key", args)()
 
 		arg := &ReadKeyValuesArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/filesystem/rm.go
+++ b/vql/filesystem/rm.go
@@ -22,7 +22,7 @@ func (self *_RmFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("rm", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "rm", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
 	if err != nil {

--- a/vql/filesystem/tempfile.go
+++ b/vql/filesystem/tempfile.go
@@ -45,7 +45,7 @@ func (self *TempfileFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("tempfile", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "tempfile", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
 	if err != nil {
@@ -139,7 +139,7 @@ func (self *TempdirFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("tempdir", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "tempdir", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
 	if err != nil {

--- a/vql/filesystem/vfs.go
+++ b/vql/filesystem/vfs.go
@@ -30,7 +30,7 @@ func (self VFSListDirectoryPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("vfs_ls", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "vfs_ls", args)()
 
 		arg := &VFSListDirectoryPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/alerts.go
+++ b/vql/functions/alerts.go
@@ -32,7 +32,7 @@ func (self *AlertFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("alert", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "alert", args)()
 
 	// If a condition is specified we ignore the alert unless the
 	// condition is true

--- a/vql/functions/commandline.go
+++ b/vql/functions/commandline.go
@@ -21,7 +21,7 @@ func (self *CommandlineToArgvFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("commandline", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "commandline", args)()
 
 	arg := &CommandlineToArgvArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/dict.go
+++ b/vql/functions/dict.go
@@ -30,7 +30,7 @@ func (self _ToDictFunc) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vf
 func (self _ToDictFunc) Call(ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("to_dict", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "to_dict", args)()
 
 	arg := &_ToDictFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -75,7 +75,7 @@ func (self _ItemsFunc) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfi
 
 func (self _ItemsFunc) Call(ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("items", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "items", args)()
 
 	arg := &_ToDictFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -112,7 +112,7 @@ func (self _DictFunc) Info(scope types.Scope, type_map *types.TypeMap) *types.Fu
 }
 
 func (self _DictFunc) Call(ctx context.Context, scope types.Scope, args *ordereddict.Dict) types.Any {
-	defer vql_subsystem.RegisterMonitor("dict", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "dict", args)()
 
 	return dict.RowToDict(ctx, scope, args)
 }
@@ -127,7 +127,7 @@ func (self *_LazyDictFunc) Info(scope types.Scope, type_map *types.TypeMap) *typ
 }
 
 func (self *_LazyDictFunc) Call(ctx context.Context, scope types.Scope, args *ordereddict.Dict) types.Any {
-	defer vql_subsystem.RegisterMonitor("lazr_dict", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "lazr_dict", args)()
 
 	return args
 }

--- a/vql/functions/encode.go
+++ b/vql/functions/encode.go
@@ -27,7 +27,7 @@ type EncodeFunction struct{}
 func (self *EncodeFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("encode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "encode", args)()
 
 	arg := &EncodeFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/entropy.go
+++ b/vql/functions/entropy.go
@@ -37,7 +37,7 @@ func (self *Entropy) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("entropy", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "entropy", args)()
 
 	arg := &entropy_args{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/eval.go
+++ b/vql/functions/eval.go
@@ -28,7 +28,7 @@ func (self EvalFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *v
 func (self EvalFunction) Call(ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("eval", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "eval", args)()
 
 	arg := &EvalFunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/expand.go
+++ b/vql/functions/expand.go
@@ -23,7 +23,7 @@ func (self ExpandPath) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("expand", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "expand", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {

--- a/vql/functions/format.go
+++ b/vql/functions/format.go
@@ -39,7 +39,7 @@ func (self *FormatFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("format", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "format", args)()
 
 	arg := &FormatArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/functions.go
+++ b/vql/functions/functions.go
@@ -47,7 +47,7 @@ func (self _Base64Decode) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("base64decode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "base64decode", args)()
 
 	arg := &_Base64DecodeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -77,7 +77,7 @@ func (self _Base85Decode) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("base85decode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "base85decode", args)()
 
 	arg := &_Base64DecodeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -112,7 +112,7 @@ func (self _Base64Encode) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("base64encode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "base64encode", args)()
 
 	arg := &_Base64EncodeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -143,7 +143,7 @@ func (self _ToLower) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("lowcase", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "lowcase", args)()
 	arg := &_ToLowerArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -168,7 +168,7 @@ func (self _ToUpper) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("upcase", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upcase", args)()
 	arg := &_ToLowerArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -197,7 +197,7 @@ func (self _ToInt) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("atoi", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "atoi", args)()
 
 	arg := &_ToIntArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -232,7 +232,7 @@ func (self _ParseFloat) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_float", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_float", args)()
 
 	arg := &_ToIntArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -294,7 +294,7 @@ func (self _UTF16) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("utf16", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "utf16", args)()
 
 	arg := &_Base64DecodeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -326,7 +326,7 @@ func (self _UTF16Encode) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("utf16_encode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "utf16_encode", args)()
 
 	arg := &_Base64EncodeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -375,7 +375,7 @@ func (self _GetFunction) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("get", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "get", args)()
 
 	arg := &_GetFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -443,7 +443,7 @@ func (self _SetFunction) Call(
 	ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("set", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "set", args)()
 
 	arg := &_SetFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/gunzip.go
+++ b/vql/functions/gunzip.go
@@ -39,7 +39,7 @@ func (self *Gunzip) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("gunzip", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "gunzip", args)()
 
 	arg := &GunzipArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/hash.go
+++ b/vql/functions/hash.go
@@ -75,7 +75,7 @@ func (self *HashFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("hash", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "hash", args)()
 
 	arg := &HashFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/humanize.go
+++ b/vql/functions/humanize.go
@@ -40,7 +40,7 @@ type HumanizeFunction struct{}
 func (self *HumanizeFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("humanize", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "humanize", args)()
 
 	arg := &HumanizeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/ints.go
+++ b/vql/functions/ints.go
@@ -38,7 +38,7 @@ func (self *IntFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("int", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "int", args)()
 
 	arg := &IntArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -96,7 +96,7 @@ func (self *StrFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("str", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "str", args)()
 
 	arg := &StrFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/lists.go
+++ b/vql/functions/lists.go
@@ -38,7 +38,7 @@ type ArrayFunction struct{}
 func (self *ArrayFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("array", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "array", args)()
 
 	result := []vfilter.Any{}
 
@@ -88,7 +88,7 @@ type JoinFunction struct{}
 func (self *JoinFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("join", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "join", args)()
 	arg := &JoinFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -117,7 +117,7 @@ type FilterFunction struct{}
 func (self *FilterFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("filter", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "filter", args)()
 	arg := &FilterFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -164,7 +164,7 @@ type LenFunction struct{}
 func (self *LenFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("len", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "len", args)()
 	arg := &LenFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {
@@ -217,7 +217,7 @@ func (self *SliceFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("slice", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "slice", args)()
 
 	arg := &SliceFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/log.go
+++ b/vql/functions/log.go
@@ -58,7 +58,7 @@ func (self *LogFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("log", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "log", args)()
 	arg := &LogFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {

--- a/vql/functions/networks.go
+++ b/vql/functions/networks.go
@@ -39,7 +39,7 @@ func (self *IpFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("ip", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "ip", args)()
 
 	arg := &IpArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/patch.go
+++ b/vql/functions/patch.go
@@ -47,7 +47,7 @@ func (self *PatchFunction) Call(
 	args *ordereddict.Dict) vfilter.Any {
 	arg := &PatchFunctionArgs{}
 
-	defer vql_subsystem.RegisterMonitor("patch", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "patch", args)()
 
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {

--- a/vql/functions/paths.go
+++ b/vql/functions/paths.go
@@ -42,7 +42,7 @@ func (self *DirnameFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("dirname", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "dirname", args)()
 
 	arg := &DirnameArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -74,7 +74,7 @@ func (self *BasenameFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("basename", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "basename", args)()
 
 	arg := &DirnameArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -112,7 +112,7 @@ func (self *RelnameFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("relpath", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "relpath", args)()
 
 	arg := &RelnameFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -149,7 +149,7 @@ func (self *PathJoinFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("path_join", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "path_join", args)()
 
 	arg := &PathJoinArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -204,7 +204,7 @@ type PathSplitFunction struct{}
 func (self *PathSplitFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("path_split", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "path_split", args)()
 
 	arg := &PathSplitArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/pid.go
+++ b/vql/functions/pid.go
@@ -33,7 +33,7 @@ type GetPidFunction struct{}
 func (self *GetPidFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("getpid", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "getpid", args)()
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {
 		scope.Log("getpid: %s", err)

--- a/vql/functions/pskill.go
+++ b/vql/functions/pskill.go
@@ -39,7 +39,7 @@ func (self *PsKillFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("pskill", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "pskill", args)()
 
 	// Need high level of access to run this - basically the same as
 	// shelling out to e.g. powershell.

--- a/vql/functions/rc4.go
+++ b/vql/functions/rc4.go
@@ -38,7 +38,7 @@ func (self *Crypto_rc4) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("crypto_rc4", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "crypto_rc4", args)()
 
 	arg := &Crypto_rc4Args{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/rot13.go
+++ b/vql/functions/rot13.go
@@ -36,7 +36,7 @@ func (self *Rot13) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("rot13", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "rot13", args)()
 
 	arg := &Rot13Args{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/similarity.go
+++ b/vql/functions/similarity.go
@@ -38,7 +38,7 @@ func (self *SimilarityFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("similarity", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "similarity", args)()
 
 	// Parse arguments using arg_parser
 	arg := &similarityArgs{}

--- a/vql/functions/sleep.go
+++ b/vql/functions/sleep.go
@@ -22,7 +22,7 @@ func (self *SleepFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("sleep", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "sleep", args)()
 
 	arg := &SleepArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/strings.go
+++ b/vql/functions/strings.go
@@ -39,7 +39,7 @@ func (self *StripFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("strip", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "strip", args)()
 
 	arg := &StripArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -84,7 +84,7 @@ func (self *SubStrFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("substr", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "substr", args)()
 
 	arg := &SubStrArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/time.go
+++ b/vql/functions/time.go
@@ -158,7 +158,7 @@ func (self _Timestamp) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfi
 func (self _Timestamp) Call(ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("timestamp", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "timestamp", args)()
 
 	arg := &_TimestampArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -478,7 +478,7 @@ var (
 func (self _TimestampFormat) Call(ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("timestamp_format", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "timestamp_format", args)()
 
 	arg := &_TimestampFormatArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/tlsh.go
+++ b/vql/functions/tlsh.go
@@ -24,7 +24,7 @@ type TLSHashFunction struct{}
 func (self *TLSHashFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("tlsh_hash", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "tlsh_hash", args)()
 
 	arg := &HashFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/unhex.go
+++ b/vql/functions/unhex.go
@@ -21,7 +21,7 @@ func (self *UnhexFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("unhex", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "unhex", args)()
 
 	arg := &UnhexFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/url.go
+++ b/vql/functions/url.go
@@ -46,7 +46,7 @@ func (self UrlFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("url", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "url", args)()
 
 	arg := &UrlArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/functions/xor.go
+++ b/vql/functions/xor.go
@@ -37,7 +37,7 @@ func (self *Xor) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("xor", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "xor", args)()
 
 	arg := &XorArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/golang/generators.go
+++ b/vql/golang/generators.go
@@ -79,7 +79,7 @@ func (self *GeneratorFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("generate", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "generate", args)()
 
 	arg := &GeneratorArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/golang/goroutines.go
+++ b/vql/golang/goroutines.go
@@ -32,7 +32,7 @@ func (self GoRoutinesPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("profile_goroutines", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "profile_goroutines", args)()
 
 		defer utils.RecoverVQL(scope)
 

--- a/vql/golang/memory.go
+++ b/vql/golang/memory.go
@@ -23,7 +23,7 @@ func (self MemoryAllocationsPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("profile_memory", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "profile_memory", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/golang/profile.go
+++ b/vql/golang/profile.go
@@ -200,7 +200,7 @@ func (self *ProfilePlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("profile", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "profile", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/golang/trace.go
+++ b/vql/golang/trace.go
@@ -30,7 +30,7 @@ func (self *TraceFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("trace", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "trace", args)()
 
 	buf := new(bytes.Buffer)
 	lf := []byte("\n")

--- a/vql/linux/audit.go
+++ b/vql/linux/audit.go
@@ -63,7 +63,7 @@ func (self AuditPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("audit", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "audit", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/linux/ebpf/ebpf.go
+++ b/vql/linux/ebpf/ebpf.go
@@ -45,7 +45,7 @@ func (self EBPFEventPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_ebpf", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_ebpf", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {
@@ -144,7 +144,7 @@ func (self EBPFEventListPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_ebpf", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_ebpf", args)()
 
 		events := ebpf.GetEvents()
 		for _, event := range events.Keys() {

--- a/vql/networking/cidrmatch.go
+++ b/vql/networking/cidrmatch.go
@@ -22,7 +22,7 @@ func (self _CIDRContains) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("cidr_contains", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "cidr_contains", args)()
 
 	arg := &_CIDRContainsArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/networking/host.go
+++ b/vql/networking/host.go
@@ -29,7 +29,7 @@ func (self *HostFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("host", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "host", args)()
 
 	arg := &HostFunctionArgs{}
 

--- a/vql/networking/http_client.go
+++ b/vql/networking/http_client.go
@@ -287,7 +287,7 @@ func (self *_HttpPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("http_client", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "http_client", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 		if err != nil {

--- a/vql/networking/mail.go
+++ b/vql/networking/mail.go
@@ -95,7 +95,7 @@ func (self MailFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("mail", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "mail", args)()
 
 	res := ordereddict.NewDict()
 

--- a/vql/networking/netcat.go
+++ b/vql/networking/netcat.go
@@ -33,7 +33,7 @@ func (self *NetcatPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("netcat", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "netcat", args)()
 
 		arg := &NetcatPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/networking/network.go
+++ b/vql/networking/network.go
@@ -46,7 +46,7 @@ func (self InterfacesPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("interfaces", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "interfaces", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/networking/upload.go
+++ b/vql/networking/upload.go
@@ -51,7 +51,7 @@ func (self *UploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload", args)()
 
 	uploader, ok := artifacts.GetUploader(scope)
 	if !ok {
@@ -159,7 +159,7 @@ func (self *UploadDirectoryFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_directory", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_directory", args)()
 
 	arg := &UploadDirectoryFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/appcache.go
+++ b/vql/parsers/appcache.go
@@ -24,7 +24,7 @@ func (self AppCompatCache) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("AppCompatCache", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "AppCompatCache", args)()
 
 		arg := AppCompatCacheArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, &arg)

--- a/vql/parsers/authenticode/authenticode.go
+++ b/vql/parsers/authenticode/authenticode.go
@@ -52,7 +52,7 @@ func (self *AuthenticodeFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("authenticode", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "authenticode", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {

--- a/vql/parsers/binary.go
+++ b/vql/parsers/binary.go
@@ -39,7 +39,7 @@ func (self ParseBinaryFunction) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_binary", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_binary", args)()
 
 	arg := &ParseBinaryFunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/crypto/pkcs7.go
+++ b/vql/parsers/crypto/pkcs7.go
@@ -30,7 +30,7 @@ func (self ParsePKCS7Function) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_pkcs7", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_pkcs7", args)()
 
 	arg := &ParsePKCS7FunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -65,7 +65,7 @@ func (self ParseX509Function) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_x509", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_x509", args)()
 
 	arg := &ParseX509FunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/crypto/pubkey.go
+++ b/vql/parsers/crypto/pubkey.go
@@ -43,7 +43,7 @@ func (self *PKEncryptFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("pk_encrypt", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "pk_encrypt", args)()
 
 	arg := &PKEncryptArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -154,7 +154,7 @@ func encryptPGP(recip []*openpgp.Entity,
 func (self *PKDecryptFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("pk_decrypt", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "pk_decrypt", args)()
 
 	arg := &PKDecryptArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/csv/csv.go
+++ b/vql/parsers/csv/csv.go
@@ -55,7 +55,7 @@ func (self ParseCSVPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_csv", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_csv", args)()
 
 		arg := &ParseCSVPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -184,7 +184,7 @@ func (self _WatchCSVPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_csv", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_csv", args)()
 
 		arg := &ParseCSVPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -255,7 +255,7 @@ func (self WriteCSVPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("write_csv", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "write_csv", args)()
 
 		arg := &WriteCSVPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/ese/ese.go
+++ b/vql/parsers/ese/ese.go
@@ -65,7 +65,7 @@ func (self _SRUMLookupId) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("srum_lookup_id", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "srum_lookup_id", args)()
 	defer utils.RecoverVQL(scope)
 
 	arg := &_SRUMLookupIdArgs{}
@@ -185,7 +185,7 @@ func (self _ESEPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_ese", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_ese", args)()
 
 		arg := &_ESEArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -271,7 +271,7 @@ func (self _ESECatalogPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_ese_catalog", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_ese_catalog", args)()
 
 		arg := &_ESECatalogArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/event_logs/evtx.go
+++ b/vql/parsers/event_logs/evtx.go
@@ -48,7 +48,7 @@ func (self _ParseEvtxPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_evtx", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_evtx", args)()
 
 		arg := &_ParseEvtxPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -142,7 +142,7 @@ func (self _WatchEvtxPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_evtx", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_evtx", args)()
 
 		// Do not close output_chan - The event log service
 		// owns it and it will be closed by it.

--- a/vql/parsers/grok.go
+++ b/vql/parsers/grok.go
@@ -32,7 +32,7 @@ func (self GrokParseFunction) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("grok", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "grok", args)()
 
 	arg := &GrokParseFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/journald/journald.go
+++ b/vql/parsers/journald/journald.go
@@ -43,7 +43,7 @@ func (self JournalPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_journald", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_journald", args)()
 
 		arg := &JournalPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -110,7 +110,7 @@ func (self WatchJournaldPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_journald", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_journald", args)()
 
 		arg := &WatchJournalPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/json.go
+++ b/vql/parsers/json.go
@@ -65,7 +65,7 @@ func (self ParseJsonFunction) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_json", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_json", args)()
 
 	arg := &ParseJsonFunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -96,7 +96,7 @@ func (self ParseJsonArray) Call(
 	ctx context.Context, scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_json_array", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_json_array", args)()
 
 	arg := &ParseJsonFunctionArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -155,7 +155,7 @@ func (self ParseJsonlPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_jsonl", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_jsonl", args)()
 
 		arg := &ParseJsonlPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -270,7 +270,7 @@ func (self ParseJsonArrayPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_json_array", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_json_array", args)()
 
 		result := ParseJsonArray{}.Call(ctx, scope, args)
 		result_value := reflect.Indirect(reflect.ValueOf(result))
@@ -559,7 +559,7 @@ func (self WriteJSONPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("write_jsonl", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "write_jsonl", args)()
 
 		arg := &WriteJSONPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -678,7 +678,7 @@ func (self WatchJsonlPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_jsonl", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_jsonl", args)()
 
 		arg := &syslog.ScannerPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/leveldb.go
+++ b/vql/parsers/leveldb.go
@@ -35,7 +35,7 @@ func (self LevelDBPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("leveldb", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "leveldb", args)()
 
 		arg := &LevelDBPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/ntfs.go
+++ b/vql/parsers/ntfs.go
@@ -107,7 +107,7 @@ func (self NTFSFunction) Call(
 	args *ordereddict.Dict) vfilter.Any {
 
 	defer utils.RecoverVQL(scope)
-	defer vql_subsystem.RegisterMonitor("parse_ntfs", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_ntfs", args)()
 
 	arg := &NTFSFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -215,7 +215,7 @@ func (self MFTScanPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_mft", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_mft", args)()
 
 		arg := &MFTScanPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -292,7 +292,7 @@ func (self NTFSI30ScanPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_ntfs_i30", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_ntfs_i30", args)()
 
 		arg := &NTFSFunctionArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -348,7 +348,7 @@ func (self NTFSRangesPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_ntfs_ranges", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_ntfs_ranges", args)()
 
 		arg := &NTFSFunctionArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/ole.go
+++ b/vql/parsers/ole.go
@@ -145,7 +145,7 @@ func (self _OLEVBAPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("olevba", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "olevba", args)()
 
 		arg := &_OLEVBAArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/pe.go
+++ b/vql/parsers/pe.go
@@ -56,7 +56,7 @@ func (self _PEFunction) Call(
 	args *ordereddict.Dict) vfilter.Any {
 
 	defer utils.RecoverVQL(scope)
-	defer vql_subsystem.RegisterMonitor("parse_pe", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_pe", args)()
 
 	arg := &_PEFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/pe_dump.go
+++ b/vql/parsers/pe_dump.go
@@ -44,7 +44,7 @@ func (self _PEDumpFunction) Call(
 	args *ordereddict.Dict) vfilter.Any {
 
 	defer utils.RecoverVQL(scope)
-	defer vql_subsystem.RegisterMonitor("pe_dump", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "pe_dump", args)()
 
 	arg := &_PEDumpFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/plist.go
+++ b/vql/parsers/plist.go
@@ -50,7 +50,7 @@ func (self *PlistFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) (result vfilter.Any) {
 
-	defer vql_subsystem.RegisterMonitor("plist", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "plist", args)()
 
 	arg := &_PlistFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -132,7 +132,7 @@ func (self _PlistPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("plist", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "plist", args)()
 
 		arg := &_PlistPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/prefetch.go
+++ b/vql/parsers/prefetch.go
@@ -48,7 +48,7 @@ func (self _PrefetchPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("prefetch", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "prefetch", args)()
 
 		arg := &_PrefetchPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/recyclebin.go
+++ b/vql/parsers/recyclebin.go
@@ -54,7 +54,7 @@ func (self _RecycleBinPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_recyclebin", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_recyclebin", args)()
 
 		arg := &_RecycleBinPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/regexparser.go
+++ b/vql/parsers/regexparser.go
@@ -144,7 +144,7 @@ func (self _ParseFileWithRegex) Call(
 	args *ordereddict.Dict) <-chan vfilter.Row {
 	output_chan := make(chan vfilter.Row)
 
-	defer vql_subsystem.RegisterMonitor("parse_records_with_regex", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_records_with_regex", args)()
 
 	arg := &_ParseFileWithRegexArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -175,7 +175,7 @@ func (self _ParseFileWithRegex) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_records_with_regex", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_records_with_regex", args)()
 
 		for _, filename := range arg.Filenames {
 			_ParseFile(ctx, filename, scope, arg, output_chan)
@@ -205,7 +205,7 @@ func (self *_ParseStringWithRegexFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) (result vfilter.Any) {
 
-	defer vql_subsystem.RegisterMonitor("parse_string_with_regex", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_string_with_regex", args)()
 
 	arg := &_ParseStringWithRegexFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -279,7 +279,7 @@ func (self _RegexReplace) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("regex_replace", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "regex_replace", args)()
 
 	arg := &_RegexReplaceArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -349,7 +349,7 @@ func (self _RegexMap) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("regex_transform", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "regex_transform", args)()
 
 	arg := &_RegexMapArg{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/splitparser.go
+++ b/vql/parsers/splitparser.go
@@ -174,7 +174,7 @@ func (self SplitRecordParser) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("split_records", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "split_records", args)()
 
 		arg := _SplitRecordParserArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, &arg)

--- a/vql/parsers/sql/sql.go
+++ b/vql/parsers/sql/sql.go
@@ -99,7 +99,7 @@ func (self SQLPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("sql", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "sql", args)()
 
 		arg := &SQLPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/syslog/auditd.go
+++ b/vql/parsers/syslog/auditd.go
@@ -37,7 +37,7 @@ func (self AuditdPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_auditd", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_auditd", args)()
 
 		reassembler, err := libaudit.NewReassembler(5, 2*time.Second,
 			&streamHandler{scope: scope, ctx: ctx, output_chan: output_chan})
@@ -126,7 +126,7 @@ func (self WatchAuditdPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_auditd", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_auditd", args)()
 
 		reassembler, err := libaudit.NewReassembler(5, 2*time.Second,
 			&streamHandler{scope: scope, ctx: ctx, output_chan: output_chan})

--- a/vql/parsers/syslog/scanner.go
+++ b/vql/parsers/syslog/scanner.go
@@ -43,7 +43,7 @@ func (self ScannerPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parse_lines", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_lines", args)()
 
 		arg := &ScannerPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -115,7 +115,7 @@ func (self WatchSyslogPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_syslog", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_syslog", args)()
 
 		arg := &ScannerPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/usn/carver.go
+++ b/vql/parsers/usn/carver.go
@@ -157,7 +157,7 @@ func (self CarveUSNPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("carve_usn", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "carve_usn", args)()
 
 		arg := &CarveUSNPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/usn/usn.go
+++ b/vql/parsers/usn/usn.go
@@ -133,7 +133,7 @@ func (self USNPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("parse_usn", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parse_usn", args)()
 
 		arg := &USNPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -231,7 +231,7 @@ func (self WatchUSNPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer utils.RecoverVQL(scope)
-		defer vql_subsystem.RegisterMonitor("watch_usn", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_usn", args)()
 
 		arg := &WatchUSNPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/xml.go
+++ b/vql/parsers/xml.go
@@ -41,7 +41,7 @@ func (self _ParseXMLFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_xml", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_xml", args)()
 
 	arg := &_ParseXMLFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/parsers/yaml.go
+++ b/vql/parsers/yaml.go
@@ -26,7 +26,7 @@ func (self ParseYamlFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("parse_yaml", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "parse_yaml", args)()
 
 	arg := &ParseYamlFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/remapping/impersonation.go
+++ b/vql/remapping/impersonation.go
@@ -34,7 +34,7 @@ func (self ImpersonatedExpand) Call(
 	ctx context.Context,
 	scope vfilter.Scope, args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("expand", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "expand", args)()
 
 	arg := &ExpandPathArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/remapping/remapping.go
+++ b/vql/remapping/remapping.go
@@ -26,7 +26,7 @@ func (self RemappingFunc) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("remap", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "remap", args)()
 
 	arg := &RemappingArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/server/backup.go
+++ b/vql/server/backup.go
@@ -27,7 +27,7 @@ func (self BackupPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("backup", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "backup", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
 		if err != nil {
@@ -104,7 +104,7 @@ func (self RestoreBackupPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("backup_restore", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "backup_restore", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
 		if err != nil {

--- a/vql/server/clients/clients.go
+++ b/vql/server/clients/clients.go
@@ -50,7 +50,7 @@ func (self ClientsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("clients", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "clients", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/clients/delete.go
+++ b/vql/server/clients/delete.go
@@ -29,7 +29,7 @@ func (self DeleteClientPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("client_delete", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "client_delete", args)()
 
 		arg := &DeleteClientArgs{}
 

--- a/vql/server/crypto/reader.go
+++ b/vql/server/crypto/reader.go
@@ -39,7 +39,7 @@ func (self ReadCryptFilePlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("read_crypto_file", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "read_crypto_file", args)()
 
 		arg := &ReadCryptFilePluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/server/crypto/writer.go
+++ b/vql/server/crypto/writer.go
@@ -36,7 +36,7 @@ func (self WriteCryptFilePlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("write_crypto_file", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "write_crypto_file", args)()
 
 		arg := &WriteCryptFilePluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/server/elastic.go
+++ b/vql/server/elastic.go
@@ -93,7 +93,7 @@ func (self _ElasticPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("elastic", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "elastic", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 		if err != nil {

--- a/vql/server/favorites/list.go
+++ b/vql/server/favorites/list.go
@@ -22,7 +22,7 @@ func (self ListFavoritesPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("favorites_list", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "favorites_list", args)()
 
 		err := services.RequireFrontend()
 		if err != nil {

--- a/vql/server/flows/delete.go
+++ b/vql/server/flows/delete.go
@@ -29,7 +29,7 @@ func (self DeleteFlowPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("delete_flow", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "delete_flow", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.DELETE_RESULTS)
 		if err != nil {

--- a/vql/server/flows/flows.go
+++ b/vql/server/flows/flows.go
@@ -29,7 +29,7 @@ func (self FlowsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("flows", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "flows", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {
@@ -193,7 +193,7 @@ func (self EnumerateFlowPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("enumerate_flow", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "enumerate_flow", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/flows/logs.go
+++ b/vql/server/flows/logs.go
@@ -29,7 +29,7 @@ func (self FlowLogsPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("flow_logs", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "flow_logs", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/flows/monitoring.go
+++ b/vql/server/flows/monitoring.go
@@ -56,7 +56,7 @@ func (self MonitoringPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("monitoring", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "monitoring", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {
@@ -167,7 +167,7 @@ func (self WatchMonitoringPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_monitoring", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_monitoring", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/flows/parallel.go
+++ b/vql/server/flows/parallel.go
@@ -63,7 +63,7 @@ func (self ParallelPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("parallel", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "parallel", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/flows/results.go
+++ b/vql/server/flows/results.go
@@ -172,7 +172,7 @@ func (self SourcePlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("source", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "source", args)()
 
 		// Depending on the parameters, we need to read from
 		// different places.
@@ -417,7 +417,7 @@ func (self FlowResultsPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("flow_results", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "flow_results", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/flows/uploads.go
+++ b/vql/server/flows/uploads.go
@@ -37,7 +37,7 @@ func (self UploadsPlugins) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("uploads", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "uploads", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/hunts/delete.go
+++ b/vql/server/hunts/delete.go
@@ -31,7 +31,7 @@ func (self DeleteHuntPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("hunt_delete", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "hunt_delete", args)()
 
 		arg := &DeleteHuntArgs{}
 

--- a/vql/server/hunts/hunts.go
+++ b/vql/server/hunts/hunts.go
@@ -52,7 +52,7 @@ func (self HuntsPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("hunts", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "hunts", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {
@@ -151,7 +151,7 @@ func (self HuntResultsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("hunt_results", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "hunt_results", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {
@@ -351,7 +351,7 @@ func (self HuntFlowsPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("hunt_flows", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "hunt_flows", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/inventory.go
+++ b/vql/server/inventory.go
@@ -226,7 +226,7 @@ func (self InventoryPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("inventory", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "inventory", args)()
 
 		config_obj, ok := vql_subsystem.GetServerConfig(scope)
 		if !ok {

--- a/vql/server/logging.go
+++ b/vql/server/logging.go
@@ -27,7 +27,7 @@ func (self LogsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("logging", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "logging", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/monitoring/delete.go
+++ b/vql/server/monitoring/delete.go
@@ -33,7 +33,7 @@ func (self DeleteEventsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("delete_events", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "delete_events", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.DELETE_RESULTS)
 		if err != nil {

--- a/vql/server/monitoring/monitoring_logs.go
+++ b/vql/server/monitoring/monitoring_logs.go
@@ -96,7 +96,7 @@ func (self MonitoringLogsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("monitoring_logs", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "monitoring_logs", args)()
 
 		// Depending on the parameters, we need to read from
 		// different places.

--- a/vql/server/notebooks/delete.go
+++ b/vql/server/notebooks/delete.go
@@ -27,7 +27,7 @@ func (self *DeleteNotebookPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("notebook_delete", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "notebook_delete", args)()
 
 		arg := &DeleteNotebookArgs{}
 

--- a/vql/server/orgs/orgs.go
+++ b/vql/server/orgs/orgs.go
@@ -21,7 +21,7 @@ func (self OrgsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("orgs", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "orgs", args)()
 
 		user_manager := services.GetUserManager()
 		org_manager, err := services.GetOrgManager()

--- a/vql/server/repository.go
+++ b/vql/server/repository.go
@@ -205,7 +205,7 @@ func (self ArtifactsPlugin) Call(
 	output_chan := make(chan vfilter.Row)
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("artifact_definitions", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "artifact_definitions", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/secrets/list.go
+++ b/vql/server/secrets/list.go
@@ -25,7 +25,7 @@ func (self SecretsPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("secrets", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "secrets", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.SERVER_ADMIN)
 		if err != nil {

--- a/vql/server/splunk.go
+++ b/vql/server/splunk.go
@@ -70,7 +70,7 @@ func (self _SplunkPlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("splunk_upload", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "splunk_upload", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 		if err != nil {

--- a/vql/server/timelines/reader.go
+++ b/vql/server/timelines/reader.go
@@ -34,7 +34,7 @@ func (self TimelinePlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("timeline", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "timeline", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {
@@ -132,7 +132,7 @@ func (self TimelineListPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("timelines", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "timelines", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.READ_RESULTS)
 		if err != nil {

--- a/vql/server/users/users.go
+++ b/vql/server/users/users.go
@@ -28,7 +28,7 @@ func (self UsersPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("users", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "users", args)()
 
 		// Access checks are done by the users module.
 

--- a/vql/sigma/sigma.go
+++ b/vql/sigma/sigma.go
@@ -36,7 +36,7 @@ func (self SigmaPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("sigma", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "sigma", args)()
 
 		arg := &SigmaPluginArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/atexit.go
+++ b/vql/tools/atexit.go
@@ -24,7 +24,7 @@ func (self AtExitFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("atexit", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "atexit", args)()
 
 	arg := &AtExitFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/azure_upload.go
+++ b/vql/tools/azure_upload.go
@@ -39,7 +39,7 @@ func (self *AzureUploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_azure", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_azure", args)()
 
 	arg := &AzureUploadArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/collector/collector.go
+++ b/vql/tools/collector/collector.go
@@ -60,7 +60,7 @@ func (self CollectPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("collect", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "collect", args)()
 
 		// This plugin allows one to create files (for the output
 		// zip), It is very privileged.

--- a/vql/tools/collector/import.go
+++ b/vql/tools/collector/import.go
@@ -58,7 +58,7 @@ func (self ImportCollectionFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("import_collection", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "import_collection", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 	if err != nil {

--- a/vql/tools/delay.go
+++ b/vql/tools/delay.go
@@ -60,7 +60,7 @@ func (self DelayPlugin) Call(ctx context.Context,
 	sub_ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
-		defer vql_subsystem.RegisterMonitor("delay", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "delay", args)()
 		defer cancel()
 
 		wg := &sync.WaitGroup{}

--- a/vql/tools/dns/tracker.go
+++ b/vql/tools/dns/tracker.go
@@ -106,7 +106,7 @@ func (self CacheDNS) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("cache_dns", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "cache_dns", args)()
 
 	arg := &CacheDNSArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/gcs_pubsub_publish.go
+++ b/vql/tools/gcs_pubsub_publish.go
@@ -32,7 +32,7 @@ func (self *GCSPubsubPublishFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("gcs_pubsub_publish", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "gcs_pubsub_publish", args)()
 
 	arg := &GCSPubsubPublishArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/gcs_upload.go
+++ b/vql/tools/gcs_upload.go
@@ -39,7 +39,7 @@ func (self *GCSUploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_gcs", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_gcs", args)()
 
 	arg := &GCSUploadArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/geoip.go
+++ b/vql/tools/geoip.go
@@ -27,7 +27,7 @@ func (self GeoIPFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("geoip", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "geoip", args)()
 
 	arg := &GeoIPFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/js.go
+++ b/vql/tools/js.go
@@ -61,7 +61,7 @@ func (self *JSCompile) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("js", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "js", args)()
 
 	arg := &JSCompileArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -103,7 +103,7 @@ func (self *JSCall) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("js_call", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "js_call", args)()
 
 	arg := &JSCallArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -164,7 +164,7 @@ func (self *JSSet) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("js_set", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "js_set", args)()
 
 	arg := &JSSetArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -221,7 +221,7 @@ func (self *JSGet) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("js_get", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "js_get", args)()
 
 	arg := &JSGetArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/logscale/plugin.go
+++ b/vql/tools/logscale/plugin.go
@@ -156,7 +156,7 @@ func (self logscalePlugin) Call(ctx context.Context,
 
 	go func() {
 		defer close(outputChan)
-		defer vql_subsystem.RegisterMonitor("logscale", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "logscale", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)
 		if err != nil {

--- a/vql/tools/magic.go
+++ b/vql/tools/magic.go
@@ -36,7 +36,7 @@ func (self MagicFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("magic", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "magic", args)()
 
 	arg := &MagicFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/process/callchain.go
+++ b/vql/tools/process/callchain.go
@@ -20,7 +20,7 @@ type getChain struct{}
 
 func (self getChain) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) types.Any {
-	defer vql_subsystem.RegisterMonitor("process_tracker_callchain", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_callchain", args)()
 
 	arg := &getChainArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/process/children.go
+++ b/vql/tools/process/children.go
@@ -15,7 +15,7 @@ type getChildren struct{}
 func (self getChildren) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) types.Any {
 
-	defer vql_subsystem.RegisterMonitor("process_tracker_children", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_children", args)()
 
 	arg := &getChainArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -47,7 +47,7 @@ type getAll struct{}
 func (self getAll) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) types.Any {
 
-	defer vql_subsystem.RegisterMonitor("process_tracker_all", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_all", args)()
 
 	tracker := GetGlobalTracker()
 	if tracker == nil {

--- a/vql/tools/process/pid.go
+++ b/vql/tools/process/pid.go
@@ -14,7 +14,7 @@ type getProcess struct{}
 
 func (self getProcess) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) types.Any {
-	defer vql_subsystem.RegisterMonitor("process_tracker_get", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_get", args)()
 
 	arg := &getChainArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/process/protocols.go
+++ b/vql/tools/process/protocols.go
@@ -33,7 +33,7 @@ func (self ProcessTrackerUpdater) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("process_tracker_updates", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_updates", args)()
 
 		if tracker == nil {
 			return

--- a/vql/tools/process/pslist.go
+++ b/vql/tools/process/pslist.go
@@ -26,7 +26,7 @@ func (self _ProcessTrackerPsList) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("process_tracker_pslist", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_pslist", args)()
 
 		for _, proc := range GetGlobalTracker().Processes(ctx, scope) {
 			select {

--- a/vql/tools/process/tracker.go
+++ b/vql/tools/process/tracker.go
@@ -425,7 +425,7 @@ func (self _InstallProcessTracker) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("process_tracker", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker", args)()
 
 	arg := &_InstallProcessTrackerArgs{}
 

--- a/vql/tools/process/tree.go
+++ b/vql/tools/process/tree.go
@@ -31,7 +31,7 @@ type getProcessTree struct{}
 
 func (self getProcessTree) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) types.Any {
-	defer vql_subsystem.RegisterMonitor("process_tracker_tree", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "process_tracker_tree", args)()
 
 	arg := &getProcessTreeArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/query.go
+++ b/vql/tools/query.go
@@ -39,7 +39,7 @@ func (self QueryPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("query", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "query", args)()
 
 		// This plugin just passes the current scope to the
 		// subquery so there is no permissions check - the

--- a/vql/tools/rekey.go
+++ b/vql/tools/rekey.go
@@ -30,7 +30,7 @@ func (self *RekeyFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("rekey", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "rekey", args)()
 
 	arg := &RekeyFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/repack.go
+++ b/vql/tools/repack.go
@@ -66,7 +66,7 @@ func (self RepackFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("repack", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "repack", args)()
 
 	arg := &RepackFunctionArgs{}
 	err := vql_subsystem.CheckAccess(scope, acls.COLLECT_SERVER)

--- a/vql/tools/rsyslog/rsyslog.go
+++ b/vql/tools/rsyslog/rsyslog.go
@@ -44,7 +44,7 @@ func (self *RsyslogFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("rsyslog", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "rsyslog", args)()
 	arg := &RsyslogFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 	if err != nil {

--- a/vql/tools/s3_upload.go
+++ b/vql/tools/s3_upload.go
@@ -50,7 +50,7 @@ func (self S3UploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_s3", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_s3", args)()
 
 	mergeScope(ctx, scope, args)
 

--- a/vql/tools/sftp_upload.go
+++ b/vql/tools/sftp_upload.go
@@ -42,7 +42,7 @@ func (self *SFTPUploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_sftp", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_sftp", args)()
 
 	arg := &SFTPUploadArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/smb_upload.go
+++ b/vql/tools/smb_upload.go
@@ -94,7 +94,7 @@ func (self *SMBUploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("upload_smb", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_smb", args)()
 
 	arg := &SMBUploadArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/tools/starlark.go
+++ b/vql/tools/starlark.go
@@ -423,7 +423,7 @@ func (self StarlarkCompileFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("starl", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "starl", args)()
 
 	arg := StarlarkCompileArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, &arg)

--- a/vql/tools/unzip.go
+++ b/vql/tools/unzip.go
@@ -48,7 +48,7 @@ func (self UnzipPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("unzip", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "unzip", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.FILESYSTEM_WRITE)
 		if err != nil {

--- a/vql/tools/webdav_upload.go
+++ b/vql/tools/webdav_upload.go
@@ -41,7 +41,7 @@ type WebDAVUploadFunction struct{}
 func (self *WebDAVUploadFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("upload_webdav", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "upload_webdav", args)()
 
 	arg := &WebDAVUploadArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/amsi.go
+++ b/vql/windows/amsi.go
@@ -28,7 +28,7 @@ func (self _AMSIFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("amsi", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "amsi", args)()
 
 	arg := &_AMSIFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/etw/etw_sessions.go
+++ b/vql/windows/etw/etw_sessions.go
@@ -73,7 +73,7 @@ func (self EtwSessions) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("etw_sessions", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "etw_sessions", args)()
 
 		arg := &EtwSessionsArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/etw/watch_etw.go
+++ b/vql/windows/etw/watch_etw.go
@@ -44,7 +44,7 @@ func (self WatchETWPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("watch_etw", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "watch_etw", args)()
 
 		arg := &WatchETWArgs{}
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/process/dump.go
+++ b/vql/windows/process/dump.go
@@ -55,7 +55,7 @@ func (self ProcDumpPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("proc_dump", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "proc_dump", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/windows/process/handles.go
+++ b/vql/windows/process/handles.go
@@ -87,7 +87,7 @@ func (self HandlesPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("handles", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "handles", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/windows/process/thread.go
+++ b/vql/windows/process/thread.go
@@ -40,7 +40,7 @@ func (self ThreadPlugin) Call(
 	go func() {
 		defer close(output_chan)
 		defer vql_subsystem.CheckForPanic(scope, "thread")
-		defer vql_subsystem.RegisterMonitor("thread", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "thread", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/windows/process/token.go
+++ b/vql/windows/process/token.go
@@ -40,7 +40,7 @@ func (self TokenFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("token", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "token", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {

--- a/vql/windows/process/vad.go
+++ b/vql/windows/process/vad.go
@@ -52,7 +52,7 @@ func (self ModulesPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("modules", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "modules", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {
@@ -113,7 +113,7 @@ func (self VADPlugin) Call(
 		defer close(output_chan)
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
-		defer vql_subsystem.RegisterMonitor("vad", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "vad", args)()
 		defer vql_subsystem.CheckForPanic(scope, "vad")
 
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/process/vad_32.go
+++ b/vql/windows/process/vad_32.go
@@ -51,7 +51,7 @@ func (self ModulesPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("modules", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "modules", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {
@@ -111,7 +111,7 @@ func (self VADPlugin) Call(
 		defer close(output_chan)
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
-		defer vql_subsystem.RegisterMonitor("vad", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "vad", args)()
 		defer vql_subsystem.CheckForPanic(scope, "vad")
 
 		err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/process/winobj.go
+++ b/vql/windows/process/winobj.go
@@ -43,7 +43,7 @@ func (self WinObjPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("winobj", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "winobj", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/windows/processes.go
+++ b/vql/windows/processes.go
@@ -194,7 +194,7 @@ func (self PslistPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("pslist", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "pslist", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {

--- a/vql/windows/registry/write.go
+++ b/vql/windows/registry/write.go
@@ -32,7 +32,7 @@ func (self *RegSetValueFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("reg_set_value", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "reg_set_value", args)()
 
 	arg := &RegSetValueFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -145,7 +145,7 @@ func (self *RegDeleteValueFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("reg_rm_value", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "reg_rm_value", args)()
 
 	arg := &RegDeleteValueFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
@@ -217,7 +217,7 @@ func (self *RegDeleteKeyFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("reg_rm_key", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "reg_rm_key", args)()
 
 	arg := &RegDeleteKeyFunctionArgs{}
 	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)

--- a/vql/windows/users.go
+++ b/vql/windows/users.go
@@ -153,7 +153,7 @@ type LookupSidFunction struct{}
 func (self *LookupSidFunction) Call(ctx context.Context,
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
-	defer vql_subsystem.RegisterMonitor("lookupSID", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "lookupSID", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {

--- a/vql/windows/winpmem.go
+++ b/vql/windows/winpmem.go
@@ -40,7 +40,7 @@ func (self WinpmemFunction) Call(
 	scope vfilter.Scope,
 	args *ordereddict.Dict) vfilter.Any {
 
-	defer vql_subsystem.RegisterMonitor("winpmem", args)()
+	defer vql_subsystem.RegisterMonitor(ctx, "winpmem", args)()
 
 	err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 	if err != nil {

--- a/vql/windows/wmi/events.go
+++ b/vql/windows/wmi/events.go
@@ -120,7 +120,7 @@ func (self WmiEventPlugin) Call(
 
 	go func() {
 		defer close(output_chan)
-		defer vql_subsystem.RegisterMonitor("wmi_events", args)()
+		defer vql_subsystem.RegisterMonitor(ctx, "wmi_events", args)()
 
 		err := vql_subsystem.CheckAccess(scope, acls.MACHINE_STATE)
 		if err != nil {


### PR DESCRIPTION
This means that if a glob was very rarely matched, the glob plugin was not cancelled quickly enough and continued running after the query itself was cancelled.