### PR TITLE
Further performance optimizations

### DIFF
--- a/accessors/file/accessor_common.go
+++ b/accessors/file/accessor_common.go
@@ -180,6 +180,8 @@ type OSFileSystemAccessor struct {
 	nocase bool
 
 	root *accessors.OSPath
+
+	scope vfilter.Scope
 }
 
 func (self OSFileSystemAccessor) ParsePath(path string) (*accessors.OSPath, error) {
@@ -204,6 +206,7 @@ func (self OSFileSystemAccessor) New(scope vfilter.Scope) (
 		},
 		root:   self.root,
 		nocase: self.nocase,
+		scope:  scope,
 	}, nil
 }
 

--- a/accessors/file/cache.go
+++ b/accessors/file/cache.go
@@ -1,0 +1,159 @@
+//go:build windows
+// +build windows
+
+package file
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	ntfs "www.velocidex.com/golang/go-ntfs/parser"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/utils/files"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/windows/wmi"
+	"www.velocidex.com/golang/vfilter"
+)
+
+var (
+	Cache             = WMICache{}
+	FILE_ACCESSOR_TAG = "$__file_accessor"
+)
+
+type WMICache struct {
+	mu            sync.Mutex
+	last          time.Time
+	logical_disks []*accessors.VirtualFileInfo
+}
+
+func (self *WMICache) maybeUpdateCache() error {
+	// Result is not too old - return it.
+	now := utils.GetTime().Now()
+	if self.last.Add(time.Minute).After(now) {
+		return nil
+	}
+
+	logical_disks, err := self.realDiscoverDriveLetters()
+	if err != nil {
+		return err
+	}
+
+	self.last = now
+	self.logical_disks = logical_disks
+
+	return nil
+}
+
+func (self *WMICache) DiscoverDriveLetters() ([]accessors.FileInfo, error) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	err := self.maybeUpdateCache()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []accessors.FileInfo
+	for _, i := range self.logical_disks {
+		result = append(result, i)
+	}
+
+	return result, nil
+}
+
+func (self *WMICache) realDiscoverDriveLetters() ([]*accessors.VirtualFileInfo, error) {
+	var result []*accessors.VirtualFileInfo
+
+	shadow_volumes, err := wmi.Query(
+		"SELECT DeviceID, Description, VolumeName, FreeSpace, "+
+			"Size, SystemName, VolumeSerialNumber "+
+			"from Win32_LogicalDisk",
+		"ROOT\\CIMV2")
+	if err == nil {
+		for _, row := range shadow_volumes {
+			size := utils.GetInt64(row, "Size")
+			device_name, pres := row.GetString("DeviceID")
+			if pres {
+				device_path, err := accessors.NewWindowsOSPath(device_name)
+				if err != nil {
+					return nil, err
+				}
+
+				err = CheckPrefix(device_path)
+				if err != nil {
+					continue
+				}
+
+				result = append(result, &accessors.VirtualFileInfo{
+					IsDir_: true,
+					Size_:  size,
+					Data_:  row,
+					Path:   device_path,
+				})
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func getDeviceReader(scope vfilter.Scope,
+	device_name string) (accessors.ReadSeekCloser, error) {
+	var device_cache *ordereddict.Dict
+
+	if !strings.HasPrefix(device_name, "\\\\") {
+		device_name = "\\\\.\\" + device_name
+	}
+
+	device_cache_any := vql_subsystem.CacheGet(scope, FILE_ACCESSOR_TAG)
+	device_cache, ok := device_cache_any.(*ordereddict.Dict)
+	if !ok || device_cache == nil {
+		device_cache = ordereddict.NewDict()
+		vql_subsystem.CacheSet(scope, FILE_ACCESSOR_TAG, device_cache)
+	}
+
+	reader_any, ok := device_cache.Get(device_name)
+	if ok {
+		reader, ok := reader_any.(accessors.ReadSeekCloser)
+		if ok {
+			return reader, nil
+		}
+	}
+
+	defer Instrument("RawDevice")()
+
+	file, err := os.Open(device_name)
+	if err != nil {
+		return nil, err
+	}
+
+	files.Add(device_name)
+	// Only close the file when the scope is destroyed.
+	vql_subsystem.GetRootScope(scope).AddDestructor(func() {
+		file.Close()
+		files.Remove(device_name)
+	})
+
+	// Need to read the raw device in pagesize sizes
+	reader, err := ntfs.NewPagedReader(file, 0x10000, 100)
+	if err != nil {
+		return nil, err
+	}
+
+	res := utils.NewReadSeekReaderAdapter(reader, nil)
+
+	// Try to figure out the size - not necessary but in case we
+	// can we can limit readers to this size.
+	stat, err1 := os.Lstat(device_name)
+	if err1 == nil {
+		res.SetSize(stat.Size())
+	}
+
+	device_cache.Set(device_name, res)
+
+	return res, nil
+}

--- a/accessors/file/instrument.go
+++ b/accessors/file/instrument.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	FileHistorgram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "file_accessor",
+			Help:    "Latency to access ntfs parser.",
+			Buckets: prometheus.LinearBuckets(0.01, 0.05, 10),
+		},
+		[]string{"action"},
+	)
+)
+
+func Instrument(access_type string) func() time.Duration {
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		FileHistorgram.WithLabelValues(access_type).Observe(v)
+	}))
+
+	return timer.ObserveDuration
+}

--- a/accessors/ntfs/cache.go
+++ b/accessors/ntfs/cache.go
@@ -1,0 +1,141 @@
+//go:build windows
+// +build windows
+
+package ntfs
+
+import (
+	"sync"
+	"time"
+
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/vql/windows/wmi"
+)
+
+var (
+	Cache = WMICache{}
+)
+
+type WMICache struct {
+	mu            sync.Mutex
+	last          time.Time
+	logical_disks []*accessors.VirtualFileInfo
+	vss           []*accessors.VirtualFileInfo
+}
+
+func (self *WMICache) realDiscoverVSS() ([]*accessors.VirtualFileInfo, error) {
+	shadow_volumes, err := wmi.Query(
+		"SELECT DeviceObject, VolumeName, InstallDate, "+
+			"OriginatingMachine from Win32_ShadowCopy",
+		"ROOT\\CIMV2")
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*accessors.VirtualFileInfo{}
+	for _, row := range shadow_volumes {
+		device_name, pres := row.GetString("DeviceObject")
+		if pres {
+			device_path, err := accessors.NewWindowsNTFSPath(device_name)
+			if err != nil {
+				return nil, err
+			}
+			virtual_directory := &accessors.VirtualFileInfo{
+				IsDir_: true,
+				Path:   device_path,
+				Size_:  0, // WMI does not give the original volume size
+				Data_:  row,
+			}
+			result = append(result, virtual_directory)
+		}
+	}
+
+	return result, nil
+}
+
+func (self *WMICache) realDiscoverLogicalDisks() ([]*accessors.VirtualFileInfo, error) {
+	result := []*accessors.VirtualFileInfo{}
+	shadow_volumes, err := wmi.Query(
+		"SELECT DeviceID, Description, VolumeName, FreeSpace, "+
+			"Size, SystemName, VolumeSerialNumber "+
+			"from Win32_LogicalDisk WHERE FileSystem = 'NTFS'",
+		"ROOT\\CIMV2")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range shadow_volumes {
+		device_name, pres := row.GetString("DeviceID")
+		if pres {
+			device_path, err := accessors.NewWindowsNTFSPath("\\\\.\\" + device_name)
+			if err != nil {
+				return nil, err
+			}
+			virtual_directory := &accessors.VirtualFileInfo{
+				IsDir_: true,
+				Size_:  utils.GetInt64(row, "Size"),
+				Path:   device_path,
+				Data_:  row,
+			}
+			result = append(result, virtual_directory)
+		}
+	}
+
+	return result, nil
+}
+
+func (self *WMICache) maybeUpdateCache() error {
+	// Result is not too old - return it.
+	now := utils.GetTime().Now()
+	if self.last.Add(time.Minute).After(now) {
+		return nil
+	}
+
+	logical_disks, err := self.realDiscoverLogicalDisks()
+	if err != nil {
+		return err
+	}
+
+	vss, err := self.realDiscoverVSS()
+	if err != nil {
+		return err
+	}
+
+	self.last = now
+	self.logical_disks = logical_disks
+	self.vss = vss
+
+	return nil
+}
+
+func (self *WMICache) DiscoverLogicalDisks() ([]*accessors.VirtualFileInfo, error) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	err := self.maybeUpdateCache()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*accessors.VirtualFileInfo
+	for _, r := range self.logical_disks {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (self *WMICache) DiscoverVSS() ([]*accessors.VirtualFileInfo, error) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	err := self.maybeUpdateCache()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*accessors.VirtualFileInfo
+	for _, r := range self.vss {
+		result = append(result, r)
+	}
+	return result, nil
+}

--- a/accessors/ntfs/instrument.go
+++ b/accessors/ntfs/instrument.go
@@ -1,0 +1,27 @@
+package ntfs
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	NTFSHistorgram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ntfs_accessor",
+			Help:    "Latency to access file accessor.",
+			Buckets: prometheus.LinearBuckets(0.01, 0.05, 10),
+		},
+		[]string{"action"},
+	)
+)
+
+func Instrument(access_type string) func() time.Duration {
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		NTFSHistorgram.WithLabelValues(access_type).Observe(v)
+	}))
+
+	return timer.ObserveDuration
+}

--- a/accessors/ntfs/mft.go
+++ b/accessors/ntfs/mft.go
@@ -110,6 +110,8 @@ func (self *MFTFileSystemAccessor) Open(path string) (
 func (self *MFTFileSystemAccessor) OpenWithOSPath(full_path *accessors.OSPath) (
 	accessors.ReadSeekCloser, error) {
 
+	defer Instrument("OpenWithOSPath")()
+
 	delegate_device, delegate_accessor, subpath, err := self.parseMFTPath(
 		full_path)
 	if err != nil {

--- a/accessors/ntfs/ntfs_accessor.go
+++ b/accessors/ntfs/ntfs_accessor.go
@@ -190,6 +190,9 @@ func (self *NTFSFileSystemAccessor) ReadDir(path string) (
 
 func (self *NTFSFileSystemAccessor) ReadDirWithOSPath(
 	fullpath *accessors.OSPath) (res []accessors.FileInfo, err error) {
+
+	defer Instrument("ReadDirWithOSPath")()
+
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -366,6 +369,8 @@ func (self *NTFSFileSystemAccessor) Open(
 func (self *NTFSFileSystemAccessor) OpenWithOSPath(
 	fullpath *accessors.OSPath) (res accessors.ReadSeekCloser, err error) {
 
+	defer Instrument("OpenWithOSPath")()
+
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -393,6 +398,8 @@ func (self *NTFSFileSystemAccessor) OpenWithOSPath(
 	// We dont want to open a subpath of the filesystem, instead we
 	// special case this as openning the raw device.
 	if len(fullpath.Components) == 0 {
+		defer Instrument("RawDevice")()
+
 		accessor, err := accessors.GetAccessor(accessor, self.scope)
 		if err != nil {
 			return nil, err
@@ -406,7 +413,7 @@ func (self *NTFSFileSystemAccessor) OpenWithOSPath(
 		files.Add(device.String())
 
 		reader, err := ntfs.NewPagedReader(
-			utils.MakeReaderAtter(file), 0x1000, 10000)
+			utils.MakeReaderAtter(file), 0x1000, 1000)
 		if err != nil {
 			return nil, err
 		}
@@ -538,6 +545,8 @@ func Open(scope vfilter.Scope, self *ntfs.MFT_ENTRY,
 	ntfs_ctx *ntfs.NTFSContext,
 	device *accessors.OSPath, accessor string,
 	filename *accessors.OSPath) (*ntfs.MFT_ENTRY, error) {
+
+	defer Instrument("Open")()
 
 	components := filename.Components
 

--- a/accessors/ntfs/ntfs_accessor_windows.go
+++ b/accessors/ntfs/ntfs_accessor_windows.go
@@ -9,10 +9,8 @@ import (
 
 	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/accessors/file"
-	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/constants"
-	"www.velocidex.com/golang/velociraptor/vql/windows/wmi"
 	"www.velocidex.com/golang/vfilter"
 )
 
@@ -38,6 +36,8 @@ func (self *WindowsNTFSFileSystemAccessor) Lstat(path string) (accessors.FileInf
 func (self *WindowsNTFSFileSystemAccessor) LstatWithOSPath(
 	os_path *accessors.OSPath) (accessors.FileInfo, error) {
 
+	defer Instrument("LstatWithOSPath")()
+
 	err := file.CheckPrefix(os_path)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (self *WindowsNTFSFileSystemAccessor) LstatWithOSPath(
 	if len(os_path.Components) == 1 {
 		// Try to match the device to the component required. This can
 		// be either a VSS volume or a Logical disk volume.
-		devices, err := discoverVSS()
+		devices, err := Cache.DiscoverVSS()
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +58,7 @@ func (self *WindowsNTFSFileSystemAccessor) LstatWithOSPath(
 				return d, nil
 			}
 		}
-		devices, err = discoverLogicalDisks()
+		devices, err = Cache.DiscoverLogicalDisks()
 		if err != nil {
 			return nil, err
 		}
@@ -71,67 +71,6 @@ func (self *WindowsNTFSFileSystemAccessor) LstatWithOSPath(
 	}
 
 	return self.MountFileSystemAccessor.LstatWithOSPath(os_path)
-}
-
-func discoverVSS() ([]*accessors.VirtualFileInfo, error) {
-	shadow_volumes, err := wmi.Query(
-		"SELECT DeviceObject, VolumeName, InstallDate, "+
-			"OriginatingMachine from Win32_ShadowCopy",
-		"ROOT\\CIMV2")
-	if err != nil {
-		return nil, err
-	}
-
-	result := []*accessors.VirtualFileInfo{}
-	for _, row := range shadow_volumes {
-		device_name, pres := row.GetString("DeviceObject")
-		if pres {
-			device_path, err := accessors.NewWindowsNTFSPath(device_name)
-			if err != nil {
-				return nil, err
-			}
-			virtual_directory := &accessors.VirtualFileInfo{
-				IsDir_: true,
-				Path:   device_path,
-				Size_:  0, // WMI does not give the original volume size
-				Data_:  row,
-			}
-			result = append(result, virtual_directory)
-		}
-	}
-
-	return result, nil
-}
-
-func discoverLogicalDisks() ([]*accessors.VirtualFileInfo, error) {
-	shadow_volumes, err := wmi.Query(
-		"SELECT DeviceID, Description, VolumeName, FreeSpace, "+
-			"Size, SystemName, VolumeSerialNumber "+
-			"from Win32_LogicalDisk WHERE FileSystem = 'NTFS'",
-		"ROOT\\CIMV2")
-	if err != nil {
-		return nil, err
-	}
-
-	result := []*accessors.VirtualFileInfo{}
-	for _, row := range shadow_volumes {
-		device_name, pres := row.GetString("DeviceID")
-		if pres {
-			device_path, err := accessors.NewWindowsNTFSPath("\\\\.\\" + device_name)
-			if err != nil {
-				return nil, err
-			}
-			virtual_directory := &accessors.VirtualFileInfo{
-				IsDir_: true,
-				Size_:  utils.GetInt64(row, "Size"),
-				Path:   device_path,
-				Data_:  row,
-			}
-			result = append(result, virtual_directory)
-		}
-	}
-
-	return result, nil
 }
 
 func (self *WindowsNTFSFileSystemAccessor) New(
@@ -159,7 +98,7 @@ func (self *WindowsNTFSFileSystemAccessor) New(
 		age: time.Now(),
 	}
 
-	vss, err := discoverVSS()
+	vss, err := Cache.DiscoverVSS()
 	if err == nil {
 		for _, fi := range vss {
 			root_fs.SetVirtualFileInfo(fi)
@@ -171,7 +110,7 @@ func (self *WindowsNTFSFileSystemAccessor) New(
 		}
 	}
 
-	logical, err := discoverLogicalDisks()
+	logical, err := Cache.DiscoverLogicalDisks()
 	if err == nil {
 		for _, fi := range logical {
 			root_fs.SetVirtualFileInfo(fi)


### PR DESCRIPTION
* On Windows the auto accessor would fallback to the ntfs accessor on all errors - however not all errors are likely to be resolved using the ntfs accessor. Mainly this is useful for permission denied, locked files etc.

  Now some errors are relayed to the user instead of retrying.

* Added instrumentation for file and ntfs accessors.