### PR TITLE
Update watch_ebpf() to use a policy

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -9988,6 +9988,17 @@
     type: string
     description: Alternatively use a secret from the secrets service. Secret must
       be of type 'Splunk'
+  - name: max_retries
+    type: int64
+    description: 'Maximum number of retries for failed uploads (default: 3).'
+  - name: retry_wait
+    type: int64
+    description: 'Base wait time in seconds for exponential backoff between retries
+      (default: 2). Actual wait times: 2s, 4s, 8s, 16s...'
+  - name: idle_conn_timeout
+    type: int64
+    description: 'How long to keep idle HTTP connections open in seconds (default:
+      55). Lower values help with firewalls/load balancer/HECs that close connections.'
   metadata:
     permissions: NETWORK
   platforms:
@@ -10953,7 +10964,7 @@
     resumable uploads because the temporary file will be cleared after
     the query ends.
   type: Function
-  version: 2
+  version: 3
   args:
   - name: file
     type: accessors.OSPath
@@ -11078,7 +11089,6 @@
   - name: credentials
     type: string
     description: The credentials to use
-    required: true
   metadata:
     permissions: FILESYSTEM_READ
   platforms:
@@ -11826,20 +11836,84 @@
 
     See https://github.com/Velocidex/tracee_velociraptor for more details.
 
+    ## Tracee policies.
+
+    As of release 0.76, when calling this plugins, callers can supply
+    a tracee policy instead of a list of events. The policy is a YAML
+    file in a format described
+    [here](https://aquasecurity.github.io/tracee/v0.14/docs/policies/)
+
+    Velociraptor supports a subset of Tracee policies. Currently:
+
+    * [Scope](https://aquasecurity.github.io/tracee/v0.14/docs/policies/scopes/): This allows targeting the policy at a particular process
+    * [Rules](https://aquasecurity.github.io/tracee/v0.14/docs/policies/rules/): This allows kernel side filtering of events - essential for reducing CPU load.
+
+    Tracee actions are not supported, as the events are simply passed
+    to the VQL query. If you want to handle the events simply handle
+    it in VQL.
+
+    NOTE: Currently all watchers that watch the same event id will
+    receive all events - regardless if their specific policy
+    applies or if another listener selected the same event with
+    another policy. Therefore events should be post-filtered again.
+
+    Therefore, Policy filters should be considered as a performance
+    optimization only. Your VQL query should **also** filter down the
+    events you are interested in to ensure that other ebpf queries'
+    policies do not match additional events.
+
+    For example:
+
+    ```yaml
+    metadata:
+       name: file-open-home
+    spec:
+      scope:
+        - global
+      rules:
+        - event: security_file_open
+          filters:
+            - args.pathname=/home/*
+    ```
+
+    The above policy matches all processes (scope is global). The
+    policy adds one event to watch (`security_file_open` reports when
+    a file is opened). Normally there are many such events, so to save
+    on CPU load, the policy also filters the pathname to start with
+    `/home/`.
+
+    This will report all processes opening all files in the `/home/`
+    directory.
+
+    ```vql
+    SELECT * FROM watch_ebpf(policy=Policy)
+    WHERE EventData.pathname =~ "^/home/"
+    ```
+
+    Note that currently the additional VQL filter is needed to avoid
+    other ebpf listners from inserting additional policies into the
+    kernel.
+
     ### See also
 
     - [ebpf_events]({{< ref "/vql_reference/linux/ebpf_events/" >}}): Dumps information about
       potential ebpf_events.
   type: Plugin
+  version: 2
   args:
   - name: events
     type: string
     description: A list of event names to acquire.
     repeated: true
-    required: true
   - name: include_env
     type: bool
     description: Include process environment variables.
+  - name: policy
+    type: string
+    description: Use a tracee policy in YAML format to specify events instead.
+  - name: regex_prefilter
+    type: string
+    description: A regex that must match the raw buffer before we process it.
   category: linux
   metadata:
     permissions: MACHINE_STATE
@@ -12784,4 +12858,3 @@
   - linux_amd64_cgo
   - windows_386_cgo
   - windows_amd64_cgo
-

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/Velocidex/grok v0.0.1
 	github.com/Velocidex/ordereddict v0.0.0-20250821063524-02dc06e46238
 	github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250
-	github.com/Velocidex/tracee_velociraptor v0.0.0-20260102153735-470363a4efa4
+	github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d
 	github.com/Velocidex/velociraptor-site-search v0.0.0-20260112074704-546a177e6dad
 	github.com/Velocidex/yara-x-go v0.0.0-20251010010632-d8eaad9c539c
 	github.com/VirusTotal/gyp v0.9.1-0.20231202132633-bb35dbf177a6
@@ -186,7 +186,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
-	github.com/aquasecurity/tracee/api v0.0.0-20251229080346-032e875eaa90 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/Velocidex/sflags v0.3.1-0.20241126160332-cc1a5b66b8f1 h1:fLJ2AjY0dtDZ
 github.com/Velocidex/sflags v0.3.1-0.20241126160332-cc1a5b66b8f1/go.mod h1:UpFVihkMZWl2JRkVRiZYie0e2l7Ry+vjlCHCs6XVKGU=
 github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250 h1:GhiTVVoHNhb0mzUDgieUwjfJeEaUHCHIVvV/mHzLQOI=
 github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250/go.mod h1:ukLFs2t1+ud7MC4oN+zImhtTRP/eQHaDL3TwLs58uUA=
-github.com/Velocidex/tracee_velociraptor v0.0.0-20260102153735-470363a4efa4 h1:k7izTGQzBedw0wzOwVvSVNoYUd+y9usbbVIBz2C7Eto=
-github.com/Velocidex/tracee_velociraptor v0.0.0-20260102153735-470363a4efa4/go.mod h1:nOb8af1ftRw8owHabTPNZ0R2X2WnPt6BftzQDRzVlxs=
+github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d h1:sO53DvohKarwGELhnDYAl1XKQ2lUsnjjKkCvT7XvD+U=
+github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d/go.mod h1:yKAS4I7VYdd6FzlEitbrqxGLoLAIeujjqpbP6OOTKxU=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130 h1:+QujZ0D7KSy3WJVchkOhMkvAUab6/CIisO5LCoN48q4=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130/go.mod h1:3/pI9BBAF7gydBWvMVtV7W1qRwshEG9lBwed/d8xfFg=
 github.com/Velocidex/velociraptor-site-search v0.0.0-20260112074704-546a177e6dad h1:AE7V8khX6vG/5jN0BRPQFY73eAZ1kIrFqnMatTl7oUw=
@@ -177,8 +177,6 @@ github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxB
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
-github.com/aquasecurity/tracee/api v0.0.0-20251229080346-032e875eaa90 h1:7c1+tK01z+wbie3Y6K49oRaRPjGVIK9zFFQh5VIPgqo=
-github.com/aquasecurity/tracee/api v0.0.0-20251229080346-032e875eaa90/go.mod h1:51UhfaqeC9MU/kMMQYHnHvz4jEu9J7E3GC0UfSO6xxw=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
Using a policy allows the kernel to pre-filter events before passing them to the query, thereby reducing CPU load.