### PR TITLE
Bugfix: When using https clients would retry too quickly on 503

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '^1.24'
+        go-version: '^1.24.7'
 
         # Caching seems to really slow down the build due to the time
         # taken to save the cache.

--- a/.github/workflows/musl.yaml
+++ b/.github/workflows/musl.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '^1.24'
+        go-version: '^1.24.7'
 
     - run: go version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go 1.24
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.24
+        go-version: 1.24.7
 
         # Caching seems to really slow down the build due to the time
         # taken to save the cache.

--- a/actions/client_info.go
+++ b/actions/client_info.go
@@ -2,11 +2,11 @@ package actions
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/Showmax/go-fqdn"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/psutils"
 )
 
@@ -42,7 +42,7 @@ func GetClientInfo(
 		result.Hostname = info.Hostname
 		result.System = info.OS
 		result.Release = info.Platform + info.PlatformVersion
-		result.Architecture = runtime.GOARCH
+		result.Architecture = utils.GetArch()
 		result.Fqdn = fqdn.Get()
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	constants "www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 // Embed build time constants into here for reporting client version.
@@ -48,7 +49,7 @@ func GetVersion() *config_proto.Version {
 		CiBuildUrl:   ci_run_url,
 		Compiler:     runtime.Version(),
 		System:       runtime.GOOS,
-		Architecture: runtime.GOARCH,
+		Architecture: utils.GetArch(),
 	}
 }
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	VERSION = "0.75.1"
+	VERSION = "0.75.2"
 
 	// This is the version of dependent client binaries that will be
 	// included in the offline collector or MSI. Usually this will be

--- a/datastore/filebased_supported.go
+++ b/datastore/filebased_supported.go
@@ -6,12 +6,49 @@ package datastore
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/Velocidex/ordereddict"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/psutils"
+	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/types"
 )
+
+var (
+	disabledWrites int64 = -1
+)
+
+func isDisabled(config_obj *config_proto.Config) bool {
+	// Only peresent in debug mode
+	if config_obj.DebugMode &&
+		atomic.LoadInt64(&disabledWrites) < 0 {
+
+		atomic.StoreInt64(&disabledWrites, 0)
+
+		vql_subsystem.RegisterFunction(
+			vfilter.GenericFunction{
+				FunctionName: "disable_writes",
+				Metadata:     vql_subsystem.VQLMetadata().Build(),
+				Function: func(
+					ctx context.Context,
+					scope vfilter.Scope,
+					args *ordereddict.Dict) types.Any {
+					ok, _ := args.GetBool("clear")
+					if ok {
+						atomic.StoreInt64(&disabledWrites, 0)
+					} else {
+						atomic.StoreInt64(&disabledWrites, 1)
+					}
+					return true
+				}})
+	}
+
+	return atomic.LoadInt64(&disabledWrites) > 0
+}
 
 func AvailableDiskSpace(
 	db DataStore, config_obj *config_proto.Config) (uint64, error) {
@@ -21,7 +58,8 @@ func AvailableDiskSpace(
 		return 0, err
 	}
 
-	min_allowed_file_space_mb := uint64(config_obj.Datastore.MinAllowedFileSpaceMb)
+	min_allowed_file_space_mb := uint64(
+		config_obj.Datastore.MinAllowedFileSpaceMb)
 	if min_allowed_file_space_mb == 0 {
 		// We need at least 50mb by default.
 		min_allowed_file_space_mb = 50
@@ -33,7 +71,8 @@ func AvailableDiskSpace(
 	if ok {
 		// If we have insufficient disk space, set the filestore to
 		// stop writing.
-		if free_mb < min_allowed_file_space_mb {
+		if isDisabled(config_obj) ||
+			free_mb < min_allowed_file_space_mb {
 			logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 			logger.Error("FileBaseDataStore: Insufficient free disk space! We need at least %v Mb but we have %v!. Disabling write operations to avoid file corruption. Free some disk space or grow the partition.",
 				min_allowed_file_space_mb, free_mb)

--- a/datastore/remote.go
+++ b/datastore/remote.go
@@ -415,6 +415,7 @@ func StartDatastore(
 		remote_datastopre_imp = NewRemoteDataStore(ctx)
 		g_impl = nil
 		remote_mu.Unlock()
+
 	} else if implementation == "FileBaseDataStore" {
 		return startFullDiskChecker(ctx, wg, config_obj)
 	}

--- a/file_store/directory/directory.go
+++ b/file_store/directory/directory.go
@@ -192,7 +192,13 @@ func (self *DirectoryFileStore) WriteFileWithCompletion(
 
 	defer api.InstrumentWithDelay("open_write", "DirectoryFileStore", filename)()
 
-	err := datastore.MkdirAll(self.db, self.config_obj, filename.Dir())
+	// Writes are only possible when the datastore is healthy.
+	err := self.db.Healthy()
+	if err != nil {
+		return nil, err
+	}
+
+	err = datastore.MkdirAll(self.db, self.config_obj, filename.Dir())
 	if err != nil {
 		logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 		logger.Error("Can not create dir: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -330,7 +330,7 @@ require (
 // HTML tags into the markdown
 replace github.com/russross/blackfriday/v2 => github.com/Velocidex/blackfriday/v2 v2.0.2-0.20200811050547-4f26a09e2b3b
 
-go 1.24.0
+go 1.24.7
 
 // Needed for syntax highlighting VQL. Removes extra fat.
 replace github.com/alecthomas/chroma => github.com/Velocidex/chroma v0.6.8-0.20200418131129-82edc291369c

--- a/services/launcher/delete.go
+++ b/services/launcher/delete.go
@@ -286,15 +286,6 @@ func (self *reporter) emit_bulk_file(
 	})
 }
 
-func (self *reporter) emit_fs(
-	item_type string, target api.FSPathSpec) {
-
-	self.emit(item_type, target.String(), func() error {
-		file_store_factory := file_store.GetFileStore(self.config_obj)
-		return file_store_factory.Delete(target)
-	})
-}
-
 func (self *reporter) should_do_it() bool {
 	self.mu.Lock()
 	defer self.mu.Unlock()

--- a/services/repository/metadata.go
+++ b/services/repository/metadata.go
@@ -104,7 +104,7 @@ func (self *metadataManager) Set(
 
 	if utils.GetTime().Now().Sub(last_write) > time.Second &&
 		repository != nil {
-		self.SaveMetadata(self.ctx, self.config_obj, self.repository)
+		_ = self.SaveMetadata(self.ctx, self.config_obj, self.repository)
 	}
 }
 
@@ -131,7 +131,7 @@ func (self *metadataManager) HouseKeeping(
 				continue
 			}
 
-			self.SaveMetadata(ctx, config_obj, repository)
+			_ = self.SaveMetadata(ctx, config_obj, repository)
 		}
 	}
 }

--- a/utils/arch.go
+++ b/utils/arch.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func GetArch() string {
+	res := runtime.GOARCH
+
+	// On windows, detect if we are running in Wow64
+	if runtime.GOOS == "windows" {
+		proc_arch := os.Getenv("PROCESSOR_ARCHITECTURE")
+		if proc_arch != "" {
+			res = proc_arch
+
+			if proc_arch == "x86" {
+				wow_arch := os.Getenv("PROCESSOR_ARCHITEW6432")
+				if wow_arch == "AMD64" {
+					res = "wow64"
+				}
+			}
+		}
+	}
+
+	return strings.ToLower(res)
+}

--- a/vql/info.go
+++ b/vql/info.go
@@ -21,13 +21,13 @@ import (
 	"context"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	fqdn "github.com/Showmax/go-fqdn"
 	"github.com/Velocidex/ordereddict"
 
 	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/velociraptor/vql/psutils"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
@@ -104,32 +104,11 @@ func init() {
 
 				item := GetInfo(info).
 					Set("Fqdn", fqdn.Get()).
-					Set("Architecture", getArch())
+					Set("Architecture", utils.GetArch())
 				result = append(result, item)
 
 				return result
 			},
 			Doc: "Get information about the running host.",
 		})
-}
-
-func getArch() string {
-	res := runtime.GOARCH
-
-	// On windows, detect if we are running in Wow64
-	if runtime.GOOS == "windows" {
-		proc_arch := os.Getenv("PROCESSOR_ARCHITECTURE")
-		if proc_arch != "" {
-			res = proc_arch
-
-			if proc_arch == "x86" {
-				wow_arch := os.Getenv("PROCESSOR_ARCHITEW6432")
-				if wow_arch == "AMD64" {
-					res = "wow64"
-				}
-			}
-		}
-	}
-
-	return strings.ToLower(res)
 }


### PR DESCRIPTION
When the disk fills up, the server switches to read only data store and returns a 503 error to the clients. This bug caused the clients to retry too quickly causing a lot of un-necessary network traffic.