### PR TITLE
Fix hunt delete artifact

### DIFF
--- a/artifacts/definitions/Server/Hunts/CancelAndDelete.yaml
+++ b/artifacts/definitions/Server/Hunts/CancelAndDelete.yaml
@@ -36,7 +36,7 @@ parameters:
 sources:
   - name: CancelFlows
     query: |
-      SELECT * FROM Artifact.Server.Utils.CancelHunt(Hunts=Hunts)
+      SELECT * FROM Artifact.Server.Utils.CancelHunt(Hunts=serialize(item=Hunts))
 
   - name: HuntFiles
     query: |


### PR DESCRIPTION
The CancelFlows source was failing with:

```text
Running query Server.Hunts.CancelAndDelete/CancelFlows on behalf of user admin
<green>Starting</> query Server.Hunts.CancelAndDelete/CancelFlows execution.
parse_json_array: invalid character 'H' looking for beginning of value
Query Stats: {""RowsScanned"":301,""PluginsCalled"":4,""FunctionsCalled"":6,""ProtocolSearch"":0,""ScopeCopy"":608}
```
when passing the already-parsed hunts array to Server.Utils.CancelHunt