### PR TITLE
fix on Artifact Linux.Sys.Pslist : empty CreatedTime and RSS

### DIFF
--- a/artifacts/definitions/Linux/Sys/Pslist.yaml
+++ b/artifacts/definitions/Linux/Sys/Pslist.yaml
@@ -17,8 +17,8 @@ sources:
   - query: |
         SELECT Pid, Ppid, Name, CommandLine, Exe,
                hash(path=Exe) as Hash,
-               Username, timestamp(epoch=CreateTime/1000) AS CreatedTime,
-               MemoryInfo.RSS AS RSS,
+               Username, CreateTime,
+               MemoryInfo.rss AS RSS,
                Exe =~ "\\(deleted\\)$" AS Deleted
         FROM process_tracker_pslist()
         WHERE Name =~ processRegex


### PR DESCRIPTION
The artifact Linux.Sys.Pslist tries to parse `CreateTime` as a timestamp, when it is already provided as string by `process_tracker_pslist()`.
Also, `RSS` is stored lower case in `MemoryInfo`.