### PR TITLE
Add back "nobreak" to stdout/stderr column types

### DIFF
--- a/artifacts/definitions/Linux/Sys/BashShell.yaml
+++ b/artifacts/definitions/Linux/Sys/BashShell.yaml
@@ -116,6 +116,10 @@ resources:
   max_batch_rows: 1
 
 column_types:
+- name: Stdout
+  type: nobreak
+- name: Stderr
+  type: nobreak
 - name: StdoutUpload
   type: preview_upload
 - name: StderrUpload

--- a/artifacts/definitions/Windows/System/PowerShell.yaml
+++ b/artifacts/definitions/Windows/System/PowerShell.yaml
@@ -128,6 +128,10 @@ sources:
 
 
 column_types:
+- name: Stdout
+  type: nobreak
+- name: Stderr
+  type: nobreak
 - name: StdoutUpload
   type: preview_upload
 - name: StderrUpload


### PR DESCRIPTION
This makes the output in raw results more readable, like in previous releases.