### PR TITLE
Bugfix: Parse integers out of secrets in mail plugin

### DIFF
--- a/accessors/file_store/accessor.go
+++ b/accessors/file_store/accessor.go
@@ -79,6 +79,11 @@ func (self FileStoreFileSystemAccessor) LstatWithOSPath(filename *accessors.OSPa
 	accessors.FileInfo, error) {
 
 	fullpath := path_specs.FromGenericComponentList(filename.Components)
+	err := isFileAccessible(fullpath)
+	if err != nil {
+		return nil, err
+	}
+
 	lstat, err := self.file_store.StatFile(fullpath)
 	if err != nil {
 		// If it didnt work, we try case insensitive open
@@ -130,6 +135,11 @@ func (self FileStoreFileSystemAccessor) ReadDirWithOSPath(
 	[]accessors.FileInfo, error) {
 
 	fullpath := path_specs.FromGenericComponentList(filename.Components)
+	err := isFileAccessible(fullpath)
+	if err != nil {
+		return nil, err
+	}
+
 	files, err := self.file_store.ListDirectory(fullpath)
 	if err != nil {
 		// If it didnt work, we try case insensitive
@@ -185,6 +195,11 @@ func (self FileStoreFileSystemAccessor) OpenWithOSPath(filename *accessors.OSPat
 		}
 	} else {
 		fullpath = path_specs.FromGenericComponentList(filename.Components)
+	}
+
+	err := isFileAccessible(fullpath)
+	if err != nil {
+		return nil, err
 	}
 
 	file, err := self.openFile(fullpath)

--- a/accessors/file_store/permissions.go
+++ b/accessors/file_store/permissions.go
@@ -1,0 +1,29 @@
+package file_store
+
+import (
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
+	"www.velocidex.com/golang/velociraptor/paths"
+)
+
+var (
+	ForbiddenPrefixes = []api.FSPathSpec{
+		paths.CONFIG_ROOT.AsFilestorePath(),
+		paths.USERS_ROOT.AsFilestorePath(),
+		paths.ORGS_ROOT.AsFilestorePath(),
+		paths.BACKUPS_ROOT,
+	}
+)
+
+// Some parts of the filestore are blocked off from reading. This
+// helps prevent circumvention of the ACL system by reading files
+// directly from disk.
+func isFileAccessible(filename api.FSPathSpec) error {
+	for _, parent := range ForbiddenPrefixes {
+		if path_specs.IsSubPath(parent, filename) {
+			return acls.PermissionDenied
+		}
+	}
+	return nil
+}

--- a/artifacts/testdata/windows/startup.in.yaml
+++ b/artifacts/testdata/windows/startup.in.yaml
@@ -1,4 +1,5 @@
 Queries:
   - SELECT Name, Details, Enabled
     FROM Artifact.Windows.Sys.StartupItems()
-    WHERE Name =~ 'msht' ORDER BY Name
+    WHERE Name =~ 'msht' AND Details =~ "Hello"
+    ORDER BY Name

--- a/artifacts/testdata/windows/startup.out.yaml
+++ b/artifacts/testdata/windows/startup.out.yaml
@@ -1,4 +1,4 @@
-Query: SELECT Name, Details, Enabled FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' ORDER BY Name
+Query: SELECT Name, Details, Enabled FROM Artifact.Windows.Sys.StartupItems() WHERE Name =~ 'msht' AND Details =~ "Hello" ORDER BY Name
 Output: [
  {
   "Name": "c:\\windows\\system32\\msht.exe",

--- a/artifacts/testdata/windows/startup.out.yaml
+++ b/artifacts/testdata/windows/startup.out.yaml
@@ -4,6 +4,11 @@ Output: [
   "Name": "c:\\windows\\system32\\msht.exe",
   "Details": "Hello",
   "Enabled": "disabled"
+ },
+ {
+  "Name": "c:\\windows\\system32\\msht.exe",
+  "Details": 1,
+  "Enabled": "disabled"
  }
 ]
 

--- a/artifacts/testdata/windows/startup.out.yaml
+++ b/artifacts/testdata/windows/startup.out.yaml
@@ -4,11 +4,6 @@ Output: [
   "Name": "c:\\windows\\system32\\msht.exe",
   "Details": "Hello",
   "Enabled": "disabled"
- },
- {
-  "Name": "c:\\windows\\system32\\msht.exe",
-  "Details": 1,
-  "Enabled": "disabled"
  }
 ]
 

--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ func GetDefaultConfig() *config_proto.Config {
 			// reachable IP address you must enable TLS!
 			BindAddress:  "127.0.0.1",
 			BindPort:     8889,
+			PublicUrl:    "https://localhost:8889/app/index.html",
 			ReverseProxy: []*config_proto.ReverseProxyConfig{},
 			Authenticator: &config_proto.Authenticator{
 				Type: "Basic",

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -5796,13 +5796,15 @@
     type: string
     description: The cell of the notebook to update. If this is empty we add a new
       cell to the notebook
+  - name: delete
+    type: bool
+    description: If set the notebook cell is removed from the notebook.
   - name: type
     type: string
     description: Set the type of the cell if needed (markdown or vql).
   - name: input
     type: string
     description: The new cell content.
-    required: true
   - name: output
     type: string
     description: If this is set, we do not calculate the cell but set this as the

--- a/file_store/test_utils/server_config.go
+++ b/file_store/test_utils/server_config.go
@@ -62,6 +62,7 @@ API:
   bind_scheme: tcp
   pinned_gw_name: GRPC_GW
 GUI:
+  public_url: https://localhost:8889/app/index.html
   bind_address: 127.0.0.1
   bind_port: 8889
   gw_certificate: |

--- a/flows/client_flow_runner_test.go
+++ b/flows/client_flow_runner_test.go
@@ -248,7 +248,7 @@ func (self *ServerTestSuite) TestFlowStates() {
 		defer closer()
 
 		// The flow is in the UNRESPONSIVE state now.
-		vtesting.WaitUntil(time.Second, self.T(), func() bool {
+		vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
 			flow_details, err = launcher.GetFlowDetails(
 				self.Ctx, self.ConfigObj, services.GetFlowOptions{},
 				self.client_id, in_flight)

--- a/flows/client_flow_runner_test.go
+++ b/flows/client_flow_runner_test.go
@@ -288,7 +288,7 @@ func (self *ServerTestSuite) TestFlowStates() {
 	}
 
 	// The client record should not have any in flight flows now.
-	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+	vtesting.WaitUntil(15*time.Second, self.T(), func() bool {
 		client_info, err = client_info_manager.Get(self.Ctx, self.client_id)
 		assert.NoError(self.T(), err)
 

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -1251,7 +1251,6 @@ class VeloPagedTable extends Component {
         return (
             <tr key={idx}
                 onClick={e=>{
-                    e.stopPropagation();
                     // Prevent the browser from selecting with shift key
                     if (e.shiftKey) {
                         document.getSelection().removeAllRanges();

--- a/services/launcher/compiler.go
+++ b/services/launcher/compiler.go
@@ -333,7 +333,8 @@ func mergeSources(
 		// queries except for the last one.
 		queries, err := vfilter.MultiParse(source.Query)
 		if err != nil {
-			return fmt.Errorf("While parsing source query: %w", err)
+			return fmt.Errorf("While parsing source query %v: %w",
+				source.Name, err)
 		}
 
 		for idx2, vql := range queries {

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -305,7 +305,7 @@ func CalculateNotebookArtifact(
 			for _, n := range s.Notebook {
 				new_source.Notebook = append(new_source.Notebook, n)
 				switch strings.ToLower(n.Type) {
-				case "vql", "md", "markdown":
+				case "vql", "md", "markdown", "none":
 					custom_cells = true
 				}
 			}

--- a/services/notebook/timelines_test.go
+++ b/services/notebook/timelines_test.go
@@ -99,7 +99,7 @@ func (self *NotebookManagerTestSuite) _TestNotebookManagerTimelines(t *assert.R)
 }
 
 func (self *NotebookManagerTestSuite) TestNotebookManagerTimelineAnnotations() {
-	assert.Retry(self.T(), 3, time.Second,
+	assert.Retry(self.T(), 10, time.Second,
 		self._TestNotebookManagerTimelineAnnotations)
 }
 

--- a/services/notebook/worker.go
+++ b/services/notebook/worker.go
@@ -102,6 +102,7 @@ func (self *NotebookWorker) ProcessUpdateRequest(
 	defer tmpl.Close()
 
 	tmpl.SetEnv("NotebookId", in.NotebookId)
+	tmpl.SetEnv("NotebookCellId", in.CellId)
 
 	// Throttle the notebook accordingly.
 	tmpl.Scope.SetContext(constants.SCOPE_QUERY_NAME,

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -250,7 +250,8 @@ func (self *Repository) LoadProto(
 				// Check we can parse it properly.
 				queries, err := vfilter.MultiParse(source.Query)
 				if err != nil {
-					return nil, fmt.Errorf("While parsing source query: %w", err)
+					return nil, fmt.Errorf("While parsing source query %v: %w",
+						source.Name, err)
 				}
 
 				// Make sure the source format is correct

--- a/services/sanity/frontend.go
+++ b/services/sanity/frontend.go
@@ -46,6 +46,10 @@ func (self *SanityChecks) CheckFrontendSettings(
 			}
 		}
 
+		if !strings.HasSuffix(config_obj.GUI.PublicUrl, "/app/index.html") {
+			return fmt.Errorf("Invalid GUI.public_url - this should refer to the externally accessible URL for the GUI application. It should end with '/app/index.html'")
+		}
+
 	}
 	return nil
 }

--- a/services/secrets.go
+++ b/services/secrets.go
@@ -57,6 +57,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Velocidex/ordereddict"
@@ -139,6 +140,14 @@ func (self *Secret) GetBool(field string, target *bool) {
 	res, pres := self.Data.GetString(field)
 	if pres && res != "" {
 		*target = vql_subsystem.GetBoolFromString(res)
+	}
+}
+
+func (self *Secret) GetUint64(field string, target *uint64) {
+	res, pres := self.Data.GetString(field)
+	if pres && res != "" {
+		res_int, _ := strconv.ParseInt(res, 0, 64)
+		*target = uint64(res_int)
 	}
 }
 

--- a/tools/survey/compile.go
+++ b/tools/survey/compile.go
@@ -64,7 +64,7 @@ func (self *ConfigSurvey) Compile() (*config_proto.Config, error) {
 	config_obj.GUI.BindPort = uint32(port)
 
 	config_obj.GUI.PublicUrl = fmt.Sprintf(
-		"https://%s:%d/", config_obj.Frontend.Hostname,
+		"https://%s:%d/app/index.html", config_obj.Frontend.Hostname,
 		config_obj.GUI.BindPort)
 
 	config_obj.GUI.Authenticator.Type = "Basic"

--- a/vql/networking/mail.go
+++ b/vql/networking/mail.go
@@ -261,35 +261,11 @@ func (self MailFunction) mergeSecretToRequest(
 		return err
 	}
 
-	get := func(field string, target *string) {
-		res := vql_subsystem.GetStringFromRow(
-			scope, secret_record.Data, field)
-		if res != "" {
-			*target = res
-		}
-	}
-
-	get_int := func(field string, target *uint64) {
-		res := vql_subsystem.GetIntFromRow(
-			scope, secret_record.Data, field)
-		if res != 0 {
-			*target = res
-		}
-	}
-
-	get_bool := func(field string, target *bool) {
-		res := vql_subsystem.GetStringFromRow(
-			scope, secret_record.Data, field)
-		if res != "" {
-			*target = vql_subsystem.GetBoolFromString(res)
-		}
-	}
-
-	get("server", &arg.Server)
-	get_int("server_port", &arg.ServerPort)
-	get("auth_username", &arg.AuthUsername)
-	get("auth_password", &arg.AuthPassword)
-	get_bool("skip_verify", &arg.SkipVerify)
+	secret_record.GetString("server", &arg.Server)
+	secret_record.GetUint64("server_port", &arg.ServerPort)
+	secret_record.GetString("auth_username", &arg.AuthUsername)
+	secret_record.GetString("auth_password", &arg.AuthPassword)
+	secret_record.GetBool("skip_verify", &arg.SkipVerify)
 
 	return nil
 }

--- a/vql/tools/packaging/fixtures/TestDEBServer.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServer.golden
@@ -108,6 +108,7 @@ GUI:
     W5gJrneEd85yOMZRQ+zR9lUBnfK+csnfdPys6Tf+lnTBlXGtXaN69rmAHD1WJp5l
     JL5WubPDAGJoNCt7TqNBOwMk6avXZPFQkVljQclVoysIBQ44Tac=
     -----END RSA PRIVATE KEY-----
+  public_url: https://localhost:8889/app/index.html
   authenticator:
     type: Basic
 CA:

--- a/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
@@ -108,6 +108,7 @@ GUI:
     W5gJrneEd85yOMZRQ+zR9lUBnfK+csnfdPys6Tf+lnTBlXGtXaN69rmAHD1WJp5l
     JL5WubPDAGJoNCt7TqNBOwMk6avXZPFQkVljQclVoysIBQ44Tac=
     -----END RSA PRIVATE KEY-----
+  public_url: https://localhost:8889/app/index.html
   authenticator:
     type: Basic
 CA:

--- a/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
@@ -108,6 +108,7 @@ GUI:
     W5gJrneEd85yOMZRQ+zR9lUBnfK+csnfdPys6Tf+lnTBlXGtXaN69rmAHD1WJp5l
     JL5WubPDAGJoNCt7TqNBOwMk6avXZPFQkVljQclVoysIBQ44Tac=
     -----END RSA PRIVATE KEY-----
+  public_url: https://localhost:8889/app/index.html
   authenticator:
     type: Basic
 CA:

--- a/vql/tools/packaging/fixtures/TestRPMServer.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServer.golden
@@ -3,7 +3,7 @@ velociraptor-server-0.74.3.x86_64.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash c96c5898fee07104e85a03456da3221631cae2287cae0cf1a90d05f817a78114
+Hash 7ee2540d1ea95ce52b68d915b991c15e1b766ec102a68ac3b7cae181f681542d
 Mode 600
 Owner root
 Group root
@@ -175,6 +175,7 @@ GUI:
     W5gJrneEd85yOMZRQ+zR9lUBnfK+csnfdPys6Tf+lnTBlXGtXaN69rmAHD1WJp5l
     JL5WubPDAGJoNCt7TqNBOwMk6avXZPFQkVljQclVoysIBQ44Tac=
     -----END RSA PRIVATE KEY-----
+  public_url: https://localhost:8889/app/index.html
   authenticator:
     type: Basic
 CA:

--- a/vql/tools/packaging/fixtures/TestRPMServerMaster.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServerMaster.golden
@@ -3,7 +3,7 @@ velociraptor-server-master-0.74.3.x86_64-localhost-8000.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash c96c5898fee07104e85a03456da3221631cae2287cae0cf1a90d05f817a78114
+Hash 7ee2540d1ea95ce52b68d915b991c15e1b766ec102a68ac3b7cae181f681542d
 Mode 600
 Owner root
 Group root

--- a/vql/tools/packaging/fixtures/TestRPMServerMinion.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServerMinion.golden
@@ -3,7 +3,7 @@ velociraptor-server-minion-0.74.3.x86_64-www.example.com-8100.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash c96c5898fee07104e85a03456da3221631cae2287cae0cf1a90d05f817a78114
+Hash 7ee2540d1ea95ce52b68d915b991c15e1b766ec102a68ac3b7cae181f681542d
 Mode 600
 Owner root
 Group root


### PR DESCRIPTION
Also:

* Prevent certain filestore parts from being read using the fs accessor.
* Add the ability to delete a notebook cell.
* Ensure GUI.public_url is properly set in configuration files. This is needed for links to work correctly.