### PR TITLE
Refactored User Manager and ACL Manager to be in memory

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Lnk.yaml
+++ b/artifacts/definitions/Windows/Forensics/Lnk.yaml
@@ -20,9 +20,9 @@ description: |
   - SusArgSize: Any lnk with Argument strings over this size is suspicious.
   - SusArgRegex: Regex for suspicious strings in Arguments.
   - SusHostnameRegex: Regex for suspicious TrackerData Hostname.
-  - VmPrefixMAC: Regex to match known Virtual Machine MacAddress prefix in TrackerData. 
+  - VmPrefixMAC: Regex to match known Virtual Machine MacAddress prefix in TrackerData.
   - RiskyExe: Regex target exe to flag as risky.
-  
+
 
   List of fields targeted by filter regex:
 
@@ -38,7 +38,7 @@ description: |
     - TrackerData.MacAddress
 
     NOTE: regex startof (^) and endof ($) line modifiers will not work.
-    
+
 
     Windows.Forensics.Lnk also will highlight suspicious lnk attributes in a Suspicious field.
 
@@ -65,9 +65,9 @@ description: |
     * CodePage - checks for existance of a ExtraData code page setting. Rare enough to report on - 936:Simplified Chinese, 949:Korean, 950:Traditional Chinese
     * Has Overlay - check for overlay and extra data attached to LNK
     * Long Base64 - check for a long base64 blog over 20 decoded characters
-    * Arguments have ticks - ticks are common in malicious LNK files  
-    * Arguments have environment variables - environment variables (%|\$env:) are common in malicious LNKs  
-    * Arguments have rare characters - looks for specific rare characters that may indicate obfuscation (\?|\!|\~|\@) 
+    * Arguments have ticks - ticks are common in malicious LNK files
+    * Arguments have environment variables - environment variables (%|\$env:) are common in malicious LNKs
+    * Arguments have rare characters - looks for specific rare characters that may indicate obfuscation (\?|\!|\~|\@)
     * Arguments have leading space - malicious LNK files may have a many leading spaces to obfuscate some tools
     * Arguments have http strings - LNKs are reguarly used as a download cradle - https?://
     * Arguments have UNC strings
@@ -116,7 +116,7 @@ parameters:
     description: Regex target exe to flag as risky.
     type: regex
     default: \\(cmd|powershell|cscript|wscript|rundll32|regsvr32|mshta|wmic|conhost)\.exe$
-    
+
 
 export: |
      LET Profile = '''
@@ -344,7 +344,7 @@ export: |
 
       ]],
       ["Empty", 0, []],
-      
+
       # Struct size includes the size field
       ["LinkTargetIDList", "x=>x.IDListSize + 2", [
         ["IDListSize", 0, "uint16"],
@@ -616,7 +616,7 @@ export: |
             ["CreateDate", 8, "FatTimestamp"],
             ["LastAccessed", 12, "FatTimestamp"],
             ["MFTReference", 20, "MFTReference"],
-            ["LongName", 46, "String", {
+            ["LongName", "x=>if(condition=x.Version > 8, then=46, else=42)", "String", {
                 "encoding": "utf16"
             }]
         ]],
@@ -1366,15 +1366,15 @@ export: |
                   then= Data,
                   else= dict(
                     Header=format(format='0x%x',args=read_file(filename=OSPath, offset=Offset,length=4)),
-                    Offset=Offset, 
+                    Offset=Offset,
                     Length=len(list=read_file(filename=OSPath, offset=Offset)),
                     Entropy=entropy(string=read_file(filename=OSPath,offset=Offset)),
                     Magic=magic(accessor='data',path=read_file(filename=OSPath,offset=Offset))
                 )))  as _value
         FROM foreach(row=Parsed.ExtraData)
       })
-        
-        
+
+
 sources:
   - query: |
      LET targets = SELECT OSPath, Mtime,Atime,Ctime,Btime,Size,
@@ -1399,9 +1399,9 @@ sources:
         Parsed.Overlay as Overlay,
         Parsed
       FROM lnk_files
-     
+
      -- Several dynamic functions to check propertystore for anormalities
-      LET find_uid(propertystore) = SELECT regex_replace(source=Value,re='''S-1-5-\d{2}-\d+-\d+-\d+-''',replace='') as Value 
+      LET find_uid(propertystore) = SELECT regex_replace(source=Value,re='''S-1-5-\d{2}-\d+-\d+-\d+-''',replace='') as Value
         FROM propertystore WHERE Description = 'SID'
       LET find_oldpath(propertystore) = SELECT Value FROM propertystore WHERE Description = 'ParsingPath'
       LET find_oldsize(propertystore) = SELECT Value FROM propertystore WHERE Description = 'System.Size'
@@ -1416,13 +1416,13 @@ sources:
                                         then= ExtraData + dict(PropertyStore=PropertyStore),
                                         else= if(condition= Overlay.Length > 4,
                                                     then= ExtraData + dict(PropertyStore=PropertyStore) + dict(Overlay=to_dict(item=Overlay)),
-                                                    else= ExtraData + dict(PropertyStore=PropertyStore) 
+                                                    else= ExtraData + dict(PropertyStore=PropertyStore)
                                                 )),
                              else= if(condition= ExtraData.Overlay,
                                         then= ExtraData,
                                         else= if(condition= Overlay.Length > 4,
                                                     then= ExtraData + dict(Overlay=to_dict(item=Overlay)),
-                                                    else= ExtraData 
+                                                    else= ExtraData
                                                 )
                                         )) as ExtraData,
                           find_uid(propertystore=PropertyStore)[0].Value as UID,
@@ -1469,20 +1469,20 @@ sources:
                 `Arguments have UNC strings` = data=~'''(\s|^)\\\\[a-z0-9$_.-]+''',
                 `Suspicious arguments` = data=~SusArgRegex
             )
-            
+
       -- find largest base64 blob over 10 characters
       LET find_b64(data) = SELECT *
-        FROM if(condition=data, 
+        FROM if(condition=data,
             then={
-                SELECT Base64,  len(list=Base64) as Length 
+                SELECT Base64,  len(list=Base64) as Length
                 FROM parse_records_with_regex(accessor='data',file=data, regex='''(?P<Base64>(https?://[^\s]+/)*[A-Za-z0-9+/]{10,}={0,2})''')
                 WHERE NOT Base64 =~ '^http' -- Implementing negative regex match: We exclude b64 strings with http prefix.
-                ORDER BY Length DESC 
+                ORDER BY Length DESC
                 LIMIT 1
             },
             else=null )
-    
-      
+
+
       LET add_suspicious = SELECT *, dict(
                 `Large Size` = SourceFile.Size > SusSize,
                 `Startup Path` = SourceFile.OSPath =~ '''\\Startup\\''',
@@ -1517,7 +1517,7 @@ sources:
       LET add_suspiciousb64 = SELECT *
             if(condition= len(list=ArgumentsDecoded) > 20, then = dict(`Long Base64`=True) + sus_cli(data=ArgumentsDecoded)) as SuspiciousCliB64
         FROM add_suspicious
-      
+
       LET upload_results = SELECT *,
             upload(file=SourceFile.OSPath) as UploadedLnk
         FROM add_suspiciousb64
@@ -1532,9 +1532,9 @@ sources:
                 then= to_dict(item=StringData) + dict(`DecodedBase64`=ArgumentsDecoded),
                 else= StringData) as StringData,
             ExtraData,
-            to_dict(item={SELECT * FROM items(item=Suspicious) WHERE _value }) + 
-                to_dict(item={SELECT * FROM items(item=SuspiciousCli) WHERE _value }) + 
-                to_dict(item={SELECT * FROM items(item=SuspiciousCliB64) WHERE _value }) 
+            to_dict(item={SELECT * FROM items(item=Suspicious) WHERE _value }) +
+                to_dict(item={SELECT * FROM items(item=SuspiciousCli) WHERE _value }) +
+                to_dict(item={SELECT * FROM items(item=SuspiciousCliB64) WHERE _value })
                     as Suspicious
         FROM if(condition=UploadLnk,
             then= upload_results,

--- a/services/acl_manager/acl_manager.go
+++ b/services/acl_manager/acl_manager.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Velocidex/ttlcache/v2"
 	"www.velocidex.com/golang/velociraptor/acls"
 	acl_proto "www.velocidex.com/golang/velociraptor/acls/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -22,34 +22,87 @@ var (
 	notLockedDownError = errors.New("PERMISSION_DENIED: Server locked down")
 )
 
+type _CachedACLObject struct {
+	policy   *acl_proto.ApiClientACL
+	username string
+}
+
 type ACLManager struct {
-	// Cache the effective policy for each principal for 60 sec.
-	lru *ttlcache.Cache
+	mu sync.Mutex
+
+	// Cache the effective policy for each principal in this org for 60 sec.
+	cache map[string]*_CachedACLObject
+}
+
+func (self *ACLManager) reloadCache(
+	ctx context.Context, config_obj *config_proto.Config) error {
+	cache := make(map[string]*_CachedACLObject)
+
+	db, err := datastore.GetDB(config_obj)
+	if err != nil {
+		return err
+	}
+
+	children, err := db.ListChildren(config_obj, paths.ACL_ROOT)
+	if err != nil {
+		return err
+	}
+
+	for _, child := range children {
+		if child.IsDir() {
+			continue
+		}
+
+		username := child.Base()
+		policy := &acl_proto.ApiClientACL{}
+		err = db.GetSubject(config_obj, child, policy)
+		if err != nil {
+			continue
+		}
+
+		// Detect ACL files with multiple casing - we reject one to
+		// avoid ACL confusion. This should not occur in normal
+		// operation!
+		lower_user_name := utils.ToLower(username)
+		old_record, pres := cache[lower_user_name]
+		if pres && old_record.username != username {
+			logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+			logger.Error("<red>ACLManager</>: In Org %v multiple casing detected for ACLs for %v, will use record for %v.",
+				utils.GetOrgId(config_obj), username, old_record.username)
+			continue
+		}
+
+		cache[lower_user_name] = &_CachedACLObject{
+			policy:   policy,
+			username: username,
+		}
+	}
+
+	// Swap the new cache quickly
+	self.mu.Lock()
+	self.cache = cache
+	self.mu.Unlock()
+
+	return nil
 }
 
 func NewACLManager(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	config_obj *config_proto.Config) (*ACLManager, error) {
-	result := &ACLManager{
-		lru: ttlcache.NewCache(),
-	}
+	self := &ACLManager{}
 
-	timeout := time.Duration(60 * time.Second)
+	refresh_duration := time.Duration(300 * time.Second)
 	if config_obj.Defaults != nil &&
 		config_obj.Defaults.AclLruTimeoutSec > 0 {
-		timeout = time.Duration(
+		refresh_duration = time.Duration(
 			config_obj.Defaults.AclLruTimeoutSec) * time.Second
 	}
 
-	// ACLs do not typically change that quickly, cache for 60 sec.
-	result.lru.SetTTL(timeout)
-	result.lru.SkipTTLExtensionOnHit(true)
-
-	go func() {
-		<-ctx.Done()
-		result.lru.Close()
-	}()
+	err := self.reloadCache(ctx, config_obj)
+	if err != nil {
+		return nil, err
+	}
 
 	backups, err := services.GetBackupService(config_obj)
 	if err == nil {
@@ -58,26 +111,36 @@ func NewACLManager(
 		})
 	}
 
-	return result, nil
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(utils.Jitter(refresh_duration)):
+				self.reloadCache(ctx, config_obj)
+			}
+		}
+
+	}()
+
+	return self, nil
 }
 
 func (self *ACLManager) GetPolicy(
 	config_obj *config_proto.Config,
 	principal string) (*acl_proto.ApiClientACL, error) {
 
-	db, err := datastore.GetDB(config_obj)
-	if err != nil {
-		return nil, err
-	}
+	self.mu.Lock()
+	defer self.mu.Unlock()
 
-	acl_obj := &acl_proto.ApiClientACL{}
-	user_path_manager := paths.UserPathManager{Name: principal}
-	err = db.GetSubject(config_obj, user_path_manager.ACL(), acl_obj)
-	if err != nil {
-		return nil, err
+	cache, pres := self.cache[utils.ToLower(principal)]
+	if pres {
+		return cache.policy, nil
 	}
-
-	return acl_obj, nil
+	return nil, utils.NotFoundError
 }
 
 // GetEffectivePolicy expands any roles in the policy object to
@@ -86,56 +149,52 @@ func (self ACLManager) GetEffectivePolicy(
 	config_obj *config_proto.Config,
 	principal string) (*acl_proto.ApiClientACL, error) {
 
-	acl_obj_any, err := self.lru.Get(principal)
-	if err == nil {
-		acl_obj, ok := acl_obj_any.(*acl_proto.ApiClientACL)
-		if ok {
-			return acl_obj, nil
-		}
-	}
-
-	db, err := datastore.GetDB(config_obj)
-	if err != nil {
-		return nil, err
-	}
-
-	acl_obj := &acl_proto.ApiClientACL{}
-
 	// The server identity is special - it means the user is an admin.
 	if principal == utils.GetSuperuserName(config_obj) {
 		return &acl_proto.ApiClientACL{SuperUser: true}, nil
 	}
 
-	user_path_manager := paths.UserPathManager{Name: principal}
-	err = db.GetSubject(config_obj, user_path_manager.ACL(), acl_obj)
+	policy, err := self.GetPolicy(config_obj, principal)
 	if err != nil {
 		return nil, err
 	}
 
-	err = acls.GetRolePermissions(config_obj, acl_obj.Roles, acl_obj)
+	err = acls.GetRolePermissions(config_obj, policy.Roles, policy)
 	if err != nil {
 		return nil, err
 	}
 
 	// Reserved for the server itself - can not be set by normal means.
-	acl_obj.SuperUser = false
+	policy.SuperUser = false
 
-	self.lru.Set(principal, acl_obj)
-
-	return acl_obj, nil
+	return policy, nil
 }
 
 func (self ACLManager) SetPolicy(
 	config_obj *config_proto.Config,
 	principal string, acl_obj *acl_proto.ApiClientACL) error {
 
-	self.lru.Remove(principal)
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	// Normalize the username casing.
+	lower_user_name := utils.ToLower(principal)
+	cache, pres := self.cache[lower_user_name]
+	if pres {
+		principal = cache.username
+	}
+
+	self.cache[lower_user_name] = &_CachedACLObject{
+		policy:   acl_obj,
+		username: principal,
+	}
 
 	db, err := datastore.GetDB(config_obj)
 	if err != nil {
 		return err
 	}
 
+	// Store the ACL with the original user casing.
 	user_path_manager := paths.UserPathManager{Name: principal}
 	return db.SetSubject(config_obj, user_path_manager.ACL(), acl_obj)
 }

--- a/services/acl_manager/acl_manager.go
+++ b/services/acl_manager/acl_manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"www.velocidex.com/golang/velociraptor/acls"
 	acl_proto "www.velocidex.com/golang/velociraptor/acls/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -136,9 +137,10 @@ func (self *ACLManager) GetPolicy(
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	cache, pres := self.cache[utils.ToLower(principal)]
+	lower_user_name := utils.ToLower(principal)
+	cache, pres := self.cache[lower_user_name]
 	if pres {
-		return cache.policy, nil
+		return proto.Clone(cache.policy).(*acl_proto.ApiClientACL), nil
 	}
 	return nil, utils.NotFoundError
 }
@@ -185,7 +187,7 @@ func (self ACLManager) SetPolicy(
 	}
 
 	self.cache[lower_user_name] = &_CachedACLObject{
-		policy:   acl_obj,
+		policy:   proto.Clone(acl_obj).(*acl_proto.ApiClientACL),
 		username: principal,
 	}
 

--- a/services/users/storage.go
+++ b/services/users/storage.go
@@ -122,7 +122,8 @@ func (self *UserStorageManager) GetUserWithHashes(ctx context.Context, username 
 	}
 
 	// Check the LRU for a cache if it is there
-	cache, pres := self.cache[utils.ToLower(username)]
+	lower_user_name := utils.ToLower(user_record.Name)
+	cache, pres := self.cache[lower_user_name]
 	if pres && cache.user_record != nil {
 		// Return a copy to protect our version.
 		return proto.Clone(cache.user_record).(*api_proto.VelociraptorUser), nil
@@ -157,8 +158,9 @@ func (self *UserStorageManager) SetUser(
 		}
 	}
 
-	// Cache the new record in memory.
+	// Cache a copy of the new record in memory.
 	cache.user_record = proto.Clone(user_record).(*api_proto.VelociraptorUser)
+
 	// Remove the org list because that will be built at runtime so it
 	// does not need to be stored.
 	cache.user_record.Orgs = nil
@@ -459,6 +461,7 @@ func (self *UserStorageManager) GetUserOptions(ctx context.Context, username str
 		return nil, fmt.Errorf("%w: %v", services.UserNotFoundError, username)
 	}
 
+	// Return a copy of the options to preserve the integrity of the cache
 	return proto.Clone(cache.gui_options).(*api_proto.SetGUIOptionsRequest), nil
 }
 

--- a/services/users/storage.go
+++ b/services/users/storage.go
@@ -159,6 +159,10 @@ func (self *UserStorageManager) SetUser(
 
 	// Cache the new record in memory.
 	cache.user_record = proto.Clone(user_record).(*api_proto.VelociraptorUser)
+	// Remove the org list because that will be built at runtime so it
+	// does not need to be stored.
+	cache.user_record.Orgs = nil
+
 	cache.timestamp = utils.GetTime().Now()
 
 	db, err := datastore.GetDB(self.config_obj)
@@ -170,7 +174,7 @@ func (self *UserStorageManager) SetUser(
 	// user name. This is compatible with the previous behavior.
 	err = db.SetSubject(self.config_obj,
 		paths.UserPathManager{Name: user_record.Name}.Path(),
-		user_record)
+		cache.user_record)
 	if err != nil {
 		return err
 	}
@@ -503,7 +507,7 @@ func (self *UserStorageManager) DeleteUser(ctx context.Context, username string)
 	}
 
 	// No more orgs for this user, Just remove the user completely
-	user_path_manager := paths.NewUserPathManager(lower_user_name)
+	user_path_manager := paths.NewUserPathManager(username)
 	err = db.DeleteSubject(self.config_obj, user_path_manager.Path())
 	if err != nil {
 		return err

--- a/services/users/storage.go
+++ b/services/users/storage.go
@@ -122,7 +122,7 @@ func (self *UserStorageManager) GetUserWithHashes(ctx context.Context, username 
 	}
 
 	// Check the LRU for a cache if it is there
-	lower_user_name := utils.ToLower(user_record.Name)
+	lower_user_name := utils.ToLower(username)
 	cache, pres := self.cache[lower_user_name]
 	if pres && cache.user_record != nil {
 		// Return a copy to protect our version.

--- a/services/users/tracker.go
+++ b/services/users/tracker.go
@@ -1,0 +1,66 @@
+package users
+
+import (
+	"context"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/vfilter"
+)
+
+func (self *UserManager) WriteProfile(ctx context.Context,
+	scope vfilter.Scope, output_chan chan vfilter.Row) {
+	storage, ok := self.storage.(*UserStorageManager)
+	if ok {
+		storage.WriteProfile(ctx, scope, output_chan)
+	}
+}
+
+func (self *UserStorageManager) WriteProfile(ctx context.Context,
+	scope vfilter.Scope, output_chan chan vfilter.Row) {
+
+	var rows []*ordereddict.Dict
+
+	org_manager, err := services.GetOrgManager()
+	if err != nil {
+		return
+	}
+
+	self.mu.Lock()
+	for key, cache := range self.cache {
+		username := cache.user_record.Name
+
+		for _, org := range org_manager.ListOrgs() {
+			org_config_obj, err := org_manager.GetOrgConfig(org.Id)
+			if err != nil {
+				continue
+			}
+
+			policy, err := services.GetPolicy(org_config_obj, username)
+			if err != nil {
+				continue
+			}
+
+			rows = append(rows, ordereddict.NewDict().
+				Set("Key", key).
+				Set("Name", username).
+				Set("LastRefresh", utils.GetTime().Now().
+					Sub(cache.timestamp).Round(time.Second).String()).
+				Set("OrgId", org.Id).
+				Set("OrgName", org.Name).
+				Set("Poilcy", policy))
+		}
+	}
+	self.mu.Unlock()
+
+	for _, r := range rows {
+		select {
+		case <-ctx.Done():
+			return
+		case output_chan <- r:
+		}
+	}
+
+}

--- a/services/users/users.go
+++ b/services/users/users.go
@@ -31,6 +31,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/services/debug"
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
@@ -206,6 +207,13 @@ func StartUserManager(
 
 	service := NewUserManager(config_obj, storage)
 	services.RegisterUserManager(service)
+
+	debug.RegisterProfileWriter(debug.ProfileWriterInfo{
+		Name:          "User Manager",
+		Description:   "Reporting information about current users registered on the system.",
+		ProfileWriter: service.WriteProfile,
+		Categories:    []string{"Global", "Services"},
+	})
 
 	return nil
 }

--- a/services/users/users_test.go
+++ b/services/users/users_test.go
@@ -1,6 +1,7 @@
 package users_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Velocidex/ordereddict"
@@ -10,6 +11,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/json"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/orgs"
+	"www.velocidex.com/golang/velociraptor/services/users"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 	"www.velocidex.com/golang/velociraptor/vtesting/goldie"
 )
@@ -109,6 +111,64 @@ func (self *UserManagerTestSuite) TestMakeUsers() {
 	golden.Set("Case insensitive user02", user_record)
 
 	goldie.Assert(self.T(), "TestMakeUsers", json.MustMarshalIndent(golden))
+}
+
+func (self *UserManagerTestSuite) TestMakeUserCaseSensetive() {
+	self.makeUserWithRoles("UserName", "", "administrator")
+	self.makeUserWithRoles("UserName", "O123", "reader")
+
+	// The querying user only has permissions in O123
+	self.makeUserWithRoles("QueryingUser", "O123", "administrator")
+	self.makeUserWithRoles("RootQueryUser", "", "administrator")
+	self.makeUserWithRoles("OrgAdmin", "", "administrator")
+
+	user_manager := services.GetUserManager()
+	storage := user_manager.(*users.UserManager).Storage().(*users.UserStorageManager)
+
+	res, err := storage.ListAllUsers(self.Ctx)
+	assert.NoError(self.T(), err)
+
+	json.Dump(res)
+
+	// Delete the user in the O123 org
+	err = user_manager.DeleteUser(self.Ctx, "QueryingUser", "UserName", []string{"O123"})
+	assert.NoError(self.T(), err)
+
+	// As far as QueryingUser is concerned the UserName is deleted
+	// because QueryingUser only has access to O123.
+	res, err = user_manager.ListUsers(self.Ctx, "QueryingUser", nil)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), 0, len(filterUser(res, "UserName")))
+
+	// However for RootQueryUser the user still exists because
+	// RootQueryUser has access to the root org.
+	res, err = user_manager.ListUsers(self.Ctx, "RootQueryUser", nil)
+	assert.NoError(self.T(), err)
+	assert.Equal(self.T(), 1, len(filterUser(res, "UserName")))
+
+	res, err = storage.ListAllUsers(self.Ctx)
+	assert.NoError(self.T(), err)
+
+	json.Dump(res)
+
+	// Add a new user with similar name
+	self.makeUserWithRoles("Username", "O123", "administrator")
+
+	res, err = storage.ListAllUsers(self.Ctx)
+	assert.NoError(self.T(), err)
+
+	json.Dump(res)
+
+}
+
+func filterUser(users []*api_proto.VelociraptorUser, username string) (
+	res []*api_proto.VelociraptorUser) {
+	for _, i := range users {
+		if strings.EqualFold(i.Name, username) {
+			res = append(res, i)
+		}
+	}
+	return res
 }
 
 func TestUserManger(t *testing.T) {

--- a/utils/string.go
+++ b/utils/string.go
@@ -1,6 +1,9 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"unicode"
+)
 
 func Elide(in string, length int) string {
 	if len(in) < length {
@@ -38,4 +41,15 @@ func ToString(x interface{}) string {
 	default:
 		return fmt.Sprintf("%v", x)
 	}
+}
+
+// Lower the string in a unicode aware way. This normalizes the
+// strings for comparisons.
+func ToLower(in string) string {
+	var result []rune
+	for _, c := range in {
+		result = append(result, unicode.ToLower(c))
+	}
+
+	return string(result)
 }


### PR DESCRIPTION
Previously there was a time based cache but we dont expect a lot of users so we can reasonable keep the user list in memory permanenetly. This helps to address potential problems in casing when saving user accounts with different cases.

The new code deliberately catches these potential casing clashes and ignores user accounts and acls for users who differ only in case. This might help resolve #4271