### PR TITLE
Refactor deletion code to improve flow deletion

### DIFF
--- a/artifacts/definitions/Generic/Utils/DeadDiskRemapping.yaml
+++ b/artifacts/definitions/Generic/Utils/DeadDiskRemapping.yaml
@@ -21,6 +21,8 @@ description: |
     level. We assume this is the windows drive and remap it to the C:
     drive.
 
+type: SERVER
+
 parameters:
   - name: ImagePath
     default: /tmp/image.dd

--- a/bin/main.go
+++ b/bin/main.go
@@ -193,6 +193,7 @@ func main() {
 		WithCustomValidator("validator: initDebugServer", initDebugServer).
 		WithCustomValidator("validator: timezone", initTimezone).
 		WithConfigMutator("Mutator: applyMinionRole", applyMinionRole).
+		WithCustomValidator("validator: ensureProxy", proxy.ConfigureProxy).
 		WithCustomValidator("validator: applyRemapping", applyRemapping).
 		WithConfigMutator("OverrideFlag", deprecatedOverride).
 		WithLogFile(*logging_flag).

--- a/datastore/memcache.go
+++ b/datastore/memcache.go
@@ -456,6 +456,7 @@ func (self *MemcacheDatastore) SetSubjectWithCompletion(
 		var wg sync.WaitGroup
 		wg.Add(1)
 		defer wg.Wait()
+
 		completion = wg.Done
 	}
 
@@ -518,7 +519,8 @@ func (self *MemcacheDatastore) DeleteSubjectWithCompletion(
 	urn api.DSPathSpec, completion func()) error {
 
 	err := self.DeleteSubject(config_obj, urn)
-	if completion != nil {
+	if completion != nil &&
+		!utils.CompareFuncs(completion, utils.SyncCompleter) {
 		completion()
 	}
 
@@ -648,7 +650,8 @@ func (self *MemcacheDatastore) SetBuffer(
 	urn api.DSPathSpec, data []byte, completion func()) error {
 
 	err := self.SetData(config_obj, urn, data)
-	if completion != nil {
+	if completion != nil &&
+		!utils.CompareFuncs(completion, utils.SyncCompleter) {
 		completion()
 	}
 	return err

--- a/datastore/remote.go
+++ b/datastore/remote.go
@@ -274,7 +274,8 @@ func (self *RemoteDataStore) _DeleteSubjectWithCompletion(
 			Tag:        urn.Tag(),
 		}})
 
-	if completion != nil {
+	if completion != nil &&
+		!utils.CompareFuncs(completion, utils.SyncCompleter) {
 		completion()
 	}
 

--- a/file_store/utils.go
+++ b/file_store/utils.go
@@ -29,3 +29,20 @@ func FlushFilestore(config_obj *config_proto.Config) error {
 
 	return nil
 }
+
+// Remove all the files that make up a bulk file.
+func DeleteBulkFile(
+	file_store api.FileStore,
+	path api.FSPathSpec) error {
+
+	// For bulk files remove their supporting index and chunk index
+	// files.
+	if path.Type() == api.PATH_TYPE_FILESTORE_ANY {
+		_ = file_store.Delete(path.
+			SetType(api.PATH_TYPE_FILESTORE_SPARSE_IDX))
+
+		_ = file_store.Delete(path.
+			SetType(api.PATH_TYPE_FILESTORE_CHUNK_INDEX))
+	}
+	return file_store.Delete(path)
+}

--- a/go.mod
+++ b/go.mod
@@ -324,6 +324,7 @@ require (
 // replace github.com/Velocidex/fileb0x => ../fileb0x
 // replace github.com/Velocidex/go-ext4 => ../go-ext4
 // replace github.com/Velocidex/amsi => ../amsi
+// replace github.com/Velocidex/go-journalctl ../go-journalctl
 
 // Remove search for html end block. This allows inserting unbalanced
 // HTML tags into the markdown

--- a/paths/notebooks.go
+++ b/paths/notebooks.go
@@ -20,6 +20,10 @@ func NotebookDir() api.DSPathSpec {
 	return NOTEBOOK_ROOT
 }
 
+func (self *NotebookPathManager) NotebookId() string {
+	return self.notebook_id
+}
+
 // Attachments are not the same as uploads - they are usually uploaded
 // by pasting in the cell eg an image. We want the attachment to
 // remain whenever the cell is updated to a new version.

--- a/result_sets/registration.go
+++ b/result_sets/registration.go
@@ -38,6 +38,11 @@ type TimedFactory interface {
 		ctx context.Context,
 		config_obj *config_proto.Config,
 		path_manager api.PathManager) (TimedResultSetReader, error)
+
+	DeleteTimedResultSet(
+		ctx context.Context,
+		config_obj *config_proto.Config,
+		path_manager api.PathManager) error
 }
 
 func NewTimedResultSetWriter(
@@ -89,6 +94,10 @@ type Factory interface {
 		log_path api.FSPathSpec,
 		options ResultSetOptions,
 	) (ResultSetReader, error)
+
+	DeleteResultSet(
+		file_store_factory api.FileStore,
+		path api.FSPathSpec) error
 }
 
 func NewResultSetWriter(
@@ -107,6 +116,21 @@ func NewResultSetWriter(
 
 	return factory.NewResultSetWriter(file_store_factory,
 		log_path, opts, completion, truncate)
+
+}
+
+func DeleteResultSet(
+	file_store_factory api.FileStore,
+	path api.FSPathSpec) error {
+	l_mu.Lock()
+	factory := rs_factory
+	l_mu.Unlock()
+
+	if factory == nil {
+		panic(errors.New("ResultSetFactory not initialized"))
+	}
+
+	return factory.DeleteResultSet(file_store_factory, path)
 
 }
 

--- a/result_sets/timed/factory.go
+++ b/result_sets/timed/factory.go
@@ -7,6 +7,7 @@ import (
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/result_sets"
+	"www.velocidex.com/golang/velociraptor/utils"
 
 	_ "www.velocidex.com/golang/velociraptor/result_sets/simple"
 )
@@ -31,6 +32,13 @@ func (self TimedFactory) NewTimedResultSetReader(
 		files:      path_manager.GetAvailableFiles(ctx),
 		config_obj: config_obj,
 	}, nil
+}
+
+func (self TimedFactory) DeleteTimedResultSet(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	path_manager api.PathManager) error {
+	return utils.NotImplementedError
 }
 
 func init() {

--- a/services/client_info/delete.go
+++ b/services/client_info/delete.go
@@ -118,7 +118,6 @@ func (self *ClientInfoManager) DeleteClient(
 
 	// Delete the actual client record.
 	if really_do_it {
-		utils.DlvBreak()
 		err = self.reallyDeleteClient(ctx, client_id, principal)
 		if err != nil {
 			progress <- services.DeleteFlowResponse{

--- a/services/client_info/storage.go
+++ b/services/client_info/storage.go
@@ -297,14 +297,13 @@ func (self *Store) SaveSnapshot(
 		logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 		logger.Info("<green>ClientInfo Manager</> Written snapshot for org %v in %v (%v records)",
 			services.GetOrgName(config_obj), time.Now().Sub(now), record_count)
-
 	}
 
 	// The final write must be synchronous because we need to
 	// guarantee it hits the disk
 	if sync {
-		defer completion()
-
+		// For sync writes we dont care about publising snapshot
+		// events. These occur during shutdown so it does not matter.
 		completion = utils.SyncCompleter
 	}
 

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -22,6 +22,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/result_sets"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/vfilter"
 )
 
 func (self *FlowStorageManager) DeleteFlow(
@@ -63,8 +64,7 @@ func (self *FlowStorageManager) DeleteFlow(
 	}
 
 	flow_path_manager := paths.NewFlowPathManager(client_id, flow_id)
-
-	upload_metadata_path := flow_path_manager.UploadMetadata()
+	flow_base_path := flow_path_manager.Path().Components()
 
 	r := &reporter{
 		really_do_it: options.ReallyDoIt,
@@ -78,30 +78,19 @@ func (self *FlowStorageManager) DeleteFlow(
 		file_store_factory, flow_path_manager.UploadMetadata())
 	if err == nil {
 		for row := range reader.Rows(ctx) {
+			// Some uploads list components relative to the client.
 			components, pres := row.GetStrings("_Components")
-			if pres {
+			if pres && len(components) > 0 {
+
+				// Make sure the uploads exist within this flow.
+				if !utils.SlicePrefixMatch(components, flow_base_path) {
+					continue
+				}
+
 				pathspec := path_specs.NewUnsafeFilestorePath(
 					components...).SetType(api.PATH_TYPE_FILESTORE_ANY)
-				r.emit_fs("Upload", pathspec)
-				r.emit_fs("UploadIdx", pathspec.
-					SetType(api.PATH_TYPE_FILESTORE_SPARSE_IDX))
-				r.emit_fs("UploadChunk", pathspec.
-					SetType(api.PATH_TYPE_FILESTORE_CHUNK_INDEX))
+				r.emit_bulk_file("Upload", pathspec)
 				continue
-			}
-
-			upload, pres := row.GetString("vfs_path")
-			if pres {
-				// Each row is the full filestore path of the upload.
-				pathspec := path_specs.NewUnsafeFilestorePath(
-					utils.SplitComponents(upload)...).
-					SetType(api.PATH_TYPE_FILESTORE_ANY)
-
-				r.emit_fs("Upload", pathspec)
-				r.emit_fs("UploadIdx", pathspec.
-					SetType(api.PATH_TYPE_FILESTORE_SPARSE_IDX))
-				r.emit_fs("UploadChunk", pathspec.
-					SetType(api.PATH_TYPE_FILESTORE_CHUNK_INDEX))
 			}
 		}
 		reader.Close()
@@ -109,9 +98,9 @@ func (self *FlowStorageManager) DeleteFlow(
 
 	// Order results to facilitate deletion - container deletion
 	// happens after we read its contents.
-	r.emit_fs("UploadMetadata", upload_metadata_path)
-	r.emit_fs("UploadMetadataIndex", upload_metadata_path.
-		SetType(api.PATH_TYPE_FILESTORE_JSON_INDEX))
+	r.emit_result_set("UploadMetadata", flow_path_manager.UploadMetadata())
+	r.emit_result_set("UploadTransactions",
+		flow_path_manager.UploadTransactions())
 
 	// Remove all result sets from artifacts.
 	for _, artifact_name := range collection_context.ArtifactsWithResults {
@@ -125,49 +114,22 @@ func (self *FlowStorageManager) DeleteFlow(
 		if err != nil {
 			continue
 		}
-		r.emit_fs("Result", result_path)
-		r.emit_fs("ResultIndex",
-			result_path.SetType(api.PATH_TYPE_FILESTORE_JSON_INDEX))
-		r.emit_fs("ResultChunkIndex",
-			result_path.SetType(api.PATH_TYPE_FILESTORE_CHUNK_INDEX))
-
+		r.emit_result_set("Result", result_path)
 	}
 
-	r.emit_fs("Log", flow_path_manager.Log())
-	r.emit_fs("LogIndex", flow_path_manager.Log().
-		SetType(api.PATH_TYPE_FILESTORE_JSON_INDEX))
+	r.emit_result_set("Log", flow_path_manager.Log())
+
 	r.emit_ds("CollectionContext", flow_path_manager.Path())
 	r.emit_ds("Task", flow_path_manager.Task())
 	r.emit_ds("Stats", flow_path_manager.Stats())
 
 	// Walk the flow's datastore and filestore
-	db, err := datastore.GetDB(config_obj)
-	if err != nil {
-		return nil, err
-	}
+	r.emit_notebook("Notebook", flow_path_manager.Notebook())
 
-	r.emit_ds("Notebook", flow_path_manager.Notebook().Path())
-	_ = datastore.Walk(config_obj, db, flow_path_manager.Notebook().DSDirectory(),
-		datastore.WalkWithoutDirectories,
-		func(path api.DSPathSpec) error {
-			r.emit_ds("NotebookData", path)
-			return nil
-		})
-
-	// Clean the empty directories
-	_ = datastore.Walk(config_obj, db, flow_path_manager.Notebook().DSDirectory(),
-		datastore.WalkWithDirectories,
-		func(path api.DSPathSpec) error {
-			_ = db.DeleteSubject(config_obj, path)
-			return nil
-		})
-
-	_ = api.Walk(file_store_factory,
-		flow_path_manager.Notebook().Directory(),
-		func(path api.FSPathSpec, info os.FileInfo) error {
-			r.emit_fs("NotebookItem", path)
-			return nil
-		})
+	// Delete anything that we missed
+	r.emit_walk_fs("Unknown",
+		flow_path_manager.Path().AsFilestorePath().
+			SetType(api.PATH_TYPE_FILESTORE_ANY))
 
 	if options.ReallyDoIt {
 		// User specified the flow must be removed immediately.
@@ -205,76 +167,166 @@ type reporter struct {
 
 func (self *reporter) emit_ds(
 	item_type string, target api.DSPathSpec) {
+	self.emit(item_type, target.String(), func() error {
+		db, err := datastore.GetDB(self.config_obj)
+		if err != nil {
+			return err
+		}
+		return db.DeleteSubject(self.config_obj, target)
+	})
+}
 
-	client_path := target.String()
-	var error_message string
+func (self *reporter) emit_result_set(
+	item_type string, target api.FSPathSpec) {
 
-	self.mu.Lock()
-	defer self.mu.Unlock()
+	self.emit(item_type, target.String(), func() error {
+		file_store_factory := file_store.GetFileStore(self.config_obj)
+		return result_sets.DeleteResultSet(file_store_factory, target)
+	})
+}
 
-	if self.seen[client_path] {
-		return
-	}
-	self.seen[client_path] = true
+func (self *reporter) emit_notebook(
+	item_type string, notebook_path_manager *paths.NotebookPathManager) {
 
-	self.id++
-	id := self.id
+	id := self.get_id()
 
 	self.pool.Submit(func() {
-		self.mu.Lock()
-		defer self.mu.Unlock()
-
-		if self.really_do_it {
-			db, err := datastore.GetDB(self.config_obj)
-			if err == nil {
-				err = db.DeleteSubject(self.config_obj, target)
-				if err != nil {
-					error_message = fmt.Sprintf(
-						"Error deleting %v: %v", client_path, err)
-				}
-			}
+		notebook_manager, err := services.GetNotebookManager(self.config_obj)
+		if err != nil {
+			return
 		}
+		output_chan := make(chan vfilter.Row)
 
-		self.responses = append(self.responses, &services.DeleteFlowResponse{
-			Id:    id,
-			Type:  item_type,
-			Data:  ordereddict.NewDict().Set("VFSPath", client_path),
-			Error: error_message,
-		})
+		go func() {
+			defer close(output_chan)
+
+			err = notebook_manager.DeleteNotebook(
+				self.ctx, notebook_path_manager.NotebookId(), output_chan,
+				self.really_do_it)
+			if err != nil {
+				self.add_response(&services.DeleteFlowResponse{
+					Type: "Notebook",
+					Id:   id,
+					Data: ordereddict.NewDict().Set("VFSPath",
+						notebook_path_manager.Path()),
+					Error: err.Error(),
+				})
+
+			}
+		}()
+
+		for row := range output_chan {
+			row_dict, ok := row.(*ordereddict.Dict)
+			if !ok {
+				continue
+			}
+			self.add_response(&services.DeleteFlowResponse{
+				Id:   self.get_id(),
+				Type: "NotebookData",
+				Data: row_dict,
+			})
+		}
 	})
+}
 
+func (self *reporter) emit_walk_fs(
+	item_type string, target api.FSPathSpec) {
+
+	self.pool.Submit(func() {
+		file_store_factory := file_store.GetFileStore(self.config_obj)
+		_ = api.Walk(file_store_factory, target,
+			func(urn api.FSPathSpec, info os.FileInfo) error {
+				error_message := ""
+				if !self.should_do_it() {
+					err := file_store_factory.Delete(urn)
+					if err != nil {
+						error_message = err.Error()
+					}
+				}
+
+				self.add_response(&services.DeleteFlowResponse{
+					Id:   self.get_id(),
+					Type: item_type,
+					Data: ordereddict.NewDict().
+						Set("VFSPath", urn.String()).
+						Set("Size", info.Size()),
+					Error: error_message,
+				})
+				return nil
+			})
+	})
+}
+
+func (self *reporter) emit_bulk_file(
+	item_type string, target api.FSPathSpec) {
+
+	self.emit(item_type, target.String(), func() error {
+		file_store_factory := file_store.GetFileStore(self.config_obj)
+		return file_store.DeleteBulkFile(file_store_factory, target)
+	})
 }
 
 func (self *reporter) emit_fs(
 	item_type string, target api.FSPathSpec) {
-	client_path := target.String()
-	var error_message string
 
+	self.emit(item_type, target.String(), func() error {
+		file_store_factory := file_store.GetFileStore(self.config_obj)
+		return file_store_factory.Delete(target)
+	})
+}
+
+func (self *reporter) should_do_it() bool {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+	return self.really_do_it
+}
+
+func (self *reporter) deduplicate(client_path string) bool {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
 	if self.seen[client_path] {
-		return
+		return true
 	}
 	self.seen[client_path] = true
+	return false
+}
 
+func (self *reporter) get_id() int {
+	self.mu.Lock()
+	defer self.mu.Unlock()
 	self.id++
-	id := self.id
+	return self.id
+}
+func (self *reporter) add_response(response *services.DeleteFlowResponse) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.responses = append(self.responses, response)
+}
+
+func (self *reporter) emit(
+	item_type string, client_path string,
+	deleter func() error) {
+
+	if self.deduplicate(client_path) {
+		return
+	}
+
+	id := self.get_id()
 
 	self.pool.Submit(func() {
-		self.mu.Lock()
-		defer self.mu.Unlock()
+		var error_message string
 
-		if self.really_do_it {
-			file_store_factory := file_store.GetFileStore(self.config_obj)
-			err := file_store_factory.Delete(target)
+		if self.should_do_it() {
+			err := deleter()
 			if err != nil {
 				error_message = fmt.Sprintf(
 					"Error deleting %v: %v", client_path, err)
 			}
 		}
 
-		self.responses = append(self.responses, &services.DeleteFlowResponse{
+		self.add_response(&services.DeleteFlowResponse{
 			Id:    id,
 			Type:  item_type,
 			Data:  ordereddict.NewDict().Set("VFSPath", client_path),

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -67,6 +67,14 @@ func StringSliceEq(a []string, b []string) bool {
 	return true
 }
 
+func SlicePrefixMatch(slice []string, prefix []string) bool {
+	if len(slice) < len(prefix) {
+		return false
+	}
+
+	return StringSliceEq(prefix, slice[:len(prefix)])
+}
+
 func FilterSlice(a []string, needle string) (res []string) {
 	for _, i := range a {
 		if i != needle {

--- a/vql/parsers/syslog/auditd.go
+++ b/vql/parsers/syslog/auditd.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux || freebsd
+// +build linux freebsd
 
 // Parse auditd log files.
 

--- a/vql/server/flows/fixtures/TestDeleteFlow.golden
+++ b/vql/server/flows/fixtures/TestDeleteFlow.golden
@@ -1,0 +1,120 @@
+[
+ {
+  "type": "Upload",
+  "data": {
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/uploads/ntfs/\"\\\\.\\C:\"/Windows/notepad.exe"
+  },
+  "error": ""
+ },
+ {
+  "type": "UploadMetadata",
+  "data": {
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/uploads.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "UploadTransactions",
+  "data": {
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/upload_transactions.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "Log",
+  "data": {
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/logs.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "CollectionContext",
+  "data": {
+   "VFSPath": "ds:/clients/C.123/collections/F.1234.json.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "Task",
+  "data": {
+   "VFSPath": "ds:/clients/C.123/collections/F.1234/task.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "Stats",
+  "data": {
+   "VFSPath": "ds:/clients/C.123/collections/F.1234/stats.json.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/artifact.json.db"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
+  },
+  "error": ""
+ },
+ {
+  "resident_paths": [
+   "/clients/C.123/flow_index.json",
+   "/clients/C.123/flow_index.json.index"
+  ]
+ }
+]

--- a/vql/server/flows/fixtures/TestEnumerateFlow.golden
+++ b/vql/server/flows/fixtures/TestEnumerateFlow.golden
@@ -1,5 +1,12 @@
 [
  {
+  "type": "Upload",
+  "data": {
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/uploads/ntfs/\"\\\\.\\C:\"/Windows/notepad.exe"
+  },
+  "error": ""
+ },
+ {
   "type": "UploadMetadata",
   "data": {
    "VFSPath": "fs:/clients/C.123/collections/F.1234/uploads.json"
@@ -7,9 +14,9 @@
   "error": ""
  },
  {
-  "type": "UploadMetadataIndex",
+  "type": "UploadTransactions",
   "data": {
-   "VFSPath": "fs:/clients/C.123/collections/F.1234/uploads.json.index"
+   "VFSPath": "fs:/clients/C.123/collections/F.1234/upload_transactions.json"
   },
   "error": ""
  },
@@ -17,13 +24,6 @@
   "type": "Log",
   "data": {
    "VFSPath": "fs:/clients/C.123/collections/F.1234/logs.json"
-  },
-  "error": ""
- },
- {
-  "type": "LogIndex",
-  "data": {
-   "VFSPath": "fs:/clients/C.123/collections/F.1234/logs.json.index"
   },
   "error": ""
  },
@@ -49,37 +49,173 @@
   "error": ""
  },
  {
-  "type": "Notebook",
+  "type": "NotebookData",
   "data": {
-   "VFSPath": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123.json.db"
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db"
   },
   "error": ""
  },
  {
   "type": "NotebookData",
   "data": {
-   "VFSPath": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db"
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db"
   },
   "error": ""
  },
  {
   "type": "NotebookData",
   "data": {
-   "VFSPath": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db"
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Notebook",
+   "vfs_path": "ds:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/artifact.json.db"
   },
   "error": ""
  },
  {
-  "type": "NotebookItem",
+  "type": "NotebookData",
   "data": {
-   "VFSPath": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json"
   },
   "error": ""
  },
  {
-  "type": "NotebookItem",
+  "type": "NotebookData",
   "data": {
-   "VFSPath": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json"
+  },
+  "error": ""
+ },
+ {
+  "type": "NotebookData",
+  "data": {
+   "notebook_id": "N.F.1234-C.123",
+   "type": "Filestore",
+   "vfs_path": "fs:/clients/C.123/collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index"
   },
   "error": ""
  }

--- a/vql/server/flows/flow_test.go
+++ b/vql/server/flows/flow_test.go
@@ -12,11 +12,15 @@ import (
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
+	"www.velocidex.com/golang/velociraptor/file_store/api"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
+	"www.velocidex.com/golang/velociraptor/result_sets"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/velociraptor/vql/server/flows"
 	"www.velocidex.com/golang/velociraptor/vtesting"
@@ -26,16 +30,28 @@ import (
 
 var (
 	sample_flow = `collections/F.1234/task.db
-collections/F.1234/uploads/ntfs/%3A%3A.%3AC/Windows/notepad.exe
-collections/F.1234/logs
+collections/F.1234/logs.json
 collections/F.1234/logs.json.index
+collections/F.1234/logs.chunk
+collections/F.1234/stats.json.db
+collections/F.1234/task.db
+collections/F.1234/upload_transactions.json
+collections/F.1234/upload_transactions.json.index
 collections/F.1234/uploads.json
 collections/F.1234/uploads.json.index
+collections/F.1234/uploads.chunk
+collections/F.1234/uploads/ntfs/\\.\C:/Windows/notepad.exe
+collections/F.1234/uploads/ntfs/\\.\C:/Windows/notepad.exe.idx
+collections/F.1234/uploads/ntfs/\\.\C:/Windows/notepad.exe.chunk
 collections/F.1234/notebook/N.F.1234-C.123.json.db
+collections/F.1234/notebook/N.F.1234-C.123/artifact.json.db
 collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT16FBL4PM.json.db
 collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU.json.db
 collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json
-collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index`
+collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/query_1.json.index
+collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json
+collections/F.1234/notebook/N.F.1234-C.123/NC.C4BKT1195IMMU/logs.json.index
+`
 )
 
 type FilestoreTestSuite struct {
@@ -44,7 +60,15 @@ type FilestoreTestSuite struct {
 	client_id, flow_id string
 }
 
-func (self *FilestoreTestSuite) TestEnumerateFlow() {
+func (self *FilestoreTestSuite) SetupTest() {
+	self.ConfigObj = self.LoadConfig()
+	self.ConfigObj.Services.NotebookService = true
+	self.ConfigObj.Services.SchedulerService = true
+
+	self.TestSuite.SetupTest()
+}
+
+func (self *FilestoreTestSuite) initFlowData() {
 	config_obj := self.ConfigObj
 	db, err := datastore.GetDB(config_obj)
 	assert.NoError(self.T(), err)
@@ -52,26 +76,51 @@ func (self *FilestoreTestSuite) TestEnumerateFlow() {
 	file_store_factory := file_store.GetFileStore(config_obj)
 
 	for _, line := range strings.Split(sample_flow, "\n") {
-		line = "/clients/C.123/" + line
-		if strings.HasSuffix(line, ".db") {
-			db.SetSubject(self.ConfigObj, paths.DSPathSpecFromClientPath(line),
-				&emptypb.Empty{})
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		line = "clients/C.123/" + line
+
+		// Data store files.
+		if strings.HasSuffix(line, ".db") ||
+			strings.HasSuffix(line, ".json.db") {
+			db.SetSubject(self.ConfigObj,
+				paths.DSPathSpecFromClientPath(line), &emptypb.Empty{})
+
 		} else {
-			path_spec := paths.FSPathSpecFromClientPath(line)
+			path_spec := path_specs.NewUnsafeFilestorePath(
+				strings.Split(line, "/")...).
+				SetType(api.PATH_TYPE_FILESTORE_ANY)
+
 			fd, err := file_store_factory.WriteFile(path_spec)
 			assert.NoError(self.T(), err)
+
 			fd.Write([]byte("X"))
 			fd.Close()
 		}
 	}
 
+	flow_pm := paths.NewFlowPathManager(self.client_id, self.flow_id)
+	rs_writer, err := result_sets.NewResultSetWriter(file_store_factory,
+		flow_pm.UploadMetadata(),
+		nil, utils.SyncCompleter, result_sets.TruncateMode)
+	assert.NoError(self.T(), err)
+
+	rs_writer.Write(ordereddict.NewDict().
+		Set("_Components", []string{
+			"clients", "C.123", "collections", "F.1234",
+			"uploads", "ntfs", `\\.\C:`,
+			"Windows", "notepad.exe"}))
+	rs_writer.Close()
+
 	// Populate the client's space with some data.
 	client_info := &actions_proto.ClientInfo{
 		ClientId: self.client_id,
 	}
-	client_path_manager := paths.NewClientPathManager(self.client_id)
-	flow_pm := paths.NewFlowPathManager(self.client_id, self.flow_id)
 
+	client_path_manager := paths.NewClientPathManager(self.client_id)
 	db.SetSubject(self.ConfigObj,
 		client_path_manager.Path(), client_info)
 
@@ -80,12 +129,10 @@ func (self *FilestoreTestSuite) TestEnumerateFlow() {
 	}
 	db.SetSubject(self.ConfigObj, flow_pm.Path(), flow_context)
 	db.SetSubject(self.ConfigObj, flow_pm.Task(), client_info)
+}
 
-	// Write some filestore files
-	fd, _ := file_store_factory.WriteFile(flow_pm.GetUploadsFile(
-		"ntfs", `\\.\C:\Windows\notepad.exe`,
-		[]string{`\\.\C:`, "Windows", "notepad.exe"}).Path())
-	fd.Close()
+func (self *FilestoreTestSuite) TestEnumerateFlow() {
+	self.initFlowData()
 
 	manager, _ := services.GetRepositoryManager(self.ConfigObj)
 	builder := services.ScopeBuilder{
@@ -106,6 +153,46 @@ func (self *FilestoreTestSuite) TestEnumerateFlow() {
 			Set("flow_id", self.flow_id).
 			Set("client_id", self.client_id)))
 	goldie.AssertJson(self.T(), "TestEnumerateFlow", result)
+}
+
+func (self *FilestoreTestSuite) TestDeleteFlow() {
+	self.initFlowData()
+
+	manager, _ := services.GetRepositoryManager(self.ConfigObj)
+	builder := services.ScopeBuilder{
+		Config:     self.ConfigObj,
+		ACLManager: acl_managers.NullACLManager{},
+		Logger: logging.NewPlainLogger(self.ConfigObj,
+			&logging.FrontendComponent),
+		Env: ordereddict.NewDict(),
+	}
+	scope := manager.BuildScope(builder)
+	defer scope.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
+	result := vtesting.RunPlugin(flows.DeleteFlowPlugin{}.Call(ctx, scope,
+		ordereddict.NewDict().
+			Set("flow_id", self.flow_id).
+			Set("client_id", self.client_id).
+			Set("really_do_it", true).
+			Set("sync", true)))
+
+	var resident_paths []string
+	for _, line := range test_utils.GetMemoryFileStore(
+		self.T(), self.ConfigObj).Paths.Keys() {
+		if strings.HasPrefix(line, "/clients/C.123/") {
+			resident_paths = append(resident_paths, line)
+		}
+	}
+
+	// Only the flow index should remain - all other files should be removed.
+	result = append(result, ordereddict.NewDict().
+		Set("resident_paths", resident_paths))
+
+	goldie.AssertJson(self.T(), "TestDeleteFlow", result)
+
 }
 
 func TestFilestorePlugin(t *testing.T) {

--- a/vql/server/flows/parallel_test.go
+++ b/vql/server/flows/parallel_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/stretchr/testify/suite"
@@ -77,7 +78,9 @@ func (self *TestSuite) TestArtifactSource() {
 	}
 	rs_writer.Close()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
 	builder := services.ScopeBuilder{
 		Config:     self.ConfigObj,
 		ACLManager: acl_managers.NullACLManager{},
@@ -141,7 +144,8 @@ func (self *TestSuite) TestHuntsSource() {
 		ArtifactIsBuiltIn: true})
 
 	assert.NoError(self.T(), err)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
 
 	hunt_dispatcher, err := services.GetHuntDispatcher(self.ConfigObj)
 	assert.NoError(self.T(), err)

--- a/vql/tools/webdav_upload.go
+++ b/vql/tools/webdav_upload.go
@@ -142,7 +142,8 @@ func upload_webdav(ctx context.Context, scope vfilter.Scope,
 	}
 
 	if skipVerify {
-		if err := networking.EnableSkipVerifyHttp(client, config_obj); err != nil {
+		err := networking.EnableSkipVerifyHttp(client, config_obj)
+		if err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Custom deletion code for result sets, bulk files and better testing ensure we do not leave files behind when deleting flows.

Also pass standard http client (with proxy support) to azure_upload() and s3_upload()