### PR TITLE
Added secret support for execve.

### DIFF
--- a/accessors/s3/s3.go
+++ b/accessors/s3/s3.go
@@ -58,6 +58,7 @@ func (self RawS3SystemAccessor) Describe() *accessors.AccessorDescriptor {
 		Description: `Allows access to S3 buckets.`,
 		Permissions: []acls.ACL_PERMISSION{acls.NETWORK},
 		ScopeVar:    constants.S3_CREDENTIALS,
+		ArgType:     S3AcccessorArgs{},
 	}
 }
 

--- a/artifacts/definitions/Server/Utils/Policy.yaml
+++ b/artifacts/definitions/Server/Utils/Policy.yaml
@@ -1,0 +1,110 @@
+name: Server.Utils.Policy
+description: |
+  This artifact defines a set of security policies.
+
+type: SERVER
+
+parameters:
+- name: ServerConfigFile
+  type: string
+  description: The path to the server.config.yaml
+
+- name: OutputFilePath
+  type: string
+  description: Where to write the modified configuration file.
+  default: /tmp/1.yaml
+
+- name: GUIAccessByIP
+  type: csv
+  description: |
+    Only allow access to the GUI from these CIDR networks.
+
+  default: |
+    CIDR,Description
+    0.0.0.0/0,Allow all (Skip)
+
+- name: LockDown
+  type: bool
+  description: If enabled, switch to lockdown mode.
+
+- name: DisableServerPlugins_Write
+  type: bool
+  default: Y
+  description: |
+    Disable server plugins that allow:
+    1. Writing to the filesystem.
+    2. Collecting server machine state.
+
+- name: DisableServerPlugins_Network
+  type: bool
+  description: |
+    Disable server plugins which allow connecting to external
+    resources over the network. These include for exaxmple:
+    1. http_client()
+    2. upload_elastic()
+    3. upload_s3()
+
+    An alternative to this setting is ForceSecrets to allow these
+    plugin to only work with named secrets.
+
+- name: ForceSecrets
+  type: bool
+  description: |
+    Force network plugins to only use named secrets. This allows an
+    admin to permit only well controlled network access without
+    allowing users to connect to arbitrary URLs.
+
+- name: DisableInventoryServiceExternalAccess
+  type: bool
+  description: |
+    Normally the inventory service attempts to download tools in its
+    own but if this is set, we prevent any external access.
+
+
+export: |
+  LET PluginsWithFileWrite <= SELECT name, metadata.permissions as perms
+      FROM help()
+      WHERE type =~ "Plugin" AND perms =~ "FILESYSTEM_WRITE|MACHINE_STATE"
+      ORDER BY name
+
+  LET FunctionsWithFileWrite <= SELECT name, metadata.permissions as perms
+      FROM help()
+      WHERE type =~ "Function" AND perms =~ "FILESYSTEM_WRITE|MACHINE_STATE"
+      ORDER BY name
+
+sources:
+- query: |
+    LET config <= parse_yaml(filename=ServerConfigFile)
+    LET GUIAccessByIP <= SELECT * FROM foreach(row= GUIAccessByIP)
+      WHERE NOT Description =~ "Skip"
+       AND CIDR =~ '''\d+\.\d+\.\d+\.\d+/\d{1,2}''' OR (
+        log(message="GUIAccessByIP: Invalid CIDR %v - rejecting",
+            args=CIDR, dedup= -1) AND FALSE )
+
+    LET _ <= GUIAccessByIP.CIDR && set(item=config.GUI,
+               field='allowed_cidr',
+               value=GUIAccessByIP.CIDR)
+
+    LET _ <= LockDown &&
+        set(item=config, field="lockdown", value=TRUE)
+
+    -- Make sure the security section exists
+    LET _ <= NOT config.security && set(item=config,
+       field="security", value=dict())
+
+    LET _ <= DisableServerPlugins_Write &&
+        set(item=config.security,
+            field="denied_plugins",
+            value=PluginsWithFileWrite.name ) AND
+        set(item=config.security,
+            field="denied_functions",
+            value=FunctionsWithFileWrite.name)
+
+    LET _ <= ForceSecrets &&
+        set(item=config.security,
+            field="vql_must_use_secrets",
+            value=TRUE )
+
+    SELECT copy(dest= OutputFilePath, accessor="data",
+                filename=serialize(item=config, format='yaml'))
+    FROM scope()

--- a/artifacts/definitions/Windows/Forensics/NotepadParser.yaml
+++ b/artifacts/definitions/Windows/Forensics/NotepadParser.yaml
@@ -2,7 +2,9 @@ name: Windows.Forensics.NotepadParser
 description: |
   Parse the Windows 11 Notepad state files.
 
-  Based on the research work published by ogmini.
+  Based on the research work published by ogmini. This artifact parses
+  the TabState and WindowState files and also uploads them for
+  preservation.
 
 reference:
   - https://github.com/ogmini/Notepad-State-Library
@@ -31,9 +33,6 @@ export: |
            sentinel: "x=>x.__D1 = 0 AND x.__D2 = 0",
         }],
         [ActiveTab, "x=>x.Tabs.EndOf", leb128],
-        [Offset, 0, Value, {
-          value: "x=>x.Tabs.EndOf",
-        }]
       ]],
 
       ["GUID", 16, [
@@ -148,32 +147,53 @@ export: |
     ]
     '''
 
+column_types:
+- name: Upload
+  type: preview_upload
+
 
 sources:
 - name: TabState
   query:
-    LET AllFiles = SELECT OSPath, Mtime, Size
-       FROM glob(globs=TabStateGlob)
+    LET AllFiles = SELECT OSPath, Mtime, Size,
+        upload(file=OSPath, mtime=Mtime) AS Upload
+    FROM glob(globs=TabStateGlob)
 
-    SELECT *, parse_binary(
+    LET AllTabState = SELECT *, parse_binary(
       filename=OSPath,
       offset=0,
       profile=WinNotepadProfile,
-      struct="TabStateHeader") AS TabState
-
+      struct="TabStateHeader") AS _TabState
     FROM AllFiles
-    WHERE TabState.Header.Signature
+    WHERE _TabState.Header.Signature
+
+    SELECT *,
+       _TabState.Header.FilePath AS EditedFile,
+       _TabState.Header.Timestamp AS EditTimestamp,
+       _TabState.Header.Content AS Content,
+       _TabState.Header.UnsavedBuffers.AddedChars AS UnsavedBuffers,
+       Upload
+    FROM AllTabState
 
 - name: WindowState
   query:
-    LET AllFiles = SELECT OSPath, Mtime, Size
-       FROM glob(globs=WindowStateGlob)
+    LET AllFiles = SELECT OSPath, Mtime, Size,
+        upload(file=OSPath, mtime=Mtime) AS Upload
+    FROM glob(globs=WindowStateGlob)
 
-    SELECT *, parse_binary(
+    LET AllTabState = SELECT *, parse_binary(
       filename=OSPath,
       offset=0,
       profile=WinNotepadProfile,
-      struct="WindowStateHeader") AS WindowState
+      struct="WindowStateHeader") AS _WindowState
 
     FROM AllFiles
-    WHERE WindowState.Signature = "NP"
+    WHERE _WindowState.Signature = "NP"
+
+
+    SELECT *,
+       _WindowState.NumberOfTabs AS NumberOfTabs,
+       _WindowState.Tabs.Value.Value AS Tabs,
+       _WindowState.ActiveTab AS ActiveTab,
+       Upload
+    FROM AllTabState

--- a/artifacts/testdata/server/testcases/execve.in.yaml
+++ b/artifacts/testdata/server/testcases/execve.in.yaml
@@ -1,0 +1,33 @@
+ConfigMerges:
+  # Enforce secret use on execve.
+  - |
+    {"security": {"vql_must_use_secrets": true}}
+
+Queries:
+- LET X <= SELECT * FROM info()
+- LET Exe <= X[0].Exe
+
+# Calling execve when secrets are enforced will fail.
+- SELECT * FROM execve(argv=[Exe, "version"])
+
+# Rejects the call.
+- SELECT * FROM test_read_logs() WHERE Log =~ "execve. Secrets are enforced" AND NOT Log =~ "SELECT"
+
+# Define a secret that allows calling the velociraptor binary only
+# with the version command.
+- |
+  SELECT secret_add(type="Execve Secrets", name="VR Version",
+                    secret=dict(prefix_commandline = Exe + " version ")),
+         secret_modify(type="Execve Secrets", name="VR Version",
+                       add_users="VelociraptorServer")
+  FROM scope()
+
+# Now call execve with the secret.
+- |
+  SELECT Stdout =~ "name. velociraptor" AS StdoutMatched, ReturnCode
+  FROM execve(argv=[Exe, "version"], secret="VR Version")
+
+# Trying to run other commands with the secret will not work they will
+# just be appended to the secret command.
+- SELECT Stderr =~ "usage. velociraptor version" AS StdoutMatched, ReturnCode
+  FROM execve(argv=["-h"], secret="VR Version")

--- a/artifacts/testdata/server/testcases/execve.out.yaml
+++ b/artifacts/testdata/server/testcases/execve.out.yaml
@@ -1,0 +1,54 @@
+Query: LET X <= SELECT * FROM info()
+Output: []
+
+Query: LET Exe <= X[0].Exe
+Output: []
+
+# Calling execve when secrets are enforced will fail.
+Query: SELECT * FROM execve(argv=[Exe, "version"])
+Output: []
+
+# Rejects the call.
+Query: SELECT * FROM test_read_logs() WHERE Log =~ "execve. Secrets are enforced" AND NOT Log =~ "SELECT"
+Output: [
+ {
+  "Log": "Velociraptor: ERROR:execve: Secrets are enforced - you must specify a secret name\n"
+ }
+]
+
+# Define a secret that allows calling the velociraptor binary only
+# with the version command.
+Query: SELECT secret_add(type="Execve Secrets", name="VR Version",
+                  secret=dict(prefix_commandline = Exe + " version ")),
+       secret_modify(type="Execve Secrets", name="VR Version",
+                     add_users="VelociraptorServer")
+FROM scope()
+
+Output: [
+ {
+  "secret_add(type=\"Execve Secrets\", name=\"VR Version\", secret=dict(prefix_commandline=Exe + \" version \"))": "VR Version",
+  "secret_modify(type=\"Execve Secrets\", name=\"VR Version\", add_users=\"VelociraptorServer\")": "VR Version"
+ }
+]
+
+# Now call execve with the secret.
+Query: SELECT Stdout =~ "name. velociraptor" AS StdoutMatched, ReturnCode
+FROM execve(argv=[Exe, "version"], secret="VR Version")
+
+Output: [
+ {
+  "StdoutMatched": true,
+  "ReturnCode": 0
+ }
+]
+
+# Trying to run other commands with the secret will not work they will
+# just be appended to the secret command.
+Query: SELECT Stderr =~ "usage. velociraptor version" AS StdoutMatched, ReturnCode FROM execve(argv=["-h"], secret="VR Version")
+Output: [
+ {
+  "StdoutMatched": true,
+  "ReturnCode": 0
+ }
+]
+

--- a/artifacts/testdata/server/testcases/notepad.in.yaml
+++ b/artifacts/testdata/server/testcases/notepad.in.yaml
@@ -1,7 +1,7 @@
 Queries:
   - LET X = scope()
   - |
-    SELECT OSPath.Basename, X.TabState.Header AS TabState, X.WindowState AS WindowState
+    SELECT OSPath.Basename, X._TabState.Header AS TabState, X._WindowState AS WindowState
     FROM Artifact.Windows.Forensics.NotepadParser(
       WindowStateGlob=srcDir + "/artifacts/testdata/files/notepad/*[01].bin",
       TabStateGlob=srcDir + "/artifacts/testdata/files/notepad/*.bin")

--- a/artifacts/testdata/server/testcases/notepad.out.yaml
+++ b/artifacts/testdata/server/testcases/notepad.out.yaml
@@ -1,7 +1,7 @@
 Query: LET X = scope()
 Output: []
 
-Query: SELECT OSPath.Basename, X.TabState.Header AS TabState, X.WindowState AS WindowState
+Query: SELECT OSPath.Basename, X._TabState.Header AS TabState, X._WindowState AS WindowState
 FROM Artifact.Windows.Forensics.NotepadParser(
   WindowStateGlob=srcDir + "/artifacts/testdata/files/notepad/*[01].bin",
   TabStateGlob=srcDir + "/artifacts/testdata/files/notepad/*.bin")
@@ -106,8 +106,7 @@ Output: [
      "Value": "C833A2C8-33A2-0001-0000-B79F74280000"
     }
    ],
-   "ActiveTab": 0,
-   "Offset": 24
+   "ActiveTab": 0
   }
  }
 ]

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -1423,9 +1423,10 @@ message RemappingConfig {
 // Various security related configuration options for the server.
 message Security {
     // A list of path prefixes allowed for the 'file' accessor. If
-    // this is empty the file accessor will be disabled. If you want
-    // to enable access to the server's filesystem you can set this to
-    // "/".
+    // this is empty the file accessor will work on all
+    // directories. If you want to disable access to the server's
+    // filesystem you can set this to a non existent directory,
+    // e.g. /nonexistent/ .
     repeated string allowed_file_accessor_prefix = 1;
 
     // A list of prefixes allowed for the fs accessor. All other
@@ -1466,6 +1467,7 @@ message Security {
     // - FILESYSTEM_WRITE
     // - FILESYSTEM_READ
     // - MACHINE_STATE
+    // - NETWORK
     repeated string lockdown_denied_permissions = 32;
 
     // Default expiry of certificate issuances (default 365 days)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -184,6 +184,7 @@ const (
 	SPLUNK_CREDS    = "Splunk Creds"
 	ELASTIC_CREDS   = "Elastic Creds"
 	SMTP_CREDS      = "SMTP Creds"
+	EXECVE_SECRET   = "Execve Secrets"
 
 	// The name of the annotation timeline
 	TIMELINE_ANNOTATION      = "Annotation"

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2309,11 +2309,14 @@
     type: int64
     description: Size of buffer to capture output per row.
   - name: env
-    type: LazyExpr
+    type: ordereddict.Dict
     description: Environment variables to launch with.
   - name: cwd
     type: string
     description: If specified we change to this working directory first.
+  - name: secret
+    type: string
+    description: The name of a secret to use.
   category: popular
   metadata:
     permissions: EXECVE
@@ -8734,6 +8737,23 @@
     "/blog/2024/2024-03-10-release-notes-0.72/#secret-management" >}})
     introduced in version 0.72 to manage these credentials.
   type: Accessor
+  args:
+  - name: secret
+    type: string
+    description: The name of a secret to use.
+  - name: region
+    type: string
+    description: The region.
+  - name: credentials_key
+    type: string
+  - name: credentials_secret
+    type: string
+  - name: credentials_token
+    type: string
+  - name: endpoint
+    type: string
+  - name: skip_verify
+    type: bool
   metadata:
     ScopeVar: S3_CREDENTIALS
     permissions: NETWORK

--- a/services/sanity/lockdown.go
+++ b/services/sanity/lockdown.go
@@ -29,6 +29,7 @@ func (self SanityChecks) CheckForLockdown(
 		StartHunt:            true,
 		Execve:               true,
 		ServerAdmin:          true,
+		Network:              true,
 		FilesystemWrite:      true,
 		FilesystemRead:       true,
 		MachineState:         true,

--- a/services/secrets/initialize.go
+++ b/services/secrets/initialize.go
@@ -120,6 +120,18 @@ var (
 			"server_port": "587",
 			"skip_verify": "FALSE",
 		},
+	}, {
+		TypeName:    constants.EXECVE_SECRET,
+		Description: "Enforce a prefix command on the execve() plugin",
+		Verifier:    "x=>x.prefix_commandline",
+		Fields: []string{
+			"prefix_commandline",
+			"env",
+			"cwd",
+		},
+		Template: map[string]string{
+			"env": "# Add extra parameters as YAML strings\n#Foo: Value\n#Baz:Value2\n",
+		},
 	}}
 )
 

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -21,7 +21,7 @@ var (
 	IOError             = errors.New("IOError")
 	NoAccessToOrgError  = errors.New("No access to org")
 	CancelledError      = errors.New("Cancelled")
-	SecretsEnforced     = errors.New("Secrets are enforced")
+	SecretsEnforced     = errors.New("Secrets are enforced - you must specify a secret name")
 )
 
 // This is a custom error type that wraps an inner error but does not

--- a/vql/common/shell.go
+++ b/vql/common/shell.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -36,6 +37,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/functions"
 	vfilter "www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
 )
@@ -348,7 +350,7 @@ func (self ShellPlugin) mergeSecretToRequest(
 	}
 
 	// Parse the command line into argv
-	secret_argv, err := shlex.Split(commandline)
+	secret_argv, err := CommandlineToArgv(commandline)
 	if err != nil {
 		return nil, err
 	}
@@ -487,4 +489,12 @@ func init() {
 	vql_subsystem.RegisterPlugin(&ShellPlugin{
 		pipeReader: defaultPipeReader,
 	})
+}
+
+func CommandlineToArgv(in string) ([]string, error) {
+	if runtime.GOOS == "windows" {
+		return functions.CommandLineToArgv(in), nil
+	}
+
+	return shlex.Split(in)
 }

--- a/vql/functions/commandline.go
+++ b/vql/functions/commandline.go
@@ -39,7 +39,7 @@ func (self *CommandlineToArgvFunction) Call(ctx context.Context,
 		return res
 	}
 
-	return commandLineToArgv(arg.Command)
+	return CommandLineToArgv(arg.Command)
 }
 
 func (self CommandlineToArgvFunction) Info(scope vfilter.Scope, type_map *vfilter.TypeMap) *vfilter.FunctionInfo {
@@ -107,7 +107,7 @@ func readNextArg(cmd string) (arg []byte, rest string) {
 // commandLineToArgv splits a command line into individual argument
 // strings, following the Windows conventions documented
 // at http://daviddeley.com/autohotkey/parameters/parameters.htm#WINARGV
-func commandLineToArgv(cmd string) []string {
+func CommandLineToArgv(cmd string) []string {
 	var args []string
 	for len(cmd) > 0 {
 		if cmd[0] == ' ' || cmd[0] == '\t' {

--- a/vql/networking/secrets.go
+++ b/vql/networking/secrets.go
@@ -169,6 +169,8 @@ func (self *_HttpPlugin) maybeForceSecrets(
 
 		filtered_urls = append(filtered_urls, url)
 	}
+
+	arg.Url = filtered_urls
 }
 
 func (self *_HttpPlugin) filterURLsWithSecret(

--- a/vql/tools/packaging/fixtures/TestDEBServer.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServer.golden
@@ -299,7 +299,7 @@ if ! getent group velociraptor >/dev/null; then
 fi
 
 if ! getent passwd velociraptor >/dev/null; then
-   adduser --system --home /etc/ --no-create-home \
+   adduser --system --home /etc/velociraptor --no-create-home \
      --ingroup velociraptor velociraptor --shell /bin/false \
      --gecos "Velociraptor server"
 fi

--- a/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
@@ -302,7 +302,7 @@ if ! getent group velociraptor >/dev/null; then
 fi
 
 if ! getent passwd velociraptor >/dev/null; then
-   adduser --system --home /etc/ --no-create-home \
+   adduser --system --home /etc/velociraptor --no-create-home \
      --ingroup velociraptor velociraptor --shell /bin/false \
      --gecos "Velociraptor server"
 fi

--- a/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
@@ -302,7 +302,7 @@ if ! getent group velociraptor >/dev/null; then
 fi
 
 if ! getent passwd velociraptor >/dev/null; then
-   adduser --system --home /etc/ --no-create-home \
+   adduser --system --home /etc/velociraptor --no-create-home \
      --ingroup velociraptor velociraptor --shell /bin/false \
      --gecos "Velociraptor server"
 fi

--- a/vql/tools/packaging/templates.go
+++ b/vql/tools/packaging/templates.go
@@ -341,7 +341,7 @@ if ! getent group {{.ServerUser}} >/dev/null; then
 fi
 
 if ! getent passwd {{.ServerUser}} >/dev/null; then
-   adduser --system --home /etc/ --no-create-home \
+   adduser --system --home /etc/{{.ServerUser}} --no-create-home \
      --ingroup {{.ServerUser}} {{.ServerUser}} --shell /bin/false \
      --gecos "{{.ServiceDescription}}"
 fi


### PR DESCRIPTION
This allows execve to be used with a secret specifying the prefix command line.

Combined with security.vql_must_use_secrets this mechanism creates a way to lock down execve() on the server to only be able to run certain approved programs controlled by a secret.