### PR TITLE
Genericize the Server.Import.Exchange utility artifact

### DIFF
--- a/artifacts/definitions/Generic/Client/Stats.yaml
+++ b/artifacts/definitions/Generic/Client/Stats.yaml
@@ -1,5 +1,12 @@
 name: Generic.Client.Stats
-description: An Event artifact which generates client's CPU and memory statistics.
+description: |
+    An Event artifact which records client's CPU and memory
+    statistics.
+
+    To learn about managing end point performance with Velociraptor
+    see this [blog
+    post](https://docs.velociraptor.app/blog/html/2019/02/10/velociraptor_performance/).
+
 parameters:
   - name: Frequency
     description: Return stats every this many seconds.
@@ -105,9 +112,6 @@ reports:
       ```sql
       {{ template "resources" }}
       ```
-
-      > To learn about managing end point performance with Velociraptor see
-        the [blog post](https://docs.velociraptor.velocidex.com/blog/html/2019/02/10/velociraptor_performance.html).
 
 column_types:
   - name: Timestamp

--- a/artifacts/definitions/Server/Import/ArtifactBundle.yaml
+++ b/artifacts/definitions/Server/Import/ArtifactBundle.yaml
@@ -1,27 +1,30 @@
-name: Server.Import.ArtifactExchange
+name: Server.Import.ArtifactBundle
+aliases:
+- Server.Import.ArtifactExchange
 description: |
-   This artifact will automatically import the latest artifact
-   exchange bundle into the current server.
+   Imports a zipped package containing Velociraptor artifacts from a
+   remote web server.
 
-   ## Security note
+   By default this artifact will automatically import the latest
+   artifact exchange bundle into the server's artifact repository.
 
-   The artifact exchange is not officially supported by the
-   Velociraptor team and contains contributions from the
-   community. The quality, security and stability of artifacts from
-   the exchange is not guaranteed. Some artifacts from the exchange
-   will fetch external binaries and run them on your endpoints! These
-   binaries are not reviewed or endorsed by the Velociraptor team or
-   Rapid7!
+   ### Security of community exchange artifacts
+
+   The artifact exchange is not tested or officially supported by the
+   Velociraptor team and contains contributions from the community.
+   The quality, security and stability of artifacts from the exchange
+   are not guaranteed. Some artifacts from the exchange will fetch
+   external binaries and run them on your endpoints! These binaries
+   are not reviewed or endorsed by the Velociraptor team or Rapid7!
 
    Contributions to the exchange must meet a lower quality bar than
-   built-in artifacts (for example lacking tests), which means that
-   they may break at any time or not work as described!
+   built-in artifacts (for example lacking CI tests), which means that
+   they may break at any time or not function as described!
 
-   Collecting any of the artifacts in the exchange is purely at your
-   own risk!.
-
-   We strongly suggest users review exchange artifacts carefully
-   before deploying them on their network!
+   All artifacts in the exchange are used purely at your own risk,
+   should you choose to do so! We strongly suggest that you review
+   exchange artifacts carefully before deploying them on your
+   network!
 
 type: SERVER
 
@@ -29,7 +32,7 @@ required_permissions:
 - SERVER_ADMIN
 
 parameters:
-   - name: ExchangeURL
+   - name: URL
      default: https://github.com/Velocidex/velociraptor-docs/raw/gh-pages/exchange/artifact_exchange_v2.zip
    - name: ArchiveGlob
      default: "/**/*.{yaml,yml}"

--- a/artifacts/definitions/Server/Import/ArtifactBundle.yaml
+++ b/artifacts/definitions/Server/Import/ArtifactBundle.yaml
@@ -8,7 +8,7 @@ description: |
    By default this artifact will automatically import the latest
    artifact exchange bundle into the server's artifact repository.
 
-   ### Security of community exchange artifacts
+   #### Security of community-contributed exchange artifacts
 
    The artifact exchange is not tested or officially supported by the
    Velociraptor team and contains contributions from the community.
@@ -63,7 +63,7 @@ sources:
         FROM foreach(row={
           SELECT Content FROM http_client(
              remove_last=TRUE,
-             tempfile_extension=".zip", url=ExchangeURL)
+             tempfile_extension=".zip", url=URL)
         }, query={
           SELECT read_file(accessor="zip", filename=OSPath) AS Definition
           FROM glob(

--- a/artifacts/definitions/Server/Import/Extras.yaml
+++ b/artifacts/definitions/Server/Import/Extras.yaml
@@ -31,5 +31,5 @@ sources:
   - query: |
       SELECT * FROM foreach(row=Details,
       query={
-        SELECT * FROM Artifact.Server.Import.ArtifactExchange(ExchangeURL=URL, Tag=Tag)
+        SELECT * FROM Artifact.Server.Import.ArtifactBundle(URL=URL, Tag=Tag)
       })

--- a/artifacts/testdata/server/testcases/import_artifacts.in.yaml
+++ b/artifacts/testdata/server/testcases/import_artifacts.in.yaml
@@ -8,7 +8,7 @@ Parameters:
       tags: #hello #world
 
 Queries:
-  - LET _ <= import(artifact="Server.Import.ArtifactExchange")
+  - LET _ <= import(artifact="Server.Import.ArtifactBundle")
   - SELECT ("Exchange",) + Tags(Data=Def),
            ("Exchange",) + Tags(Data='')
     FROM scope()

--- a/artifacts/testdata/server/testcases/import_artifacts.out.yaml
+++ b/artifacts/testdata/server/testcases/import_artifacts.out.yaml
@@ -1,4 +1,4 @@
-Query: LET _ <= import(artifact="Server.Import.ArtifactExchange")
+Query: LET _ <= import(artifact="Server.Import.ArtifactBundle")
 Output: []
 
 Query: SELECT ("Exchange",) + Tags(Data=Def), ("Exchange",) + Tags(Data='') FROM scope()

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -7986,11 +7986,15 @@
   description: |
     Scan processes using yara rules.
 
-    This plugin uses yara's own engine to scan process memory for the signatures.
+    This plugin uses yara's own engine to scan process memory for the
+    signatures.
 
     {{% notice note %}}
 
-    Process memory access depends on having the [SeDebugPrivilege](https://support.microsoft.com/en-au/help/131065/how-to-obtain-a-handle-to-any-process-with-sedebugprivilege) which depends on how Velociraptor was started. Even when running as System, some processes are not accessible.
+    Process memory access depends on having the
+    [SeDebugPrivilege](https://mskb.pkisolutions.com/kb/131065) which
+    depends on how Velociraptor was started. Even when running as
+    System, some processes are not accessible.
 
     {{% /notice %}}
   type: Plugin


### PR DESCRIPTION
Going forward, users should preferably use `Server.Import.Extras` to import the exchange artifacts.

- Aliased the old name for backward compatibility, as some people might be using it with bootstrap artifacts or scripts, but we should aim to remove it in future.
- If run on it's own it will default to importing the exchange artifacts

Also
- fixed an old link + comment in Generic.Client.Stats
- updated a dead link in the VQL reference.