### PR TITLE
Bugfix: Propagate column types from the artifact to notebook cells

### DIFF
--- a/artifacts/definitions/Demo/Plugins/GUI.yaml
+++ b/artifacts/definitions/Demo/Plugins/GUI.yaml
@@ -220,6 +220,14 @@ sources:
                  TRUE, 4, NULL
           FROM scope()
 
+      - type: VQL
+        name: Test Default ColumnTypes
+        template: |
+          /*
+          ## Make sure Base64hex data is automatically typed
+          */
+          SELECT base64encode(string="This should popup in a hex editor") AS Base64Hex FROM scope()
+
       - type: Markdown
         name: Scatter Chart
         template: |

--- a/artifacts/definitions/Linux/Sys/BashShell.yaml
+++ b/artifacts/definitions/Linux/Sys/BashShell.yaml
@@ -21,4 +21,15 @@ parameters:
 
 sources:
   - query: |
-      SELECT * FROM execve(argv=["/bin/bash", "-c", Command])
+      LET SizeLimit <= 4096
+      SELECT if(condition=len(list=Stdout) < SizeLimit,
+                then=Stdout) AS Stdout,
+             if(condition=len(list=Stdout) >= SizeLimit,
+                then=upload(accessor="data",
+                            file=Stdout, name="Stdout")) AS StdoutUpload
+      FROM execve(argv=["/bin/bash", "-c", Command],
+                  length=10000000)
+
+column_types:
+- name: StdoutUpload
+  type: preview_upload

--- a/artifacts/definitions/Windows/System/CmdShell.yaml
+++ b/artifacts/definitions/Windows/System/CmdShell.yaml
@@ -29,4 +29,15 @@ parameters:
 
 sources:
   - query: |
-      SELECT * FROM execve(argv=["cmd.exe", "/c", Command])
+      LET SizeLimit <= 4096
+      SELECT if(condition=len(list=Stdout) < SizeLimit,
+                then=Stdout) AS Stdout,
+             if(condition=len(list=Stdout) >= SizeLimit,
+                then=upload(accessor="data",
+                            file=Stdout, name="Stdout")) AS StdoutUpload
+
+      FROM execve(argv=["cmd.exe", "/c", Command], length=10000000)
+
+column_types:
+- name: StdoutUpload
+  type: preview_upload

--- a/artifacts/definitions/Windows/System/PowerShell.yaml
+++ b/artifacts/definitions/Windows/System/PowerShell.yaml
@@ -42,7 +42,17 @@ parameters:
 
 sources:
   - query: |
-      SELECT * FROM execve(argv=[PowerShellExe,
+      LET SizeLimit <= 4096
+      SELECT if(condition=len(list=Stdout) < SizeLimit,
+                then=Stdout) AS Stdout,
+             if(condition=len(list=Stdout) >= SizeLimit,
+                then=upload(accessor="data",
+                            file=Stdout, name="Stdout")) AS StdoutUpload
+      FROM execve(argv=[PowerShellExe,
         "-ExecutionPolicy", "Unrestricted", "-encodedCommand",
         base64encode(string=utf16_encode(string=Command))
-      ])
+      ], length=10000000)
+
+column_types:
+- name: StdoutUpload
+  type: preview_upload

--- a/docs/wix/README.md
+++ b/docs/wix/README.md
@@ -6,7 +6,7 @@ can be used to build a Windows installer package (MSI) which
 automatically installs the service.
 
 The advantage of building your own MSI is that you can customize
-aspect of the installtion like service names, binary names etc. If you
+aspect of the installation like service names, binary names etc. If you
 are happy with the default settings it is easier to just use the
 official distributed MSI packages.
 
@@ -29,7 +29,7 @@ Next, follow these steps:
    revision.
 
 2. Optional: Generate valid GUIDs to replace all GUIDs in the config
-   file. You can use the linux uuidgen program to make new GUIDs.
+   file. You can use the Linux `uuidgen` program to make new GUIDs.
 
 3. Optional: You can customize the description, comments, service name
    etc. If you decided to rename the binary you can adjust the name in
@@ -81,8 +81,8 @@ provides you the opportunity to manually replace the file at a later
 stage with a correctly formatted file specific for your deployment.
 
 However, it is possible to repack a new client configuration file into
-the MSI using the following command (i.e. replace the file within the
-MSI):
+the MSI using the artifact `Server.Utils.CreateMSI` or the following
+command (i.e. replace the file within the MSI):
 
 ```
 velociraptor config repack --exe velociraptor.msi client.config.yaml repacked_velociraptor.msi -v
@@ -96,6 +96,11 @@ the configuration wizard.
 Repacking replaces the placeholder inside the MSI with the real
 configuration file. The new MSI will then automatically install the
 correct configuration file.
+
+If you want to build a customized MSI which can also be repacked you
+need to use the placeholder config file (located in the
+`output/client.config.yaml` file) in the MSI, then the repacking code
+can find it and replace it with the final config as needed.
 
 # Official Velociraptor MSI
 

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/Velocidex/go-vhdx v0.0.0-20250511013458-5cba970cdeda
 	github.com/Velocidex/go-vmdk v0.0.0-20250505140221-bd4633ce2fbf
 	github.com/Velocidex/grok v0.0.1
-	github.com/Velocidex/ordereddict v0.0.0-20230909174157-2aa49cc5d11d
+	github.com/Velocidex/ordereddict v0.0.0-20250626035939-2f7f022fc719
 	github.com/Velocidex/sigma-go v0.0.0-20241025122940-1b771d3d57a9
 	github.com/Velocidex/tracee_velociraptor v0.0.0-20250620124218-01f48d6fc3a1
 	github.com/VirusTotal/gyp v0.9.1-0.20231202132633-bb35dbf177a6

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,9 @@ github.com/Velocidex/json v0.0.0-20220224052537-92f3c0326e5a h1:AeXPUzhU0yhID/v5
 github.com/Velocidex/json v0.0.0-20220224052537-92f3c0326e5a/go.mod h1:ukJBuruT9b24pdgZwWDvOaCYHeS03B7oQPCUWh25bwM=
 github.com/Velocidex/ordereddict v0.0.0-20220107075049-3dbe58412844/go.mod h1:Y5Tfx5SKGOzkulpqfonrdILSPIuNg+GqKE/DhVJgnpg=
 github.com/Velocidex/ordereddict v0.0.0-20221110130714-6a7cb85851cd/go.mod h1:+MqO5UMBemyFSm+yRXslbpFTwPUDhFHUf7HPV92twg4=
-github.com/Velocidex/ordereddict v0.0.0-20230909174157-2aa49cc5d11d h1:fn372EqKyazBxYUP5HPpBi3jId4MXuppEypEALGfvEk=
 github.com/Velocidex/ordereddict v0.0.0-20230909174157-2aa49cc5d11d/go.mod h1:+MqO5UMBemyFSm+yRXslbpFTwPUDhFHUf7HPV92twg4=
+github.com/Velocidex/ordereddict v0.0.0-20250626035939-2f7f022fc719 h1:7wx3n0HY8WkEQYehirMb2bhf1zTsw4Di4mjpVysl2Sc=
+github.com/Velocidex/ordereddict v0.0.0-20250626035939-2f7f022fc719/go.mod h1:+MqO5UMBemyFSm+yRXslbpFTwPUDhFHUf7HPV92twg4=
 github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a h1:H7dVazNcaE80V8cy99TF7LPpwzvr1uJ4I2nDjb5ek7E=
 github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a/go.mod h1:/fy/Eg4TQz9KkJduvZfGCnbWTQ/LKaknS2wYB52cU6c=
 github.com/Velocidex/sflags v0.3.1-0.20241126160332-cc1a5b66b8f1 h1:fLJ2AjY0dtDZEBhekp3bxyxGpWh5D/+NfOVlGXB5ROA=

--- a/gui/velociraptor/src/components/clients/shell-viewer.jsx
+++ b/gui/velociraptor/src/components/clients/shell-viewer.jsx
@@ -21,6 +21,7 @@ import Button from 'react-bootstrap/Button';
 import { withRouter }  from "react-router-dom";
 import { JSONparse } from '../utils/json_parse.jsx';
 import ToolTip from '../widgets/tooltip.jsx';
+import PreviewUpload from '../widgets/preview_uploads.jsx';
 
 // Refresh every 5 seconds
 const SHELL_POLL_TIME = 5000;
@@ -238,7 +239,18 @@ class _VeloShellCell extends Component {
 
         let output = "";
         if (this.state.loaded) {
+            let client_id = this.props.flow.client_id;
+            let flow_id = this.props.flow.session_id;
+
             output = [this.state.output.map((item, index) => {
+                if (item.StdoutUpload) {
+                    return <div className='notebook-output' key={index} >
+                             <PreviewUpload
+                               env={{client_id: client_id,
+                                 flow_id: flow_id}}
+                               upload={item.StdoutUpload} />
+                           </div>;
+                }
                 return <div className='notebook-output' key={index} >
                          <pre> {item.Stdout} </pre>
                        </div>;

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
@@ -1037,6 +1037,7 @@ export default class NotebookCellRenderer extends React.Component {
               { this.state.showFormatTablesDialog &&
                 <FormatTableDialog
                   cell={this.state.cell}
+                  notebook_metadata={this.props.notebook_metadata}
                   saveCell={cell=>{
                       this.saveCell(cell);
                   }}

--- a/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-format-tables.jsx
@@ -9,7 +9,7 @@ import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
+import { JSONparse } from '../utils/json_parse.jsx';
 
 // components/core/table.jsx getFormatter
 const column_types = [
@@ -24,6 +24,7 @@ const column_type_args_regex = /`([^`]+)`='([^']+)'/g;
 export default class FormatTableDialog extends Component {
     static propTypes = {
         cell: PropTypes.object,
+        notebook_metadata: PropTypes.object,
         saveCell: PropTypes.func,
         closeDialog: PropTypes.func,
         columns: PropTypes.array,
@@ -68,9 +69,30 @@ export default class FormatTableDialog extends Component {
                        selected_columns: _.map(selection, x=>x.column)});
     }
 
+    // Get the column types from the notebook env. We use that as the
+    // initial set.
+    getDefaultColumnTypes = ()=>{
+        let res = {};
+        let md = this.props.notebook_metadata || {};
+        let requests = md.requests || [];
+        _.each(requests, x=>{
+            _.each(x.env, x=>{
+                if(x.key === "ColumnTypes") {
+                    _.each(JSONparse(x.value), (v, k)=>{
+                        res[k] = v;
+                    });
+                }
+            });
+        });
+
+        return res;
+    }
+
     parseColumnTypes = vql=>{
+        const default_types = this.getDefaultColumnTypes();
         let selection = [];
         let selected_columns = [];
+        let types = {};
         let prefix = "";
         let suffix = "";
         let match = vql && vql.match(column_type_regex);
@@ -83,10 +105,19 @@ export default class FormatTableDialog extends Component {
             _.each(arg_match, x=>{
                 selected_columns.push(x[1]);
                 selection.push({column: x[1], type: x[2]});
+                types[x[1]] = x[2];
             });
         } else {
             suffix = vql;
         }
+
+        // merge the default types with the selected types.
+        _.each(default_types, (v, k)=>{
+            if(!types[k]) {
+                selection.push({column: k, type: v});
+                selected_columns.push(k);
+            };
+        });
 
         this.setState({selection: selection,
                        selected_columns: selected_columns,
@@ -104,7 +135,7 @@ export default class FormatTableDialog extends Component {
                             type: this.state.new_selection_type});
         }
 
-        if (selection) {
+        if (!_.isEmpty(selection)) {
             // Build the VQL for ColumnTypes
             let vql = "LET ColumnTypes<=dict("+
                 _.map(this.state.selection,

--- a/services/notebook/calculate_test.go
+++ b/services/notebook/calculate_test.go
@@ -20,6 +20,8 @@ import (
 	"www.velocidex.com/golang/velociraptor/vtesting"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 	"www.velocidex.com/golang/velociraptor/vtesting/goldie"
+
+	_ "www.velocidex.com/golang/velociraptor/vql/parsers"
 )
 
 var (
@@ -38,6 +40,10 @@ parameters:
 - name: StringArg
   type: string
   default: "This is a test"
+
+column_types:
+  - name: TypedColumn
+    type: integer
 
 # This will actually get this URL below.
 tools:

--- a/services/notebook/fixtures/TestNotebookFromTemplate.golden
+++ b/services/notebook/fixtures/TestNotebookFromTemplate.golden
@@ -66,9 +66,16 @@
      {
       "key": "Tool_SomeTool_URLs",
       "value": "[\"https://localhost:8000/public/152038a5bc46cb8fc68ee6eac0269c6a3fba574c4a96a650ed26aa9b02b1cb64\"]"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{\"TypedColumn\":\"integer\"}"
      }
     ],
     "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
+     },
      {
       "VQL": "LET Bool \u003c= get(field='Bool') = TRUE OR get(field='Bool') =~ '^(Y|TRUE|YES|OK)$' "
      }
@@ -90,13 +97,13 @@
  },
  "Cell": {
   "input": "SELECT log(message=\"StringArg Should be Hello because default is overriden %v\", args=StringArg),\n       log(message=\"Tool is available through local url %v\", args=Tool_SomeTool_URL)\nFROM scope()\n",
-  "output": "\u003cdiv class=\"panel\"\u003e\u003cvelo-csv-viewer base-url=\"'v1/GetTable'\" params='%7B%22notebook_id%22%3A%22N.01%22%2C%22client_id%22%3A%22%22%2C%22cell_id%22%3A%22NC.02-03%22%2C%22table_id%22%3A1%2C%22TableOptions%22%3A%7B%7D%2C%22Version%22%3A%7D' /\u003e\u003c/div\u003e",
+  "output": "\u003cdiv class=\"panel\"\u003e\u003cvelo-csv-viewer base-url=\"'v1/GetTable'\" params='%7B%22notebook_id%22%3A%22N.01%22%2C%22client_id%22%3A%22%22%2C%22cell_id%22%3A%22NC.02-03%22%2C%22table_id%22%3A1%2C%22TableOptions%22%3A%7B%22TypedColumn%22%3A%22integer%22%7D%2C%22Version%22%3A%7D' /\u003e\u003c/div\u003e",
   "data": "{}",
   "cell_id": "NC.02",
   "messages": [
    "DEFAULT:StringArg Should be Hello because default is overriden Hello\n",
    "DEFAULT:Tool is available through local url https://localhost:8000/public/152038a5bc46cb8fc68ee6eac0269c6a3fba574c4a96a650ed26aa9b02b1cb64\n",
-   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":4,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
+   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":5,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
   ],
   "type": "vql",
   "current_version": "03",
@@ -171,9 +178,16 @@
      {
       "key": "Tool_SomeTool_URLs",
       "value": "[\"https://localhost:8000/public/152038a5bc46cb8fc68ee6eac0269c6a3fba574c4a96a650ed26aa9b02b1cb64\"]"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{\"TypedColumn\":\"integer\"}"
      }
     ],
     "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
+     },
      {
       "VQL": "LET Bool \u003c= get(field='Bool') = TRUE OR get(field='Bool') =~ '^(Y|TRUE|YES|OK)$' "
      }
@@ -195,12 +209,12 @@
  },
  "UpdatedCell": {
   "input": "SELECT log(message='StringArg should be Goodbye now: %v', args=StringArg) FROM scope()",
-  "output": "\u003cdiv class=\"panel\"\u003e\u003cvelo-csv-viewer base-url=\"'v1/GetTable'\" params='%7B%22notebook_id%22%3A%22N.01%22%2C%22client_id%22%3A%22%22%2C%22cell_id%22%3A%22NC.02-04%22%2C%22table_id%22%3A1%2C%22TableOptions%22%3A%7B%7D%2C%22Version%22%3A%7D' /\u003e\u003c/div\u003e",
+  "output": "\u003cdiv class=\"panel\"\u003e\u003cvelo-csv-viewer base-url=\"'v1/GetTable'\" params='%7B%22notebook_id%22%3A%22N.01%22%2C%22client_id%22%3A%22%22%2C%22cell_id%22%3A%22NC.02-04%22%2C%22table_id%22%3A1%2C%22TableOptions%22%3A%7B%22TypedColumn%22%3A%22integer%22%7D%2C%22Version%22%3A%7D' /\u003e\u003c/div\u003e",
   "data": "{}",
   "cell_id": "NC.02",
   "messages": [
    "DEFAULT:StringArg should be Goodbye now: Goodbye\n",
-   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":3,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
+   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":4,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
   ],
   "type": "vql",
   "current_version": "04",

--- a/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
@@ -20,6 +20,15 @@
      {
       "key": "ArtifactName",
       "value": "Notebooks.Default"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{}"
+     }
+    ],
+    "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
      }
     ],
     "max_row": 1000
@@ -56,6 +65,15 @@
      {
       "key": "ArtifactName",
       "value": "Notebooks.Default"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{}"
+     }
+    ],
+    "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
      }
     ],
     "max_row": 1000

--- a/services/notebook/fixtures/TestNotebookManagerTimelines.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelines.golden
@@ -20,6 +20,15 @@
      {
       "key": "ArtifactName",
       "value": "Notebooks.Default"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{}"
+     }
+    ],
+    "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
      }
     ],
     "max_row": 1000

--- a/services/notebook/fixtures/TestNotebookManagerUpdateCell.golden
+++ b/services/notebook/fixtures/TestNotebookManagerUpdateCell.golden
@@ -21,6 +21,15 @@
      {
       "key": "ArtifactName",
       "value": "Notebooks.Default"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{}"
+     }
+    ],
+    "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
      }
     ],
     "max_row": 1000
@@ -44,7 +53,7 @@
   "data": "{}",
   "cell_id": "NC.02",
   "messages": [
-   "DEBUG:Query Stats: {\"RowsScanned\":0,\"PluginsCalled\":0,\"FunctionsCalled\":0,\"ProtocolSearch\":0,\"ScopeCopy\":0}\n"
+   "DEBUG:Query Stats: {\"RowsScanned\":0,\"PluginsCalled\":0,\"FunctionsCalled\":1,\"ProtocolSearch\":0,\"ScopeCopy\":0}\n"
   ],
   "type": "markdown",
   "current_version": "04",
@@ -59,7 +68,7 @@
   "data": "{}",
   "cell_id": "NC.02",
   "messages": [
-   "DEBUG:Query Stats: {\"RowsScanned\":2,\"PluginsCalled\":1,\"FunctionsCalled\":0,\"ProtocolSearch\":0,\"ScopeCopy\":5}\n"
+   "DEBUG:Query Stats: {\"RowsScanned\":2,\"PluginsCalled\":1,\"FunctionsCalled\":1,\"ProtocolSearch\":0,\"ScopeCopy\":5}\n"
   ],
   "type": "vql",
   "current_version": "05",
@@ -91,6 +100,15 @@
      {
       "key": "ArtifactName",
       "value": "Notebooks.Default"
+     },
+     {
+      "key": "ColumnTypes",
+      "value": "{}"
+     }
+    ],
+    "Query": [
+     {
+      "VQL": "LET ColumnTypes \u003c= parse_json(data=ColumnTypes)"
      }
     ],
     "max_row": 1000

--- a/services/notebook/initial_test.go
+++ b/services/notebook/initial_test.go
@@ -112,7 +112,9 @@ var (
 			},
 			check: func(t *testing.T, response *artifacts_proto.Artifact,
 				spec *flows_proto.ArtifactSpec) {
-				AssertDictRegex(t, "Welcome to Velociraptor", "Sources.0.Notebook.0.Template", response)
+				AssertDictRegex(t,
+					"Welcome to Velociraptor",
+					"Sources.0.Notebook.0.Template", response)
 			},
 		},
 
@@ -405,7 +407,8 @@ func AssertDictRegex(t *testing.T, regex, selector string, item protoreflect.Pro
 func GetField(selector string, item protoreflect.ProtoMessage) string {
 	scope := vql_subsystem.MakeScope()
 	ctx := context.Background()
-	var result interface{} = vfilter.RowToDict(ctx, scope, proto.Clone(item))
+	var result interface{} = vfilter.RowToDict(
+		ctx, scope, proto.Clone(item)).SetCaseInsensitive()
 	var pres bool
 
 	for _, member := range strings.Split(selector, ".") {

--- a/services/notebook/timelines_test.go
+++ b/services/notebook/timelines_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (self *NotebookManagerTestSuite) TestNotebookManagerTimelines() {
-	assert.Retry(self.T(), 3, time.Second,
+	assert.Retry(self.T(), 10, time.Second,
 		self._TestNotebookManagerTimelines)
 }
 

--- a/services/scheduler/fixtures/TestNotebookMinionScheduler.golden
+++ b/services/scheduler/fixtures/TestNotebookMinionScheduler.golden
@@ -5,7 +5,7 @@
   "data": "{}",
   "cell_id": "NC.XXX",
   "messages": [
-   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":1,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
+   "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":2,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
   ],
   "type": "vql",
   "current_version": "XXX",

--- a/services/scheduler/minion_test.go
+++ b/services/scheduler/minion_test.go
@@ -20,6 +20,8 @@ import (
 	"www.velocidex.com/golang/velociraptor/vtesting"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 	"www.velocidex.com/golang/velociraptor/vtesting/goldie"
+
+	_ "www.velocidex.com/golang/velociraptor/vql/parsers"
 )
 
 var (

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -80,7 +80,7 @@ func (self ShellPlugin) Call(
 		arg := &ShellPluginArgs{}
 		err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
 		if err != nil {
-			scope.Log("execve: %v", err)
+			scope.Error("execve: %v", err)
 			return
 		}
 

--- a/vql/server/notebooks/notebooks_test.go
+++ b/vql/server/notebooks/notebooks_test.go
@@ -22,6 +22,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 
 	_ "www.velocidex.com/golang/velociraptor/accessors/data"
+	_ "www.velocidex.com/golang/velociraptor/vql/parsers"
 )
 
 var testArtifacts = []string{`

--- a/vql/tools/repack.go
+++ b/vql/tools/repack.go
@@ -420,7 +420,7 @@ func RepackMSI(
 	cab_header_offset, page_0_present := page_map[0]
 
 	if len(page_map) == 0 || cab_header_length == 0 || !page_0_present {
-		scope.Log("client_repack: I can not seem to locate the embedded config???? To repack an MSI, be sure to build from custom.xml with the custom.config.yaml file.")
+		scope.Log("client_repack: I can not seem to locate the embedded config???? To repack an MSI, be sure to build from the placeholder config as described in https://docs.velociraptor.app/docs/deployment/clients/#building-a-custom-msi-package-from-scratch .")
 		return vfilter.Null{}
 	}
 


### PR DESCRIPTION
This fixes artifacts that defined column types - there were ignored in notebooks. The `Format Column` GUI now also honors the column types and shows them as preconfigured.

Also: Automatically create an upload preview column for shell artifacts with large output. This makes it better to view in the GUI and possible to handle a lot of output