### PR TITLE
Allow remapping rules to be passed to offline collector.

### DIFF
--- a/artifacts/definitions/Server/Utils/CreateCollector.yaml
+++ b/artifacts/definitions/Server/Utils/CreateCollector.yaml
@@ -168,6 +168,7 @@ parameters:
             level=Level,
             concurrency=Concurrency,
             format=Format,
+            remapping=Remapping,
             metadata=ContainerMetadata)
 
   - name: S3Collection
@@ -242,6 +243,10 @@ parameters:
     type: hidden
     default: |
       LET S = scope()
+      LET Remapping <= if(condition=Remapping,
+          then=log(message="Will load remapping rules from %v", args=Remapping) &&
+               read_file(filename=Remapping),
+          else="")
 
       // Add all the tools we are going to use to the inventory.
       LET _ <= SELECT inventory_add(tool=ToolName, hash=ExpectedHash, version=S.Version)
@@ -365,6 +370,7 @@ parameters:
           password=pass[0].Pass,
           level=Level,
           concurrency=Concurrency,
+          remapping=Remapping,
           metadata=ContainerMetadata)
 
       LET _ <= if(condition=NOT Result[0].Upload.Path,
@@ -490,6 +496,7 @@ sources:
                          type="json"
                          ),
                     dict(name="Level", default=opt_level, type="int"),
+                    dict(name="Remapping", default=""),
                     dict(name="Concurrency", default=opt_concurrency, type="int"),
                     dict(name="Format", default=opt_format),
                     dict(name="OutputPrefix", default=opt_output_directory),


### PR DESCRIPTION
This PR allows a remapping file to be passed to the offline collector. For example:

```
Collector_velociraptor-v0.75.1-windows-amd64.exe -- --args Remapping=C:/remapping.yaml
```