### PR TITLE
Windows.Forensics.RDPCache: apply DateAfter/DateBefore to Parsed source

### DIFF
--- a/artifacts/definitions/Windows/Forensics/RDPCache.yaml
+++ b/artifacts/definitions/Windows/Forensics/RDPCache.yaml
@@ -70,6 +70,12 @@ sources:
   - name: Parsed
     description: Parsed RDP BitmapCache files.
     query: |
+      -- Scope parsing to the requested DateAfter/DateBefore window.
+      LET DateAfterTime <= if(condition=DateAfter,
+        then=DateAfter, else=timestamp(epoch="1600-01-01"))
+      LET DateBeforeTime <= if(condition=DateBefore,
+        then=DateBefore, else=timestamp(epoch="2200-01-01"))
+
       LET PROFILE = '''[
         ["BIN_CONTAINER", 0, [
             [Magic, 0, String, {length: 8, term_hex : "FFFFFF" }],
@@ -114,6 +120,8 @@ sources:
             WHERE OSPath =~ '\.bin$'
                 AND OSPath =~ UserRegex
                 AND NOT IsDir
+                AND Mtime > DateAfterTime
+                AND Mtime < DateBeforeTime
         })
 
       LET find_index_differential = SELECT *, 0 - Parsed.CachedFiles.Index[0] as IndexDif


### PR DESCRIPTION
Fixes #3781.

The DateAfter/DateBefore parameters were only applied in the TargetFiles source. This applies them to the Parsed source as well, so .BIN files outside the requested window are filtered out before parse_binary() runs instead of being parsed and discarded in a notebook afterward.

The filter uses the Mtime of the .BIN container file. Individual cached bitmaps carry no timestamps, so the container Mtime is the finest granularity available. Boundaries are exclusive, matching TargetFiles.
