### PR TITLE
Update IISLogs.yaml

### DIFF
--- a/artifacts/definitions/Windows/Applications/IISLogs.yaml
+++ b/artifacts/definitions/Windows/Applications/IISLogs.yaml
@@ -54,8 +54,8 @@ sources:
             /*
             ### IIS grok
 
-            Note:  IIS doesnt have a standard logging format so Ive added some
-            suggestions. Comment in preffered or add your modify your own.
+            Note:  IIS doesn't have a standard logging format so we have added some
+            suggestions. Comment in preferred or add / modify your own.
             */
 
             LET target_grok = "%{TIMESTAMP_ISO8601:LogTimeStamp} %{IPORHOST:Site} %{WORD:Method} %{URIPATH:UriPath} %{NOTSPACE:QueryString} %{NUMBER:Port} %{NOTSPACE:Username} %{IPORHOST:Clienthost} %{NOTSPACE:Useragent} %{NOTSPACE:Referrer} %{NUMBER:Response} %{NUMBER:Subresponse} %{NUMBER:Win32status} %{NUMBER:Timetaken:int}"

--- a/artifacts/definitions/Windows/Applications/IISLogs.yaml
+++ b/artifacts/definitions/Windows/Applications/IISLogs.yaml
@@ -1,13 +1,17 @@
 name: Windows.Applications.IISLogs
 description: |
   This artifact enables grep of IISLogs.
-  Parameters include SearchRegex and WhitelistRegex as regex terms.
+  Parameters include SearchRegex and WhitelistRegex as regex terms and MoreRecentThan as timestamp to improve performance on systems with many and/or huge log files.
+  Hint: Make sure to get the right location of the log files as they are often stored at different non-default locations.
 
-author: "Matt Green - @mgreen27"
+author: "Matt Green - @mgreen27, Updated by Stephan Mikiss"
 
 parameters:
   - name: IISLogFiles
     default: '*:/inetpub/logs/**3/*.log'
+  - name: MoreRecentThan
+    default: ""
+    type: timestamp
   - name: SearchRegex
     description: "Regex of strings to search in line."
     default: ' POST '
@@ -21,16 +25,26 @@ sources:
   - precondition: SELECT OS From info() where OS = 'windows'
 
     query: |
-      LET files = SELECT OSPath FROM glob(globs=IISLogFiles)
+      LET files = SELECT OSPath,Mtime AS MTime FROM glob(globs=IISLogFiles)
+      
+      LET more_recent = SELECT * FROM if(
+        condition=MoreRecentThan,
+        then={
+          SELECT * FROM files
+          WHERE MTime > MoreRecentThan
+        }, else=files)
 
-      SELECT * FROM foreach(row=files,
+      SELECT * FROM foreach(row=more_recent,
           query={
-              SELECT Line, OSPath FROM parse_lines(filename=OSPath)
+              SELECT grok(data=Line,grok="%{TIMESTAMP_ISO8601:LogTimeStamp}").LogTimeStamp as EventTime,Line, OSPath FROM parse_lines(filename=OSPath)
               WHERE
                 Line =~ SearchRegex
                 AND NOT if(condition= WhitelistRegex,
                     then= Line =~ WhitelistRegex,
                     else= FALSE)
+                    AND if(condition= MoreRecentThan,
+                        then= EventTime > MoreRecentThan,
+                        else= TRUE)
           })
 
     notebook:
@@ -40,8 +54,8 @@ sources:
             /*
             ### IIS grok
 
-            Note:  IIS doesn't have a standard logging format so we have added some
-            suggestions. Comment in preferred or add / modify your own.
+            Note:  IIS doesnt have a standard logging format so Ive added some
+            suggestions. Comment in preffered or add your modify your own.
             */
 
             LET target_grok = "%{TIMESTAMP_ISO8601:LogTimeStamp} %{IPORHOST:Site} %{WORD:Method} %{URIPATH:UriPath} %{NOTSPACE:QueryString} %{NUMBER:Port} %{NOTSPACE:Username} %{IPORHOST:Clienthost} %{NOTSPACE:Useragent} %{NOTSPACE:Referrer} %{NUMBER:Response} %{NUMBER:Subresponse} %{NUMBER:Win32status} %{NUMBER:Timetaken:int}"

--- a/artifacts/definitions/Windows/Applications/IISLogs.yaml
+++ b/artifacts/definitions/Windows/Applications/IISLogs.yaml
@@ -1,8 +1,11 @@
 name: Windows.Applications.IISLogs
 description: |
   This artifact enables grep of IISLogs.
-  Parameters include SearchRegex and WhitelistRegex as regex terms and MoreRecentThan as timestamp to improve performance on systems with many and/or huge log files.
-  Hint: Make sure to get the right location of the log files as they are often stored at different non-default locations.
+  Parameters include SearchRegex and WhitelistRegex as regex terms and MoreRecentThan as timestamp.
+  
+  **Hint:** Make sure to get the right location of the log files as they are often stored at different non-default locations.
+  
+  **Hint 2:** MoreRecentThan filter is only applied to the Last Modified Time of files returned by the IISLogFiles glob. This improves the artefact's performance on systems with many log files. Use the SearchRegex filter for filtering on a per line basis.
 
 author: "Matt Green - @mgreen27, Updated by Stephan Mikiss"
 
@@ -36,15 +39,12 @@ sources:
 
       SELECT * FROM foreach(row=more_recent,
           query={
-              SELECT grok(data=Line,grok="%{TIMESTAMP_ISO8601:LogTimeStamp}").LogTimeStamp as EventTime,Line, OSPath FROM parse_lines(filename=OSPath)
+              SELECT Line, OSPath FROM parse_lines(filename=OSPath)
               WHERE
                 Line =~ SearchRegex
                 AND NOT if(condition= WhitelistRegex,
                     then= Line =~ WhitelistRegex,
                     else= FALSE)
-                    AND if(condition= MoreRecentThan,
-                        then= EventTime > MoreRecentThan,
-                        else= TRUE)
           })
 
     notebook:


### PR DESCRIPTION
Added a 'MoreRecentThan' parameter. This greatly improves the artifact performance on systems with many and/or huge log files. Additionally, the timestamp is extracted into a separate field by default which helps in filtering for specific timeframes.