### PR TITLE
Bugfix: Create a new empty config for the debian server command 

### DIFF
--- a/.github/workflows/musl.yaml
+++ b/.github/workflows/musl.yaml
@@ -69,6 +69,7 @@ jobs:
         GIT_DOCKER_PAT: ${{ secrets.GIT_DOCKER_PAT }}
       run: |
         echo $GIT_DOCKER_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        export PATH=$PATH:~/go/bin/:/usr/local/musl/bin
         go run make.go -v Container
 
     - name: StoreBinaries

--- a/accessors/mount.go
+++ b/accessors/mount.go
@@ -71,9 +71,10 @@ func (self *node) Debug() string {
 }
 
 // Lookup a child by name. If not found returns nil
-func (self *node) GetChild(name string) *node {
+func (self *node) GetChild(
+	name string, manipulator PathManipulator) *node {
 	for _, c := range self.children {
-		if c.name == name {
+		if manipulator.ComponentEqual(c.name, name) {
 			return c
 		}
 	}
@@ -83,9 +84,10 @@ func (self *node) GetChild(name string) *node {
 
 // Get the child node for the given name. If the node is not found, we
 // create a new node based on our last mount point.
-func (self *node) MakeChild(name string) *node {
+func (self *node) MakeChild(
+	name string, manipulator PathManipulator) *node {
 	for _, c := range self.children {
-		if c.name == name {
+		if manipulator.ComponentEqual(c.name, name) {
 			return c
 		}
 	}
@@ -193,7 +195,7 @@ func (self *MountFileSystemAccessor) getDelegateNode(os_path *OSPath) (
 
 	for idx, c := range os_path.Components {
 		if c != "" {
-			next_node := node.GetChild(c)
+			next_node := node.GetChild(c, os_path.Manipulator)
 
 			// There is no internal mount point, use the last known
 			// mounted filesystem.
@@ -359,7 +361,7 @@ func (self *MountFileSystemAccessor) AddMapping(
 
 	for _, c := range target.Components {
 		if c != "" {
-			node = node.MakeChild(c)
+			node = node.MakeChild(c, target.Manipulator)
 		}
 	}
 

--- a/artifacts/definitions/Generic/Utils/Crypto.yaml
+++ b/artifacts/definitions/Generic/Utils/Crypto.yaml
@@ -1,0 +1,49 @@
+name: Generic.Utils.Crypto
+description: |
+  A utility artifact to provide helpful utility functions.
+
+  To use, import this artifact and use the functions.
+
+export: |
+  /* Verify against python
+
+  ```python
+  import hmac
+
+  def HMAC(Key, Message):
+    a = hmac.new(key=Key, digestmod="sha256")
+    a.update(Message)
+    print(a.hexdigest())
+  ```
+
+  */
+  LET Sha256Blocksize <= 64
+
+  // Helper function to hash easier.
+  LET Sha256Hash(X) = unhex(string=hash(accessor="data", path=X).SHA256)
+
+  // The key is hashed if it is longer than blocksize and padded if not.
+  LET HMACGetKey(Key) = if(
+    condition=len(list=Key) <= Sha256Blocksize,
+    then=Key + "\x00" * (Sha256Blocksize - len(list=Key)),
+    else=HMACGetKey(Key=Sha256Hash(X=Key)))
+
+  // HMAC relies on an inner key pad and outer key pad that are
+  // combined with 2 rounds of hashes.
+  LET OKeyPad(Key) = xor(key=HMACGetKey(Key=Key),
+       string="\x5c" * Sha256Blocksize)
+  LET IKeyPad(Key) = xor(key=HMACGetKey(Key=Key),
+       string="\x36" * Sha256Blocksize)
+
+  -- A Helper function to make displaying easier
+  LET HexEncode(X) = format(format="%x", args=[X,])
+
+  -- Finally this is the hmac function
+  LET HMac(Key, Message) = Sha256Hash(X=
+    OKeyPad(Key=Key) + Sha256Hash(X=IKeyPad(Key=Key) + Message))
+
+sources:
+- query: |
+    // Sample usage
+    SELECT HexEncode(X=HMac(Key="Secret", Message="My Message"))
+    FROM scope()

--- a/artifacts/definitions/Server/Internal/ToolDependencies.yaml
+++ b/artifacts/definitions/Server/Internal/ToolDependencies.yaml
@@ -7,19 +7,19 @@ description: |
 
 tools:
   - name: VelociraptorWindows
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.4-windows-amd64.exe
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.5-windows-amd64.exe
     serve_locally: true
-    version: 0.76.4
+    version: 0.76.5
 
   - name: VelociraptorWindows_x86
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.4-windows-386.exe
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.5-windows-386.exe
     serve_locally: true
-    version: 0.76.4
+    version: 0.76.5
 
   - name: VelociraptorLinux
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.4-linux-amd64-musl
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.5-linux-amd64-musl
     serve_locally: true
-    version: 0.76.4
+    version: 0.76.5
 
   # On MacOS we cannot embed the config in the binary so we use a
   # shell script stub instead. See
@@ -31,14 +31,14 @@ tools:
     serve_locally: true
 
   - name: VelociraptorWindowsMSI
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.4-windows-amd64.msi
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.5-windows-amd64.msi
     serve_locally: true
-    version: 0.76.4
+    version: 0.76.5
 
   - name: VelociraptorWindows_x86MSI
-    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.4-windows-386.msi
+    url: https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.5-windows-386.msi
     serve_locally: true
-    version: 0.76.4
+    version: 0.76.5
 
   - name: DocsIndex
     url: https://github.com/Velocidex/velociraptor-docs/raw/refs/heads/gh-pages/docs_index/docs_index_v1.zip

--- a/artifacts/testdata/server/testcases/hash_utils.in.yaml
+++ b/artifacts/testdata/server/testcases/hash_utils.in.yaml
@@ -1,0 +1,10 @@
+Queries:
+- LET _ <= import(artifact="Generic.Utils.Crypto")
+
+# Cover short key, long keys and key around the blocksize.
+- SELECT HexEncode(X=HMac(Key="Secret", Message="My Message")),
+    HexEncode(X=HMac(Key="Secret" * 20, Message="My Message")),
+    HexEncode(X=HMac(Key=("Secret" * 20)[:63], Message="My Message")),
+    HexEncode(X=HMac(Key=("Secret" * 20)[:64], Message="My Message")),
+    HexEncode(X=HMac(Key=("Secret" * 20)[:65], Message="My Message"))
+  FROM scope()

--- a/artifacts/testdata/server/testcases/hash_utils.out.yaml
+++ b/artifacts/testdata/server/testcases/hash_utils.out.yaml
@@ -1,0 +1,15 @@
+Query: LET _ <= import(artifact="Generic.Utils.Crypto")
+Output: []
+
+# Cover short key, long keys and key around the blocksize.
+Query: SELECT HexEncode(X=HMac(Key="Secret", Message="My Message")), HexEncode(X=HMac(Key="Secret" * 20, Message="My Message")), HexEncode(X=HMac(Key=("Secret" * 20)[:63], Message="My Message")), HexEncode(X=HMac(Key=("Secret" * 20)[:64], Message="My Message")), HexEncode(X=HMac(Key=("Secret" * 20)[:65], Message="My Message")) FROM scope()
+Output: [
+ {
+  "HexEncode(X=HMac(Key=\"Secret\", Message=\"My Message\"))": "bf66efbe1b6ac6905b805a6e7014dc6342131f43cdc744a8d05ef2227a3c8f1d",
+  "HexEncode(X=HMac(Key=\"Secret\" * 20, Message=\"My Message\"))": "dc9a7797f1680c1a69a408370a1a14bc4d24f503e6421c3efc0fb5c79b9d19fe",
+  "HexEncode(X=HMac(Key=(\"Secret\" * 20)[:63], Message=\"My Message\"))": "5135964920e878545f130f618a864bf04513ffc8acff0baf9439acae78d7897a",
+  "HexEncode(X=HMac(Key=(\"Secret\" * 20)[:64], Message=\"My Message\"))": "b33127af063b4096ecfea33eec0de171b5b72d9cc807efd5e678b4cead045fc7",
+  "HexEncode(X=HMac(Key=(\"Secret\" * 20)[:65], Message=\"My Message\"))": "e66035788fd6d7108044dd98d87eecc332e5b9309a538326da313c038ea2a109"
+ }
+]
+

--- a/bin/debian.go
+++ b/bin/debian.go
@@ -30,9 +30,11 @@ import (
 	"path/filepath"
 
 	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/config"
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
+	"www.velocidex.com/golang/velociraptor/utils/tempfile"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 )
 
@@ -69,16 +71,24 @@ func doServerDeb() error {
 	// deb on the same system where the logs should go.
 	logging.DisableLogging()
 
-	config_obj, err := makeDefaultConfigLoader().
-		WithRequiredFrontend().LoadAndValidate()
-	if err != nil {
-		return fmt.Errorf("Unable to load config file: %w", err)
+	if *config_path == "" {
+		return fmt.Errorf("A server config must be specified using the --config flag")
 	}
+
+	temp_dir, err := tempfile.TempDir("debian")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp_dir)
+
+	blank_config := config.GetDefaultConfig()
+	blank_config.Datastore.Location = temp_dir
+	blank_config.Datastore.FilestoreDirectory = temp_dir
 
 	ctx, cancel := install_sig_handler()
 	defer cancel()
 
-	sm, err := startup.StartToolServices(ctx, config_obj)
+	sm, err := startup.StartToolServices(ctx, blank_config)
 	defer sm.Close()
 
 	if err != nil {
@@ -110,7 +120,8 @@ func doServerDeb() error {
 		Env: ordereddict.NewDict().
 			Set("Release", *debian_command_release).
 			Set("Output", *server_debian_command_output).
-			Set("BinaryToPackage", *server_debian_command_binary),
+			Set("BinaryToPackage", *server_debian_command_binary).
+			Set("ConfigPath", *config_path),
 	}
 
 	query := `
@@ -119,6 +130,7 @@ func doServerDeb() error {
        SELECT OSPath
        FROM deb_create(exe=BinaryToPackage, server=TRUE,
                        directory_name=Output,
+                       config=read_file(filename=ConfigPath, length=1000000),
                        release=Release)`
 
 	err = runQueryWithEnv(query, builder, "json")
@@ -134,16 +146,24 @@ func doClientDeb() error {
 	// deb on the same system where the logs should go.
 	logging.DisableLogging()
 
-	config_obj, err := makeDefaultConfigLoader().
-		WithRequiredClient().LoadAndValidate()
-	if err != nil {
-		return fmt.Errorf("Unable to load config file: %w", err)
+	if *config_path == "" {
+		return fmt.Errorf("A server config must be specified using the --config flag")
 	}
+
+	temp_dir, err := tempfile.TempDir("debian")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp_dir)
+
+	blank_config := config.GetDefaultConfig()
+	blank_config.Datastore.Location = temp_dir
+	blank_config.Datastore.FilestoreDirectory = temp_dir
 
 	ctx, cancel := install_sig_handler()
 	defer cancel()
 
-	sm, err := startup.StartToolServices(ctx, config_obj)
+	sm, err := startup.StartToolServices(ctx, blank_config)
 	defer sm.Close()
 
 	if err != nil {
@@ -175,7 +195,8 @@ func doClientDeb() error {
 		Env: ordereddict.NewDict().
 			Set("Release", *debian_command_release).
 			Set("Output", *client_debian_command_output).
-			Set("BinaryToPackage", *client_debian_command_binary),
+			Set("BinaryToPackage", *client_debian_command_binary).
+			Set("ConfigPath", *config_path),
 	}
 
 	query := `
@@ -184,6 +205,7 @@ func doClientDeb() error {
        SELECT OSPath
        FROM deb_create(exe=BinaryToPackage,
                        directory_name=Output,
+                       config=read_file(filename=ConfigPath, length=1000000),
                        release=Release)`
 
 	err = runQueryWithEnv(query, builder, "json")

--- a/bin/rpm.go
+++ b/bin/rpm.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 
 	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/config"
 	logging "www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/startup"
+	"www.velocidex.com/golang/velociraptor/utils/tempfile"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 )
 
@@ -48,16 +50,24 @@ func doClientRPM() error {
 	// package on the same system where the logs should go.
 	logging.DisableLogging()
 
-	config_obj, err := makeDefaultConfigLoader().
-		WithRequiredClient().LoadAndValidate()
-	if err != nil {
-		return fmt.Errorf("Unable to load config file: %w", err)
+	if *config_path == "" {
+		return fmt.Errorf("A server config must be specified using the --config flag")
 	}
+
+	temp_dir, err := tempfile.TempDir("debian")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp_dir)
+
+	blank_config := config.GetDefaultConfig()
+	blank_config.Datastore.Location = temp_dir
+	blank_config.Datastore.FilestoreDirectory = temp_dir
 
 	ctx, cancel := install_sig_handler()
 	defer cancel()
 
-	sm, err := startup.StartToolServices(ctx, config_obj)
+	sm, err := startup.StartToolServices(ctx, blank_config)
 	defer sm.Close()
 
 	if err != nil {
@@ -94,7 +104,8 @@ func doClientRPM() error {
 		Env: ordereddict.NewDict().
 			Set("Release", *rpm_command_release).
 			Set("Output", *client_rpm_command_output).
-			Set("BinaryToPackage", *client_rpm_command_binary),
+			Set("BinaryToPackage", *client_rpm_command_binary).
+			Set("ConfigPath", *config_path),
 	}
 
 	query := `
@@ -103,6 +114,7 @@ func doClientRPM() error {
        SELECT OSPath
        FROM rpm_create(exe=BinaryToPackage,
                        directory_name=Output,
+                       config=read_file(filename=ConfigPath, length=1000000),
                        release=Release)
 `
 
@@ -120,15 +132,24 @@ func doServerRPM() error {
 	// package on the same system where the logs should go.
 	logging.DisableLogging()
 
-	config_obj, err := makeDefaultConfigLoader().
-		WithRequiredFrontend().LoadAndValidate()
-	if err != nil {
-		return fmt.Errorf("Unable to load config file: %w", err)
+	if *config_path == "" {
+		return fmt.Errorf("A server config must be specified using the --config flag")
 	}
+
+	temp_dir, err := tempfile.TempDir("debian")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp_dir)
+
+	blank_config := config.GetDefaultConfig()
+	blank_config.Datastore.Location = temp_dir
+	blank_config.Datastore.FilestoreDirectory = temp_dir
+
 	ctx, cancel := install_sig_handler()
 	defer cancel()
 
-	sm, err := startup.StartToolServices(ctx, config_obj)
+	sm, err := startup.StartToolServices(ctx, blank_config)
 	defer sm.Close()
 
 	if err != nil {
@@ -165,7 +186,8 @@ func doServerRPM() error {
 		Env: ordereddict.NewDict().
 			Set("Release", *rpm_command_release).
 			Set("Output", *server_rpm_command_output).
-			Set("BinaryToPackage", *server_rpm_command_binary),
+			Set("BinaryToPackage", *server_rpm_command_binary).
+			Set("ConfigPath", *config_path),
 	}
 
 	query := `
@@ -174,6 +196,7 @@ func doServerRPM() error {
        SELECT OSPath
        FROM rpm_create(exe=BinaryToPackage, server=TRUE,
                        directory_name=Output,
+                       config=read_file(filename=ConfigPath, length=1000000),
                        release=Release)
 `
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,9 @@ func GetDefaultConfig() *config_proto.Config {
 			Level2WritebackSuffix: ".bak",
 			TempdirWindows:        "$ProgramFiles\\Velociraptor\\Tools",
 			MaxPoll:               60,
+			ServerUrls: []string{
+				"https://127.0.0.1:8889/",
+			},
 
 			// By default restart the client if we are unable to
 			// contact the server within this long. (NOTE - even a

--- a/config/validate.go
+++ b/config/validate.go
@@ -12,6 +12,14 @@ import (
 	"www.velocidex.com/golang/velociraptor/utils"
 )
 
+var (
+	// Set for tests where we dont want the version to be updated. In
+	// real life the version is updated when the config is loaded and
+	// migrated. The Version field is simply a tag of the version of
+	// the program used to update the config last.
+	DO_NOT_UPDATE_VERSION = false
+)
+
 // Ensures client config is valid, fills in defaults for missing values etc.
 func ValidateClientConfig(config_obj *config_proto.Config) error {
 	migrate(config_obj)
@@ -71,11 +79,13 @@ func ValidateClientConfig(config_obj *config_proto.Config) error {
 		}
 	}
 
-	config_obj.Version = GetVersion()
+	if !DO_NOT_UPDATE_VERSION {
+		config_obj.Version = GetVersion()
 
-	// The client's config contains the running version of the client
-	// itself.
-	config_obj.Client.Version = GetVersion()
+		// The client's config contains the running version of the client
+		// itself.
+		config_obj.Client.Version = GetVersion()
+	}
 
 	// Ensure the writeback service is configured.
 	writeback_service := writeback.GetWritebackService()
@@ -165,17 +175,19 @@ func ValidateFrontendConfig(config_obj *config_proto.Config) error {
 	// The server should always update the client part to ensure new
 	// clients created from this server will keep the correct server
 	// version.
-	if config_obj.Client != nil {
-		version := GetVersion()
+	if !DO_NOT_UPDATE_VERSION {
+		if config_obj.Client != nil {
+			version := GetVersion()
 
-		config_obj.Client.ServerVersion = &config_proto.Version{
-			Version:   version.Version,
-			BuildTime: version.BuildTime,
-			Commit:    version.Commit,
+			config_obj.Client.ServerVersion = &config_proto.Version{
+				Version:   version.Version,
+				BuildTime: version.BuildTime,
+				Commit:    version.Commit,
+			}
 		}
-	}
 
-	config_obj.Version = GetVersion()
+		config_obj.Version = GetVersion()
+	}
 
 	return nil
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -173,8 +173,9 @@ func ValidateFrontendConfig(config_obj *config_proto.Config) error {
 			BuildTime: version.BuildTime,
 			Commit:    version.Commit,
 		}
-
 	}
+
+	config_obj.Version = GetVersion()
 
 	return nil
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	VERSION = "0.76.4"
+	VERSION = "0.76.5"
 
 	// This is the version of dependent client binaries that will be
 	// included in the offline collector or MSI. Usually this will be

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -4230,7 +4230,7 @@
     incorrect. This plugin will walk all hunt flows and re-tally all
     the stats to reset the hunt overview into the correct values.
 
-    On some installtions this is a very expensive operation as it
+    On some installations this is a very expensive operation as it
     generates a lot of IO.
   type: Plugin
   args:
@@ -13266,4 +13266,3 @@
   - linux_amd64_cgo
   - windows_386_cgo
   - windows_amd64_cgo
-

--- a/magefile.go
+++ b/magefile.go
@@ -911,27 +911,27 @@ func Container() error {
 	// We really want the sumo build inside the container.
 	builder.sumo = true
 
-	_, err := os.Stat("output/" + builder.Name())
-	if os.IsNotExist(err) {
+	target := "output/" + builder.Name()
+	fmt.Printf("Getting binary from %v\n", target)
+
+	// Copy the binary to the docker directory
+	err := sh.Copy("Docker/bin/velociraptor", target)
+	if err != nil {
+		// If it is not there, build it.
 		err := LinuxMuslSumo()
 		if err != nil {
 			return err
 		}
-
-	} else if err != nil {
-		return err
-	}
-
-	// Copy the binary to the docker directory
-	err = sh.Copy("Docker/bin/velociraptor", "output/"+builder.Name())
-	if err != nil {
-		return err
+		err = sh.Copy("Docker/bin/velociraptor", target)
+		if err != nil {
+			return err
+		}
 	}
 
 	image := "ghcr.io/velocidex/velociraptor-server:" + tag
 
 	// Build the docker image
-	err = sh.Run("docker", "build", "-t", image,
+	err = sh.Run("docker", "buildx", "build", "-t", image,
 		"--label", fmt.Sprintf("version=%v", constants.VERSION),
 		"--label", "commit_hash="+hash(),
 		"--label", "build_time="+time.Now().Format(time.RFC3339),

--- a/vql/parsers/binary.go
+++ b/vql/parsers/binary.go
@@ -23,6 +23,7 @@ type ParseBinaryFunctionArg struct {
 	Profile  string            `vfilter:"optional,field=profile,doc=Profile to use (see [vfilter](https://github.com/Velocidex/vtypes))."`
 	Struct   string            `vfilter:"required,field=struct,doc=Name of the struct in the profile to instantiate."`
 	Offset   int64             `vfilter:"optional,field=offset,doc=Start parsing from this offset"`
+	Env      *ordereddict.Dict `vfilter:"optional,field=env,doc=Additional environment variables to make available to the profile"`
 }
 type ParseBinaryFunction struct{}
 
@@ -32,6 +33,7 @@ func (self ParseBinaryFunction) Info(scope vfilter.Scope, type_map *vfilter.Type
 		Doc:      "Parse a binary file into a datastructure using a profile.",
 		ArgType:  type_map.AddType(scope, &ParseBinaryFunctionArg{}),
 		Metadata: vql.VQLMetadata().Permissions(acls.FILESYSTEM_READ).Build(),
+		Version:  2,
 	}
 }
 
@@ -71,7 +73,14 @@ func (self ParseBinaryFunction) Call(
 		return &vfilter.Null{}
 	}
 
-	obj, err := profile.Parse(scope, arg.Struct, paged_reader, arg.Offset)
+	subscope := scope.Copy()
+	defer subscope.Close()
+
+	if arg.Env != nil {
+		subscope.AppendVars(arg.Env)
+	}
+
+	obj, err := profile.Parse(subscope, arg.Struct, paged_reader, arg.Offset)
 	if err != nil {
 		scope.Log("parse_binary: %v", err)
 		return &vfilter.Null{}

--- a/vql/tools/collector/collector_manager.go
+++ b/vql/tools/collector/collector_manager.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Velocidex/ordereddict"
-	"gopkg.in/yaml.v2"
+	"github.com/Velocidex/yaml/v2"
 	"www.velocidex.com/golang/velociraptor/actions"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"

--- a/vql/tools/magic.go
+++ b/vql/tools/magic.go
@@ -105,9 +105,11 @@ func (self MagicFunction) Call(
 		return vfilter.Null{}
 	}
 
-	// Just let libmagic handle the path
-	if arg.Accessor == "" {
-		magic, err := handle.File(arg.Path.String())
+	// Just let libmagic handle the path if it can
+	filename, err := accessors.GetUnderlyingAPIFilename(arg.Accessor,
+		scope, arg.Path)
+	if err == nil {
+		magic, err := handle.File(filename)
 		if err != nil {
 			scope.Log("magic: %v", err)
 			return vfilter.Null{}

--- a/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMaster.golden
@@ -210,6 +210,14 @@ Frontend:
 ExtraFrontends:
 - hostname: www.example.com
   bind_port: 8100
+  resources:
+    connections_per_second: 100
+    notifications_per_second: 10
+    max_upload_size: 10485760
+    expected_clients: 10000
+    default_log_batch_time: 100
+    default_monitoring_log_batch_time: 100
+    disable_file_buffering: true
 Datastore:
   implementation: Test
   location: /tmp

--- a/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
+++ b/vql/tools/packaging/fixtures/TestDEBServerMinion.golden
@@ -210,6 +210,14 @@ Frontend:
 ExtraFrontends:
 - hostname: www.example.com
   bind_port: 8100
+  resources:
+    connections_per_second: 100
+    notifications_per_second: 10
+    max_upload_size: 10485760
+    expected_clients: 10000
+    default_log_batch_time: 100
+    default_monitoring_log_batch_time: 100
+    disable_file_buffering: true
 Datastore:
   implementation: Test
   location: /tmp

--- a/vql/tools/packaging/fixtures/TestRPMServer.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServer.golden
@@ -3,7 +3,7 @@ velociraptor-server-0.74.3.x86_64.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash 658e8ab09d4795b94f6600dc3485d0149e48774047ad0cebb27d0809ca0e4cac
+Hash 285a9bde13bfdea31e2526a766d6b04f357848cc45fbc3a6034ee2b0eee7b3ea
 Mode 600
 Owner root
 Group root
@@ -278,6 +278,14 @@ Frontend:
 ExtraFrontends:
 - hostname: www.example.com
   bind_port: 8100
+  resources:
+    connections_per_second: 100
+    notifications_per_second: 10
+    max_upload_size: 10485760
+    expected_clients: 10000
+    default_log_batch_time: 100
+    default_monitoring_log_batch_time: 100
+    disable_file_buffering: true
 Datastore:
   implementation: Test
   location: /tmp

--- a/vql/tools/packaging/fixtures/TestRPMServerMaster.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServerMaster.golden
@@ -3,7 +3,7 @@ velociraptor-server-master-0.74.3.x86_64-localhost-8000.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash 658e8ab09d4795b94f6600dc3485d0149e48774047ad0cebb27d0809ca0e4cac
+Hash 285a9bde13bfdea31e2526a766d6b04f357848cc45fbc3a6034ee2b0eee7b3ea
 Mode 600
 Owner root
 Group root

--- a/vql/tools/packaging/fixtures/TestRPMServerMinion.golden
+++ b/vql/tools/packaging/fixtures/TestRPMServerMinion.golden
@@ -3,7 +3,7 @@ velociraptor-server-minion-0.74.3.x86_64-www.example.com-8100.rpm
 >> /etc/velociraptor/server.config.yaml
 
 File /etc/velociraptor/server.config.yaml
-Hash 658e8ab09d4795b94f6600dc3485d0149e48774047ad0cebb27d0809ca0e4cac
+Hash 285a9bde13bfdea31e2526a766d6b04f357848cc45fbc3a6034ee2b0eee7b3ea
 Mode 600
 Owner root
 Group root

--- a/vql/tools/packaging/package.go
+++ b/vql/tools/packaging/package.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/Velocidex/ordereddict"
+	"github.com/Velocidex/yaml/v2"
 	"google.golang.org/protobuf/proto"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/accessors/file"
@@ -124,7 +125,17 @@ func (self CreatePackagePlugin) Call(ctx context.Context,
 			return
 		}
 
-		var target_config *config_proto.Config
+		target_config_obj := config_obj
+
+		// Populate the config from the plugin arg.
+		if arg.Config != "" {
+			target_config_obj = &config_proto.Config{}
+			err = yaml.UnmarshalStrict([]byte(arg.Config), target_config_obj)
+			if err != nil {
+				scope.Log("ERROR:%v: %v", self.name, err)
+				return
+			}
+		}
 
 		var spec *PackageSpec
 		if arg.PackageSpec != nil {
@@ -134,17 +145,17 @@ func (self CreatePackagePlugin) Call(ctx context.Context,
 				return
 			}
 			if spec.Server {
-				target_config, err = validateServerConfig(config_obj)
+				target_config_obj, err = validateServerConfig(target_config_obj)
 				if err != nil {
 					scope.Log("ERROR:%v: %v", self.name, err)
 					return
 				}
 
 				// We force the binary to run as the velociraptor user
-				target_config.Frontend.RunAsUser = spec.Expansion.ServerUser
+				target_config_obj.Frontend.RunAsUser = spec.Expansion.ServerUser
 
 			} else {
-				target_config, err = validateClientConfig(config_obj, arg.Config)
+				target_config_obj, err = validateClientConfig(target_config_obj, arg.Config)
 				if err != nil {
 					scope.Log("ERROR:%v: %v", self.name, err)
 					return
@@ -153,18 +164,18 @@ func (self CreatePackagePlugin) Call(ctx context.Context,
 
 		} else if arg.Server {
 			spec = self.serverSpecFactory()
-			target_config, err = validateServerConfig(config_obj)
+			target_config_obj, err = validateServerConfig(target_config_obj)
 			if err != nil {
 				scope.Log("ERROR:%v: %v", self.name, err)
 				return
 			}
 
 			// We force the binary to run as the velociraptor user
-			target_config.Frontend.RunAsUser = spec.Expansion.ServerUser
+			target_config_obj.Frontend.RunAsUser = spec.Expansion.ServerUser
 
 		} else {
 			spec = self.clientSpecFactory()
-			target_config, err = validateClientConfig(config_obj, arg.Config)
+			target_config_obj, err = validateClientConfig(target_config_obj, arg.Config)
 			if err != nil {
 				scope.Log("ERROR:%v: %v", self.name, err)
 				return
@@ -222,7 +233,7 @@ func (self CreatePackagePlugin) Call(ctx context.Context,
 		}
 
 		for _, package_spec := range expandSpec(
-			spec, target_config, arch, arg.Release, exe_bytes) {
+			spec, target_config_obj, arch, arg.Release, exe_bytes) {
 
 			builder, err := self.builder(package_spec)
 			if err != nil {
@@ -309,7 +320,7 @@ func validateServerConfig(config_obj *config_proto.Config) (*config_proto.Config
 		return nil, errors.New("Server Config requires a Frontend and Client sections.")
 	}
 
-	return res, nil
+	return res, config.ValidateFrontendConfig(res)
 }
 
 func validateClientConfig(

--- a/vql/tools/packaging/rpm_test.go
+++ b/vql/tools/packaging/rpm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/rpmpack"
 	"github.com/stretchr/testify/suite"
+	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store/test_utils"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
@@ -188,5 +189,6 @@ func (self *PackagingTestSuite) TestRPMServerMinion() {
 }
 
 func TestPackaging(t *testing.T) {
+	config.DO_NOT_UPDATE_VERSION = true
 	suite.Run(t, &PackagingTestSuite{})
 }

--- a/vql/unimplemented.go
+++ b/vql/unimplemented.go
@@ -5,10 +5,10 @@ import (
 	"runtime"
 
 	"github.com/Velocidex/ordereddict"
-	"gopkg.in/yaml.v2"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts/assets"
 	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/utils/yaml"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/types"
 )

--- a/vql/utils/help.go
+++ b/vql/utils/help.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Velocidex/ordereddict"
-	"gopkg.in/yaml.v2"
+	"github.com/Velocidex/yaml/v2"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts/assets"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"


### PR DESCRIPTION
Previous code used the config that was provided to repack in the deb
file. This cause the code to inadvertandly use it with initializing
the VQL context, causing it to e.g. access the filestore directory.

Now the filestore directory is using a temporary directory which is
removed after the tool completes.