### PR TITLE
Fix artifact pack upload silently swallowing errors

### DIFF
--- a/gui/velociraptor/src/components/artifacts/artifacts-upload.jsx
+++ b/gui/velociraptor/src/components/artifacts/artifacts-upload.jsx
@@ -35,6 +35,7 @@ export default class ArtifactsUpload extends React.Component {
         // after upload the server will cache the file here.
         vfs_path: [],
         errors: [],
+        imported: [],
     }
 
     componentDidMount() {
@@ -110,7 +111,8 @@ export default class ArtifactsUpload extends React.Component {
 
                      this.setState({loading:false,
                                     vfs_path: response.data.vfs_path,
-                                    uploaded: uploaded});
+                                    uploaded: uploaded,
+                                    errors: response.data.errors || []});
                  }).catch(err=>{
                      this.setState({loading: false});
                  });
@@ -129,6 +131,14 @@ export default class ArtifactsUpload extends React.Component {
                  this.source.token).then(response => {
                      if (response.data.cancel) {
                          return ;
+                     }
+                     let errors = response.data.errors || [];
+                     let imported = response.data.successful_artifacts || [];
+                     if (errors.length > 0) {
+                         this.setState({loading: false,
+                                        errors: errors,
+                                        imported: imported});
+                         return;
                      }
                      this.props.onClose();
                  }).catch(response=>{
@@ -240,6 +250,11 @@ export default class ArtifactsUpload extends React.Component {
                         no_toolbar={true}
                       />
                     </Form> }
+
+                  { this.state.imported.length > 0 &&
+                    <Alert variant="success">
+                      {T("Successfully imported")} {this.state.imported.length}
+                    </Alert> }
 
                   { this.state.errors.length > 0 &&
                     <Container className="artifact-import-errors">


### PR DESCRIPTION
LoadArtifactPack returned per-file validation errors, but the upload dialog never surfaced them, so bad artifacts were silently dropped. Also show a success message after import instead of leaving the dialog looking like nothing happened when some artifacts fail.

Before the fix:
<img width="1176" height="743" alt="image" src="https://github.com/user-attachments/assets/b2545f03-900d-492a-9803-ccf3808cce9b" />

After:
<img width="1176" height="743" alt="image" src="https://github.com/user-attachments/assets/2909b59f-6cf6-4239-8d5d-a7fc6ba3a330" />