### PR TITLE
Add support for alphanumeric-only e-mail barrier

### DIFF
--- a/artifacts/definitions/Generic/Utils/SendEmail.yaml
+++ b/artifacts/definitions/Generic/Utils/SendEmail.yaml
@@ -60,10 +60,20 @@ parameters:
     Refuse to send mails more often than this interval (in seconds). This throttling
     is applied to the whole server.
 
+- name: UseSimpleBoundary
+  type: bool
+  description: |
+    Use a barrier consisting of only [A-Za-z0-9] characters. Some e-mail clients
+    do not support / conform to the RFC 2045 standard, and cannot handle
+    boundaries with characters other than simple lower- and upper-case letters,
+    as well as numbers (i.e not ['()+_,./:=?']).
+
 export: |
   LET _RandomString = SELECT format(format="%c", args=20 + rand(range=107)) AS Ch
     FROM range(end=1000)
-    WHERE Ch =~ "[A-Za-z0-9'()+_,./:=?]"
+    WHERE Ch =~ if(condition=UseSimpleBoundary,
+                   then="[A-Za-z0-9]",
+                   else="[A-Za-z0-9'()+_,./:=?]")
     LIMIT 70
 
   -- Create a random string suitable as a MIME boundary:
@@ -78,7 +88,7 @@ export: |
 
   -- Wrap Sections in boundaries. Header may be used to create a sub-boundary,
   -- useful for multipart/alternative:
-  LET WrapInBoundary(Boundary, Sections, Header) = template(
+  LET WrapInBoundary(Boundary, Sections, Header="") = template(
       template="{{ if .header }}{{ .header }}; boundary={{ .boundary }}\r\n\r\n{{ end }}{{ range .sections }}--{{ $.boundary }}\r\n{{ . }}{{ end }}--{{ $.boundary }}--\r\n",
       expansion=dict(
         boundary=Boundary,
@@ -87,14 +97,14 @@ export: |
 
   -- Add content type ("plain" or "html") and newlines to text. If Encode is set,
   -- encode the text in Base64 and add a suitable transfer header:
-  LET WrapText(Value, Type, Encode) = if(
+  LET WrapText(Value, Type, Encode=false) = if(
       condition=Value,
       then=format(
         format='Content-Type: text/%s; charset="utf-8"%s\r\n\r\n%v\r\n',
-        args=[Type, if(condition=get(field='Encode', default=false),
+        args=[Type, if(condition=Encode,
                        then="\r\nContent-Transfer-Encoding: base64",
                        else=""), if(
-          condition=get(field='Encode', default=false),
+          condition=Encode,
           then=EncodeData(Data=Value),
           else=Value)]))
 
@@ -116,24 +126,32 @@ export: |
   LET AttachFile(Path, Filename) = template(
       template='Content-Type: application/octet-stream; name="{{ .name }}"\r\nContent-Disposition: attachment; filename="{{ .filename }}"\r\nContent-Transfer-Encoding: base64\r\n\r\n{{ .data }}\r\n\r\n',
       expansion=dict(
-        name=regex_replace(source=basename(path=Filename),
-                           re='''\..+$''',
-                           replace=''),
-        filename=basename(path=Filename),
-        data=EncodeFile(Filename=Path)))
+        name=regex_replace(
+          source=basename(
+            path=Filename),
+          re='''\..+$''',
+          replace=''),
+        filename=basename(
+          path=Filename),
+        data=EncodeFile(
+          Filename=Path)))
 
   -- Call AttachFile() for each file in Files that exist. Files must be an array
   -- of dicts with the members "Path" and an optional "Filename", which is used
   -- to replace the attachment filename. Useful for temporary files:
-  LET AttachFiles(Files) = array(_={
-     SELECT AttachFile(
-       Path=Path,
-       Filename=get(field='Filename', default= Path)) AS Part
-     FROM foreach(row=Files)
-     WHERE (stat(filename=Path).OSPath
+  LET AttachFiles(Files) = SELECT AttachFile(Path=Path,
+                                             Filename=
+                                               get(field='Filename',
+                                                   default=
+                                                     Path)) AS Part
+    FROM foreach(row=Files)
+    WHERE (stat(filename=Path).OSPath
        AND log(message="Attaching %v", args=Path, dedup=-1, level='INFO')) OR NOT
-           log(message="Fail to attach %v", args=Path, dedup=-1, level='WARN')
-  })
+      log(
+        message="Fail to attach %v",
+        args=Path,
+        dedup=-1,
+        level='WARN')
 
 sources:
 - query: |
@@ -152,7 +170,7 @@ sources:
     LET Headers <= dict(`Content-Type`='multipart/mixed; boundary=' + Boundary)
 
     -- Build the email parts - first the text message, then the attachments.
-    LET Message <= WrapInBoundary(Header="",
+    LET Message <= WrapInBoundary(
         Boundary=Boundary,
         Sections=Texts + AttachFiles(Files=FilesToUpload).Part)
 


### PR DESCRIPTION
Some e-mail clients do not seem to support barriers according to the RFC 2045 standard, like Evolution. Add an option that uses only alphanumeric characters for barriers, so that e-mails can be parsed by these clients.

Since default VQL function arguments are now supported, the previous use of `get()` for optional arguments have been removed.