### PR TITLE
Update SysmonInstall.yaml

### DIFF
--- a/artifacts/definitions/Windows/Sysinternals/SysmonInstall.yaml
+++ b/artifacts/definitions/Windows/Sysinternals/SysmonInstall.yaml
@@ -37,9 +37,13 @@ sources:
        ToolName="SysmonBinary")
     })
 
-    LET existing_hash = SELECT lowcase(
-       string=parse_string_with_regex(
-          string=Stdout, regex="hash:.+SHA256=([^\\n\\r]+)").g1) AS Hash
+    LET ParseHash(string) = lowcase(
+        string=parse_string_with_regex(
+            string=string, regex="hash:.+SHA256=([^\\n\\r]+)").g1
+    )
+
+    LET existing_hash = SELECT
+        ParseHash(string=utf16(string=Stdout)) || ParseHash(string=Stdout) AS Hash
     FROM execve(argv=[bin[0].OSPath, "-c"])
 
     LET sysmon_config = SELECT * FROM Artifact.Generic.Utils.FetchBinary(


### PR DESCRIPTION
Sysmon v15.20 outputs in utf16 format, v15.15 and before outputs in utf8. Added code to check for both.