### PR TITLE
Fix table CSS when the table is empty.

### DIFF
--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -1510,7 +1510,9 @@ class VeloPagedTable extends Component {
     renderTable = ()=>{
         return (
             <>
-              <HotKeys keyMap={this.keymap} component={"span"} handlers={this.handlers}>
+              <HotKeys keyMap={this.keymap}
+                       className="table-panel"
+                       component={"div"} handlers={this.handlers}>
                 <Table tabIndex="0" className="paged-table">
                   <thead>
                     <tr className="paged-table-header">

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.css
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.css
@@ -22,7 +22,7 @@
     margin-bottom: 5px;
 }
 
-.report-viewer .panel {
+.report-viewer .table-panel {
     overflow-x: auto;
 }
 

--- a/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
+++ b/gui/velociraptor/src/components/notebooks/notebook-cell-renderer.jsx
@@ -762,6 +762,23 @@ export default class NotebookCellRenderer extends React.Component {
         let selected = this.props.selected_cell_id &&
             this.state.cell.cell_id === this.props.selected_cell_id;
 
+        let cell_id = this.state.cell.cell_id;
+        let cells = (this.props.notebook_metadata &&
+                     this.props.notebook_metadata.cell_metadata) || [];
+        let pos = 0;
+        // Find the cell position.
+        for(pos=0;pos < cells.length; pos++) {
+            if(cell_id == cells[pos].cell_id) {
+                break;
+            }
+        }
+
+        // If the cell is first it can not go up.
+        let cellCanGoUp = pos !== 0;
+
+        // If the cell is last it can not go down.
+        let cellCanGoDown = pos < cells.length -1 ;
+
         // There are 3 states for the cell:
         // 1. The cell is selected but not being edited: Show the cell manipulation toolbar.
         // 2. The cell is being edited: Show the editing toolbar
@@ -815,7 +832,7 @@ export default class NotebookCellRenderer extends React.Component {
                   </Button>
                 </ToolTip>
                 <ToolTip tooltip={T("Up Cell")}>
-                  <Button disabled={this.props.notebookLocked}
+                  <Button disabled={!cellCanGoUp}
                           onClick={() => {
                               this.props.upCell(this.state.cell.cell_id);
                           }}
@@ -824,7 +841,7 @@ export default class NotebookCellRenderer extends React.Component {
                   </Button>
                 </ToolTip>
                 <ToolTip tooltip={T("Down Cell")}>
-                  <Button disabled={this.props.notebookLocked}
+                  <Button disabled={!cellCanGoDown}
                           onClick={() => {
                               this.props.downCell(this.state.cell.cell_id);
                           }}

--- a/vql/psutils/host_darwin_cgo.go
+++ b/vql/psutils/host_darwin_cgo.go
@@ -11,7 +11,7 @@ package psutils
 // getUUID()
 // {
 //     CFMutableDictionaryRef matching = IOServiceMatching("IOPlatformExpertDevice");
-//     io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, matching);
+//     io_service_t service = IOServiceGetMatchingService(0, matching);
 //     CFStringRef serialNumber = IORegistryEntryCreateCFProperty(service,
 //         CFSTR("IOPlatformUUID"), kCFAllocatorDefault, 0);
 //     const char *str = CFStringGetCStringPtr(serialNumber, kCFStringEncodingUTF8);


### PR DESCRIPTION
Makes the column selector appear again.