### PR TITLE
Remove unnecessary 'not /' characters from basePathRegEx

### DIFF
--- a/services/sanity/frontend.go
+++ b/services/sanity/frontend.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	basePathRegEx = regexp.MustCompile("^/[^/][a-zA-Z0-9_-]+[^/]$")
+	basePathRegEx = regexp.MustCompile("^/[a-zA-Z0-9_-]$")
 )
 
 func (self *SanityChecks) CheckDatastoreSettings(

--- a/services/sanity/frontend.go
+++ b/services/sanity/frontend.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	basePathRegEx = regexp.MustCompile("^/[a-zA-Z0-9_-]$")
+	basePathRegEx = regexp.MustCompile(`^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$`)
 )
 
 func (self *SanityChecks) CheckDatastoreSettings(


### PR DESCRIPTION
The former regex in https://github.com/Velocidex/velociraptor/blob/e16721ee09af6f8bfca40e14c7f5438d815c7013/services/sanity/frontend.go#L14 is misleading. 

The 'not /' character `[^/]` at the beginning and end of the basePathRegex forces you to have a base_path of at least 3 characters, which does not match the error message.
Furthermore it also allows you to use not intended paths like:

/*a* - where * stands for every character not within the alphanumeric character regex in between, which might cause problems or at least gives the opportunity to build unfunctional urls.

The removal of those  characters should be enough, as the regex not implicitly does not allow `/` after the first  character or at the end by the nature of the ^$ signs.

@blobbfischer