### PR TITLE
Fix overzealous css heading selector

### DIFF
--- a/gui/velociraptor/src/components/docs/docs.css
+++ b/gui/velociraptor/src/components/docs/docs.css
@@ -25,7 +25,7 @@
     font-size: var(--font-size-large);
 }
 
-.hit-body.accordion-body h1,h2,h3,h4,h5,h6 {
+.hit-body.accordion-body :is(h1,h2,h3,h4,h5,h6) {
     font-weight: 700;
 }
 


### PR DESCRIPTION
My previous PR accidentally changed heading styles outside of the integrated docs search.