### PR TITLE
Add some time filters to RDPCache artifact

### DIFF
--- a/artifacts/definitions/Windows/Forensics/RDPCache.yaml
+++ b/artifacts/definitions/Windows/Forensics/RDPCache.yaml
@@ -48,22 +48,17 @@ sources:
   - name: TargetFiles
     description: RDP BitmapCache files in scope.
     query: |
-      LET time_test(stamp) =
-            if(condition= DateBefore AND DateAfter,
-                then= stamp < DateBefore AND stamp > DateAfter,
-                else=
-            if(condition=DateBefore,
-                then= stamp < DateBefore,
-                else=
-            if(condition= DateAfter,
-                then= stamp > DateAfter,
-                else= True
-            )))
+      -- firstly set timebounds for performance
+      LET DateAfterTime <= if(condition=DateAfter,
+        then=DateAfter, else=timestamp(epoch="1600-01-01"))
+      LET DateBeforeTime <= if(condition=DateBefore,
+        then=DateBefore, else=timestamp(epoch="2200-01-01"))
             
       LET results = SELECT OSPath, Size, Mtime, Atime, Ctime, Btime
         FROM glob(globs=RDPCacheGlob,accessor=Accessor)
         WHERE OSPath =~ UserRegex
-            AND time_test(stamp=Mtime)
+            AND Mtime > DateAfterTime
+            AND Mtime < DateBeforeTime
 
       LET upload_results = SELECT *, upload(file=OSPath) as CacheUpload
         FROM results

--- a/artifacts/definitions/Windows/Forensics/RDPCache.yaml
+++ b/artifacts/definitions/Windows/Forensics/RDPCache.yaml
@@ -27,6 +27,12 @@ parameters:
      default: .
      description: Regex filter of user to target. StartOf(^) and EndOf($)) regex may behave unexpectanly.
      type: regex
+   - name: DateAfter
+     type: timestamp
+     description: "search for cache files modified after this date. YYYY-MM-DDTmm:hh:ssZ"
+   - name: DateBefore
+     type: timestamp
+     description: "search for cache files modified before this date. YYYY-MM-DDTmm:hh:ssZ"
    - name: ParseCache
      description: If selected will parse .BIN RDPcache files.
      type: bool
@@ -42,9 +48,22 @@ sources:
   - name: TargetFiles
     description: RDP BitmapCache files in scope.
     query: |
+      LET time_test(stamp) =
+            if(condition= DateBefore AND DateAfter,
+                then= stamp < DateBefore AND stamp > DateAfter,
+                else=
+            if(condition=DateBefore,
+                then= stamp < DateBefore,
+                else=
+            if(condition= DateAfter,
+                then= stamp > DateAfter,
+                else= True
+            )))
+            
       LET results = SELECT OSPath, Size, Mtime, Atime, Ctime, Btime
         FROM glob(globs=RDPCacheGlob,accessor=Accessor)
         WHERE OSPath =~ UserRegex
+            AND time_test(stamp=Mtime)
 
       LET upload_results = SELECT *, upload(file=OSPath) as CacheUpload
         FROM results

--- a/artifacts/definitions/Windows/Forensics/RDPCache.yaml
+++ b/artifacts/definitions/Windows/Forensics/RDPCache.yaml
@@ -25,7 +25,7 @@ parameters:
      description: Set accessor to use. blank is default, file for api, ntfs for raw, ntfs_vss for vss
    - name: UserRegex
      default: .
-     description: Regex filter of user to target. StartOf(^) and EndOf($)) regex may behave unexpectanly.
+     description: Regex filter of user to target. StartOf(^) and EndOf($)) regex may behave unexpectedly.
      type: regex
    - name: DateAfter
      type: timestamp


### PR DESCRIPTION
Add a quick filter to enable boxing for last modified for cache files. The dynamic function technique wont be too resource intensive due to the few files returned by these globs usually.