### PR TITLE
Bugfix: Sigma correlations sharing a source rule now all fire

### DIFF
--- a/vql/sigma/evaluator/evaluate.go
+++ b/vql/sigma/evaluator/evaluate.go
@@ -41,18 +41,18 @@ type VQLRuleEvaluator struct {
 
 	fieldmappings *FieldMappingResolver
 
-	// If this rule has a correlator, then forward the match to the
-	// correlator.
-	Correlator *SigmaCorrelator `json:"correlator,omitempty" yaml:"correlator,omitempty"`
+	// If this rule has correlators, then forward the match to each of
+	// them. A source rule may be referenced by more than one correlation.
+	Correlators []*SigmaCorrelator `json:"correlators,omitempty" yaml:"correlators,omitempty"`
 }
 
 func (self *VQLRuleEvaluator) GetCorrelatorRule() *VQLRuleEvaluator {
-	if self.Correlator == nil {
+	if len(self.Correlators) == 0 {
 		return self
 	}
 
 	res := &VQLRuleEvaluator{
-		Rule:          self.Correlator.Rule,
+		Rule:          self.Correlators[0].Rule,
 		fieldmappings: self.fieldmappings,
 		scope:         self.scope,
 	}
@@ -183,15 +183,16 @@ func (self *VQLRuleEvaluator) Match(ctx context.Context,
 		}
 	}
 
-	// If we get here the base rule would have matched - if there is a
-	// correlator tell it about it.
-	if result.Match && self.Correlator != nil {
+	// If we get here the base rule would have matched. When there are
+	// correlators the pool dispatches the event to each of them and
+	// emits one row per fired correlation.
+	if result.Match && len(self.Correlators) > 0 {
 		// Tag the event with the rule that actually matched it. This
 		// makes it easy to see which rule from the correlation
 		// matched each event.
 		event.Set("_MatchingRule", self.Rule.Title)
 
-		return self.Correlator.Match(ctx, scope, self, event)
+		return &result, nil
 	}
 
 	// Record the total hits

--- a/vql/sigma/fixtures/TestSigmaCorrelation.golden
+++ b/vql/sigma/fixtures/TestSigmaCorrelation.golden
@@ -224,5 +224,73 @@
    "Details": null
   }
  ],
- "Correlation Test TEMPORAL Expired match should not fire": []
+ "Correlation Test TEMPORAL Expired match should not fire": [],
+ "Correlation Test Multiple correlations share one source rule": [
+  {
+   "Timestamp": "2026-05-18T12:00:00+10:00",
+   "EventID": 9999,
+   "Computer": "test",
+   "_MatchingRule": "Marker File Created",
+   "_Correlations": [
+    {
+     "Timestamp": "2026-05-18T12:00:00+10:00",
+     "EventID": 9999,
+     "Computer": "test",
+     "_MatchingRule": "Marker File Created"
+    }
+   ],
+   "_Rule": {
+    "Title": "Correlation A",
+    "Correlation": {
+     "type": "event_count",
+     "rules": [
+      "marker_file_created"
+     ],
+     "group-by": [
+      "Computer"
+     ],
+     "timespan": "10s",
+     "condition": {
+      "gte": 1
+     }
+    },
+    "Id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "Level": "high"
+   },
+   "Details": null
+  },
+  {
+   "Timestamp": "2026-05-18T12:00:00+10:00",
+   "EventID": 9999,
+   "Computer": "test",
+   "_MatchingRule": "Marker File Created",
+   "_Correlations": [
+    {
+     "Timestamp": "2026-05-18T12:00:00+10:00",
+     "EventID": 9999,
+     "Computer": "test",
+     "_MatchingRule": "Marker File Created"
+    }
+   ],
+   "_Rule": {
+    "Title": "Correlation B",
+    "Correlation": {
+     "type": "event_count",
+     "rules": [
+      "marker_file_created"
+     ],
+     "group-by": [
+      "Computer"
+     ],
+     "timespan": "10s",
+     "condition": {
+      "gte": 1
+     }
+    },
+    "Id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    "Level": "high"
+   },
+   "Details": null
+  }
+ ]
 }

--- a/vql/sigma/pool.go
+++ b/vql/sigma/pool.go
@@ -59,36 +59,74 @@ func (self *workerJob) Run() {
 			continue
 		}
 
-		// The below operates on a copy of the event so as not to
-		// interfere with other threads
-		event_copy := evaluator.NewEvent(event.Copy())
-		if match.CorrelationHits == nil {
-			event_copy.Set("_Match", match)
-		} else {
-			event_copy.Set("_Correlations", match.CorrelationHits)
+		// If this source rule feeds one or more correlations, dispatch
+		// the matching event to each correlator and emit one row per
+		// fired correlation.
+		if len(rule.Correlators) > 0 {
+			for _, correlator := range rule.Correlators {
+				// Only feed the correlator when the base rule actually
+				// matched. Otherwise (in debug mode) we would pollute
+				// the timespan state with non matching events.
+				corr_match := match
+				if match.Match {
+					corr_match, err = correlator.Match(
+						self.ctx, subscope, rule, event)
+					if err != nil {
+						functions.DeduplicatedLog(self.ctx, subscope,
+							"While evaluating correlation %v: %v",
+							correlator.Title, err)
+						continue
+					}
+				}
+
+				if !self.debug && !corr_match.Match {
+					continue
+				}
+
+				// Report the correlation rule as the hit.
+				if !self.emit(subscope, event, corr_match,
+					correlator.VQLRuleEvaluator) {
+					return
+				}
+			}
+			continue
 		}
 
-		// If this is a correlation rule, we report the actual
-		// correlation rule as a hit.
-		if rule.Correlator != nil {
-			// From here on we use the correlation rule to determine
-			// the details or post match enrichment.
-			rule = rule.Correlator.VQLRuleEvaluator
-		}
-
-		event_copy.Set("_Rule", rule)
-
-		self.sigma_context.AddDetail(self.ctx, subscope, event_copy, rule)
-		rule.MaybeEnrichForReporting(self.ctx, subscope, event_copy)
-
-		self.sigma_context.IncHitCount()
-
-		select {
-		case <-self.ctx.Done():
+		if !self.emit(subscope, event, match, rule) {
 			return
-
-		case self.output_chan <- event_copy:
 		}
+	}
+}
+
+// emit writes a single matching row to the output channel. It operates
+// on a copy of the event so as not to interfere with other threads.
+// Returns false if the context was cancelled.
+func (self *workerJob) emit(
+	subscope vfilter.Scope,
+	event *evaluator.Event,
+	match *evaluator.Result,
+	rule *evaluator.VQLRuleEvaluator) bool {
+
+	event_copy := evaluator.NewEvent(event.Copy())
+	if match.CorrelationHits == nil {
+		event_copy.Set("_Match", match)
+	} else {
+		event_copy.Set("_Correlations", match.CorrelationHits)
+	}
+
+	event_copy.Set("_Rule", rule)
+
+	self.sigma_context.AddDetail(self.ctx, subscope, event_copy, rule)
+	rule.MaybeEnrichForReporting(self.ctx, subscope, event_copy)
+
+	self.sigma_context.IncHitCount()
+
+	select {
+	case <-self.ctx.Done():
+		return false
+
+	case self.output_chan <- event_copy:
+		return true
 	}
 }
 

--- a/vql/sigma/runner.go
+++ b/vql/sigma/runner.go
@@ -43,7 +43,7 @@ func (self *SigmaExecutionContext) ChargeTime(ns int64) {
 // in serial while non-correlations run in parallel
 func (self *SigmaExecutionContext) balance() {
 	for _, r := range self.rules {
-		if r.Correlator == nil {
+		if len(r.Correlators) == 0 {
 			self.non_correlations = append(self.non_correlations, r)
 		} else {
 			self.correlations = append(self.correlations, r)
@@ -300,7 +300,7 @@ func NewSigmaContext(
 					continue
 				}
 
-				rule.Correlator = c
+				rule.Correlators = append(rule.Correlators, c)
 			}
 		}
 	}

--- a/vql/sigma/sigma_test.go
+++ b/vql/sigma/sigma_test.go
@@ -53,6 +53,7 @@ type testCase struct {
 	fieldmappings     *ordereddict.Dict
 	rows              []*ordereddict.Dict
 	log_regex         string
+	expected_count    int // 0 = unchecked; >0 asserts exact row count
 	debug             bool
 }
 
@@ -1063,6 +1064,60 @@ level: high
 					Set("Timestamp", "2024-10-10T12:35:00+10").
 					Set("cs-method", "POST"),
 			},
+		}, {
+			// Two correlations referencing one source rule must both fire.
+			description: "Correlation Test Multiple correlations share one source rule",
+			rule: `
+title: Marker File Created
+id: 11111111-1111-1111-1111-111111111111
+name: marker_file_created
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 9999
+  condition: selection
+level: low
+---
+title: Correlation A
+id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+correlation:
+  type: event_count
+  rules:
+    - marker_file_created
+  group-by:
+    - Computer
+  timespan: 10s
+  condition:
+    gte: 1
+level: high
+---
+title: Correlation B
+id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+correlation:
+  type: event_count
+  rules:
+    - marker_file_created
+  group-by:
+    - Computer
+  timespan: 10s
+  condition:
+    gte: 1
+level: high
+`,
+			fieldmappings: ordereddict.NewDict().
+				Set("Timestamp", "x=>x.Timestamp").
+				Set("EventID", "x=>x.EventID").
+				Set("Computer", "x=>x.Computer"),
+			rows: []*ordereddict.Dict{
+				ordereddict.NewDict().
+					Set("Timestamp", "2026-05-18T12:00:00+10:00").
+					Set("EventID", 9999).
+					Set("Computer", "test"),
+			},
+			// One row per correlation rule.
+			expected_count: 2,
 		},
 	}
 )
@@ -1119,6 +1174,12 @@ func (self *SigmaTestSuite) TestSigmaCorrelations() {
 			serialized2 := json.MustMarshalString(rows[j])
 			return string(serialized1) < string(serialized2)
 		})
+
+		if test_case.expected_count > 0 {
+			assert.Equal(self.T(), test_case.expected_count, len(rows),
+				"%s: expected %d rows, got %d",
+				test_case.description, test_case.expected_count, len(rows))
+		}
 
 		result.Set(test_case.description, rows)
 


### PR DESCRIPTION
Lets a Sigma source rule feed more than one correlation so they all fire. Previously a source rule held a single correlator, so when two correlations shared it only one fired.

Fixes: #4832