### PR TITLE
Allow a zip file to be imported with the --definitions flag

### DIFF
--- a/services/repository/files.go
+++ b/services/repository/files.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"fmt"
@@ -55,13 +56,75 @@ func InitializeGlobalRepositoryFromFilesystem(
 	return global_repository, nil
 }
 
+func loadRepositoryFromZipFile(
+	ctx context.Context, config_obj *config_proto.Config,
+	global_repository services.Repository,
+	filename string, options services.ArtifactOptions) (services.Repository, error) {
+
+	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	basename := filepath.Base(filename)
+
+	reader, err := zip.OpenReader(filename)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"artifact definition location %v should be a directory or a zip file: %v",
+			filename, err)
+	}
+	defer reader.Close()
+
+	for _, f := range reader.File {
+		if !strings.HasSuffix(f.Name, ".yml") &&
+			!strings.HasSuffix(f.Name, ".yaml") {
+			continue
+		}
+
+		infd, err := reader.Open(f.Name)
+		if err != nil {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, errors.New("Cancelled")
+
+		default:
+		}
+
+		data, err := utils.ReadAllWithLimit(infd, constants.MAX_MEMORY)
+		if err != nil {
+			continue
+		}
+
+		artifact_obj, err := global_repository.LoadYaml(string(data), options)
+		if err != nil {
+			logger.Info("Unable to load custom "+
+				"artifact %s:%s: %v", basename, f.Name, err)
+			continue
+		}
+		artifact_obj.Raw = string(data)
+		logger.Info("Loaded %s:%s", basename, f.Name)
+	}
+
+	return global_repository, nil
+}
+
 func loadRepositoryFromDirectory(
 	ctx context.Context, config_obj *config_proto.Config,
 	global_repository services.Repository,
 	directory string, options services.ArtifactOptions) (services.Repository, error) {
 
+	stat, err := os.Lstat(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	if !stat.IsDir() {
+		return loadRepositoryFromZipFile(ctx, config_obj,
+			global_repository, directory, options)
+	}
+
 	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
-	err := filepath.Walk(directory,
+	err = filepath.Walk(directory,
 		func(path string, finfo os.FileInfo, err error) error {
 			if err != nil {
 				return fmt.Errorf(


### PR DESCRIPTION
This is more convenient than having to unzip it first.