### PR TITLE
Order journal entries by time

### DIFF
--- a/artifacts/definitions/Linux/Forensics/Journal.yaml
+++ b/artifacts/definitions/Linux/Forensics/Journal.yaml
@@ -116,3 +116,4 @@ sources:
                EventData.SYSLOG_IDENTIFIER AS Unit,
                EventData.MESSAGE AS Message
         FROM source()
+        ORDER BY Timestamp


### PR DESCRIPTION
When I use this notebook suggestion, I easily get confused if I forget to sort the entries by timestamp. Now the entries are sorted by default. Since this is a notebook suggestion, opted in by the user, the additional processing required should be fine.