### PR TITLE
small change to normalize clientid field

### DIFF
--- a/artifacts/definitions/Server/Utils/DeleteMonitoringData.yaml
+++ b/artifacts/definitions/Server/Utils/DeleteMonitoringData.yaml
@@ -42,7 +42,7 @@ sources:
       WHERE IsDir
         AND Hostname =~ HostnameRegex
 
-      LET SearchRegisteredClientsQuery = SELECT client_id,
+      LET SearchRegisteredClientsQuery = SELECT client_id AS ClientId,
            os_info.hostname AS hostname
       FROM clients()
       WHERE hostname =~ HostnameRegex


### PR DESCRIPTION
Normalized client_id as `ClientId` for both client searches. Fixes #4437 