### PR TITLE
Add MaxFileSize argument to Generic.Collectors.File

### DIFF
--- a/artifacts/definitions/Generic/Collectors/File.yaml
+++ b/artifacts/definitions/Generic/Collectors/File.yaml
@@ -34,6 +34,13 @@ parameters:
     description: How often to flush the NTFS cache. (Default is never).
     default: "1000000"
 
+  - name: MaxFileSize
+    type: int
+    default: 0
+    description: |
+      The max size in bytes of the individual files to collect. 
+      Set to 0 to disable it.
+
 
 sources:
    - name: All Matches Metadata
@@ -49,13 +56,16 @@ sources:
 
       -- Join all the collection rules into a single Glob plugin. This ensure we
       -- only make one pass over the filesystem. We only want LFNs.
-      LET hits = SELECT OSPath AS SourceFile, Size,
+      LET all_hits = SELECT OSPath AS SourceFile, Size,
                Btime AS Created,
                Ctime AS Changed,
                Mtime AS Modified,
                Atime AS LastAccessed
         FROM glob(globs=specs.Glob, accessor=Accessor)
         WHERE NOT IsDir AND log(message="Found " + SourceFile)
+    
+      LET size_hits = SELECT * FROM all_hits WHERE Size <= MaxFileSize     
+      LET hits = if(condition=MaxFileSize > 0, then=size_hits, else=all_hits)
 
       -- Pass all the results to the next query. This will serialize
       -- to disk if there are too many results.


### PR DESCRIPTION
This PR adds a argument `MaxFileSize` to `Generic.Collectors.File`, which allows you to only collect files with a certain max file size. This allows us for example to only collect small executables, preventing from collecting a lot of big data.