### PR TITLE
Add corrupted/archived journal files to the default glob arg.

### DIFF
--- a/artifacts/definitions/Linux/Forensics/Journal.yaml
+++ b/artifacts/definitions/Linux/Forensics/Journal.yaml
@@ -9,7 +9,7 @@ parameters:
 - name: JournalGlob
   type: glob
   description: A Glob expression for finding journal files.
-  default: /{run,var}/log/journal/*/*.journal
+  default: /{run,var}/log/journal/*/*.journal{,~}
 - name: IdentifierRegex
   type: regex
   description: "Regex of event source e.g sshd or kernel"


### PR DESCRIPTION
I have noticed that the journal artifact sometimes is missing thousands of events. I narrowed it down to cases where the computer has been rebooted, and I noticed that we are not inspecting "~" files. From the systemd-journald man page:

> systemd-journald writes files with the .journal suffix. If the daemon
> is stopped uncleanly, or if files are found to be corrupted, they are
> renamed using the .journal~ suffix and journald starts writing to a new
> file.

These files are readable in all my tests so far, and they contain lots of valuable events. The glob therefore now includes them.