### PR TITLE
Add all executing arguments to PowerShell artifact

### DIFF
--- a/artifacts/definitions/Windows/System/PowerShell.yaml
+++ b/artifacts/definitions/Windows/System/PowerShell.yaml
@@ -54,7 +54,8 @@ sources:
              if(condition=len(list=Stderr) >= SizeLimit,
                 then=upload(accessor="data",
                             file=Stderr,
-                            name="Stderr" + str(str=count()))) AS StderrUpload
+                            name="Stderr" + str(str=count()))) AS StderrUpload,
+             *
       FROM execve(argv=[PowerShellExe,
         "-ExecutionPolicy", "Unrestricted", "-encodedCommand",
         base64encode(string=utf16_encode(string=Command))


### PR DESCRIPTION
This MR adds all arguments of `execve` of the Powershell artifact, this way we have access to the `ReturnCode` which is useful in further processing, and to see if your execution was succesful or not.