### PR TITLE
docs: update oidc-cognito authenticator

### DIFF
--- a/docs/references/server.config.yaml
+++ b/docs/references/server.config.yaml
@@ -561,7 +561,7 @@ GUI:
   ## authenticator to use.
   authenticator:
     ## The type of authenticator to use. Currently:
-    ## basic, google, azure, oidc-cognito, github, saml, oidc, multi
+    ## basic, google, azure, oidc-cognito (prior to v0.75.6), github, saml, oidc, multi
     type: basic
 
     ## Used by SAML authenticator


### PR DESCRIPTION
Simple documentation fix that updates the reference to `oidc-cognito` in `server.config.yaml` to specify that the authenticator only exists prior to v0.75.6.

It was removed in favor of the regular `oidc` authenticator as the issues that required a separate authenticator were fixed in the AWS upstream repository.

This pull request addresses #4622.