### PR TITLE
Fix goroutine leak when server monitoring tables are updated concurrently

### DIFF
--- a/scripts/dlv.star
+++ b/scripts/dlv.star
@@ -31,7 +31,6 @@ number_color = "\x1b[37m"
 comment_color = "\x1b[92m"
 arrow_color = "\x1b[93m"
 tab_color = "\x1b[90m"
-max_string_len = 1000
 
 proto_fields = ["state", "sizeCache", "unknownFields"]
 

--- a/scripts/dlv.star
+++ b/scripts/dlv.star
@@ -31,6 +31,7 @@ number_color = "\x1b[37m"
 comment_color = "\x1b[92m"
 arrow_color = "\x1b[93m"
 tab_color = "\x1b[90m"
+max_string_len = 1000
 
 proto_fields = ["state", "sizeCache", "unknownFields"]
 

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -30,6 +30,13 @@ import (
 )
 
 type EventTable struct {
+	// Serializes StartQueries()/Close(). Always taken before mu.
+	// _Close() releases mu while draining the query goroutines (they
+	// call Tracer() on exit) - update_mu stops a concurrent updater
+	// entering that window and overwriting wg and cancel, which
+	// orphans the queries the other updater started.
+	update_mu sync.Mutex
+
 	mu sync.Mutex
 
 	config_obj *config_proto.Config
@@ -50,7 +57,11 @@ type EventTable struct {
 }
 
 func (self *EventTable) Wait() {
-	self.wg.Wait()
+	self.mu.Lock()
+	wg := self.wg
+	self.mu.Unlock()
+
+	wg.Wait()
 }
 
 func (self *EventTable) Tracer() *QueryTracer {
@@ -61,6 +72,9 @@ func (self *EventTable) Tracer() *QueryTracer {
 }
 
 func (self *EventTable) Close() {
+	self.update_mu.Lock()
+	defer self.update_mu.Unlock()
+
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
@@ -216,6 +230,8 @@ func (self *EventTable) equal(events []*actions_proto.VQLCollectorArgs) bool {
 
 // Start the queries in the request
 func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
+	self.update_mu.Lock()
+	defer self.update_mu.Unlock()
 
 	request := self.Get()
 

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -439,7 +439,7 @@ func (self *EventTable) _RunQuery(
 			}
 
 			// Remove the query from the tracer immediately as well as
-			// on exit. It is safe to call mulitple times.
+			// on exit. It is safe to call multiple times.
 			self.Tracer().Clear(query.VQL)
 		}
 	}()

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -30,13 +30,6 @@ import (
 )
 
 type EventTable struct {
-	// Serializes StartQueries()/Close(). Always taken before mu.
-	// _Close() releases mu while draining the query goroutines (they
-	// call Tracer() on exit) - update_mu stops a concurrent updater
-	// entering that window and overwriting wg and cancel, which
-	// orphans the queries the other updater started.
-	update_mu sync.Mutex
-
 	mu sync.Mutex
 
 	config_obj *config_proto.Config
@@ -48,20 +41,10 @@ type EventTable struct {
 	// Wait for all subqueries to finish using this wg
 	wg *sync.WaitGroup
 
-	logger *serverLogger
-
 	tracer *QueryTracer
 
 	request         *flows_proto.ArtifactCollectorArgs
 	current_queries []*actions_proto.VQLCollectorArgs
-}
-
-func (self *EventTable) Wait() {
-	self.mu.Lock()
-	wg := self.wg
-	self.mu.Unlock()
-
-	wg.Wait()
 }
 
 func (self *EventTable) Tracer() *QueryTracer {
@@ -72,9 +55,6 @@ func (self *EventTable) Tracer() *QueryTracer {
 }
 
 func (self *EventTable) Close() {
-	self.update_mu.Lock()
-	defer self.update_mu.Unlock()
-
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
@@ -82,32 +62,26 @@ func (self *EventTable) Close() {
 }
 
 func (self *EventTable) _Close() {
+	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
+
 	// Close the old table.
 	if self.cancel != nil {
-		logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 		logger.Info("<red>Closing</> Server Monitoring Event table for %v",
 			services.GetOrgName(self.config_obj))
 
 		self.cancel()
 		self.cancel = nil
 	}
-
-	// Wait here until all the old queries are cancelled. Do not hold
-	// the lock while we are waiting or the event table will be
-	// deadlocked.
-	wg := self.wg
-	self.mu.Unlock()
-	wg.Wait()
-	self.mu.Lock()
-
-	// Get ready for the next run.
-	self.wg = &sync.WaitGroup{}
 }
 
 func (self *EventTable) Get() *flows_proto.ArtifactCollectorArgs {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	return self._Get()
+}
+
+func (self *EventTable) _Get() *flows_proto.ArtifactCollectorArgs {
 	if self.request == nil {
 		return &flows_proto.ArtifactCollectorArgs{}
 	}
@@ -175,6 +149,9 @@ func (self *EventTable) Update(
 
 	logger.Info("<green>server_monitoring</>: Updating monitoring table")
 
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	// Now store the monitoring table on disk.
 	db, err := datastore.GetDB(config_obj)
 	if err != nil {
@@ -186,12 +163,10 @@ func (self *EventTable) Update(
 		return err
 	}
 
-	self.mu.Lock()
 	self.request = request
-	self.mu.Unlock()
 
 	// Update the queries immediately
-	return self.StartQueries(config_obj)
+	return self._StartQueries(config_obj, request)
 }
 
 // Compare a new set of queries with the current set to see if they
@@ -228,15 +203,22 @@ func (self *EventTable) equal(events []*actions_proto.VQLCollectorArgs) bool {
 	return true
 }
 
-// Start the queries in the request
-func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
-	self.update_mu.Lock()
-	defer self.update_mu.Unlock()
-
-	request := self.Get()
-
+// Restart the queries in the request
+func (self *EventTable) RestartQueries(config_obj *config_proto.Config) error {
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	request := self._Get()
+
+	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
+	logger.Debug("ServerMonitoring: Restarting %v Queries", len(request.Artifacts))
+
+	return self._StartQueries(config_obj, request)
+}
+
+func (self *EventTable) _StartQueries(
+	config_obj *config_proto.Config,
+	request *flows_proto.ArtifactCollectorArgs) error {
 
 	// Compile the ArtifactCollectorArgs into a list of requests.
 	launcher, err := services.GetLauncher(config_obj)
@@ -257,9 +239,8 @@ func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
 	// No ACLs enforced on server events.
 	acl_manager := acl_managers.NullACLManager{}
 
-	// Make a context for all the VQL queries.
+	// Make a cancellable context for all the sub VQL queries.
 	subctx, cancel := context.WithCancel(self.parent_ctx)
-	defer cancel()
 
 	// Compile the collection request into multiple
 	// VQLCollectorArgs - each will be collected in a different
@@ -270,6 +251,7 @@ func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
 			IgnoreMissingArtifacts: true,
 		}, request)
 	if err != nil {
+		cancel()
 		return err
 	}
 
@@ -278,6 +260,7 @@ func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
 	if self.equal(vql_requests) {
 		logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
 		logger.Info("server_monitoring: Skipping table update because queries have not changed.")
+		cancel()
 		return nil
 	}
 
@@ -289,12 +272,11 @@ func (self *EventTable) StartQueries(config_obj *config_proto.Config) error {
 	self.current_queries = vql_requests
 
 	// Create a new ctx for the new run.
-	new_ctx, cancel := context.WithCancel(self.parent_ctx)
 	self.cancel = cancel
 
 	// Run each collection separately in parallel.
 	for _, vql_request := range vql_requests {
-		err = self.RunQuery(new_ctx, config_obj, self.wg, vql_request)
+		err = self._RunQuery(subctx, config_obj, self.wg, vql_request)
 		if err != nil {
 			return err
 		}
@@ -314,7 +296,7 @@ func getArtifactName(vql_request *actions_proto.VQLCollectorArgs) string {
 	return ""
 }
 
-func (self *EventTable) RunQuery(
+func (self *EventTable) _RunQuery(
 	ctx context.Context,
 	config_obj *config_proto.Config,
 	wg *sync.WaitGroup,
@@ -362,7 +344,7 @@ func (self *EventTable) RunQuery(
 		config_obj, constants.VELOCIRAPTOR_SERVER_CLIENT_ID, "",
 		artifact_name, artifact_modes.MODE_SERVER_EVENT)
 
-	self.logger = &serverLogger{
+	logger := &serverLogger{
 		config_obj:   self.config_obj,
 		path_manager: log_path_manager,
 		ctx:          ctx,
@@ -379,7 +361,7 @@ func (self *EventTable) RunQuery(
 			self.config_obj, principal),
 		Env:        ordereddict.NewDict(),
 		Repository: repository,
-		Logger:     log.New(self.logger, "", 0),
+		Logger:     log.New(logger, "", 0),
 	}
 
 	for _, env_spec := range vql_request.Env {
@@ -396,24 +378,31 @@ func (self *EventTable) RunQuery(
 
 	scope.Log("server_monitoring: Collecting <green>%v</>", artifact_name)
 
+	// Add the queries to tracer immediately - the goroutines below
+	// will remove them asynchronously as they are completed.
+	for _, query := range vql_request.Query {
+		self.tracer.Set(query.VQL)
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		//defer rs_writer.Close()
 		defer scope.Close()
+
 		defer scope.Log("server_monitoring: Finished collecting %v", artifact_name)
 
 		for _, query := range vql_request.Query {
 			query_log := actions.QueryLog.AddQuery(query.VQL)
-			query_start := uint64(utils.GetTime().Now().UTC().UnixNano() / 1000)
 
-			// Record the current query.
-			self.Tracer().Set(query.VQL)
+			// Can call multiple times: Cover error paths
+			defer query_log.Close()
 			defer self.Tracer().Clear(query.VQL)
+
+			query_start := uint64(utils.GetTime().Now().UTC().UnixNano() / 1000)
 
 			vql, err := vfilter.Parse(query.VQL)
 			if err != nil {
-				query_log.Close()
 				return
 			}
 
@@ -423,7 +412,6 @@ func (self *EventTable) RunQuery(
 			for {
 				select {
 				case <-ctx.Done():
-					query_log.Close()
 					return
 
 				case <-time.After(utils.Jitter(
@@ -434,6 +422,7 @@ func (self *EventTable) RunQuery(
 
 				case row, ok := <-eval_chan:
 					if !ok {
+						// Remove this query immediately
 						query_log.Close()
 						break one_query
 					}
@@ -448,18 +437,18 @@ func (self *EventTable) RunQuery(
 						ctx, config_obj, event, journal_opts)
 				}
 			}
-			self.tracer.Clear(query.VQL)
-		}
 
+			// Remove the query from the tracer immediately as well as
+			// on exit. It is safe to call mulitple times.
+			self.Tracer().Clear(query.VQL)
+		}
 	}()
 
 	return nil
 }
 
 func (self *EventTable) startLoadFileLoop(
-	ctx context.Context,
-	wg *sync.WaitGroup, config_obj *config_proto.Config) error {
-	defer wg.Done()
+	ctx context.Context, config_obj *config_proto.Config) error {
 
 	notifier, err := services.GetNotifier(config_obj)
 	if err != nil {
@@ -481,7 +470,8 @@ func (self *EventTable) startLoadFileLoop(
 
 			notification, remove = notifier.ListenForNotification(
 				loadFileQueue(config_obj))
-			err := self.StartQueries(config_obj)
+
+			err := self.RestartQueries(config_obj)
 			if err != nil {
 				logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 				logger.Error("startLoadFileLoop: %v", err)
@@ -495,8 +485,6 @@ func (self *EventTable) Start(
 	ctx context.Context,
 	wg *sync.WaitGroup, config_obj *config_proto.Config) error {
 
-	defer wg.Done()
-
 	journal, err := services.GetJournal(config_obj)
 	if err != nil {
 		return err
@@ -504,7 +492,9 @@ func (self *EventTable) Start(
 
 	wg.Add(1)
 	go func() {
-		err := self.startLoadFileLoop(ctx, wg, config_obj)
+		defer wg.Done()
+
+		err := self.startLoadFileLoop(ctx, config_obj)
 		if err != nil {
 			logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 			logger.Error("startLoadFileLoop: %v", err)
@@ -575,12 +565,13 @@ func NewServerMonitoringService(
 	manager := &EventTable{
 		config_obj: config_obj,
 		parent_ctx: ctx,
-		wg:         &sync.WaitGroup{},
+		wg:         wg,
 		tracer:     NewQueryTracer(),
 	}
 
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer manager.Close()
 
 		err := manager.Start(ctx, wg, config_obj)

--- a/services/server_monitoring/server_monitoring_test.go
+++ b/services/server_monitoring/server_monitoring_test.go
@@ -498,7 +498,7 @@ sources:
 	})
 }
 
-// Test that modifiying artifacts quickly results in only one event
+// Test that modifying artifacts quickly results in only one event
 // table restart.
 func (self *ServerMonitoringTestSuite) TestUpdateDebounceWhenArtifactModified() {
 	run_count := int64(0)

--- a/services/server_monitoring/server_monitoring_test.go
+++ b/services/server_monitoring/server_monitoring_test.go
@@ -397,8 +397,8 @@ func (self *ServerMonitoringTestSuite) TestConcurrentUpdatesDoNotLeakQueries() {
 	wg.Wait()
 
 	// Now install an empty table - every started query must quit. If
-	// an update overwrote another updater's cancel function, the
-	// orphaned queries can never be cancelled and run_count stays
+	// an update overwrote the cancel function of a concurrent update,
+	// the orphaned queries can never be cancelled and run_count stays
 	// above zero.
 	err = event_table.Update(self.Ctx,
 		self.ConfigObj, "",

--- a/services/server_monitoring/server_monitoring_test.go
+++ b/services/server_monitoring/server_monitoring_test.go
@@ -3,7 +3,7 @@ package server_monitoring_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -156,7 +156,10 @@ func (self *ServerMonitoringTestSuite) TestMultipleArtifacts() {
 	assert.Equal(self.T(), "Server.Clock", configuration.Artifacts[0])
 
 	// Wait here until all the queries are done.
-	event_table.(*server_monitoring.EventTable).Wait()
+	tracer := event_table.(*server_monitoring.EventTable).Tracer()
+	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		return len(tracer.Dump()) == 0
+	})
 
 	// Expected Server.Clock rows:
 	// {"Foo":"Y","Foo2":"DefaultFoo2","BoolFoo":true,"_ts":1602103388}
@@ -215,8 +218,12 @@ func (self *ServerMonitoringTestSuite) TestAlertEvent() {
 		})
 	assert.NoError(self.T(), err)
 
+	tracer := event_table.(*server_monitoring.EventTable).Tracer()
+
 	// Wait here until all the queries are done.
-	event_table.(*server_monitoring.EventTable).Wait()
+	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		return len(tracer.Dump()) == 0
+	})
 
 	golden := ordereddict.NewDict()
 
@@ -268,9 +275,8 @@ sources:
 	assert.NoError(self.T(), err)
 
 	// Wait until the query is installed.
-	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
-		return len(event_table.(*server_monitoring.EventTable).Tracer().Dump()) > 0
-	})
+	tracer := event_table.(*server_monitoring.EventTable).Tracer()
+	assert.Equal(self.T(), 1, len(tracer.Dump()))
 
 	// Now install an empty table - all queries should quit.
 	err = event_table.Update(self.Ctx,
@@ -283,7 +289,7 @@ sources:
 
 	// Wait until all queries are done.
 	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
-		return len(event_table.(*server_monitoring.EventTable).Tracer().Dump()) == 0
+		return len(tracer.Dump()) == 0
 	})
 }
 
@@ -492,6 +498,73 @@ sources:
 	})
 }
 
+// Test that modifiying artifacts quickly results in only one event
+// table restart.
+func (self *ServerMonitoringTestSuite) TestUpdateDebounceWhenArtifactModified() {
+	run_count := int64(0)
+
+	vql_subsystem.OverridePlugin(
+		vfilter.GenericListPlugin{
+			PluginName: "register_run_count",
+			Function: func(
+				ctx context.Context, scope vfilter.Scope,
+				args *ordereddict.Dict) []vfilter.Row {
+
+				atomic.AddInt64(&run_count, 1)
+
+				return nil
+			},
+		})
+
+	manager, err := services.GetRepositoryManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	set_artifact := func(i int) {
+		_, err = manager.SetArtifactFile(self.Ctx, self.ConfigObj,
+			utils.GetSuperuserName(self.ConfigObj), fmt.Sprintf(`
+name: TestArtifactCount
+type: SERVER_EVENT
+sources:
+- query: |
+    SELECT * FROM register_run_count()
+    WHERE log(message="Step %%v!", dedup=-1, args=%d)
+`, i), "")
+
+		assert.NoError(self.T(), err)
+	}
+
+	set_artifact(0)
+
+	// Install a table with a an artifact that uses the plugin.
+	event_table, err := services.GetServerEventManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	err = event_table.Update(self.Ctx,
+		self.ConfigObj, "",
+		&flows_proto.ArtifactCollectorArgs{
+			Artifacts: []string{"TestArtifactCount"},
+			Specs:     []*flows_proto.ArtifactSpec{},
+		})
+	assert.NoError(self.T(), err)
+
+	// Wait here until the query is installed.
+	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		return atomic.LoadInt64(&run_count) == 1
+	})
+
+	// Add the new custom artifacts to the repository many times
+	for i := 0; i < 10; i++ {
+		set_artifact(i)
+	}
+
+	// Wait for the debounce to fire.
+	time.Sleep(time.Second)
+
+	// Overall we should run the query only one more time as all the
+	// others were debounced.
+	assert.Equal(self.T(), int64(2), atomic.LoadInt64(&run_count))
+}
+
 // Make sure watch monitoring can follow server event streams.
 func (self *ServerMonitoringTestSuite) TestWatchMonitoring() {
 	repository := self.LoadArtifacts(`
@@ -553,7 +626,7 @@ func readAll(filename string) string {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		return ""
 	}

--- a/services/server_monitoring/server_monitoring_test.go
+++ b/services/server_monitoring/server_monitoring_test.go
@@ -74,6 +74,11 @@ type: SERVER_EVENT
 sources:
 - query: SELECT * FROM register_run_count() WHERE log(message="Finished!", dedup=-1)
 `, `
+name: WaitForCancel2
+type: SERVER_EVENT
+sources:
+- query: SELECT * FROM register_run_count() WHERE log(message="Finished2!", dedup=-1)
+`, `
 name: EventTest.Alert
 type: SERVER_EVENT
 sources:
@@ -336,6 +341,74 @@ func (self *ServerMonitoringTestSuite) TestQueriesAreCancelled() {
 
 	// Wait until all queries are done and cancelled.
 	vtesting.WaitUntil(5*time.Second, self.T(), func() bool {
+		return atomic.LoadInt64(&run_count) == 0
+	})
+}
+
+// Concurrent updates must not orphan running queries: every query
+// that is started must be cancellable by a later update.
+func (self *ServerMonitoringTestSuite) TestConcurrentUpdatesDoNotLeakQueries() {
+	run_count := int64(0)
+
+	actions.QueryLog.Clear()
+
+	vql_subsystem.OverridePlugin(
+		vfilter.GenericListPlugin{
+			PluginName: "register_run_count",
+			Function: func(
+				ctx context.Context, scope vfilter.Scope,
+				args *ordereddict.Dict) []vfilter.Row {
+
+				atomic.AddInt64(&run_count, 1)
+
+				// Wait here until we get cancelled.
+				<-ctx.Done()
+				atomic.AddInt64(&run_count, -1)
+
+				return nil
+			},
+		})
+
+	event_table, err := services.GetServerEventManager(self.ConfigObj)
+	assert.NoError(self.T(), err)
+
+	// Hammer the table from several updaters, alternating between
+	// two artifact sets so every update really reloads the table.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			for j := 0; j < 10; j++ {
+				name := "WaitForCancel"
+				if (i+j)%2 == 0 {
+					name = "WaitForCancel2"
+				}
+				err := event_table.Update(self.Ctx,
+					self.ConfigObj, "",
+					&flows_proto.ArtifactCollectorArgs{
+						Artifacts: []string{name},
+					})
+				assert.NoError(self.T(), err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Now install an empty table - every started query must quit. If
+	// an update overwrote another updater's cancel function, the
+	// orphaned queries can never be cancelled and run_count stays
+	// above zero.
+	err = event_table.Update(self.Ctx,
+		self.ConfigObj, "",
+		&flows_proto.ArtifactCollectorArgs{
+			Artifacts: []string{},
+			Specs:     []*flows_proto.ArtifactSpec{},
+		})
+	assert.NoError(self.T(), err)
+
+	vtesting.WaitUntil(10*time.Second, self.T(), func() bool {
 		return atomic.LoadInt64(&run_count) == 0
 	})
 }


### PR DESCRIPTION
`EventTable._Close()` has to release `mu` while it waits for the old query goroutines to drain, because they call `Tracer()` (which takes `mu`) on their way out. But that opens a window: a concurrent `StartQueries()`, for example `set_server_monitoring` racing the artifact-modification reload loop can enter, start its own queries, and then have its `self.wg` and `self.cancel` overwritten when the first caller re-acquires the lock. The overwritten generation keeps running but is untracked and can never be cancelled. Every race costs one leaked generation; we hit this in production and saw the same SERVER_EVENT artifact collecting 6 times in parallel after a burst of table reloads.

The fix keeps the unlock-during-drain (it is required) and instead serializes updaters: a dedicated `update_mu` is held for the whole `StartQueries()`/`Close()` operation, so no second updater can enter the drain window, while `mu` stays free for the query goroutines' callbacks. Also fixes `Wait()` reading `self.wg` without the lock.

The new test (`TestConcurrentUpdatesDoNotLeakQueries`) runs four concurrent updaters alternating between two artifact sets and then installs an empty table. If any generation was orphaned its queries can never be cancelled and the live-query counter never drains. It fails on master in ~10 seconds and passes with this change. Note that it is a logic race, not a data race - every write happens under `mu`, so the race detector alone does not catch it, the test does. Full server_monitoring suite passes with `-race -tags server_vql`.

Full disclosure, same as my last PR (Velocidex/evtx#39): investigated and tested together with an AI assistant (Claude); I reviewed the analysis and the patch myself. This is the race I mentioned on Discord — it is what we were seeing at ThreatLight when spamming monitoring table updates.
