### PR TITLE
Fix external links

### DIFF
--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -2151,7 +2151,7 @@
     description: Password for HTTP Basic Authentication.
   - name: cloud_id
     type: string
-    description: Endpoint for the Elastic Service (https://elastic.co/cloud).
+    description: Endpoint for the [Elastic Cloud Service](https://elastic.co/cloud).
   - name: api_key
     type: string
     description: Base64-encoded token for authorization; if set, overrides username
@@ -6606,7 +6606,8 @@
     description: The accessor to use
   - name: profile
     type: string
-    description: Profile to use (see https://github.com/Velocidex/vtypes).
+    description: Profile to use (see [vfilter](https://github.com/Velocidex/vtypes)
+      ).
   - name: struct
     type: string
     description: Name of the struct in the profile to instantiate.

--- a/vql/parsers/binary.go
+++ b/vql/parsers/binary.go
@@ -20,7 +20,7 @@ import (
 type ParseBinaryFunctionArg struct {
 	Filename *accessors.OSPath `vfilter:"required,field=filename,doc=Binary file to open."`
 	Accessor string            `vfilter:"optional,field=accessor,doc=The accessor to use"`
-	Profile  string            `vfilter:"optional,field=profile,doc=Profile to use (see https://github.com/Velocidex/vtypes)."`
+	Profile  string            `vfilter:"optional,field=profile,doc=Profile to use (see [vfilter](https://github.com/Velocidex/vtypes))."`
 	Struct   string            `vfilter:"required,field=struct,doc=Name of the struct in the profile to instantiate."`
 	Offset   int64             `vfilter:"optional,field=offset,doc=Start parsing from this offset"`
 }

--- a/vql/server/elastic.go
+++ b/vql/server/elastic.go
@@ -71,7 +71,7 @@ type _ElasticPluginArgs struct {
 	Addresses          []string            `vfilter:"optional,field=addresses,doc=A list of Elasticsearch nodes to use."`
 	Username           string              `vfilter:"optional,field=username,doc=Username for HTTP Basic Authentication."`
 	Password           string              `vfilter:"optional,field=password,doc=Password for HTTP Basic Authentication."`
-	CloudID            string              `vfilter:"optional,field=cloud_id,doc=Endpoint for the Elastic Service (https://elastic.co/cloud)."`
+	CloudID            string              `vfilter:"optional,field=cloud_id,doc=Endpoint for the [Elastic Cloud Service](https://elastic.co/cloud)."`
 	APIKey             string              `vfilter:"optional,field=api_key,doc=Base64-encoded token for authorization; if set, overrides username and password."`
 	WaitTime           int64               `vfilter:"optional,field=wait_time,doc=Batch elastic upload this long (2 sec)."`
 	PipeLine           string              `vfilter:"optional,field=pipeline,doc=Pipeline for uploads"`


### PR DESCRIPTION
These raw links were being improperly converted to HTML by Hugo. Making them markdown links solves the problem.