### PR TITLE
Update watch_ebpf() to track policies in events.

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -11852,16 +11852,6 @@
     to the VQL query. If you want to handle the events simply handle
     it in VQL.
 
-    NOTE: Currently all watchers that watch the same event id will
-    receive all events - regardless if their specific policy
-    applies or if another listener selected the same event with
-    another policy. Therefore events should be post-filtered again.
-
-    Therefore, Policy filters should be considered as a performance
-    optimization only. Your VQL query should **also** filter down the
-    events you are interested in to ensure that other ebpf queries'
-    policies do not match additional events.
-
     For example:
 
     ```yaml
@@ -11887,12 +11877,16 @@
 
     ```vql
     SELECT * FROM watch_ebpf(policy=Policy)
-    WHERE EventData.pathname =~ "^/home/"
     ```
 
-    Note that currently the additional VQL filter is needed to avoid
-    other ebpf listners from inserting additional policies into the
-    kernel.
+    NOTES:
+
+    1. The policy name is optional, if you do not specify it, a random
+       name is used. This is preferable to ensure that a second
+       instance of the query can register the same policy again.
+
+    2. There is a limit of 64 policies leading to a limit of 64
+       concurrent `watch_ebpf()` queries.
 
     ### See also
 

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/Velocidex/grok v0.0.1
 	github.com/Velocidex/ordereddict v0.0.0-20250821063524-02dc06e46238
 	github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250
-	github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d
+	github.com/Velocidex/tracee_velociraptor v0.0.0-20260113161018-f7c951ffeab2
 	github.com/Velocidex/velociraptor-site-search v0.0.0-20260112074704-546a177e6dad
 	github.com/Velocidex/yara-x-go v0.0.0-20251010010632-d8eaad9c539c
 	github.com/VirusTotal/gyp v0.9.1-0.20231202132633-bb35dbf177a6

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/Velocidex/sflags v0.3.1-0.20241126160332-cc1a5b66b8f1 h1:fLJ2AjY0dtDZ
 github.com/Velocidex/sflags v0.3.1-0.20241126160332-cc1a5b66b8f1/go.mod h1:UpFVihkMZWl2JRkVRiZYie0e2l7Ry+vjlCHCs6XVKGU=
 github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250 h1:GhiTVVoHNhb0mzUDgieUwjfJeEaUHCHIVvV/mHzLQOI=
 github.com/Velocidex/sigma-go v0.0.0-20241113062227-c1c5ea4b5250/go.mod h1:ukLFs2t1+ud7MC4oN+zImhtTRP/eQHaDL3TwLs58uUA=
-github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d h1:sO53DvohKarwGELhnDYAl1XKQ2lUsnjjKkCvT7XvD+U=
-github.com/Velocidex/tracee_velociraptor v0.0.0-20260113081034-dbc8107f6e3d/go.mod h1:yKAS4I7VYdd6FzlEitbrqxGLoLAIeujjqpbP6OOTKxU=
+github.com/Velocidex/tracee_velociraptor v0.0.0-20260113161018-f7c951ffeab2 h1:jlV2oHd2u9XQnGZxPB5zxqsG+iNAjBS1TVV/gnCaD6Q=
+github.com/Velocidex/tracee_velociraptor v0.0.0-20260113161018-f7c951ffeab2/go.mod h1:yKAS4I7VYdd6FzlEitbrqxGLoLAIeujjqpbP6OOTKxU=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130 h1:+QujZ0D7KSy3WJVchkOhMkvAUab6/CIisO5LCoN48q4=
 github.com/Velocidex/ttlcache/v2 v2.9.1-0.20240517145123-a3f45e86e130/go.mod h1:3/pI9BBAF7gydBWvMVtV7W1qRwshEG9lBwed/d8xfFg=
 github.com/Velocidex/velociraptor-site-search v0.0.0-20260112074704-546a177e6dad h1:AE7V8khX6vG/5jN0BRPQFY73eAZ1kIrFqnMatTl7oUw=

--- a/vql/linux/ebpf/profile.go
+++ b/vql/linux/ebpf/profile.go
@@ -21,19 +21,25 @@ func WriteProfile(ctx context.Context,
 
 	} else {
 		stats := gEbpfManager.Stats()
-		idle := ""
-		if stats.NumberOfListeners == 0 {
-			idle = stats.IdleTime.String()
+
+		if len(stats.Listeners) == 0 {
+			output_chan <- ordereddict.NewDict().
+				Set("EBFProgramStatus", stats.EBFProgramStatus).
+				Set("IdleTime", stats.IdleTime.String()).
+				Set("IdleUnloadTimeout", stats.IdleUnloadTimeout.String())
+			return
 		}
 
-		output_chan <- ordereddict.NewDict().
-			Set("EBFProgramStatus", stats.EBFProgramStatus).
-			Set("NumberOfListeners", stats.NumberOfListeners).
-			Set("EIDMonitored", stats.EIDMonitored).
-			Set("IdleTime", idle).
-			Set("IdleUnloadTimeout", stats.IdleUnloadTimeout.String()).
-			Set("PrefilteredCount", stats.PrefilterEventCount).
-			Set("EventCount", stats.EventCount)
+		for _, l := range stats.Listeners {
+			output_chan <- ordereddict.NewDict().
+				Set("EBFProgramStatus", stats.EBFProgramStatus).
+				Set("IdleTime", "").
+				Set("IdleUnloadTimeout", stats.IdleUnloadTimeout.String()).
+				Set("PoilcyID", l.PolicyID).
+				Set("Poilcy", l.Policy).
+				Set("EventCount", l.EventCount).
+				Set("EIDMonitored", l.EIDMonitored)
+		}
 	}
 }
 


### PR DESCRIPTION
The event will only be distributed to the watcher that matched the policy.

Also updated the ebpf tracker to report on each lister and policy.