### PR TITLE
Force spinner to spin always.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -160,6 +160,12 @@ func (self *ApiServer) CollectArtifact(
 		return nil, Status(self.verbose, err)
 	}
 
+	// Allow a custom artifact to override the specified artifacts.
+	if in.AllowCustomOverrides {
+		ModifyRequestForCustomArtifacts(
+			ctx, org_config_obj, repository, request)
+	}
+
 	flow_id, err := launcher.ScheduleArtifactCollection(
 		ctx, org_config_obj, acl_manager, repository, request,
 		utils.BackgroundWriter)

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -851,3 +851,25 @@ func MakeCollectorRequest(
 
 	return result
 }
+
+func ModifyRequestForCustomArtifacts(
+	ctx context.Context,
+	config_obj *config_proto.Config,
+	repository services.Repository,
+	request *flows_proto.ArtifactCollectorArgs) {
+	for i, name := range request.Artifacts {
+		custom_name := "Custom." + name
+		_, pres := repository.Get(ctx, config_obj, custom_name)
+		if pres {
+			request.Artifacts[i] = custom_name
+		}
+	}
+
+	for _, spec := range request.Specs {
+		custom_name := "Custom." + spec.Artifact
+		_, pres := repository.Get(ctx, config_obj, custom_name)
+		if pres {
+			spec.Artifact = custom_name
+		}
+	}
+}

--- a/artifacts/definitions/Generic/Client/Info.yaml
+++ b/artifacts/definitions/Generic/Client/Info.yaml
@@ -199,7 +199,7 @@ reports:
 
       {{ define "computerinfo" }}
       LET X <= SELECT *
-        FROM source(source="LinuxInfo')
+        FROM source(source="LinuxInfo")
         LIMIT 1
 
       SELECT humanize(bytes=TotalPhysicalMemory) AS  TotalPhysicalMemory,

--- a/artifacts/testdata/windows/winobj.in.yaml
+++ b/artifacts/testdata/windows/winobj.in.yaml
@@ -2,7 +2,7 @@ Queries:
 # Resolve drive letter to kernel device names using winobj.
 - SELECT Name,
      split(sep_string="\\", string=Name)[-1] AS Drive,
-     upcase(string=SymlinkTarget) AS Target,
+     regex_replace(source=upcase(string=SymlinkTarget), re="\\d", replace="_") AS Target,
      len(list=SymlinkTarget) AS Len
   FROM winobj()
   WHERE Name =~ "^\\\\GLOBAL\\?\\?\\\\.:"

--- a/artifacts/testdata/windows/winobj.out.yaml
+++ b/artifacts/testdata/windows/winobj.out.yaml
@@ -1,17 +1,16 @@
 # Resolve drive letter to kernel device names using winobj.
-Query: SELECT Name, split(sep_string="\\", string=Name)[-1] AS Drive, upcase(string=SymlinkTarget) AS Target, len(list=SymlinkTarget) AS Len FROM winobj() WHERE Name =~ "^\\\\GLOBAL\\?\\?\\\\.:"
+Query: SELECT Name, split(sep_string="\\", string=Name)[-1] AS Drive, regex_replace(source=upcase(string=SymlinkTarget), re="\\d", replace="_") AS Target, len(list=SymlinkTarget) AS Len FROM winobj() WHERE Name =~ "^\\\\GLOBAL\\?\\?\\\\.:"
 Output: [
  {
   "Name": "\\GLOBAL??\\D:",
   "Drive": "D:",
-  "Target": "\\DEVICE\\HARDDISKVOLUME5",
+  "Target": "\\DEVICE\\HARDDISKVOLUME_",
   "Len": 23
  },
  {
   "Name": "\\GLOBAL??\\C:",
   "Drive": "C:",
-  "Target": "\\DEVICE\\HARDDISKVOLUME4",
+  "Target": "\\DEVICE\\HARDDISKVOLUME_",
   "Len": 23
  }
 ]
-

--- a/executor/pool.go
+++ b/executor/pool.go
@@ -85,8 +85,6 @@ func newPoolClientMux(ctx context.Context, config_obj *config_proto.Config) (*po
 
 	go func() {
 		for msg := range self.ClientExecutor.ReadResponse() {
-			utils.DlvBreak()
-
 			// Maybe cache the results in a transaction.
 			self.maybeCacheResult(msg)
 

--- a/gui/velociraptor/package-lock.json
+++ b/gui/velociraptor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "velociraptor",
-    "version": "0.76",
+    "version": "0.77",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/gui/velociraptor/package.json
+++ b/gui/velociraptor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "velociraptor",
-    "version": "0.76",
+    "version": "0.77",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/gui/velociraptor/src/components/clients/host-info.jsx
+++ b/gui/velociraptor/src/components/clients/host-info.jsx
@@ -401,7 +401,7 @@ class VeloHostInfo extends Component {
             return <div className="client-details dashboard">
                      <VeloReportViewer
                        artifact={this.props.client.last_interrogate_artifact_name ||
-                                 "Custom.Generic.Client.Info"}
+                                 "Generic.Client.Info"}
                        client={this.props.client}
                        type="CLIENT"
                        flow_id={this.props.client.last_interrogate_flow_id} />
@@ -427,49 +427,34 @@ class VeloHostInfo extends Component {
         if (this.state.interrogateOperationId) {
             return;
         }
-        let interrogate_artifact = "Custom.Generic.Client.Info";
-
-        // 1. Check for custom interrogate artifact
-        // 2. Launch the correct interrogate artifact
-        // 3. Wait for the flow to complete.
-        api.post("v1/GetArtifacts", {
-            fields: {name: true},
-            name: true,
-            number_of_results: 1000,
-            search_term: interrogate_artifact,
+        let interrogate_artifact = "Generic.Client.Info";
+        api.post("v1/CollectArtifact", {
+            urgent: true,
+            client_id: this.props.client.client_id,
+            allow_custom_overrides: true,
+            artifacts: [interrogate_artifact],
         }, this.source.token).then((response) => {
-            if (_.isEmpty(response.data.items)) {
-                interrogate_artifact = "Generic.Client.Info";
-            }
+            this.setState({interrogateOperationId: response.data.flow_id});
 
-            api.post("v1/CollectArtifact", {
-                urgent: true,
-                client_id: this.props.client.client_id,
-                allow_custom_overrides: true,
-                artifacts: [interrogate_artifact],
-            }, this.source.token).then((response) => {
-                this.setState({interrogateOperationId: response.data.flow_id});
+            // Start polling for flow completion.
+            this.interrogate_interval = setInterval(() => {
+                api.get("v1/GetFlowDetails", {
+                    client_id: this.props.client.client_id,
+                    flow_id: this.state.interrogateOperationId,
+                }, this.source.token).then((response) => {
+                    let context = response.data.context;
+                    if (!context || context.state === "RUNNING") {
+                        return;
+                    }
 
-                // Start polling for flow completion.
-                this.interrogate_interval = setInterval(() => {
-                    api.get("v1/GetFlowDetails", {
-                        client_id: this.props.client.client_id,
-                        flow_id: this.state.interrogateOperationId,
-                    }, this.source.token).then((response) => {
-                        let context = response.data.context;
-                        if (!context || context.state === "RUNNING") {
-                            return;
-                        }
+                    // The node is refreshed with the correct flow id,
+                    // we can stop polling.
+                    clearInterval(this.interrogate_interval);
+                    this.interrogate_interval = undefined;
 
-                        // The node is refreshed with the correct flow id,
-                        // we can stop polling.
-                        clearInterval(this.interrogate_interval);
-                        this.interrogate_interval = undefined;
-
-                        this.setState({interrogateOperationId: null});
-                    });
-                }, INTERROGATE_POLL_TIME);
-            });
+                    this.setState({interrogateOperationId: null});
+                });
+            }, INTERROGATE_POLL_TIME);
         });
     }
 

--- a/gui/velociraptor/src/components/docs/doc-button.jsx
+++ b/gui/velociraptor/src/components/docs/doc-button.jsx
@@ -169,6 +169,11 @@ class HelpDialog extends Component {
 
     renderTags = tags=>{
         return _.map(tags, (x, idx)=>{
+            // Limit the number of tags - some pages have a ridiculous
+            // number.
+            if(idx > 4) {
+                return <></>;
+            }
             return <Badge
                      onClick={()=>this.searchTag(x)}
                      className="tag"

--- a/gui/velociraptor/src/components/hunts/hunt-overview.jsx
+++ b/gui/velociraptor/src/components/hunts/hunt-overview.jsx
@@ -290,7 +290,7 @@ export default class HuntOverview extends React.Component {
                     onClick={this.recalcStats}
                     variant="outline-default">
                     <FontAwesomeIcon icon="refresh"
-                                     className={this.state.recal && "fa-spin"}/>
+                                     spin={this.state.recalc}/>
                   </Button>
                 </Card.Header>
                 <Card.Body>

--- a/gui/velociraptor/src/css/index.css
+++ b/gui/velociraptor/src/css/index.css
@@ -302,3 +302,18 @@ button.link {
     scrollbar-width: thin;
     scrollbar-color: var(--color-scrollbar-main) var(--color-scrollbar-background);
 }
+
+
+/* Ignore the FontAwesome prefers-reduced-motion setting - it just
+   looks like the page is broken when icons stop spinning.
+*/
+@media (prefers-reduced-motion: reduce) {
+  .fa-spin,
+  .fa-spin-pulse {
+      animation-name: fa-spin;
+      animation-direction: var(--fa-animation-direction, normal);
+      animation-duration: var(--fa-animation-duration, 1s);
+      animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+      animation-timing-function: var(--fa-animation-timing, steps(8));
+  }
+}

--- a/services/client_monitoring/client_monitoring.go
+++ b/services/client_monitoring/client_monitoring.go
@@ -398,9 +398,6 @@ func (self *ClientEventTable) ProcessArtifactModificationEvent(
 		return
 	}
 
-	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
-	logger.Debug("<green>Updating Client Event Table</> because %v was updated", modified_name)
-
 	setter, _ := event.GetString("setter")
 
 	// Determine if the modified artifact affects us.

--- a/services/launcher/journal.go
+++ b/services/launcher/journal.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/Velocidex/ordereddict"
-	"github.com/kaptinlin/messageformat-go/pkg/logger"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/file_store"
 	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/result_sets"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -131,9 +131,10 @@ func (self *FlowStorageManager) RemoveFlowsFromJournal(
 		file_store_factory, paths.FLOWS_JOUNRNAL)
 
 	// No journal there is nothing to do.
-	if err != nil {
+	if err != nil || journal_reader.TotalRows() == 0 {
 		return nil
 	}
+
 	for row := range journal_reader.Rows(ctx) {
 		client_id, _ := row.GetString("ClientId")
 		if client_id == "" {
@@ -155,6 +156,11 @@ func (self *FlowStorageManager) RemoveFlowsFromJournal(
 	}
 	journal_reader.Close()
 
+	// Nothing to do.
+	if len(id_map) == 0 {
+		return nil
+	}
+
 	var r_err error
 	for client_id, flows := range id_map {
 		err := self.RemoveClientFlowsFromIndex(ctx, config_obj, client_id, flows)
@@ -163,8 +169,9 @@ func (self *FlowStorageManager) RemoveFlowsFromJournal(
 		}
 	}
 
+	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
 	logger.Debug("<green>FlowStorageManager</> housekeeping run (%v): Reindexed %v flows",
-		utils.GetOrgId(config_obj), (id_map))
+		utils.GetOrgId(config_obj), len(id_map))
 
 	// Only clear the journal if all reindex operations are successful.
 	if r_err == nil {

--- a/services/server_monitoring/server_monitoring.go
+++ b/services/server_monitoring/server_monitoring.go
@@ -99,10 +99,6 @@ func (self *EventTable) ProcessArtifactModificationEvent(
 		return
 	}
 
-	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
-	logger.Info("server_monitoring: Reloading table because artifact %v was updated",
-		modified_name)
-
 	notifier, err := services.GetNotifier(config_obj)
 	if err == nil {
 		notifier.NotifyDirectListener(loadFileQueue(config_obj))
@@ -118,9 +114,6 @@ func (self *EventTable) ProcessServerMetadataModificationEvent(
 	if !pres || client_id != constants.VELOCIRAPTOR_SERVER_CLIENT_ID {
 		return
 	}
-
-	logger := logging.GetLogger(self.config_obj, &logging.FrontendComponent)
-	logger.Info("<green>server_monitoring</>: Reloading table because server metadata was updated")
 
 	notifier, err := services.GetNotifier(config_obj)
 	if err == nil {


### PR DESCRIPTION
Recent FontAwesome switched the spinner off when the OS setting prefers-reduced-motion is set to reduced. This causes the application to appear broken and unresponsive without the spinner feedback. This PR forces the spinner to work even if the prefers-reduced-motion is set.

Also this PR fixes the substitution of the custom Generic.Client.Info from the GUI interrogate screen.