### PR TITLE
Rework the shell interface

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -123,7 +123,10 @@ func (self *ApiServer) CollectArtifact(
 
 	// Build a request based on user input.
 	request := &flows_proto.ArtifactCollectorArgs{
-		ClientId:        in.ClientId,
+		ClientId: in.ClientId,
+
+		// Flow id may be specified to relaucnh a collection.
+		FlowId:          in.FlowId,
 		Artifacts:       in.Artifacts,
 		Specs:           in.Specs,
 		Creator:         user_record.Name,

--- a/artifacts/definitions/Linux/Sys/BashShell.yaml
+++ b/artifacts/definitions/Linux/Sys/BashShell.yaml
@@ -22,13 +22,35 @@ parameters:
 sources:
   - query: |
       LET SizeLimit <= 4096
-      SELECT if(condition=len(list=Stdout) < SizeLimit,
+      LET Now <= str(str=now())
+
+      LET Output = SELECT "" AS Command,
+             timestamp(epoch=now()) AS Timestamp,
+             if(condition=len(list=Stdout) < SizeLimit,
                 then=Stdout) AS Stdout,
              if(condition=len(list=Stdout) >= SizeLimit,
                 then=upload(accessor="data",
-                            file=Stdout, name="Stdout")) AS StdoutUpload
+                            file=Stdout,
+                            name="Stdout/" + Now)) AS StdoutUpload,
+             if(condition=len(list=Stderr) < SizeLimit,
+                then=Stderr) AS Stderr,
+             if(condition=len(list=Stderr) >= SizeLimit,
+                then=upload(accessor="data",
+                            file=Stderr,
+                            name="Stderr/" + Now)) AS StderrUpload
+
       FROM execve(argv=["/bin/bash", "-c", Command],
                   length=10000000)
+
+      SELECT * FROM chain(a={
+         SELECT Command,
+                timestamp(epoch=now()) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
+         FROM scope()
+      }, b=Output)
 
 column_types:
 - name: StdoutUpload

--- a/artifacts/definitions/Windows/Collectors/Remapping.yaml
+++ b/artifacts/definitions/Windows/Collectors/Remapping.yaml
@@ -193,14 +193,17 @@ export: |
                                        path_type="zip",
                                        Path="client_info.json")))
 
-  -- Set the hostname either from the parameters or read it from the file itself
-  LET DerivedHostname = Hostname ||
-                        CollectionHostinfo.Hostname ||
-                        CollectionHostinfo.hostname
+  -- Set the hostname either from the parameters or read it from the
+  -- file itself. Validate the hostname to have only allowed hostname chars.
+  LET DerivedHostname = parse_string_with_regex(
+    string=Hostname || CollectionHostinfo.Hostname || CollectionHostinfo.hostname,
+    regex="([a-z0-9-.]+)"
+  ).g1
 
   LET Remappings = parse_yaml(
                     filename=template(template=CommonRemapping,
-                                      expansion=dict(Hostname=DerivedHostname)),
+                                      expansion=dict(
+                                        Hostname=DerivedHostname || "Unknown")),
                     accessor="data")
 
   -- Normalize the drive name from device to drive. NTFS accessor uses

--- a/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
+++ b/artifacts/definitions/Windows/EventLogs/EvtxHunter.yaml
@@ -72,6 +72,10 @@ parameters:
     type: hidden
     description: "Add message DB path if desired for offline parsing"
 
+implied_permissions:
+  # For imported Windows.Sys.AllUsers
+  - FILESYSTEM_WRITE
+
 imports:
   - Windows.Sys.AllUsers
 

--- a/artifacts/definitions/Windows/Forensics/SRUM.yaml
+++ b/artifacts/definitions/Windows/Forensics/SRUM.yaml
@@ -31,6 +31,9 @@ parameters:
     description: Select to Upload the SRUM database file 'srudb.dat'
     type: bool
 
+implied_permissions:
+  - FILESYSTEM_WRITE
+
 export: |
   LET ResolveESEId(OSPath, Accessor, Id) = cache(
       name="ESE",

--- a/artifacts/definitions/Windows/Sys/AllUsers.yaml
+++ b/artifacts/definitions/Windows/Sys/AllUsers.yaml
@@ -20,6 +20,9 @@ parameters:
   - name: remoteRegKey
     default: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*
 
+implied_permissions:
+  - FILESYSTEM_WRITE
+
 export: |
   -- Cache function for lookupSID
   LET LookupSIDCache(SID) = cache(name="SID", key=SID,

--- a/artifacts/definitions/Windows/Sys/Users.yaml
+++ b/artifacts/definitions/Windows/Sys/Users.yaml
@@ -12,6 +12,9 @@ parameters:
   - name: remoteRegKey
     default: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*
 
+implied_permissions:
+  - FILESYSTEM_WRITE
+
 imports:
   - Windows.Sys.AllUsers
 

--- a/artifacts/definitions/Windows/System/CmdShell.yaml
+++ b/artifacts/definitions/Windows/System/CmdShell.yaml
@@ -30,13 +30,33 @@ parameters:
 sources:
   - query: |
       LET SizeLimit <= 4096
-      SELECT if(condition=len(list=Stdout) < SizeLimit,
+      LET Now <= str(str=now())
+
+      LET Output = SELECT "" AS Command,
+             timestamp(epoch=now()) AS Timestamp,
+             if(condition=len(list=Stdout) < SizeLimit,
                 then=Stdout) AS Stdout,
              if(condition=len(list=Stdout) >= SizeLimit,
                 then=upload(accessor="data",
-                            file=Stdout, name="Stdout")) AS StdoutUpload
-
+                            file=Stdout,
+                            name="Stdout/" + Now)) AS StdoutUpload,
+             if(condition=len(list=Stderr) < SizeLimit,
+                then=Stdout) AS Stderr,
+             if(condition=len(list=Stderr) >= SizeLimit,
+                then=upload(accessor="data",
+                            file=Stdout,
+                            name="Stderr/" + Now)) AS StderrUpload
       FROM execve(argv=["cmd.exe", "/c", Command], length=10000000)
+
+      SELECT * FROM chain(a={
+         SELECT Command,
+                timestamp(epoch=now()) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
+         FROM scope()
+      }, b=Output)
 
 column_types:
 - name: StdoutUpload

--- a/artifacts/definitions/Windows/System/PowerShell.yaml
+++ b/artifacts/definitions/Windows/System/PowerShell.yaml
@@ -43,23 +43,38 @@ parameters:
 sources:
   - query: |
       LET SizeLimit <= 4096
-      SELECT if(condition=len(list=Stdout) < SizeLimit,
+      LET Now <= str(str=now())
+
+      LET Output = SELECT "" AS Command,
+             timestamp(epoch=now()) AS Timestamp,
+             if(condition=len(list=Stdout) < SizeLimit,
                 then=Stdout) AS Stdout,
              if(condition=len(list=Stdout) >= SizeLimit,
                 then=upload(accessor="data",
                             file=Stdout,
-                            name="Stdout" + str(str=count()))) AS StdoutUpload,
+                            name="Stdout/" + Now)) AS StdoutUpload,
              if(condition=len(list=Stderr) < SizeLimit,
                 then=Stderr) AS Stderr,
              if(condition=len(list=Stderr) >= SizeLimit,
                 then=upload(accessor="data",
                             file=Stderr,
-                            name="Stderr" + str(str=count()))) AS StderrUpload,
+                            name="Stderr/" + Now)) AS StderrUpload,
              *
       FROM execve(argv=[PowerShellExe,
         "-ExecutionPolicy", "Unrestricted", "-encodedCommand",
         base64encode(string=utf16_encode(string=Command))
       ], length=10000000)
+
+      SELECT * FROM chain(a={
+         SELECT Command,
+                timestamp(epoch=now()) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
+         FROM scope()
+      }, b=Output)
+
 
 column_types:
 - name: StdoutUpload

--- a/flows/artifacts.go
+++ b/flows/artifacts.go
@@ -75,7 +75,7 @@ var (
 type CollectionContext struct {
 	mu sync.Mutex
 
-	flows_proto.ArtifactCollectorContext
+	*flows_proto.ArtifactCollectorContext
 
 	// We batch all monitoring JSONL rows and then flush them at the
 	// end.
@@ -96,9 +96,12 @@ type CollectionContext struct {
 }
 
 func NewCollectionContext(
-	ctx context.Context, config_obj *config_proto.Config) *CollectionContext {
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	artifact_collector_ctx *flows_proto.ArtifactCollectorContext,
+) *CollectionContext {
 	self := &CollectionContext{
-		ArtifactCollectorContext: flows_proto.ArtifactCollectorContext{},
+		ArtifactCollectorContext: artifact_collector_ctx,
 		monitoring_batch:         make(map[string]*jsonBatch),
 	}
 
@@ -123,7 +126,7 @@ func NewCollectionContext(
 		// completion.
 		row := ordereddict.NewDict().
 			Set("Timestamp", time.Now().UTC().Unix()).
-			Set("Flow", proto.Clone(&self.ArtifactCollectorContext)).
+			Set("Flow", proto.Clone(self.ArtifactCollectorContext)).
 			Set("FlowId", self.SessionId).
 			Set("ClientId", self.ClientId)
 
@@ -255,22 +258,40 @@ func closeContext(
 		}
 	}
 
+	if collection_context.State == flows_proto.ArtifactCollectorContext_WAITING {
+		collection_context.State = flows_proto.ArtifactCollectorContext_RUNNING
+	}
+
+	query_status := crypto_proto.VeloStatus_PROGRESS
+	switch collection_context.State {
+	case flows_proto.ArtifactCollectorContext_ERROR:
+		query_status = crypto_proto.VeloStatus_GENERIC_ERROR
+	case flows_proto.ArtifactCollectorContext_FINISHED:
+		query_status = crypto_proto.VeloStatus_OK
+	}
+
 	collection_context.Dirty = false
+
+	// Write a fake stats object - this is for backwards
+	// compatibility. Older clients do not have QueryStats.
+	collection_context.QueryStats = []*crypto_proto.VeloStatus{{
+		Duration:              collection_context.ExecutionDuration,
+		ExpectedUploadedBytes: int64(collection_context.TotalExpectedUploadedBytes),
+		ResultRows:            int64(collection_context.TotalCollectedRows),
+		LogRows:               int64(collection_context.TotalLogs),
+		Status:                query_status,
+	}}
+
+	launcher_service, err := services.GetLauncher(config_obj)
+	if err != nil {
+		return err
+	}
 
 	// Write the data before we fire the event so the data is
 	// available to any listeners of the event.
-	db, err := datastore.GetDB(config_obj)
-	if err != nil {
-		collection_context.State = flows_proto.ArtifactCollectorContext_ERROR
-		collection_context.Status = err.Error()
-	}
-
-	flow_path_manager := paths.NewFlowPathManager(
-		collection_context.ClientId, collection_context.SessionId)
-
-	return db.SetSubjectWithCompletion(
-		config_obj, flow_path_manager.Path(),
-		collection_context, collection_context.completer.GetCompletionFunc())
+	return launcher_service.Storage().WriteFlow(
+		ctx, config_obj, collection_context.ArtifactCollectorContext,
+		collection_context.completer.GetCompletionFunc())
 }
 
 func flushContextUploadedFiles(
@@ -313,32 +334,29 @@ func LoadCollectionContext(
 	ctx context.Context, config_obj *config_proto.Config,
 	client_id, flow_id string) (*CollectionContext, error) {
 
+	// Handle monitoring flows especially.
 	if flow_id == constants.MONITORING_WELL_KNOWN_FLOW {
-		result := NewCollectionContext(ctx, config_obj)
+		result := NewCollectionContext(ctx, config_obj,
+			&flows_proto.ArtifactCollectorContext{})
 		result.SessionId = flow_id
 		result.ClientId = client_id
 
 		return result, nil
 	}
 
-	flow_path_manager := paths.NewFlowPathManager(client_id, flow_id)
-	collection_context := NewCollectionContext(ctx, config_obj)
-	db, err := datastore.GetDB(config_obj)
+	launcher_service, err := services.GetLauncher(config_obj)
 	if err != nil {
 		return nil, err
 	}
 
-	err = db.GetSubject(config_obj, flow_path_manager.Path(),
-		&collection_context.ArtifactCollectorContext)
+	context_obj, err := launcher_service.Storage().LoadCollectionContext(
+		ctx, config_obj, client_id, flow_id)
 	if err != nil {
 		return nil, err
 	}
 
-	if collection_context.SessionId == "" {
-		return nil, errors.New("Unknown flow " + client_id + " " + flow_id)
-	}
+	collection_context := NewCollectionContext(ctx, config_obj, context_obj)
 	collection_context.TotalLoads++
-	collection_context.Dirty = false
 
 	return collection_context, nil
 }

--- a/flows/artifacts_test.go
+++ b/flows/artifacts_test.go
@@ -314,7 +314,7 @@ func (self *TestSuite) TestResourceLimits() {
 	// Collection has 1 row and it is still in the running state.
 	assert.Equal(self.T(), collection_context.TotalCollectedRows, uint64(1))
 	assert.Equal(self.T(), collection_context.State,
-		flows_proto.ArtifactCollectorContext_RUNNING)
+		flows_proto.ArtifactCollectorContext_IN_PROGRESS)
 
 	// Send another row
 	message.ResponseId++
@@ -330,7 +330,7 @@ func (self *TestSuite) TestResourceLimits() {
 	// Collection has 2 rows and it is still in the running state.
 	assert.Equal(self.T(), collection_context.TotalCollectedRows, uint64(2))
 	assert.Equal(self.T(), collection_context.State,
-		flows_proto.ArtifactCollectorContext_RUNNING)
+		flows_proto.ArtifactCollectorContext_IN_PROGRESS)
 
 	// Now send 5 rows in one message. We should accept the 5 rows
 	// but terminate the flow due to resource exhaustion.
@@ -406,15 +406,14 @@ func (self *TestSuite) TestClientUploaderStoreFile() {
 		nilTime, nilTime, nilTime, nilTime, 0, reader)
 
 	// Get a new collection context.
-	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj)
-	collection_context.ArtifactCollectorContext = flows_proto.ArtifactCollectorContext{
-		SessionId:           self.flow_id,
-		ClientId:            self.client_id,
-		OutstandingRequests: 1,
-		Request: &flows_proto.ArtifactCollectorArgs{
-			Artifacts: []string{"Generic.Client.Info"},
-		},
-	}
+	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj,
+		&flows_proto.ArtifactCollectorContext{
+			SessionId:           self.flow_id,
+			ClientId:            self.client_id,
+			OutstandingRequests: 1,
+			Request: &flows_proto.ArtifactCollectorArgs{
+				Artifacts: []string{"Generic.Client.Info"},
+			}})
 
 	for _, response := range resp.Drain.WaitForStatsMessage(self.T()) {
 		response.Source = self.client_id
@@ -652,17 +651,6 @@ func (self *TestSuite) testCollectionCompletion(
 	outstanding_requests int64,
 	requests []*crypto_proto.VeloMessage) *flows_proto.ArtifactCollectorContext {
 	// Get a new collection context.
-	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj)
-	collection_context.ArtifactCollectorContext = flows_proto.ArtifactCollectorContext{
-		SessionId:           self.flow_id,
-		ClientId:            self.client_id,
-		State:               flows_proto.ArtifactCollectorContext_RUNNING,
-		OutstandingRequests: outstanding_requests,
-		Request: &flows_proto.ArtifactCollectorArgs{
-			Artifacts: []string{"Generic.Client.Info"},
-		},
-	}
-
 	runner := NewFlowRunner(self.Ctx, self.ConfigObj)
 
 	wg := &sync.WaitGroup{}
@@ -734,13 +722,13 @@ func (self *TestSuite) TestClientUploaderStoreSparseFile() {
 		nilTime, nilTime, nilTime, nilTime, 0, reader)
 
 	// Get a new collection context.
-	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj)
-	collection_context.ArtifactCollectorContext = flows_proto.ArtifactCollectorContext{
-		SessionId:           self.flow_id,
-		ClientId:            self.client_id,
-		OutstandingRequests: 1,
-		Request:             &flows_proto.ArtifactCollectorArgs{},
-	}
+	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj,
+		&flows_proto.ArtifactCollectorContext{
+			SessionId:           self.flow_id,
+			ClientId:            self.client_id,
+			OutstandingRequests: 1,
+			Request:             &flows_proto.ArtifactCollectorArgs{},
+		})
 
 	for _, msg := range resp.Drain.WaitForStatsMessage(self.T()) {
 		msg.Source = self.client_id
@@ -868,12 +856,12 @@ func (self *TestSuite) TestClientUploaderStoreSparseFileNTFS() {
 		nilTime, nilTime, nilTime, nilTime, 0, fd)
 
 	// Get a new collection context.
-	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj)
-	collection_context.ArtifactCollectorContext = flows_proto.ArtifactCollectorContext{
-		SessionId: self.flow_id,
-		ClientId:  self.client_id,
-		Request:   &flows_proto.ArtifactCollectorArgs{},
-	}
+	collection_context := NewCollectionContext(self.Ctx, self.ConfigObj,
+		&flows_proto.ArtifactCollectorContext{
+			SessionId: self.flow_id,
+			ClientId:  self.client_id,
+			Request:   &flows_proto.ArtifactCollectorArgs{},
+		})
 
 	// Process it.
 	for _, resp := range resp.Drain.WaitForStatsMessage(self.T()) {

--- a/flows/client_flow_runner.go
+++ b/flows/client_flow_runner.go
@@ -14,7 +14,6 @@ import (
 	constants "www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/crypto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
-	"www.velocidex.com/golang/velociraptor/datastore"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
 	"www.velocidex.com/golang/velociraptor/json"
@@ -29,15 +28,13 @@ import (
 )
 
 /*
-  This flow runner processes messages from newer clients which support
-  CLIENT_API_VERSION >= 4.
+This flow runner processes messages from newer clients which support
+CLIENT_API_VERSION >= 4.
 
-  These clients maintain the state of the flow on the client
-  itself. This means the server does not need to maintain a lot of
-  information about each flow making it much faster.
-
+These clients maintain the state of the flow on the client
+itself. This means the server does not need to maintain a lot of
+information about each flow making it much faster.
 */
-
 type ClientFlowRunner struct {
 	ctx        context.Context
 	config_obj *config_proto.Config
@@ -294,7 +291,7 @@ func (self *ClientFlowRunner) removeInflightChecks(
 func (self *ClientFlowRunner) ProcessSingleMessage(
 	ctx context.Context, msg *crypto_proto.VeloMessage) error {
 
-	flow_id := msg.SessionId
+	flow_id, child_flow_id := splitSessionIdToParentAndChild(msg.SessionId)
 	client_id := msg.Source
 
 	if flow_id == constants.MONITORING_WELL_KNOWN_FLOW {
@@ -323,7 +320,8 @@ func (self *ClientFlowRunner) ProcessSingleMessage(
 	}
 
 	if msg.VQLResponse != nil {
-		err := self.VQLResponse(ctx, client_id, flow_id, msg.VQLResponse)
+		err := self.VQLResponse(
+			ctx, client_id, flow_id, child_flow_id, msg.VQLResponse)
 		if err != nil {
 			return fmt.Errorf("VQLResponse: %w", err)
 		}
@@ -601,16 +599,13 @@ func (self *ClientFlowRunner) FlowStats(
 	// Recompose the flow context from the QueryStats
 	launcher.UpdateFlowStats(stats)
 
-	// Store the updated flow object in the datastore
-	flow_path_manager := paths.NewFlowPathManager(client_id, flow_id)
-	db, err := datastore.GetDB(self.config_obj)
+	launcher_service, err := services.GetLauncher(self.config_obj)
 	if err != nil {
-		return err
+		return nil
 	}
 
-	// Just a blind write will eventually hit the disk.
-	err = db.SetSubjectWithCompletion(self.config_obj,
-		flow_path_manager.Stats(), stats, nil)
+	err = launcher_service.Storage().WriteFlowStats(ctx, self.config_obj,
+		stats, utils.BackgroundWriter)
 	if err != nil {
 		return err
 	}
@@ -703,10 +698,11 @@ func (self *ClientFlowRunner) FlowStats(
 }
 
 func (self *ClientFlowRunner) VQLResponse(
-	ctx context.Context, client_id, flow_id string,
+	ctx context.Context, client_id, flow_id, child_flow_id string,
 	response *actions_proto.VQLResponse) error {
 
-	if response == nil || response.Query == nil || response.Query.Name == "" {
+	if response == nil || response.Query == nil ||
+		response.Query.Name == "" {
 		return nil
 	}
 
@@ -751,7 +747,7 @@ func (self *ClientFlowRunner) VQLResponse(
 		// = 0 but Part > 0 - which means we must ignore QueryStartRow
 		// and NOT set the start row.
 
-	} else {
+	} else if child_flow_id == "" {
 		// Modern clients set the start row properly. We can check it
 		// against the result set index to ensure these rows are
 		// appended at the correct index in the result set.
@@ -761,6 +757,19 @@ func (self *ClientFlowRunner) VQLResponse(
 			// retransmitted - Just drop it on the floor.
 			return err
 		}
+
+	} else {
+		// This flow is a child flow of an existing flow. This allows
+		// it to append results so we turn off restransmission
+		// protections.
+		err := rs_writer.SetStartRow(rs_writer.TotalRows())
+		if err != nil {
+			// Something is wrong - the packet may have been
+			// retransmitted - Just drop it on the floor.
+			return err
+		}
+
+		response.ByteOffset = uint64(rs_writer.TotalBytes())
 	}
 
 	if response.UncompressedSize > 0 {
@@ -856,4 +865,12 @@ func (self *ClientFlowRunner) ProcessMessages(ctx context.Context,
 	}
 
 	return message_info.IterateJobs(ctx, self.config_obj, self.ProcessSingleMessage)
+}
+
+func splitSessionIdToParentAndChild(sesion_id string) (string, string) {
+	parts := strings.SplitN(sesion_id, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
 }

--- a/flows/proto/artifact_collector.pb.go
+++ b/flows/proto/artifact_collector.pb.go
@@ -641,6 +641,11 @@ type ArtifactCollectorContext struct {
 	ClientId  string                 `protobuf:"bytes,27,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	SessionId string                 `protobuf:"bytes,13,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	Request   *ArtifactCollectorArgs `protobuf:"bytes,11,opt,name=request,proto3" json:"request,omitempty"`
+	// When a flow is relaunched, we store the old requests in this
+	// parameter. Relaunching a flow is not common but can be done in
+	// order to fetch new data but still keep the data in the same
+	// flow.
+	PreviousFlows []*ArtifactCollectorContext `protobuf:"bytes,38,rep,name=previous_flows,json=previousFlows,proto3" json:"previous_flows,omitempty"`
 	// If an error occurs this is the backtrace.
 	Backtrace string `protobuf:"bytes,1,opt,name=backtrace,proto3" json:"backtrace,omitempty"`
 	// When the collection was created.
@@ -733,6 +738,13 @@ func (x *ArtifactCollectorContext) GetSessionId() string {
 func (x *ArtifactCollectorContext) GetRequest() *ArtifactCollectorArgs {
 	if x != nil {
 		return x.Request
+	}
+	return nil
+}
+
+func (x *ArtifactCollectorContext) GetPreviousFlows() []*ArtifactCollectorContext {
+	if x != nil {
+		return x.PreviousFlows
 	}
 	return nil
 }
@@ -1189,12 +1201,13 @@ const file_artifact_collector_proto_rawDesc = "" +
 	"\x04type\x18\x06 \x01(\tR\x04type\".\n" +
 	"\vPingContext\x12\x1f\n" +
 	"\vactive_time\x18\x01 \x01(\x04R\n" +
-	"activeTime\"\xb1\v\n" +
+	"activeTime\"\xf9\v\n" +
 	"\x18ArtifactCollectorContext\x12\x1b\n" +
 	"\tclient_id\x18\x1b \x01(\tR\bclientId\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\r \x01(\tR\tsessionId\x126\n" +
-	"\arequest\x18\v \x01(\v2\x1c.proto.ArtifactCollectorArgsR\arequest\x12\x1c\n" +
+	"\arequest\x18\v \x01(\v2\x1c.proto.ArtifactCollectorArgsR\arequest\x12F\n" +
+	"\x0eprevious_flows\x18& \x03(\v2\x1f.proto.ArtifactCollectorContextR\rpreviousFlows\x12\x1c\n" +
 	"\tbacktrace\x18\x01 \x01(\tR\tbacktrace\x12\x1f\n" +
 	"\vcreate_time\x18\x03 \x01(\x04R\n" +
 	"createTime\x12\x1d\n" +
@@ -1288,19 +1301,20 @@ var file_artifact_collector_proto_depIdxs = []int32{
 	13, // 3: proto.ArtifactCollectorArgs.compiled_collector_args:type_name -> proto.VQLCollectorArgs
 	3,  // 4: proto.ArtifactCollectorResponse.request:type_name -> proto.ArtifactCollectorArgs
 	3,  // 5: proto.ArtifactCollectorContext.request:type_name -> proto.ArtifactCollectorArgs
-	0,  // 6: proto.ArtifactCollectorContext.state:type_name -> proto.ArtifactCollectorContext.State
-	14, // 7: proto.ArtifactCollectorContext.query_stats:type_name -> proto.VeloStatus
-	5,  // 8: proto.ArtifactCollectorContext.uploaded_files:type_name -> proto.ArtifactUploadedFileInfo
-	15, // 9: proto.ArtifactCollectorContext.logs:type_name -> proto.LogMessage
-	3,  // 10: proto.LabelEvents.artifacts:type_name -> proto.ArtifactCollectorArgs
-	3,  // 11: proto.ClientEventTable.artifacts:type_name -> proto.ArtifactCollectorArgs
-	8,  // 12: proto.ClientEventTable.label_events:type_name -> proto.LabelEvents
-	16, // 13: proto.ClientEventTable.client_message:type_name -> proto.VeloMessage
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	7,  // 6: proto.ArtifactCollectorContext.previous_flows:type_name -> proto.ArtifactCollectorContext
+	0,  // 7: proto.ArtifactCollectorContext.state:type_name -> proto.ArtifactCollectorContext.State
+	14, // 8: proto.ArtifactCollectorContext.query_stats:type_name -> proto.VeloStatus
+	5,  // 9: proto.ArtifactCollectorContext.uploaded_files:type_name -> proto.ArtifactUploadedFileInfo
+	15, // 10: proto.ArtifactCollectorContext.logs:type_name -> proto.LogMessage
+	3,  // 11: proto.LabelEvents.artifacts:type_name -> proto.ArtifactCollectorArgs
+	3,  // 12: proto.ClientEventTable.artifacts:type_name -> proto.ArtifactCollectorArgs
+	8,  // 13: proto.ClientEventTable.label_events:type_name -> proto.LabelEvents
+	16, // 14: proto.ClientEventTable.client_message:type_name -> proto.VeloMessage
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_artifact_collector_proto_init() }

--- a/flows/proto/artifact_collector.proto
+++ b/flows/proto/artifact_collector.proto
@@ -134,6 +134,12 @@ message ArtifactCollectorContext {
     string session_id = 13;
     ArtifactCollectorArgs request = 11;
 
+    // When a flow is relaunched, we store the old requests in this
+    // parameter. Relaunching a flow is not common but can be done in
+    // order to fetch new data but still keep the data in the same
+    // flow.
+    repeated ArtifactCollectorContext previous_flows = 38;
+
     // If an error occurs this is the backtrace.
     string backtrace = 1;
 

--- a/gui/velociraptor/src/components/clients/shell-viewer.css
+++ b/gui/velociraptor/src/components/clients/shell-viewer.css
@@ -101,17 +101,24 @@ div.dt-buttons {
     line-height: 1.31;
     word-break: break-all;
     word-wrap: break-word;
-    color: var(--color-foreground);
     background-color: var(--color-canvas-background);
     border: 1px solid var(--color-panel-border);
     border-radius: 4px;
 }
 
+.shell-output-container .notebook-input pre {
+    color: var(--color-sidebar-disabled-foreground);
+    margin: 0;
+    border-radius: 0;
+}
+
+.shell-output-container .notebook-output pre {
+    color: var(--color-foreground);
+    border-radius: 0;
+}
+
 .shell-results {
-    /* Toolbar - padding - host toolbar - shell command controls - footer */
-    max-height: calc(100vh - 50px - 20px - 47px -  66px - 40px);
-    overflow-y: auto;
-    padding-bottom: 100px;
+    overflow-y: none;
 }
 
 .shell-command .velo-ace-editor {
@@ -133,4 +140,10 @@ div.dt-buttons {
 .shell-info {
     white-space: nowrap;
     display: inline-flex;
+}
+
+.shell-output-container {
+    max-height: 50vh;
+    overflow-y: auto;
+    overflow-x: hidden;
 }

--- a/gui/velociraptor/src/components/clients/shell-viewer.jsx
+++ b/gui/velociraptor/src/components/clients/shell-viewer.jsx
@@ -30,6 +30,7 @@ const SHELL_POLL_TIME = 5000;
 class _VeloShellCell extends Component {
     static propTypes = {
         flow: PropTypes.object,
+        artifact: PropTypes.string,
         client: PropTypes.object,
         fetchLastShellCollections: PropTypes.func.isRequired,
 
@@ -101,7 +102,6 @@ class _VeloShellCell extends Component {
             if (!response || !response.data || !response.data.rows) {
                 return;
             };
-
             this.setState({output: parseTableResponse(response),
                            artifact: artifact});
         });
@@ -120,6 +120,34 @@ class _VeloShellCell extends Component {
             this.props.fetchLastShellCollections();
         }.bind(this));
     };
+
+
+    // Launch the command within this shell session.
+    launchCommand = e=>{
+        if (!this.props.flow || !this.props.flow.session_id ||
+            !this.props.flow.client_id) {
+            return;
+        }
+
+        var params = {
+            client_id: this.props.client.client_id,
+            flow_id: this.props.flow.session_id,
+            artifacts: [this.props.artifact],
+            specs: [{
+                artifact: this.props.artifact,
+                parameters: {
+                    env: [{key: "Command", value: this.state.command}],
+                }
+            }],
+            urgent: true,
+        };
+
+        api.post('v1/CollectArtifact', params).then(response=>{
+            // Refresh the artifacts immediately.
+            this.props.fetchLastShellCollections();
+        }, this.source.token);
+
+    }
 
     render() {
         let buttons = [];
@@ -231,6 +259,22 @@ class _VeloShellCell extends Component {
             let flow_id = this.props.flow.session_id;
 
             output = [this.state.output.map((item, index) => {
+                let timestamp = item.Timestamp || "";
+                if (item.Stdout) {
+                    return <div className='notebook-output' key={index} >
+                             <pre> {item.Stdout} </pre>
+                           </div>;
+                }
+
+                if (item.Command) {
+                    return <div className='notebook-input' key={index} >
+                             {timestamp && <VeloTimestamp
+                                             usec={ timestamp }
+                                           />}
+                            <pre> {item.Command} </pre>
+                           </div>;
+                }
+
                 if (item.StdoutUpload) {
                     return <div className='notebook-output' key={index} >
                              <PreviewUpload
@@ -239,6 +283,7 @@ class _VeloShellCell extends Component {
                                upload={item.StdoutUpload} />
                            </div>;
                 }
+
                 return <div className='notebook-output' key={index} >
                          <pre> {item.Stdout} </pre>
                        </div>;
@@ -247,13 +292,13 @@ class _VeloShellCell extends Component {
             if (this.props.flow.state  === 'ERROR') {
                 output.push(<Button variant="danger" key="errors"
                                     onClick={e=>{this.viewFlow("logs");}}
-                                    size="lg" block>
+                                    size="lg" >
                               {T('Error')}
                             </Button>);
             } else {
                 output.push(<Button variant="link" key="logs"
                                     onClick={e=>{this.viewFlow("logs");}}
-                                    size="lg" block>
+                                    size="lg" >
                               {T('Logs')}
                             </Button>);
             }
@@ -279,17 +324,33 @@ class _VeloShellCell extends Component {
 
                 <div className='notebook-input'>
                   <div className="cell-toolbar">
-                    <div className="btn-group" role="group">
-                      { buttons }
-                    </div>
-                    <div className="btn-group float-right" role="group">
-                      { flow_status }
-                    </div>
+                    <InputGroup className="mb-3 d-flex">
+                      <div className="btn-group" role="group">
+                        { buttons }
+                      </div>
+                      <textarea rows="1"
+                                className="form-control"
+                                placeholder={this.getInput()}
+                                spellCheck="false"
+                                value={this.state.command}
+                                onChange={(e) =>this.setState({
+                                    command: e.target.value,
+                                })}>
+                      </textarea>
+                      <div className="btn-group float-right" role="group">
+                        <Button
+                          variant="default"
+                          onClick={this.launchCommand}>
+                          {T("Launch")}
+                        </Button>
+                        { flow_status }
+                      </div>
+                    </InputGroup>
                   </div>
-
-                  <pre> { this.getInput() } </pre>
                 </div>
-                {output}
+                <div className="shell-output-container">
+                  {output}
+                </div>
               </div>
             </>
         );
@@ -484,13 +545,13 @@ class _VeloVQLCell extends Component {
             if (this.props.flow.state  === 'ERROR') {
                 output.push(<Button variant="danger" key="ERROR"
                                     onClick={e=>{this.viewFlow("logs");}}
-                                    size="lg" block>
+                                    size="lg" >
                               {T('Error')}
                             </Button>);
             } else {
                 output.push(<Button variant="link" key="Logs"
                                     onClick={e=>{this.viewFlow("logs");}}
-                                    size="lg" block>
+                                    size="lg" >
                               {T('Logs')}
                             </Button>);
             }
@@ -699,6 +760,7 @@ class ShellViewer extends Component {
 
             return (
                 <VeloShellCell key={index}
+                               artifact={artifact}
                                fetchLastShellCollections={
                                    this.fetchLastShellCollections}
                                flow={flow}

--- a/gui/velociraptor/src/components/utils/table.jsx
+++ b/gui/velociraptor/src/components/utils/table.jsx
@@ -8,11 +8,15 @@ export function parseTableResponse(response) {
     for(var row=0; row<response.data.rows.length; row++) {
         let item = {};
         let current_row = JSONparse(response.data.rows[row].json);
-        if (!_.isArray(current_row) || current_row.length < columns.length) {
+        if (!_.isArray(current_row)) {
             continue;
         }
 
-        for(let column=0; column<columns.length; column++) {
+        if(current_row.length > columns.length) {
+            current_row = current_row.splice(columns.length);
+        }
+
+        for(let column=0; column<current_row.length; column++) {
             item[columns[column]] = current_row[column];
         }
         data.push(item);

--- a/result_sets/api.go
+++ b/result_sets/api.go
@@ -29,6 +29,8 @@ type ResultSetWriter interface {
 	// Provide a hint as to the next row id we are writing. This is
 	// only useful for some implementations of result set writers.
 	SetStartRow(start_row int64) error
+	TotalRows() int64
+	TotalBytes() int64
 
 	// Result sets may be updated in place.
 	Update(index uint64, row *ordereddict.Dict) error

--- a/result_sets/simple/simple.go
+++ b/result_sets/simple/simple.go
@@ -68,16 +68,14 @@ type ResultSetWriterImpl struct {
 	sync bool
 }
 
-// This tells us that we expect to write the next row at this offset.
-// We need to ensure the file is actually as we expect it to be.
-func (self *ResultSetWriterImpl) SetStartRow(start_row int64) error {
+func (self *ResultSetWriterImpl) TotalRows() int64 {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
 	// Calculate the number of rows currently in the file.
 	idx_size, err := self.index_fd.Size()
 	if err != nil {
-		return err
+		return 0
 	}
 
 	// The number of rows in the underlying file.
@@ -86,8 +84,19 @@ func (self *ResultSetWriterImpl) SetStartRow(start_row int64) error {
 	// Corrent for any rows we have in memory waiting to be flushed.
 	number_of_rows += int64(len(self.rows))
 
+	return number_of_rows
+}
+
+func (self *ResultSetWriterImpl) TotalBytes() int64 {
+	size, _ := self.fd.Size()
+	return size
+}
+
+// This tells us that we expect to write the next row at this offset.
+// We need to ensure the file is actually as we expect it to be.
+func (self *ResultSetWriterImpl) SetStartRow(start_row int64) error {
 	// This is a retransmission
-	if number_of_rows > start_row {
+	if self.TotalRows() > start_row {
 		return retransmissionError
 	}
 

--- a/result_sets/simple/sink.go
+++ b/result_sets/simple/sink.go
@@ -9,6 +9,14 @@ func (self NullResultSetWriter) WriteJSONL(
 	return nil
 }
 
+func (self NullResultSetWriter) TotalRows() int64 {
+	return 0
+}
+
+func (self NullResultSetWriter) TotalBytes() int64 {
+	return 0
+}
+
 func (self NullResultSetWriter) WriteCompressedJSONL(
 	serialized []byte, byte_offset uint64, uncompressed_size int,
 	total_rows uint64) error {

--- a/services/debug/profile.go
+++ b/services/debug/profile.go
@@ -117,7 +117,6 @@ func getChildren(self *CategoryTreeNode) {
 			getChildren(new_node)
 		}
 	}
-
 }
 
 func GetProfileTree() *CategoryTreeNode {

--- a/services/launcher/flows.go
+++ b/services/launcher/flows.go
@@ -229,12 +229,6 @@ func (self *Launcher) CancelFlow(
 // collection. We derive this information from the specific results of
 // each query.
 func UpdateFlowStats(collection_context *flows_proto.ArtifactCollectorContext) {
-	// Support older collections which do not have this info
-	if len(collection_context.QueryStats) == 0 &&
-		collection_context.InflightTime == 0 {
-		return
-	}
-
 	// Now update the overall collection statuses based on all the
 	// individual query status. The collection status is a high level
 	// overview of the entire collection.

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -123,6 +123,7 @@ import (
 	"github.com/go-errors/errors"
 	"google.golang.org/protobuf/proto"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
+	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/artifacts"
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -657,9 +658,31 @@ func (self *Launcher) WriteArtifactCollectionRecord(
 		return "", err
 	}
 
+	var existing_flow *api_proto.FlowDetails
+
+	// The session Id we use to store the flow.
 	session_id := collector_request.FlowId
+
+	// The session_id we send to the client.
+	var client_session_id string
+
 	if session_id == "" {
 		session_id = utils.NewFlowId(client_id)
+		client_session_id = session_id
+
+	} else {
+		// The user asked for a pre-determined flow id. It might be an
+		// existing flow. In this case we operate if flow append mode.
+		existing_flow, err = self.GetFlowDetails(ctx, config_obj,
+			services.GetFlowOptions{}, client_id, session_id)
+		if err == nil && existing_flow.Context != nil &&
+			existing_flow.Context.Request != nil {
+
+			// When relaunching a flow, we modify the flow id to
+			// distinguish it from its parent flow.
+			client_session_id = fmt.Sprintf("%s/%d", session_id,
+				len(existing_flow.Context.PreviousFlows))
+		}
 	}
 
 	// How long to batch log messages for on the client.
@@ -675,7 +698,7 @@ func (self *Launcher) WriteArtifactCollectionRecord(
 	// Compile all the requests into specific tasks to be sent to the
 	// client.
 	task := &crypto_proto.VeloMessage{
-		SessionId: session_id,
+		SessionId: client_session_id,
 		RequestId: constants.ProcessVQLResponses,
 		FlowRequest: &crypto_proto.FlowRequest{
 			LogBatchTime:   batch_delay,
@@ -727,6 +750,11 @@ func (self *Launcher) WriteArtifactCollectionRecord(
 		OutstandingRequests: int64(len(vql_collector_args)),
 	}
 
+	if existing_flow != nil {
+		collection_context.PreviousFlows = append(
+			collection_context.PreviousFlows, existing_flow.Context)
+	}
+
 	// Record the tasks for provenance of what we actually did.
 	err = self.Storage().WriteTask(
 		ctx, config_obj, client_id, redactTask(task))
@@ -774,7 +802,9 @@ func (self *Launcher) WriteArtifactCollectionRecord(
 	}
 
 	// Write the flow on the index.
-	err = self.Storage().WriteFlowIndex(ctx, config_obj, collection_context)
+	if existing_flow == nil {
+		err = self.Storage().WriteFlowIndex(ctx, config_obj, collection_context)
+	}
 	return collection_context.SessionId, err
 }
 

--- a/vql/server/flows/create.go
+++ b/vql/server/flows/create.go
@@ -37,6 +37,7 @@ import (
 
 type ScheduleCollectionFunctionArg struct {
 	ClientId     string            `vfilter:"required,field=client_id,doc=The client id to schedule a collection on"`
+	FlowId       string            `vfilter:"optional,field=flow_id,doc=If a flow id is specified we do not create a new flow, but instead add the collection to this flow."`
 	Artifacts    []string          `vfilter:"required,field=artifacts,doc=A list of artifacts to collect"`
 	Env          *ordereddict.Dict `vfilter:"optional,field=env,doc=Parameters to apply to the artifact (an alternative to a full spec)"`
 	Spec         *ordereddict.Dict `vfilter:"optional,field=spec,doc=Parameters to apply to the artifacts"`
@@ -86,7 +87,7 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 	// COLLECT_CLIENT for clients
 	// COLLECT_SERVER for server
 	// COLLECT_BASIC for artifacts with the basic metadata set
-
+	// SERVER_ADMIN to append to a flow
 	acl_manager, ok := artifacts.GetACLManager(scope)
 	if !ok {
 		acl_manager = acl_managers.NullACLManager{}
@@ -140,6 +141,7 @@ func (self *ScheduleCollectionFunction) Call(ctx context.Context,
 
 	request := &flows_proto.ArtifactCollectorArgs{
 		ClientId:       arg.ClientId,
+		FlowId:         arg.FlowId,
 		Artifacts:      arg.Artifacts,
 		Creator:        vql_subsystem.GetPrincipal(scope),
 		OpsPerSecond:   float32(arg.OpsPerSecond),
@@ -202,7 +204,7 @@ func (self ScheduleCollectionFunction) Info(scope vfilter.Scope, type_map *vfilt
 		ArgType: type_map.AddType(scope, &ScheduleCollectionFunctionArg{}),
 		Metadata: vql_subsystem.VQLMetadata().Permissions(
 			acls.COLLECT_CLIENT, acls.COLLECT_SERVER, acls.COLLECT_BASIC).Build(),
-		Version: 2,
+		Version: 3,
 	}
 }
 

--- a/vql/tools/collector/collector_manager.go
+++ b/vql/tools/collector/collector_manager.go
@@ -493,14 +493,15 @@ func newCollectionManager(
 	}
 
 	return &collectionManager{
-		ctx:                subctx,
-		cancel:             cancel,
-		config_obj:         config_obj,
-		collection_context: flows.NewCollectionContext(ctx, config_obj),
-		concurrency:        utils.NewConcurrencyControl(concurrency, time.Hour),
-		output_chan:        output_chan,
-		scope:              scope,
-		throttler:          &throttler.DummyThrottler{},
+		ctx:        subctx,
+		cancel:     cancel,
+		config_obj: config_obj,
+		collection_context: flows.NewCollectionContext(
+			ctx, config_obj, &flows_proto.ArtifactCollectorContext{}),
+		concurrency: utils.NewConcurrencyControl(concurrency, time.Hour),
+		output_chan: output_chan,
+		scope:       scope,
+		throttler:   &throttler.DummyThrottler{},
 	}
 }
 
@@ -547,7 +548,7 @@ func (self *collectionManager) Close() error {
 		self.collection_context.StartTime = uint64(self.start_time.UnixNano())
 		self.collection_context.CreateTime = uint64(self.start_time.UnixNano())
 
-		launcher.UpdateFlowStats(&self.collection_context.ArtifactCollectorContext)
+		launcher.UpdateFlowStats(self.collection_context.ArtifactCollectorContext)
 
 		// Merge in the container stats
 		container_stats := self.container.Stats()

--- a/vql/tools/panic.go
+++ b/vql/tools/panic.go
@@ -13,7 +13,7 @@ func init() {
 	vql_subsystem.RegisterPlugin(
 		vfilter.GenericListPlugin{
 			PluginName: "panic",
-			Metadata:   vql_subsystem.VQLMetadata().Permissions(acls.MACHINE_STATE).Build(),
+			Metadata:   vql_subsystem.VQLMetadata().Permissions(acls.SERVER_ADMIN).Build(),
 			Function: func(
 				ctx context.Context,
 				scope vfilter.Scope,


### PR DESCRIPTION
Velociraptor's shell interface is not a true shell - each interaction evaluates a commmand in a separate flow, and the shell interface displays the output in a separate UI cell for each command

This is not how most people want to use the shell. Most users expect the shell to consist of a "session" where each command builds on the previous one and they are all visible in the same UI element.

This PR introduces a new concept - relaunching a collection. This feature allows the user to relaunch an existing collection with the same flow id as a previous collection. The client will run the new collection and the results will be appended to the old collection.

When used in the shell, this allows each command to be appended to the previous ones inside a flow. This keeps all shell commands in the same flow. The new UI shows them all as belonging to the same session.

Currently there is no client side state kept so it is not a real session, but this is the first step.