### PR TITLE
Invert incorrect logic in snap status filter

### DIFF
--- a/artifacts/definitions/Linux/Debian/Packages.yaml
+++ b/artifacts/definitions/Linux/Debian/Packages.yaml
@@ -193,5 +193,5 @@ sources:
               NULL AS Architecture
               FROM source(
                 source="Snaps")
-              WHERE NOT Status IN ("installed", "active")
+              WHERE Status IN ("installed", "active")
             })


### PR DESCRIPTION
Tests do not need to be updated.