### PR TITLE
fix: missing rpm release specification

### DIFF
--- a/artifacts/definitions/Server/Utils/CreateLinuxPackages.yaml
+++ b/artifacts/definitions/Server/Utils/CreateLinuxPackages.yaml
@@ -23,6 +23,8 @@ parameters:
     type: yaml
   - name: ServiceName
     description: Customize the service name
+  - name: Release
+    description: Customize the release version
   - name: Maintainer
     description: Customize the maintainer
   - name: MaintainerEmail
@@ -56,8 +58,8 @@ sources:
        {"Name": "{{ .SysvService }}",
         "Vendor": "%v",
         "Version": "{{ .Version }}",
-        "Release": "{{ .Release}}",
-        "Arch": "{{.Arch}}",
+        "Release": "{{ .Release }}",
+        "Arch": "{{ .Arch }}",
         "BuildTime": "%v"
        }
        ''', args=[Vendor, timestamp(epoch=now())])))
@@ -67,6 +69,7 @@ sources:
 
     LET UpdateExpansion(Expansion) = Expansion + dict(
        Name=ServiceName || Expansion.Name,
+       Release=Release || Expansion.Release,
        SysvService=ServiceName || Expansion.SysvService,
        Maintainer=Maintainer || Expansion.Maintainer,
        MaintainerEmail=MaintainerEmail || Expansion.MaintainerEmail,
@@ -88,6 +91,7 @@ sources:
         directory_name=TmpDir,
         package_spec=RPMSpec +
             dict(Expansion=UpdateExpansion(Expansion=RPMSpec.Expansion)),
+        release=Release || RPMSpec.Expansion.Release,
         config=serialize(item=client_config, format="yaml"))
     })
 

--- a/vql/tools/packaging/templates.go
+++ b/vql/tools/packaging/templates.go
@@ -496,6 +496,7 @@ func NewClientRPMSpec() *PackageSpec {
 		Templates: RPMClientTemplate,
 		Expansion: TemplateExpansion{
 			Name:            "velociraptor-client",
+			Release:         "A",
 			Maintainer:      "Velocidex Enterprises",
 			MaintainerEmail: "support@velocidex.com",
 			Homepage:        "https://www.velocidex.com",


### PR DESCRIPTION
This pull request fixes the missing RPM release specification issue observed in #4577.

It looks like when the RPM client package is created using the `rpm_create` plugin, the release is not extracted from the template or specification definition. Instead, the release is determined by the `release` argument to the plugin. This happens in the [expandSpec](https://github.com/Velocidex/velociraptor/blob/29442ef0525c87d1988343a680e4e3d5222a336e/vql/tools/packaging/package.go#L266) function in `package.go` which directly takes in the `arg.Release` argument.

To fix this, I have added a default `Release` ("A") to the RPM specification and also modified the `Server.Utils.CreateLinuxPackages` artifact to include a new parameter allowing users to specify a custom release, as well as passing the parameter or default from the specification to the `rpm_create` plugin.

I couldn't locate any tests for the `Server.Utils.CreateLinuxPackages` artifact, however please let me know if I've missed them and I'll update/add the tests for this change.




