### PR TITLE
Remove the use of the non-existing field "Fqdn" from Linux.Users.InteractiveUsers and Linux.Users.RootUsers

### DIFF
--- a/artifacts/definitions/Linux/Users/InteractiveUsers.yaml
+++ b/artifacts/definitions/Linux/Users/InteractiveUsers.yaml
@@ -20,12 +20,11 @@ sources:
       WHERE OS = 'linux'
 
     query: |
-      SELECT Fqdn AS Host,
-              User,
-              Description,
-              Uid,
-              Gid,
-              Homedir,
-              Shell 
+      SELECT User,
+             Description,
+             Uid,
+             Gid,
+             Homedir,
+             Shell 
       FROM Artifact.Linux.Sys.Users()
       WHERE NOT Shell IN split(string=NonInteractiveExecutables, sep_string=",")

--- a/artifacts/definitions/Linux/Users/RootUsers.yaml
+++ b/artifacts/definitions/Linux/Users/RootUsers.yaml
@@ -24,8 +24,7 @@ sources:
           FROM Artifact.Linux.Sys.Users()
         },
         query={
-          SELECT Fqdn AS Host,
-                 User,
+          SELECT User,
                  Description,
                  Uid,
                  Gid,


### PR DESCRIPTION
Both the artifact Linux.Users.InteractiveUsers and Linux.Users.RootUsers try to extract "Fqdn" from Artifact.Linux.Sys.Users no such field exist.

The fix was to remove it from the VQL queries to avoid warnings at execution.