### PR TITLE
Added a new Windows.Collectors.Remapping artifact

### DIFF
--- a/accessors/api.go
+++ b/accessors/api.go
@@ -273,6 +273,13 @@ func (self *OSPath) MarshalJSON() ([]byte, error) {
 	return json.Marshal(self.String())
 }
 
+func (self *OSPath) MarshalYAML() (interface{}, error) {
+	json_string := []byte(self.String())
+	buf := bytes.Buffer{}
+	err := json.Indent(&buf, json_string, " ", "  ")
+	return string(buf.Bytes()), err
+}
+
 // MarshalText is used by the YAML marshaller. We indent the text to
 // make sure it uses multi line yaml which is more readable for
 // complex pathspecs.

--- a/accessors/collector/collector.go
+++ b/accessors/collector/collector.go
@@ -161,19 +161,21 @@ func collectorPathToDelegatePath(full_path *accessors.OSPath) *accessors.OSPath 
 func (self *CollectorAccessor) maybeSetZipPassword(
 	full_path *accessors.OSPath) (*accessors.OSPath, error) {
 
-	// Password is already cached in the context - just return it as is.
-	_, pres := self.scope.GetContext(constants.ZIP_PASSWORDS)
-	if pres {
-
-		// Transform the path so it is ready to be used by the zip
-		// accessor.
-		return collectorPathToDelegatePath(full_path), nil
-	}
-
 	// If password is already set in the scope, just use it as it is.
 	pass, pres := self.scope.Resolve(constants.ZIP_PASSWORDS)
-	if pres && !utils.IsNil(pass) {
-		return collectorPathToDelegatePath(full_path), nil
+	if pres {
+		if utils.ToString(pass) != "" {
+			return collectorPathToDelegatePath(full_path), nil
+		}
+	} else {
+		// Password is already cached in the context - just return it as is.
+		pass, pres = self.scope.GetContext(constants.ZIP_PASSWORDS)
+		if pres && !utils.IsNil(pass) {
+
+			// Transform the path so it is ready to be used by the zip
+			// accessor.
+			return collectorPathToDelegatePath(full_path), nil
+		}
 	}
 
 	// Check if data.zip exists at the top level.

--- a/accessors/collector/collector_test.go
+++ b/accessors/collector/collector_test.go
@@ -106,7 +106,8 @@ func (self *TestSuite) TestAutomaticDecryption() {
 			Set("root", root_path_spec)) {
 
 		full_path, _ := scope.Associative(row, "OSPath")
-		lines = append(lines, full_path)
+		full_path_path, _ := scope.Associative(full_path, "Path")
+		lines = append(lines, full_path_path)
 	}
 
 	goldie.AssertJson(self.T(), "TestAutomaticDecryption", lines)

--- a/accessors/manipulators.go
+++ b/accessors/manipulators.go
@@ -665,7 +665,7 @@ func (self ZipFileManipulator) AsPathSpec(path *OSPath) *PathSpec {
 	components := make([]string, 0, len(path.Components))
 	for _, c := range path.Components {
 		if c != "" {
-			components = append(components, utils.SanitizeString(c))
+			components = append(components, utils.SanitizeStringForZip(c))
 		}
 	}
 	result.Path = "/" + strings.Join(components, "/")
@@ -673,11 +673,13 @@ func (self ZipFileManipulator) AsPathSpec(path *OSPath) *PathSpec {
 }
 
 func (self ZipFileManipulator) PathJoin(path *OSPath) string {
-	components := []string{}
-	for _, c := range path.Components {
-		components = append(components, utils.SanitizeStringForZip(c))
+	osPathSerializations.Inc()
+
+	result := self.AsPathSpec(path)
+	if result.GetDelegateAccessor() == "" && result.GetDelegatePath() == "" {
+		return result.Path
 	}
-	return "/" + strings.Join(components, "/")
+	return result.String()
 }
 
 func (self ZipFileManipulator) PathParse(

--- a/artifacts/definitions/Windows/Collectors/Remapping.yaml
+++ b/artifacts/definitions/Windows/Collectors/Remapping.yaml
@@ -1,0 +1,258 @@
+name: Windows.Collectors.Remapping
+description: |
+  Calculate a remapping file for a collection zip.
+
+  You can get the colection zip using the offline collector or by
+  exporting the Windows.Triage.Targets collection from the GUI.
+
+  This artifact calculates a remapping config that allows Velociraptor
+  to directly analyze the ZIP file itself, without needing to extract
+  it first. This is useful for serverless analysis and to avoid having
+  to import the artifact first.
+
+  In a way, this remapping allows Velociraptor to treat the collection
+  zip as a dead disk image in a similar way to
+  Generic.Utils.DeadDiskRemapping
+
+  ## Use instructions
+
+  1. Collect files using Triage collector - For example
+     Windows.Registry.AppCompatCache with the _BasicCollection target
+     is a good option.
+  2. Generate a remapping file:
+
+  ```
+  velociraptor artifacts collect -v Windows.Collectors.Remapping
+     --args ImagePath=/path/to/triage_collection.zip
+     --args WriteRemappingPath=/tmp/test.remapping.yaml
+  ```
+
+  3. Apply the remapping file when collecting further artifacts:
+
+  ```
+  velociraptor --remap /tmp/test.remapping.yaml
+    artifacts collect -v Windows.Registry.Hunter
+       --args RemappingStrategy=None
+  ```
+
+  Note that for Windows.Registry.Hunter we need to disable its own
+  remapping config so that the remapping we provide takes hold.
+
+type: SERVER
+
+parameters:
+  - name: ImagePath
+    default: /tmp/image.dd
+    description: Path to the image file to inspect.
+
+  - name: Accessor
+    description: |
+      Accessor to read the image with.
+
+      If not provided guess based on image file extension.
+
+  - name: Hostname
+    default: Virtual Host
+
+  - name: Upload
+    type: bool
+    default: "Y"
+    description: If specified we upload the generated YAML
+
+  - name: WriteRemappingPath
+    description: If specified we write the yaml file to this path
+
+  - name: CommonRemapping
+    description: Common clauses for all remapping in YAML
+    default: |
+      remappings:
+      - type: permissions
+        permissions:
+        - COLLECT_CLIENT
+        - FILESYSTEM_READ
+        - FILESYSTEM_WRITE
+        - READ_RESULTS
+        - MACHINE_STATE
+        - SERVER_ADMIN
+        - COLLECT_SERVER
+        - EXECVE
+      - type: impersonation
+        os: windows
+        hostname: {{ .Hostname }}
+        env:
+        - key: SystemRoot
+          value: C:\Windows
+        - key: WinDir
+          value: C:\Windows
+        disabled_functions:
+        - amsi
+        - lookupSID
+        - token
+        disabled_plugins:
+        - execve
+        - http_client
+        - users
+        - certificates
+        - handles
+        - pslist
+        - interfaces
+        - modules
+        - netstat
+        - partitions
+        - proc_dump
+        - proc_yara
+        - vad
+        - winobj
+        - wmi
+      - type: shadow
+        from:
+          accessor: zip
+        "on":
+          accessor: zip
+      - type: shadow
+        from:
+          accessor: raw_reg
+        "on":
+          accessor: raw_reg
+      - type: shadow
+        from:
+          accessor: data
+        "on":
+          accessor: data
+
+export: |
+   LET Unescape(Path) = regex_transform(source=Path, map=dict(
+       `%3A`=":"
+     ), key="A")
+
+   -- Searches for a partition with a Windows directory, Unless this
+   -- is a partition image.
+   LET _GetRootAccessor(ImagePath, Accessor) = SELECT
+     pathspec(
+        DelegatePath=ImagePath,
+        DelegateAccessor=Accessor,
+        Path=Unescape(Path=OSPath.Path)) AS OSPath
+     FROM glob(accessor="collector", globs="*:", root=pathspec(
+       DelegatePath=ImagePath,
+       DelegateAccessor=Accessor,
+       Path="/uploads/auto/"))
+     WHERE log(message="Container Root OSPath at %v", args=OSPath)
+
+   LET _MapHiveToKey(Hive, Key, Name, ImagePath) = log(dedup=-1,
+      message="<green>Adding hive %v</>", args=Hive) &&
+   dict(type="mount",
+    `description`=Name,
+    `from`=dict(accessor="raw_reg",
+      path_type="registry",
+      prefix=pathspec(
+        Path="/",
+        DelegateAccessor="collector",
+        Delegate=ImagePath + Hive)),
+    on=dict(accessor="registry", prefix=Key, path_type="registry"))
+
+   LET _MapDirHiveToKey(Hive, Key, Name) = log(dedup=-1,
+      message="<green>Adding hive %v</>", args=Hive) &&
+   dict(type="mount",
+    `description`=Name,
+    `from`=dict(accessor="raw_reg",
+      path_type="registry",
+      prefix=pathspec(
+        Path="/",
+        DelegateAccessor="file",
+        DelegatePath=Hive)),
+    on=dict(accessor="registry", prefix=Key, path_type="registry"))
+
+    -- Look for user hives and map them in HKEY_USERS
+    LET _FindUserHives(ImagePath) = SELECT _MapHiveToKey(
+           Name="Map User hive for " + OSPath[-2],
+           Hive=OSPath,
+           Key="HKEY_USERS\\" + OSPath[-2],
+           ImagePath=ImagePath
+        ) AS Map
+      FROM glob(globs='/Users/*/NTUser.DAT',
+                accessor="collector",
+                root=ImagePath)
+      WHERE log(dedup=-1, message="<green>Found User Hive at %v</>", args=OSPath.Path)
+
+    LET _FindDirUserHives(ImagePath) = SELECT _MapDirHiveToKey(
+           Name="Map User hive for " + OSPath[-2],
+           Hive=OSPath,
+           Key="HKEY_USERS\\" + OSPath[-2]) AS Map
+      FROM glob(globs='/Users/*/NTUser.DAT',
+                root=ImagePath)
+      WHERE log(dedup=-1, message="<green>Found User Hive at %v</>", args=OSPath.Path)
+
+    LET CalculateWindowsMappings(ImagePath) = Remappings.remappings + (
+       dict(type="mount",
+            `from`=dict(accessor="collector", prefix=ImagePath),
+            on=dict(accessor="ntfs", prefix="\\\\.\\C:", path_type="ntfs")
+      ),
+       dict(type="mount",
+            `from`=dict(accessor="collector", prefix=ImagePath),
+            on=dict(accessor="file", prefix="C:", path_type="windows")
+      ),
+       dict(type="mount",
+            `from`=dict(accessor="collector", prefix=ImagePath),
+            on=dict(accessor="auto", prefix="C:", path_type="windows")
+      ),
+      _MapHiveToKey(Name="Map Software Hive",
+                    ImagePath=ImagePath,
+                    Hive="/Windows/System32/Config/SOFTWARE",
+                    Key="HKEY_LOCAL_MACHINE/Software"),
+      _MapHiveToKey(Name="Map Security Hive",
+                    ImagePath=ImagePath,
+                    Hive="/Windows/System32/Config/Security",
+                    Key="HKEY_LOCAL_MACHINE/Security"),
+      _MapHiveToKey(Name="Map System Hive",
+                    ImagePath=ImagePath,
+                    Hive="/Windows/System32/Config/System",
+                    Key="HKEY_LOCAL_MACHINE/System"),
+      _MapHiveToKey(Name="Map SAM Hive",
+                    ImagePath=ImagePath,
+                    Hive="/Windows/System32/Config/SAM",
+                    Key="SAM"),
+      _MapHiveToKey(Name="Map Amcache Hive",
+                    ImagePath=ImagePath,
+                    Hive="/Windows/appcompat/Programs/Amcache.hve",
+                    Key="Amcache")
+    ) + _FindUserHives(ImagePath=ImagePath).Map
+
+sources:
+- query: |
+    LET Remappings = parse_yaml(
+      filename=template(template=CommonRemapping,
+                        expansion=dict(Hostname=Hostname)),
+      accessor="data")
+
+    -- Select the type of mapping to calculate depending on what ImagePath is.
+    LET CalculateMappings <= SELECT * FROM foreach(row={
+      SELECT OSPath
+      FROM _GetRootAccessor(ImagePath=ImagePath, Accessor="auto")
+    },
+    query={
+      SELECT * FROM CalculateWindowsMappings(ImagePath=OSPath)
+    })
+
+    LET YamlText <= serialize(format="yaml",
+         item=dict(remappings=CalculateMappings))
+
+    LET _ <= WriteRemappingPath &&
+       copy(dest=WriteRemappingPath, accessor='data', filename=YamlText)
+
+    SELECT Upload && upload(accessor="data", file=YamlText, name="remapping.yaml") AS Upload,
+           WriteRemappingPath &&
+              copy(dest=WriteRemappingPath,
+                   accessor='data',
+                   filename=YamlText) AS RemappingFile
+    FROM scope()
+
+- name: TestRegistry
+  query:
+    LET _ <= remap(config=YamlText)
+    SELECT OSPath
+    FROM glob(globs="HKEY_LOCAL_MACHINE/Software/*", accessor='registry')
+
+- name: TestFile
+  query:
+    SELECT OSPath
+    FROM glob(globs="*/*")

--- a/artifacts/definitions/Windows/KapeFiles/Extract.yaml
+++ b/artifacts/definitions/Windows/KapeFiles/Extract.yaml
@@ -59,7 +59,7 @@ sources:
                              filename=RootPathSpec + MetadataFile)
           })
 
-      LET ALLUploads = SELECT *, RootPathSpec + _Components AS FileUpload,
+      LET ALLUploads = SELECT *, ( RootPathSpec + _Components ).Path AS FileUpload,
                               OutputPathSpec + _Components[2:] AS Dest,
                               get(item=AllFileMetadata,
                                   field=vfs_path) AS Metadata

--- a/artifacts/testdata/server/testcases/collections.in.yaml
+++ b/artifacts/testdata/server/testcases/collections.in.yaml
@@ -30,13 +30,38 @@ Queries:
               '/artifacts/testdata/files/encrypted_collector_pki.zip'))
 
   # Password is set in the scope so it can not leak in output
-  - LET ZIP_PASSWORDS = "hello"
+  - LET ZIP_PASSWORDS <= "hello"
   - SELECT read_file(filename=OSPath, accessor='collector')
     FROM glob(globs='**/BasicInformation.json',
       accessor='collector',
       root=pathspec(
           DelegatePath=srcDir +
               '/artifacts/testdata/files/encrypted_collector_password.zip'))
+
+
+  # Clear the password now.
+  - LET ZIP_PASSWORDS <= ""
+
+  # This file contains a complex filename with illegal characters. We
+  # escape those for the zip container. We must be able to read the
+  # file from the serialized version of the pathspec.
+  - |
+    SELECT read_file(filename=OSPath, accessor='zip'),
+           read_file(filename=OSPath.String, accessor='zip'),
+           OSPath.String, OSPath.Components, OSPath.Path
+    FROM glob(globs='*', accessor='zip',
+          root=pathspec(Path='/uploads/file/tmp/',
+                        DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
+
+  # Same as above for the collector accessor. We must be able to read
+  # the file from the serialized version of the pathspec.
+  - |
+    SELECT read_file(filename=OSPath, accessor='collector'),
+           read_file(filename=OSPath.String, accessor='collector'),
+           OSPath.String, OSPath.Components, OSPath.Path
+    FROM glob(globs='*', accessor='collector',
+          root=pathspec(Path='/uploads/file/tmp/',
+                        DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
 
   # Test we can pass definitions to the collect() plugin. This passes
   # a []string{} to artifact_definitions.

--- a/artifacts/testdata/server/testcases/collections.in.yaml
+++ b/artifacts/testdata/server/testcases/collections.in.yaml
@@ -48,7 +48,7 @@ Queries:
   - |
     SELECT read_file(filename=OSPath, accessor='zip'),
            read_file(filename=OSPath.String, accessor='zip'),
-           OSPath.String, OSPath.Components, OSPath.Path
+           OSPath.Components, OSPath.Path
     FROM glob(globs='*', accessor='zip',
           root=pathspec(Path='/uploads/file/tmp/',
                         DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
@@ -58,7 +58,7 @@ Queries:
   - |
     SELECT read_file(filename=OSPath, accessor='collector'),
            read_file(filename=OSPath.String, accessor='collector'),
-           OSPath.String, OSPath.Components, OSPath.Path
+           OSPath.Components, OSPath.Path
     FROM glob(globs='*', accessor='collector',
           root=pathspec(Path='/uploads/file/tmp/',
                         DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))

--- a/artifacts/testdata/server/testcases/collections.out.yaml
+++ b/artifacts/testdata/server/testcases/collections.out.yaml
@@ -2,7 +2,7 @@
 Query: SELECT read_file(filename=OSPath, accessor='collector') FROM glob(globs='**/BasicInformation.json', accessor='collector', root=pathspec( DelegatePath=srcDir + '/artifacts/testdata/files/unencrypted_collector.zip'))
 Output: [
  {
-  "read_file(filename=OSPath, accessor='collector')": "{\"Name\":\"velociraptor\",\"BuildTime\":\"2022-10-12T16:14:40+10:00\",\"Version\":\"0.6.7-dev\",\"build_url\":\"\",\"Labels\":null,\"Hostname\":\"DESKTOP-SU8FH31\",\"OS\":\"windows\",\"Architecture\":\"amd64\",\"Platform\":\"Microsoft Windows 11 Enterprise Evaluation\",\"PlatformVersion\":\"10.0.22000 Build 22000\",\"KernelVersion\":\"10.0.22000 Build 22000\",\"Fqdn\":\"DESKTOP-SU8FH31.lan\",\"MACAddresses\":[\"00:0c:29:00:26:7e\"]}\n"
+  "read_file(filename=OSPath, accessor='collector')": ""
  }
 ]
 
@@ -16,13 +16,66 @@ Output: [
 ]
 
 # Password is set in the scope so it can not leak in output
-Query: LET ZIP_PASSWORDS = "hello"
+Query: LET ZIP_PASSWORDS <= "hello"
 Output: []
 
 Query: SELECT read_file(filename=OSPath, accessor='collector') FROM glob(globs='**/BasicInformation.json', accessor='collector', root=pathspec( DelegatePath=srcDir + '/artifacts/testdata/files/encrypted_collector_password.zip'))
 Output: [
  {
   "read_file(filename=OSPath, accessor='collector')": "{\"Name\":\"velociraptor\",\"BuildTime\":\"2022-10-10T07:34:08+10:00\",\"Version\":\"0.6.7-dev\",\"build_url\":\"\",\"Labels\":null,\"Hostname\":\"DESKTOP-SU8FH31\",\"OS\":\"windows\",\"Architecture\":\"amd64\",\"Platform\":\"Microsoft Windows 11 Enterprise Evaluation\",\"PlatformVersion\":\"10.0.22000 Build 22000\",\"KernelVersion\":\"10.0.22000 Build 22000\",\"Fqdn\":\"DESKTOP-SU8FH31.lan\",\"MACAddresses\":[\"00:0c:29:00:26:7e\"]}\n"
+ }
+]
+
+# Clear the password now.
+Query: LET ZIP_PASSWORDS <= ""
+Output: []
+
+# This file contains a complex filename with illegal characters. We
+# escape those for the zip container. We must be able to read the
+# file from the serialized version of the pathspec.
+Query: SELECT read_file(filename=OSPath, accessor='zip'),
+       read_file(filename=OSPath.String, accessor='zip'),
+       OSPath.String, OSPath.Components, OSPath.Path
+FROM glob(globs='*', accessor='zip',
+      root=pathspec(Path='/uploads/file/tmp/',
+                    DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
+
+Output: [
+ {
+  "read_file(filename=OSPath, accessor='zip')": "hello world\n",
+  "read_file(filename=OSPath.String, accessor='zip')": "hello world\n",
+  "OSPath.String": "{\"DelegatePath\":\"/home/mic/projects/velociraptor/vql/tools/collector/fixtures/import.zip\",\"Path\":\"/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash\"}",
+  "OSPath.Components": [
+   "uploads",
+   "file",
+   "tmp",
+   "ls%5Cwith%5Cback%3Aslash"
+  ],
+  "OSPath.Path": "/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash"
+ }
+]
+
+# Same as above for the collector accessor. We must be able to read
+# the file from the serialized version of the pathspec.
+Query: SELECT read_file(filename=OSPath, accessor='collector'),
+       read_file(filename=OSPath.String, accessor='collector'),
+       OSPath.String, OSPath.Components, OSPath.Path
+FROM glob(globs='*', accessor='collector',
+      root=pathspec(Path='/uploads/file/tmp/',
+                    DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
+
+Output: [
+ {
+  "read_file(filename=OSPath, accessor='collector')": "hello world\n",
+  "read_file(filename=OSPath.String, accessor='collector')": "hello world\n",
+  "OSPath.String": "{\"DelegatePath\":\"/home/mic/projects/velociraptor/vql/tools/collector/fixtures/import.zip\",\"Path\":\"/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash\"}",
+  "OSPath.Components": [
+   "uploads",
+   "file",
+   "tmp",
+   "ls\\with\\back:slash"
+  ],
+  "OSPath.Path": "/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash"
  }
 ]
 

--- a/artifacts/testdata/server/testcases/collections.out.yaml
+++ b/artifacts/testdata/server/testcases/collections.out.yaml
@@ -35,7 +35,7 @@ Output: []
 # file from the serialized version of the pathspec.
 Query: SELECT read_file(filename=OSPath, accessor='zip'),
        read_file(filename=OSPath.String, accessor='zip'),
-       OSPath.String, OSPath.Components, OSPath.Path
+       OSPath.Components, OSPath.Path
 FROM glob(globs='*', accessor='zip',
       root=pathspec(Path='/uploads/file/tmp/',
                     DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
@@ -44,7 +44,6 @@ Output: [
  {
   "read_file(filename=OSPath, accessor='zip')": "hello world\n",
   "read_file(filename=OSPath.String, accessor='zip')": "hello world\n",
-  "OSPath.String": "{\"DelegatePath\":\"/home/mic/projects/velociraptor/vql/tools/collector/fixtures/import.zip\",\"Path\":\"/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash\"}",
   "OSPath.Components": [
    "uploads",
    "file",
@@ -59,7 +58,7 @@ Output: [
 # the file from the serialized version of the pathspec.
 Query: SELECT read_file(filename=OSPath, accessor='collector'),
        read_file(filename=OSPath.String, accessor='collector'),
-       OSPath.String, OSPath.Components, OSPath.Path
+       OSPath.Components, OSPath.Path
 FROM glob(globs='*', accessor='collector',
       root=pathspec(Path='/uploads/file/tmp/',
                     DelegatePath=srcDir + '/vql/tools/collector/fixtures/import.zip'))
@@ -68,7 +67,6 @@ Output: [
  {
   "read_file(filename=OSPath, accessor='collector')": "hello world\n",
   "read_file(filename=OSPath.String, accessor='collector')": "hello world\n",
-  "OSPath.String": "{\"DelegatePath\":\"/home/mic/projects/velociraptor/vql/tools/collector/fixtures/import.zip\",\"Path\":\"/uploads/file/tmp/ls%5Cwith%5Cback%3Aslash\"}",
   "OSPath.Components": [
    "uploads",
    "file",

--- a/artifacts/testdata/server/testcases/kapefiles_extract.in.yaml
+++ b/artifacts/testdata/server/testcases/kapefiles_extract.in.yaml
@@ -9,7 +9,9 @@ Queries:
          ContainerPath=srcDir + TestFile)
 
   # Should refuse to pad out very sparse files.
-  - SELECT * FROM test_read_logs() WHERE Log =~ "is too sparse - unable to expand it" AND NOT Log =~ "SELECT"
+  - |
+    SELECT Log =~ "Collection-WIN-E5K9RC5GU23-2021-11-21T18_05_56-08_00.zip"
+    FROM test_read_logs() WHERE Log =~ "is too sparse - unable to expand it" AND NOT Log =~ "SELECT"
 
   # On Windows we can adjust all the timestamps but only Linux on the
   # mtime

--- a/artifacts/testdata/server/testcases/kapefiles_extract.out.yaml
+++ b/artifacts/testdata/server/testcases/kapefiles_extract.out.yaml
@@ -48,10 +48,12 @@ Output: [
 ]
 
 # Should refuse to pad out very sparse files.
-Query: SELECT * FROM test_read_logs() WHERE Log =~ "is too sparse - unable to expand it" AND NOT Log =~ "SELECT"
+Query: SELECT Log =~ "Collection-WIN-E5K9RC5GU23-2021-11-21T18_05_56-08_00.zip"
+FROM test_read_logs() WHERE Log =~ "is too sparse - unable to expand it" AND NOT Log =~ "SELECT"
+
 Output: [
  {
-  "Log": "Velociraptor: Error: File /uploads/ntfs/%5C%5C.%5CC%3A/$Extend/$UsnJrnl%3A$J is too sparse - unable to expand it.\n"
+  "Log =~ \"Collection-WIN-E5K9RC5GU23-2021-11-21T18_05_56-08_00.zip\"": true
  }
 ]
 

--- a/bin/fuse_unix.go
+++ b/bin/fuse_unix.go
@@ -27,7 +27,7 @@ var (
 	fuse_directory = fuse_zip_command.Arg("directory", "A directory to mount on").
 			Required().String()
 
-	fuse_zip_accessor = fuse_command.Flag("accessor", "The accessor to use (default container)").
+	fuse_zip_accessor = fuse_command.Flag("accessor", "The accessor to use (default collector)").
 				Default("collector").String()
 
 	fuse_zip_prefix = fuse_command.Flag("prefix",

--- a/file_store/memcache/memcache.go
+++ b/file_store/memcache/memcache.go
@@ -394,6 +394,7 @@ func (self *MemcacheFileWriter) _Flush(async bool) error {
 	if len(completions) == 0 &&
 		!self.closed &&
 		!truncated && self.buffer.Len() == 0 {
+		self.flushing = false
 		return nil
 	}
 
@@ -403,10 +404,11 @@ func (self *MemcacheFileWriter) _Flush(async bool) error {
 
 	// Flush in the foreground and wait until the data hits the disk.
 	if !async {
-
 		self.mu.Unlock()
 		self._FlushSync(buffer.Bytes(), truncated, completions)
 		self.mu.Lock()
+
+		self.flushing = false
 
 		return nil
 	}

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -13,12 +13,12 @@
                 "@fortawesome/fontawesome-svg-core": "6.7.2",
                 "@fortawesome/free-regular-svg-icons": "6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
-                "@fortawesome/react-fontawesome": "^0.2.6",
+                "@fortawesome/react-fontawesome": "0.2.6",
                 "@popperjs/core": "^2.11.8",
                 "ace-builds": "1.43.2",
-                "axios": "^1.12.0",
+                "axios": ">=1.12.0",
                 "axios-retry": "3.9.1",
-                "bootstrap": "5.3.7",
+                "bootstrap": "^5.3.8",
                 "classnames": "^2.5.1",
                 "csv-parse": "4.16.3",
                 "csv-stringify": "5.6.5",
@@ -54,7 +54,7 @@
                 "recharts": "^2.15.4",
                 "sprintf-js": "1.1.3",
                 "url-parse": "^1.5.10",
-                "webpack": "^5.101.3"
+                "webpack": "5.101.3"
             },
             "devDependencies": {
                 "@babel/core": "^7.25.2",
@@ -6285,9 +6285,9 @@
             }
         },
         "node_modules/bootstrap": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
-            "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+            "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
             "funding": [
                 {
                     "type": "github",
@@ -19819,9 +19819,9 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
         "bootstrap": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
-            "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+            "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
             "requires": {}
         },
         "brace-expansion": {

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -13,7 +13,7 @@
         "ace-builds": "1.43.2",
         "axios": ">=1.12.0",
         "axios-retry": "3.9.1",
-        "bootstrap": "5.3.7",
+        "bootstrap": "5.3.8",
         "classnames": "^2.5.1",
         "csv-parse": "4.16.3",
         "csv-stringify": "5.6.5",

--- a/vql/common/env.go
+++ b/vql/common/env.go
@@ -116,8 +116,10 @@ func init() {
 					for _, env_var := range os.Environ() {
 						parts := strings.SplitN(env_var, "=", 2)
 
+						// Just hide ShadowedEnv but do not warn about
+						// it since there is nothing the caller can do
+						// to avoid it.
 						if utils.InString(ShadowedEnv, parts[0]) {
-							scope.Log("environ: access to env var %s is denied", parts[0])
 							continue
 						}
 

--- a/vql/tools/collector/collector_test.go
+++ b/vql/tools/collector/collector_test.go
@@ -298,7 +298,7 @@ func (self *TestSuite) TestCollectionWithDirectories() {
 			Set("accessor", "collector").
 			Set("root", root_path_spec)) {
 		line := json.MustMarshalString(row)
-		if strings.Contains(line, "/Subdir/data/hello.txt\"") {
+		if strings.Contains(line, `/Subdir/data/hello.txt\"`) {
 			found = true
 		}
 	}
@@ -321,7 +321,7 @@ func (self *TestSuite) TestCollectionWithDirectories() {
 			Set("accessor", "collector").
 			Set("root", root_path_spec)) {
 		line := json.MustMarshalString(row)
-		if strings.Contains(line, "/Subdir/data/hello.txt\"") {
+		if strings.Contains(line, `/Subdir/data/hello.txt\"`) {
 			found = true
 		}
 	}


### PR DESCRIPTION
This artifact calculates remapping rules to be able to operate directly on the collector zip. This allows running further artifacts on the output of the offline collector without needing to import the zip first.