### PR TITLE
Impose a maximum size on datastore objects.

### DIFF
--- a/api/tables/table.go
+++ b/api/tables/table.go
@@ -68,6 +68,9 @@ func GetTable(
 	case "STACK":
 		result, err = getStackTable(ctx, config_obj, in)
 
+	case "USER_MESSAGES":
+		result, err = getUserMessages(ctx, in, principal)
+
 	case "NOTEBOOKS":
 		result, err = getNotebookTable(ctx, config_obj, in, principal)
 
@@ -485,4 +488,24 @@ func GetTableOptions(in *api_proto.GetTableRequest) (
 	options.EndIdx = in.EndIdx
 
 	return options, nil
+}
+
+func getUserMessages(
+	ctx context.Context,
+	in *api_proto.GetTableRequest,
+	principal string) (
+	*api_proto.GetTableResponse, error) {
+
+	org_manager, err := services.GetOrgManager()
+	if err != nil {
+		return nil, err
+	}
+
+	// User messages live in the root org.
+	root_config_obj, err := org_manager.GetOrgConfig(services.ROOT_ORG_ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return getTable(ctx, root_config_obj, in, principal)
 }

--- a/config/proto/config.pb.go
+++ b/config/proto/config.pb.go
@@ -2873,6 +2873,14 @@ type DatastoreConfig struct {
 	// should not happen normally but may happen if the deployment has
 	// been very active or due to a bug!
 	MaxDirSize uint64 `protobuf:"varint,13,opt,name=max_dir_size,json=maxDirSize,proto3" json:"max_dir_size,omitempty"`
+	// The maximum size of stored objects in the datastore. The
+	// Datastore is assumed to contain smallish objects which are read
+	// and written atomically. This setting places a limit on the size
+	// of these objects to mainain efficiency and speed. If you hit
+	// this limit it means that you need to rethink your approach. See
+	// https://docs.velociraptor.app/knowledge_base/tips/grpc_errors/
+	// The default size is 4Mb.
+	MaxObjectSize uint64 `protobuf:"varint,20,opt,name=max_object_size,json=maxObjectSize,proto3" json:"max_object_size,omitempty"`
 	// How long to expire the memcache (default 10 min)
 	MemcacheExpirationSec uint64 `protobuf:"varint,4,opt,name=memcache_expiration_sec,json=memcacheExpirationSec,proto3" json:"memcache_expiration_sec,omitempty"`
 	// How many mutations to queue up ahead of busy writers. By
@@ -2983,6 +2991,13 @@ func (x *DatastoreConfig) GetDiskCheckFrequencySec() int64 {
 func (x *DatastoreConfig) GetMaxDirSize() uint64 {
 	if x != nil {
 		return x.MaxDirSize
+	}
+	return 0
+}
+
+func (x *DatastoreConfig) GetMaxObjectSize() uint64 {
+	if x != nil {
+		return x.MaxObjectSize
 	}
 	return 0
 }
@@ -5402,7 +5417,7 @@ const file_config_proto_rawDesc = "" +
 	"\x15client_event_max_wait\x18\x17 \x01(\x04R\x12clientEventMaxWait\x12D\n" +
 	"\x1eartifact_definitions_directory\x18  \x01(\tR\x1cartifactDefinitionsDirectory\x124\n" +
 	"\x16collection_error_regex\x18# \x01(\tR\x14collectionErrorRegex\x12&\n" +
-	"\x0fdo_not_redirect\x18\x1a \x01(\bR\rdoNotRedirect\"\xc2\b\n" +
+	"\x0fdo_not_redirect\x18\x1a \x01(\bR\rdoNotRedirect\"\xea\b\n" +
 	"\x0fDatastoreConfig\x12&\n" +
 	"\x0eimplementation\x18\x01 \x01(\tR\x0eimplementation\x12\x1a\n" +
 	"\blocation\x18\x02 \x01(\tR\blocation\x12/\n" +
@@ -5411,7 +5426,8 @@ const file_config_proto_rawDesc = "" +
 	"\x19min_allowed_file_space_mb\x18\x0f \x01(\x03R\x15minAllowedFileSpaceMb\x127\n" +
 	"\x18disk_check_frequency_sec\x18\x10 \x01(\x03R\x15diskCheckFrequencySec\x12 \n" +
 	"\fmax_dir_size\x18\r \x01(\x04R\n" +
-	"maxDirSize\x126\n" +
+	"maxDirSize\x12&\n" +
+	"\x0fmax_object_size\x18\x14 \x01(\x04R\rmaxObjectSize\x126\n" +
 	"\x17memcache_expiration_sec\x18\x04 \x01(\x04R\x15memcacheExpirationSec\x12C\n" +
 	"\x1ememcache_write_mutation_buffer\x18\x05 \x01(\x03R\x1bmemcacheWriteMutationBuffer\x12E\n" +
 	"\x1fmemcache_write_mutation_writers\x18\x06 \x01(\x03R\x1cmemcacheWriteMutationWriters\x129\n" +

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -983,6 +983,15 @@ message DatastoreConfig {
     // been very active or due to a bug!
     uint64 max_dir_size = 13;
 
+    // The maximum size of stored objects in the datastore. The
+    // Datastore is assumed to contain smallish objects which are read
+    // and written atomically. This setting places a limit on the size
+    // of these objects to mainain efficiency and speed. If you hit
+    // this limit it means that you need to rethink your approach. See
+    // https://docs.velociraptor.app/knowledge_base/tips/grpc_errors/
+    // The default size is 4Mb.
+    uint64 max_object_size = 20;
+
     // How long to expire the memcache (default 10 min)
     uint64 memcache_expiration_sec = 4;
 

--- a/constants/memory.go
+++ b/constants/memory.go
@@ -11,4 +11,7 @@ const (
 
 	// The GUI will truncate the env to this many chars
 	MAX_ENV_TRUNCATE_LIMIT = 100
+
+	// The default max size of datastore objects.
+	MAX_DATASTORE_OBJECTS = 4 * 1024 * 1024
 )

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -119,6 +119,17 @@ func (self BaseTestSuite) TestSetSubjectWithCompletion() {
 	assert.Equal(self.T(), result[0], "Done")
 }
 
+func (self BaseTestSuite) TestSetSubjectLargeData() {
+	message := &crypto_proto.VeloMessage{
+		Source: strings.Repeat("Server", 1024*1024),
+	}
+	urn := path_specs.NewSafeDatastorePath("a", "b", "c").
+		SetType(api.PATH_TYPE_DATASTORE_PROTO)
+	err := self.datastore.SetSubject(self.config_obj, urn, message)
+	assert.Error(self.T(), err)
+	assert.True(self.T(), errors.Is(err, utils.MemoryError))
+}
+
 func (self BaseTestSuite) TestSetGetSubject() {
 	message := &crypto_proto.VeloMessage{Source: "Server"}
 

--- a/datastore/filebased.go
+++ b/datastore/filebased.go
@@ -308,6 +308,15 @@ func writeContentToFile(
 		return datastoreNotConfiguredError
 	}
 
+	max_size := uint64(constants.MAX_DATASTORE_OBJECTS)
+	if config_obj.Datastore.MaxObjectSize > 0 {
+		max_size = config_obj.Datastore.MaxObjectSize
+	}
+
+	if uint64(len(data)) > max_size {
+		return utils.Wrap(utils.MemoryError, "Datastore object exceeded")
+	}
+
 	filename := AsDatastoreFilename(db, config_obj, urn)
 
 	// Truncate the file immediately so we don't need to make a second

--- a/datastore/memcache.go
+++ b/datastore/memcache.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/constants"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -490,6 +491,15 @@ func (self *MemcacheDatastore) SetSubjectWithCompletion(
 func (self *MemcacheDatastore) SetData(
 	config_obj *config_proto.Config,
 	urn api.DSPathSpec, data []byte) (err error) {
+
+	max_size := uint64(constants.MAX_DATASTORE_OBJECTS)
+	if config_obj.Datastore.MaxObjectSize > 0 {
+		max_size = config_obj.Datastore.MaxObjectSize
+	}
+
+	if uint64(len(data)) > max_size {
+		return utils.Wrap(utils.MemoryError, "Datastore object exceeded")
+	}
 
 	err = self.data_cache.Set(
 		AsDatastoreFilename(self, config_obj, urn), &BulkData{

--- a/flows/artifacts_test.go
+++ b/flows/artifacts_test.go
@@ -310,7 +310,8 @@ func (self *TestSuite) TestResourceLimits() {
 	runner.Close(self.Ctx)
 
 	// Load the collection context and see what happened.
-	collection_context, err := LoadCollectionContext(self.Ctx, self.ConfigObj,
+	collection_context, err := LoadCollectionContext(
+		self.Ctx, self.ConfigObj,
 		self.client_id, flow_id, services.GetFlowOptions{})
 	assert.NoError(self.T(), err)
 

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -14570,10 +14570,9 @@
             "dev": true
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-            "license": "MIT",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
             "engines": {
                 "node": ">=14.14"
             }
@@ -25923,9 +25922,9 @@
             "dev": true
         },
         "tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="
         },
         "tmpl": {
             "version": "1.0.5",

--- a/gui/velociraptor/src/components/core/snackbar.jsx
+++ b/gui/velociraptor/src/components/core/snackbar.jsx
@@ -34,6 +34,13 @@ export default class Snackbar extends React.Component {
 
     componentDidMount = () => {
         api.hooks.push(this.warn);
+        setInterval(()=>{
+            this.setState({now: Date.now()});
+        }, 1000);
+    }
+
+    componentWillUnmount = ()=>{
+        clearInterval(this.interval);
     }
 
     addMessage = (toasts, message)=>{
@@ -43,6 +50,7 @@ export default class Snackbar extends React.Component {
             if(message===toasts[i].body) {
                 toasts[i].key = getID();
                 toasts[i].show = true;
+                toasts[i].timestamp = Date.now();
                 return toasts;
             }
         }
@@ -51,6 +59,7 @@ export default class Snackbar extends React.Component {
             header: "Error",
             body: message,
             key: getID(),
+            timestamp: Date.now(),
         });
 
         // Only keep the last 5 toasts
@@ -74,6 +83,7 @@ export default class Snackbar extends React.Component {
 
     state = {
         toasts: [],
+        now: Date.now(),
     }
 
     dismiss = ()=>{
@@ -84,9 +94,8 @@ export default class Snackbar extends React.Component {
         return <ToastContainer>
                  {_.map(this.state.toasts, (t, idx)=>{
                      return <Toast key={t.key}
-                                   show={t.show}
-                                   delay={TIMEOUT}
-                                   autohide
+                                   show={t.show && (
+                                       (t.timestamp + TIMEOUT) > this.state.now)}
                                    bg="warning"
                                    onClose={()=>{
                          t.show = false,
@@ -94,6 +103,8 @@ export default class Snackbar extends React.Component {
                      }}>
                               <Toast.Header>
                                 <strong className="me-auto">{t.header}</strong>
+                                <small>{ parseInt((t.timestamp + TIMEOUT -
+                                                   this.state.now) / 1000) + 1 }</small>
                               </Toast.Header>
                               <Toast.Body>{t.body}</Toast.Body>
                             </Toast>;

--- a/gui/velociraptor/src/components/core/user.jsx
+++ b/gui/velociraptor/src/components/core/user.jsx
@@ -82,20 +82,15 @@ class _UserSettings extends React.Component {
                             document.body.classList.add("veloci-light");
                         }
                     }
-
-                    if(_.isEqual(traits, this.state.traits)) {
-                        return;
-                    };
-
                     this.setState({
                         traits: traits,
-                        messages: response.data.messages || []});
+                        messages: response.data.messages || 0});
                 });
     }
 
     state = {
         traits: {},
-        messages: [],
+        messages: 0,
         updateTraits: this.updateTraits,
     }
 

--- a/gui/velociraptor/src/components/hunts/hunt-overview.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-overview.jsx
@@ -56,6 +56,14 @@ export default class HuntOverview extends React.Component {
         clearInterval(this.interval);
     }
 
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        let current_hunt_id = this.props.hunt && this.props.hunt.hunt_id;
+        let prev_hunt_id = prevProps.hunt && prevProps.hunt.hunt_id;
+        if(current_hunt_id != prev_hunt_id) {
+            this.loadFullHunt();
+        }
+    }
+
     huntState = () => {
         let hunt = this.props.hunt;
         let stopped = hunt.stats && hunt.stats.stopped;

--- a/gui/velociraptor/src/components/users/global-messages.jsx
+++ b/gui/velociraptor/src/components/users/global-messages.jsx
@@ -92,12 +92,12 @@ export default class GlobalMessages extends Component {
     }
 
     render() {
-        let msg = this.context.messages || [];
+        let msg = this.context.messages || 0;
         return (
             <>
               <Button
                 variant="primary"
-                disabled={msg.length == 0}
+                disabled={!msg}
                 className={" danger global-messages"}
                 onClick={()=>this.setState({show_messages: true})}
               >

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base32"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"path"
 	"strings"
 	"sync"
@@ -376,6 +377,12 @@ func (self *HuntDispatcher) CreateHunt(
 		hunt.StartTime = hunt.CreateTime
 	}
 
+	err = self.Store.SetHunt(ctx, hunt)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"While writing hunt %v: %w", hunt.HuntId, err)
+	}
+
 	row := ordereddict.NewDict().
 		Set("Timestamp", utils.GetTime().Now().UTC().Unix()).
 		Set("Hunt", hunt)
@@ -392,10 +399,6 @@ func (self *HuntDispatcher) CreateHunt(
 		return nil, err
 	}
 
-	err = self.Store.SetHunt(ctx, hunt)
-	if err != nil {
-		return nil, err
-	}
 	return hunt, nil
 }
 

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -1529,6 +1530,40 @@ func (self *LauncherTestSuite) getIndex(client_id string) (
 		res = append(res, r)
 	}
 	return res
+}
+
+func (self *LauncherTestSuite) TestScheduleHugeArtifact() {
+	t := self.T()
+
+	flow_id := "F.FlowIdHuge"
+
+	launcher, err := services.GetLauncher(self.ConfigObj)
+	assert.NoError(t, err)
+
+	repository := self.LoadArtifacts(DependentArtifacts...)
+	acl_manager := acl_managers.NullACLManager{}
+
+	defer utils.SetFlowIdForTests(flow_id)()
+
+	flow_id, err = launcher.ScheduleArtifactCollection(
+		self.Ctx, self.ConfigObj, acl_manager,
+		repository, &flows_proto.ArtifactCollectorArgs{
+			Creator:   "admin",
+			ClientId:  constants.VELOCIRAPTOR_SERVER_CLIENT_ID,
+			Artifacts: []string{"Test.Artifact"},
+			Specs: []*flows_proto.ArtifactSpec{{
+				Artifact: "Test.Artifact",
+				Parameters: &flows_proto.ArtifactParameters{
+					Env: []*actions_proto.VQLEnv{{
+						Key:   "Foo",
+						Value: strings.Repeat("Hello", 1024*1024),
+					}},
+				},
+			}},
+		}, utils.SyncCompleter)
+
+	assert.Error(t, err)
+	assert.True(self.T(), errors.Is(err, utils.MemoryError))
 }
 
 func TestLauncher(t *testing.T) {

--- a/services/launcher/storage.go
+++ b/services/launcher/storage.go
@@ -48,8 +48,8 @@ func (self *FlowStorageManager) WriteFlow(
 		return err
 	}
 
-	sesion_id, _ := utils.SplitSessionIdToParentAndChild(flow.SessionId)
-	flow_path_manager := paths.NewFlowPathManager(flow.ClientId, sesion_id)
+	session_id, _ := utils.SplitSessionIdToParentAndChild(flow.SessionId)
+	flow_path_manager := paths.NewFlowPathManager(flow.ClientId, session_id)
 
 	completer, closer := utils.NewCompleter(completion)
 	defer closer()
@@ -91,7 +91,8 @@ func (self *FlowStorageManager) WriteFlow(
 			config_obj, flow_path_manager.Requests(),
 			requests, completer.GetCompletionFunc())
 		if err != nil {
-			return err
+			return fmt.Errorf(
+				"While writing flow %v: %w", session_id, err)
 		}
 	}
 


### PR DESCRIPTION
Velociraptor's datastore abstration assumes that datastore objects are reasonably small so they can be read and written atomically. However, sometimes, these can become very large. This happens especially for:

1. Artifacts that contain a lot of data internally for example `Windows.Hayabusa.Rules` contains all the Sigma rules inside the artifact.
2. Artifacts that can accept very large parameters, for example `Generic.Detection.Yara.Glob` can include large yara rules as a parameter.

Both these situations cause the size of the compiled artifact to be large:
1. The Flow object request to the client becomes very large.
2. Tasts scheduled for the clients are very large
3. Hunt requests become very large.

This makes it worse with a distributed master/minion architecture which requires the minions to fetch large objects from the master for scheduling clients. This can sometimes lead to gRPC errors due to the large requests.

This PR limits the size of the datastore objects to enforce a reasonable limit. This ensures that performance remains reasonable and prevents grpc `received message larger than max` errors.

However, the downside is that very large artifacts will not be able to schedule any more. These artifacts can be redesigned to work more efficiently:

* For artifacts that include large data blobs internally, they can be compressed or extracted into a tool (see https://docs.velociraptor.app/docs/artifacts/tools/ ).
* Artifacts that include large parameters (e.g. Yara rulesets) can be changed to include a URL to the ruleset which can be fetched by the client (for example `Generic.Detection.Yara.Glob` has the `YaraUrl` parameter instead).