### PR TITLE
json: fix writeJsonObject emitting bare } for an empty object

### DIFF
--- a/json/csv.go
+++ b/json/csv.go
@@ -220,8 +220,11 @@ func writeJsonObject(
 		}
 	}
 
-	if len(buf) == 0 {
-		buf = append(buf, '{', '}')
+	// Only the opening brace was written (no object keys and no extra
+	// keys), so close it as an empty object rather than clobbering the
+	// opening brace.
+	if len(buf) == 1 {
+		buf = append(buf, '}', '\n')
 		return buf
 	}
 

--- a/json/csv_test.go
+++ b/json/csv_test.go
@@ -2,6 +2,7 @@ package json_test
 
 import (
 	"bytes"
+	stdjson "encoding/json"
 	"fmt"
 	"testing"
 
@@ -17,6 +18,24 @@ import (
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
 	"www.velocidex.com/golang/velociraptor/vtesting/goldie"
 )
+
+// An empty object with a non-nil (but empty) extra_data Dict used to
+// serialize to a bare "}" which is not valid JSON. It should round
+// trip as "{}".
+func TestConvertJSONLEmptyObject(t *testing.T) {
+	json_in := make(chan []byte, 1)
+	json_in <- []byte("{}\n")
+	close(json_in)
+
+	out := &bytes.Buffer{}
+	json.ConvertJSONL(json_in, out, nil, ordereddict.NewDict())
+
+	assert.Equal(t, "{}\n", out.String())
+
+	var decoded map[string]interface{}
+	err := stdjson.Unmarshal(bytes.TrimSpace(out.Bytes()), &decoded)
+	assert.NoError(t, err)
+}
 
 type CSVUtilsTestSuite struct {
 	test_utils.TestSuite


### PR DESCRIPTION
An empty JSON object serializes to a bare `}`, which isn't valid JSON. In writeJsonObject the buffer always starts with the opening brace, so the `len(buf) == 0` guard can never fire. When the object has no keys and there are no extra columns, the buffer stays exactly `{` and the final `buf[len(buf)-1] = '}'` overwrites that opening brace, so the line comes out as `}` instead of `{}`.

The fix checks for `len(buf) == 1` (only the opening brace was written) and closes it as `{}` with a trailing newline to match the normal path. Nothing changes for objects that have keys or extra columns.

I added a small regression test that pushes an empty object through ConvertJSONL with a non-nil extra_data dict and confirms the line round trips as valid JSON. It failed before the change and passes after, and the existing json suite still passes. Thanks for taking a look.
