### PR TITLE
fix for iops limit in throttler

### DIFF
--- a/executor/throttler/throttler.go
+++ b/executor/throttler/throttler.go
@@ -75,7 +75,7 @@ func (self *Throttler) CanRun(stats *statsCollector) bool {
 	}
 
 	if self.iops_limit > 0 &&
-		stats.GetAverageIOPS() > self.cpu_load_limit {
+		stats.GetAverageIOPS() > self.iops_limit {
 		return false
 	}
 


### PR DESCRIPTION
corrected variable used to check IOPS limit value against avg IOPS. Addresses #4473 