### PR TITLE
Added more detailed logging for VFS Downloads

### DIFF
--- a/services/vfs_service/vfs_service.go
+++ b/services/vfs_service/vfs_service.go
@@ -125,6 +125,20 @@ func (self *VFSService) ProcessDownloadFile(
 		SHA256, _ := row.GetString("Sha256")
 		Error, _ := row.GetString("Error")
 
+		// Code to log metadata about the downloaded file.
+		user := ""
+		if flow.Request != nil {
+			user = flow.Request.Creator
+		}
+
+		logger.Debug(
+			"VFSService: Collecting %s from %s for %s, flow=%s",
+			Path,
+			client_id,
+			user,
+			flow_id
+		)
+
 		// Figure out where the file was uploaded to.
 		uploaded_file_manager := flow_path_manager.GetUploadsFile(
 			Accessor, Path, Components)


### PR DESCRIPTION
I added a quick logger.Debug to ProcessDownloadFile, to log the user that downloaded a file, the path of the downloaded file, the client ID and the flow ID.

This will make it clearer from the logs, which user performed the action, without having to check in the GUI