### PR TITLE
Add two VQL suggestions to Evtx artifact

### DIFF
--- a/artifacts/definitions/Windows/EventLogs/Evtx.yaml
+++ b/artifacts/definitions/Windows/EventLogs/Evtx.yaml
@@ -99,3 +99,44 @@ sources:
           )
 
       SELECT * FROM evtxsearch(pathList=fspaths)
+
+    notebook:
+       - name: Simplified view
+         type: vql_suggestion
+         template: |
+            LET Levels <= dict(
+                `0`='Always',
+                `1`='Critical',
+                `2`='Error',
+                `3`='Warning',
+                `4`='Info',
+                `5`='Verbose')
+            LET S = scope()
+
+            SELECT TimeCreated,
+                   System AS _System,
+                   EventID,
+                   get(item=Levels, field=str(str=System.Level)) AS Level,
+                   S.System.Execution.ProcessID AS PID,
+                   Message,
+                   S.EventData AS Data
+            FROM source()
+            ORDER BY TimeCreated
+
+       - name: Event count as plot
+         type: vql_suggestion
+         template: |
+            /*
+            # Event count
+
+            {{ define "Events" }}
+            SELECT int(int=TimeCreated.Unix / 60) * 60 AS MinBin,
+                                    count() AS Count
+              FROM source()
+              GROUP BY MinBin
+              ORDER BY MinBin
+            {{ end }}
+            {{ Query "Events" | TimeChart }}
+            */
+
+            LET Dummy <= 42


### PR DESCRIPTION
On suggestion adds a user-friendly view for viewing the most most useful fields, along with mapping log level values to strings. The other plots the number of events over time, indicating spikes.