### PR TITLE
Bugfix: Limit number of entries emitted into process_tracker_tree()

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
-        node-version: 20
+        node-version: 22.19
 
     - name: npm install gui
       run: |

--- a/vql/tools/process/api.go
+++ b/vql/tools/process/api.go
@@ -12,8 +12,10 @@ type IProcessTracker interface {
 	Enrich(ctx context.Context, scope vfilter.Scope, id string) (*ProcessEntry, bool)
 	Stats() cache.Stats
 	Processes(ctx context.Context, scope vfilter.Scope) []*ProcessEntry
-	Children(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry
-	CallChain(ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry
+	Children(ctx context.Context, scope vfilter.Scope,
+		id string, max_items int64) []*ProcessEntry
+	CallChain(ctx context.Context, scope vfilter.Scope,
+		id string, max_items int64) []*ProcessEntry
 
 	// Listen to the update stream from the tracker.
 	Updates() chan *ProcessEntry

--- a/vql/tools/process/callchain.go
+++ b/vql/tools/process/callchain.go
@@ -13,7 +13,8 @@ import (
 )
 
 type getChainArgs struct {
-	Id string `vfilter:"required,field=id,doc=Process ID."`
+	Id       string `vfilter:"required,field=id,doc=Process ID."`
+	MaxItems int64  `vfilter:"optional,field=max_items,doc=The maximum number of process entries to return (default 10)"`
 }
 
 type getChain struct{}
@@ -35,7 +36,7 @@ func (self getChain) Call(ctx context.Context,
 		return &vfilter.Null{}
 	}
 
-	return tracker.CallChain(ctx, scope, arg.Id)
+	return tracker.CallChain(ctx, scope, arg.Id, arg.MaxItems)
 }
 
 func (self getChain) Info(scope types.Scope,

--- a/vql/tools/process/children.go
+++ b/vql/tools/process/children.go
@@ -24,13 +24,17 @@ func (self getChildren) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
+	if arg.MaxItems == 0 {
+		arg.MaxItems = 100
+	}
+
 	tracker := GetGlobalTracker()
 	if tracker == nil {
 		scope.Log("process_tracker_children: Initialize a process tracker first with process_tracker_install()")
 		return &vfilter.Null{}
 	}
 
-	return tracker.Children(ctx, scope, arg.Id)
+	return tracker.Children(ctx, scope, arg.Id, arg.MaxItems)
 }
 
 func (self getChildren) Info(scope types.Scope,

--- a/vql/tools/process/dummy.go
+++ b/vql/tools/process/dummy.go
@@ -104,7 +104,12 @@ func (self *DummyProcessTracker) Processes(
 }
 
 func (self *DummyProcessTracker) CallChain(
-	ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry {
+	ctx context.Context, scope vfilter.Scope,
+	id string, max_items int64) []*ProcessEntry {
+
+	if max_items == 0 {
+		max_items = 10
+	}
 
 	lookup := self.getLookup(ctx, scope)
 	result := []*ProcessEntry{}
@@ -117,6 +122,9 @@ func (self *DummyProcessTracker) CallChain(
 		}
 
 		result = append(result, proc)
+		if int64(len(result)) > max_items {
+			break
+		}
 		id = proc.ParentId
 	}
 
@@ -124,12 +132,20 @@ func (self *DummyProcessTracker) CallChain(
 }
 
 func (self *DummyProcessTracker) Children(
-	ctx context.Context, scope vfilter.Scope, id string) []*ProcessEntry {
+	ctx context.Context, scope vfilter.Scope,
+	id string, max_items int64) []*ProcessEntry {
+
+	if max_items == 0 {
+		max_items = 10
+	}
 
 	result := []*ProcessEntry{}
 	for _, proc := range self.Processes(ctx, scope) {
 		if proc.ParentId == id {
 			result = append(result, proc)
+			if int64(len(result)) > max_items {
+				break
+			}
 		}
 	}
 

--- a/vql/tools/process/fixtures/TestForkBomb.golden
+++ b/vql/tools/process/fixtures/TestForkBomb.golden
@@ -1,0 +1,29 @@
+{
+ "Number": 4,
+ "JSONTreeSize": 895,
+ "TrackedCount": 12
+}{
+ "Number": 13,
+ "JSONTreeSize": 3401,
+ "TrackedCount": 39
+}{
+ "Number": 40,
+ "JSONTreeSize": 11714,
+ "TrackedCount": 120
+}{
+ "Number": 121,
+ "JSONTreeSize": 38925,
+ "TrackedCount": 363
+}{
+ "Number": 364,
+ "JSONTreeSize": 127938,
+ "TrackedCount": 1092
+}{
+ "Number": 1000,
+ "JSONTreeSize": 379946,
+ "TrackedCount": 3279
+}{
+ "Number": 1000,
+ "JSONTreeSize": 411007,
+ "TrackedCount": 9840
+}


### PR DESCRIPTION
The Generic.System.Pstree artifact puts then entire tree into a single JSON row which can exceed buffer size in some cases. This causes problems in deeply nested trees.