### PR TITLE
linux: fall back to direct /proc read for pslist(pid=X) on rootkit hidden processes

### DIFF
--- a/vql/psutils/process_freebsd_hidden.go
+++ b/vql/psutils/process_freebsd_hidden.go
@@ -1,0 +1,14 @@
+//go:build freebsd
+// +build freebsd
+
+package psutils
+
+import (
+	"context"
+
+	"github.com/Velocidex/ordereddict"
+)
+
+func GetProcessDirect(ctx context.Context, pid int32) (*ordereddict.Dict, error) {
+	return nil, NotImplementedError
+}

--- a/vql/psutils/process_linux_hidden.go
+++ b/vql/psutils/process_linux_hidden.go
@@ -1,0 +1,156 @@
+//go:build linux
+// +build linux
+
+package psutils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+)
+
+const clockTicksPerSecond = 100
+
+func GetProcessDirect(ctx context.Context, pid int32) (*ordereddict.Dict, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("invalid pid %d", pid)
+	}
+
+	procRoot := fmt.Sprintf("/proc/%d", pid)
+
+	statusBytes, err := os.ReadFile(procRoot + "/status")
+	if err != nil {
+		return nil, err
+	}
+
+	name, ppid, uid := parseProcStatus(statusBytes)
+
+	result := ordereddict.NewDict().SetCaseInsensitive().
+		Set("Pid", pid).
+		Set("Name", name).
+		Set("Ppid", ppid).
+		Set("CommandLine", readProcCmdline(procRoot+"/cmdline"))
+
+	// CreateTime: derived from /proc/<pid>/stat starttime + /proc/stat btime.
+	if createTime, ok := readProcCreateTime(procRoot + "/stat"); ok {
+		result.Set("CreateTime", createTime.Format(time.RFC3339))
+	} else {
+		result.Set("CreateTime", "")
+	}
+
+	// Exe and Cwd: readlink does not enumerate the parent directory.
+	exe, _ := os.Readlink(procRoot + "/exe")
+	result.Set("Exe", exe)
+
+	cwd, _ := os.Readlink(procRoot + "/cwd")
+	result.Set("Cwd", cwd)
+
+	result.Set("Username", lookupUsername(uid))
+
+	// Marker so artifacts can distinguish records recovered via the
+	// fallback path from records returned by the normal gopsutil path.
+	result.Set("HiddenProcess", true)
+
+	return result, nil
+}
+
+// parseProcStatus extracts Name, PPid and the real Uid from the contents of
+// /proc/<pid>/status. Returns ("", 0, -1) for missing fields.
+func parseProcStatus(data []byte) (name string, ppid int32, uid int) {
+	uid = -1
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "Name:"):
+			name = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+		case strings.HasPrefix(line, "PPid:"):
+			if v, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "PPid:"))); err == nil {
+				ppid = int32(v)
+			}
+		case strings.HasPrefix(line, "Uid:"):
+			// "Uid:\treal\teffective\tsaved\tfs"
+			fields := strings.Fields(strings.TrimPrefix(line, "Uid:"))
+			if len(fields) > 0 {
+				if v, err := strconv.Atoi(fields[0]); err == nil {
+					uid = v
+				}
+			}
+		}
+	}
+	return
+}
+
+func readProcCmdline(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	data = bytes.TrimRight(data, "\x00")
+	return strings.ReplaceAll(string(data), "\x00", " ")
+}
+
+func readProcCreateTime(statPath string) (time.Time, bool) {
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return time.Time{}, false
+	}
+	closeIdx := bytes.LastIndexByte(data, ')')
+	if closeIdx < 0 || closeIdx+2 >= len(data) {
+		return time.Time{}, false
+	}
+	fields := strings.Fields(string(data[closeIdx+1:]))
+	// After ')', "state" is index 0, so starttime (field 22 overall) is
+	// index 19 in this slice.
+	const starttimeIdx = 19
+	if len(fields) <= starttimeIdx {
+		return time.Time{}, false
+	}
+	startTicks, err := strconv.ParseUint(fields[starttimeIdx], 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	btime, ok := readBtime()
+	if !ok {
+		return time.Time{}, false
+	}
+	seconds := int64(startTicks / clockTicksPerSecond)
+	return time.Unix(int64(btime)+seconds, 0), true
+}
+
+func readBtime() (uint64, bool) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return 0, false
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "btime ") {
+			v, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "btime ")), 10, 64)
+			if err != nil {
+				return 0, false
+			}
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func lookupUsername(uid int) string {
+	if uid < 0 {
+		return ""
+	}
+	if u, err := user.LookupId(strconv.Itoa(uid)); err == nil {
+		return u.Username
+	}
+	return strconv.Itoa(uid)
+}

--- a/vql/psutils/process_linux_hidden_test.go
+++ b/vql/psutils/process_linux_hidden_test.go
@@ -1,0 +1,68 @@
+//go:build linux
+// +build linux
+
+package psutils
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseProcStatus(t *testing.T) {
+	data := strings.Join([]string{
+		"Name:\tsshd",
+		"Umask:\t0022",
+		"State:\tS (sleeping)",
+		"Tgid:\t1234",
+		"Ngid:\t0",
+		"Pid:\t1234",
+		"PPid:\t1",
+		"TracerPid:\t0",
+		"Uid:\t1000\t1000\t1000\t1000",
+		"Gid:\t1000\t1000\t1000\t1000",
+	}, "\n")
+
+	name, ppid, uid := parseProcStatus([]byte(data))
+	if name != "sshd" {
+		t.Fatalf("Name: got %q, want %q", name, "sshd")
+	}
+	if ppid != 1 {
+		t.Fatalf("Ppid: got %d, want 1", ppid)
+	}
+	if uid != 1000 {
+		t.Fatalf("Uid: got %d, want 1000", uid)
+	}
+}
+
+func TestParseProcStatusMissingFields(t *testing.T) {
+
+	data := "Name:\tonly-name\n"
+	name, ppid, uid := parseProcStatus([]byte(data))
+	if name != "only-name" {
+		t.Fatalf("Name: got %q", name)
+	}
+	if ppid != 0 {
+		t.Fatalf("Ppid default should be 0, got %d", ppid)
+	}
+	if uid != -1 {
+		t.Fatalf("Uid default should be -1, got %d", uid)
+	}
+}
+
+func TestReadProcCreateTime_AwkwardComm(t *testing.T) {
+	tmp := t.TempDir()
+	statPath := tmp + "/stat"
+
+	fields := make([]string, 22)
+	fields[0] = "S"
+	for i := 1; i < len(fields); i++ {
+		fields[i] = "0"
+	}
+	fields[19] = "12345"
+	content := "1 (weird ) name) " + strings.Join(fields, " ") + "\n"
+	if err := os.WriteFile(statPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = readProcCreateTime(statPath)
+}

--- a/vql/psutils/process_posix.go
+++ b/vql/psutils/process_posix.go
@@ -17,6 +17,9 @@ import (
 func GetProcess(ctx context.Context, pid int32) (*ordereddict.Dict, error) {
 	process_obj, err := process.NewProcessWithContext(ctx, pid)
 	if err != nil {
+		if direct, directErr := GetProcessDirect(ctx, pid); directErr == nil {
+			return direct, nil
+		}
 		return nil, err
 	}
 

--- a/vql/psutils/process_posix.go
+++ b/vql/psutils/process_posix.go
@@ -17,10 +17,26 @@ import (
 func GetProcess(ctx context.Context, pid int32) (*ordereddict.Dict, error) {
 	process_obj, err := process.NewProcessWithContext(ctx, pid)
 	if err != nil {
-		if direct, directErr := GetProcessDirect(ctx, pid); directErr == nil {
-			return direct, nil
+		p := &process.Process{
+			Pid: pid,
 		}
-		return nil, err
+		p.CreateTimeWithContext(ctx)
+
+		// Check if the process is really there.
+		_, errs := p.Status()
+		if errs != nil {
+			return nil, err
+		}
+
+		// Make the process as hidden
+		return getProcessData(p).
+			Set("Hidden", true), nil
+		/*
+			if direct, directErr := GetProcessDirect(ctx, pid); directErr == nil {
+				return direct, nil
+			}
+			return nil, err
+		*/
 	}
 
 	return getProcessData(process_obj), nil


### PR DESCRIPTION
## Summary
- Fixes #4761: `pslist(pid=X)` on Linux fails for processes hidden by LKM/eBPF rootkits that intercept gopsutil's existence probe, even though `/proc/<pid>/...` remains directly traversable.
- Adds a Linux-only direct `/proc` reader as a fallback when gopsutil's `process.NewProcessWithContext` errors.
- Normal visible-process behavior is unchanged: the fallback only runs on the error branch.

## Root cause
`GetProcess()` currently relies on `process.NewProcessWithContext()` for targeted PID lookups and the current Linux implementation in Velociraptor does not have a fallback path when that check fails.

In the scenario described in the issue above, some rootkits hide a process from the usual `/proc`-based existence checks, while direct access to `/proc/<pid>/status`, `/proc/<pid>/maps` or `/proc/<pid>/mem` can still succeed. As a result, `pslist(pid=X)` reports the process as missing even though targeted `/proc` access is still possible.