### PR TITLE
Bugfix: Deduplicate uploads by case insensitive name on windows.

### DIFF
--- a/accessors/api.go
+++ b/accessors/api.go
@@ -401,6 +401,27 @@ func GetUnderlyingAPIFilename(accessor string,
 	return raw_accessor.GetUnderlyingAPIFilename(path)
 }
 
+// For case insensitive filesystems, the canonical filename (used in
+// comparisons) can be different from the actual filename.
+type CanonicalFilenameAccessor interface {
+	GetCanonicalFilename(path *OSPath) string
+}
+
+func GetCanonicalFilename(accessor string,
+	scope vfilter.Scope, path *OSPath) string {
+	accessor_obj, err := GetAccessor(accessor, scope)
+	if err != nil {
+		return path.String()
+	}
+
+	raw_accessor, ok := accessor_obj.(CanonicalFilenameAccessor)
+	if !ok {
+		return path.String()
+	}
+
+	return raw_accessor.GetCanonicalFilename(path)
+}
+
 type AccessorDescriptor struct {
 	Name        string
 	Description string

--- a/accessors/file/auto_windows.go
+++ b/accessors/file/auto_windows.go
@@ -115,6 +115,12 @@ type AutoFilesystemAccessor struct {
 	file_delegate accessors.FileSystemAccessor
 }
 
+// On Windows filesystems are usually case insensitive.
+func (self AutoFilesystemAccessor) GetCanonicalFilename(
+	path *accessors.OSPath) string {
+	return strings.ToLower(path.String())
+}
+
 func (self AutoFilesystemAccessor) ParsePath(path string) (
 	*accessors.OSPath, error) {
 	return accessors.NewWindowsOSPath(path)

--- a/accessors/file/os_windows.go
+++ b/accessors/file/os_windows.go
@@ -169,6 +169,12 @@ func (self OSFileSystemAccessor) ReadDir(path string) (
 	return self.ReadDirWithOSPath(full_path)
 }
 
+// On Windows filesystems are usually case insensitive.
+func (self OSFileSystemAccessor) GetCanonicalFilename(
+	path *accessors.OSPath) string {
+	return strings.ToLower(path.String())
+}
+
 func (self OSFileSystemAccessor) ReadDirWithOSPath(
 	full_path *accessors.OSPath) ([]accessors.FileInfo, error) {
 	var result []accessors.FileInfo

--- a/accessors/ntfs/ntfs_accessor.go
+++ b/accessors/ntfs/ntfs_accessor.go
@@ -188,6 +188,12 @@ func (self *NTFSFileSystemAccessor) ReadDir(path string) (
 	return self.ReadDirWithOSPath(fullpath)
 }
 
+// NTFS filesystems are usually case insensitive.
+func (self NTFSFileSystemAccessor) GetCanonicalFilename(
+	path *accessors.OSPath) string {
+	return strings.ToLower(path.String())
+}
+
 func (self *NTFSFileSystemAccessor) ReadDirWithOSPath(
 	fullpath *accessors.OSPath) (res []accessors.FileInfo, err error) {
 

--- a/accessors/raw_registry/raw_registry.go
+++ b/accessors/raw_registry/raw_registry.go
@@ -270,6 +270,12 @@ type RawRegFileSystemAccessor struct {
 	cache *RawRegFileSystemAccessorCache
 }
 
+// Registery filesystems are usually case insensitive.
+func (self RawRegFileSystemAccessor) GetCanonicalFilename(
+	path *accessors.OSPath) string {
+	return strings.ToLower(path.String())
+}
+
 func getRegHiveCache(scope vfilter.Scope) *rawHiveCache {
 	result_any := vql_subsystem.CacheGet(scope, RawRegFileSystemTag)
 	if result_any != nil {

--- a/accessors/registry/registry_windows.go
+++ b/accessors/registry/registry_windows.go
@@ -392,6 +392,12 @@ func (self RegFileSystemAccessor) Describe() *accessors.AccessorDescriptor {
 	}
 }
 
+// Registery filesystems are usually case insensitive.
+func (self RegFileSystemAccessor) GetCanonicalFilename(
+	path *accessors.OSPath) string {
+	return strings.ToLower(path.String())
+}
+
 func (self *RegFileSystemAccessor) New(scope vfilter.Scope) (
 	accessors.FileSystemAccessor, error) {
 

--- a/artifacts/definitions/Windows/System/TaskScheduler.yaml
+++ b/artifacts/definitions/Windows/System/TaskScheduler.yaml
@@ -45,9 +45,23 @@ sources:
                     replace='')) AS XML
         FROM read_file(filenames=OSPath)
 
+      // Extract the binary from the command line. Fix up some common
+      // problems with the command specification.
+      LET _ExpandedTransforms <= dict(
+         `^\\\\SystemRoot\\\\`="%SystemRoot%\\",
+         `^system32\\\\`="%SystemRoot%\\System32\\",
+         `^{.+}.+`="\\$0",
+         `^.:\\\\Program Files[^\\\\]*\\\\[^ ]+`='"$0"',
+         `^%[^ ]+%[^ ]+`='"$0"'
+      )
+
+      LET ExpandPath(Path) = lowcase(string=commandline_split(
+        command=expand(path=regex_transform(source=Path,
+         map=_ExpandedTransforms)))[0])
+
       LET Results = SELECT XML.Task.RegistrationInfo.URI AS TaskName,
             Mtime,
-            expand(path=XML.Task.Actions.Exec.Command)  AS Command,
+            ExpandPath(Path=XML.Task.Actions.Exec.Command)  AS Command,
             XML.Task.Actions.Exec.Arguments AS Arguments,
             XML.Task.Principals.Principal.UserId AS UserId,
             XML.Task.Principals.Principal.RunLevel AS RunLevel,
@@ -66,7 +80,7 @@ sources:
 
       SELECT *,
          authenticode(filename=Command) AS Authenticode,
-         if(condition=UploadCommands and ExpandedCommand,
+         if(condition=UploadCommands AND Command,
             then=upload(file=Command)) AS Upload
       FROM Results
       WHERE UserId =~ Username

--- a/reporting/container.go
+++ b/reporting/container.go
@@ -395,7 +395,8 @@ func (self *Container) Upload(
 		store_as_name = filename
 	}
 
-	result, closer := uploads.DeduplicateUploads(scope, store_as_name)
+	result, closer := uploads.DeduplicateUploads(
+		accessor, scope, store_as_name)
 	defer closer(result)
 	if result != nil {
 		return result, nil

--- a/reporting/uploader.go
+++ b/reporting/uploader.go
@@ -44,7 +44,8 @@ func (self *NotebookUploader) Upload(
 		store_as_name = filename
 	}
 
-	result, closer := uploads.DeduplicateUploads(scope, store_as_name)
+	result, closer := uploads.DeduplicateUploads(
+		accessor, scope, store_as_name)
 	defer closer(result)
 	if result != nil {
 		return result, nil

--- a/services/server_artifacts/server_uploader.go
+++ b/services/server_artifacts/server_uploader.go
@@ -58,7 +58,8 @@ func (self *ServerUploader) Upload(
 		store_as_name = filename
 	}
 
-	result, closer := uploads.DeduplicateUploads(scope, store_as_name)
+	result, closer := uploads.DeduplicateUploads(
+		accessor, scope, store_as_name)
 	defer closer(result)
 	if result != nil {
 		return result, nil

--- a/services/users/storage.go
+++ b/services/users/storage.go
@@ -139,7 +139,6 @@ func (self *UserStorageManager) SetUser(
 	defer self.mu.Unlock()
 
 	if user_record.Name == "" {
-		utils.PrintStack()
 		return errors.New("Must set a username")
 	}
 

--- a/uploads/client_uploader.go
+++ b/uploads/client_uploader.go
@@ -277,7 +277,7 @@ func (self *VelociraptorUploader) Upload(
 		store_as_name = filename
 	}
 
-	result, closer := DeduplicateUploads(scope, store_as_name)
+	result, closer := DeduplicateUploads(accessor, scope, store_as_name)
 	defer closer(result)
 	if result != nil {
 		return result, nil

--- a/uploads/file_based.go
+++ b/uploads/file_based.go
@@ -92,7 +92,7 @@ func (self *FileBasedUploader) Upload(
 		store_as_name = filename
 	}
 
-	result, closer := DeduplicateUploads(scope, store_as_name)
+	result, closer := DeduplicateUploads(accessor, scope, store_as_name)
 	defer closer(result)
 	if result != nil {
 		return result, nil

--- a/utils/copy.go
+++ b/utils/copy.go
@@ -21,7 +21,14 @@ var (
 
 func ReadAllWithLimit(
 	fd io.Reader, limit int) ([]byte, error) {
-	return ioutil.ReadAll(io.LimitReader(fd, int64(limit)))
+
+	// If we reach the limit signal this as an error!
+	res, err := ioutil.ReadAll(io.LimitReader(fd, int64(limit)))
+	if len(res) >= limit {
+		return nil, Wrap(IOError, "Memory buffer exceeded")
+	}
+
+	return res, err
 }
 
 func ReadAllWithCtx(

--- a/vql/parsers/journald/watcher.go
+++ b/vql/parsers/journald/watcher.go
@@ -16,11 +16,15 @@ import (
 )
 
 var (
+	mu               sync.Mutex
 	gJournaldService *JournaldWatcherService
 )
 
 func StartGlobalJournaldService(
 	ctx context.Context, config_obj *config_proto.Config) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	gJournaldService = NewJournaldWatcherService(ctx, config_obj)
 }
 


### PR DESCRIPTION
On Windows the filesystems are case insensitive so the upload() plugin may encounter various versions of the same filename. This PR takes it into account and deduplicates based on the canonical lower cased name.