### PR TITLE
fix: missing rpm release specification

### DIFF
--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -81,6 +81,11 @@ func doClientRPM() error {
 		*client_rpm_command_output = "."
 	}
 
+	// By default it should be set to A
+	if *rpm_command_release == "" {
+		*rpm_command_release = "A"
+	}
+	
 	logger := &LogWriter{config_obj: sm.Config}
 	builder := services.ScopeBuilder{
 		Config:     sm.Config,
@@ -141,7 +146,12 @@ func doServerRPM() error {
 	if *server_rpm_command_output == "" {
 		*server_rpm_command_output = "."
 	}
-
+	
+	// By default it should be set to A
+	if *rpm_command_release == "" {
+		*rpm_command_release = "A"
+	}
+	
 	logger := &LogWriter{config_obj: sm.Config}
 	builder := services.ScopeBuilder{
 		Config:     sm.Config,


### PR DESCRIPTION
I’ve just seen #4577 and #4587 — this one is probably on me. 
In #3270 I incorrectly assumed that .Default("A") would take effect, but it looks like it didn’t because the field may have been an empty string (e.g. same for server_rpm_command_output - https://github.com/Velocidex/velociraptor/blob/master/bin/rpm.go#L140-L143). 
Sorry for the oversight on my part.