### PR TITLE
netstat: Rename SENT state to SYN_SENT

### DIFF
--- a/vql/networking/netstat_darwin.go
+++ b/vql/networking/netstat_darwin.go
@@ -102,7 +102,7 @@ func to_addr(family C.uint32_t, addr *[16]byte, port C.uint16_t) Addr {
 var socketStates = map[uint16]string{
 	0:  "CLOSE", // CLOSED
 	1:  "LISTEN",
-	2:  "SENT",     // SYN_SENT
+	2:  "SYN_SENT",
 	3:  "SYN_RCVD", // SYN_RECEIVED
 	4:  "ESTAB",    // ESTABLISHED
 	5:  "CLOSE_WAIT",

--- a/vql/networking/netstat_freebsd.go
+++ b/vql/networking/netstat_freebsd.go
@@ -95,7 +95,7 @@ func to_addr(family C.uint32_t, addr *[16]byte, port C.uint16_t) Addr {
 var socketStates = map[uint16]string{
 	0:  "CLOSE", // CLOSED
 	1:  "LISTEN",
-	2:  "SENT",     // SYN_SENT
+	2:  "SYN_SENT",
 	3:  "SYN_RCVD", // SYN_RECEIVED
 	4:  "ESTAB",    // ESTABLISHED
 	5:  "CLOSE_WAIT",

--- a/vql/networking/netstat_linux.go
+++ b/vql/networking/netstat_linux.go
@@ -26,8 +26,8 @@ import (
 // constants from netinet/tcp.h, renamed to match Windows
 // implementation
 var socketStates = map[uint16]string{
-	1:  "ESTAB",    // ESTABLISHED
-	2:  "SENT",     // SYN_SENT
+	1:  "ESTAB", // ESTABLISHED
+	2:  "SYN_SENT",
 	3:  "SYN_RCVD", // SYN_RECV
 	4:  "FIN_WAIT1",
 	5:  "FIN_WAIT2",

--- a/vql/networking/netstat_windows.go
+++ b/vql/networking/netstat_windows.go
@@ -57,7 +57,7 @@ var (
 	MIB_TCP_STATE = map[int]string{
 		1:  "CLOSED",
 		2:  "LISTEN",
-		3:  "SENT",
+		3:  "SYN_SENT",
 		4:  "SYN_RCVD",
 		5:  "ESTAB",
 		6:  "FIN_WAIT1",


### PR DESCRIPTION
This corrects a long-standing misnomer in the socket state mapping. `SENT` has a very different meaning from `SYN_SENT`, potentially leading you to believe there is an active established connection with data going out, rather than a mere connection attempt.

As you can see in the diff, all other platforms officially call it `SYN_SENT`. And Windows is no exception there, `3` is defined as `MIB_TCP_STATE_SYN_SENT`.