### PR TITLE
fix: add missing columns to stateful shell ack rows

### DIFF
--- a/artifacts/definitions/Linux/Sys/BashShell.yaml
+++ b/artifacts/definitions/Linux/Sys/BashShell.yaml
@@ -67,8 +67,13 @@ sources:
 
       // Always send the command id to ack we received the command.
       SELECT * FROM chain(a={
-         SELECT CommandId,
-                timestamp(epoch=now(ns=TRUE)) AS Timestamp
+         SELECT "" AS Command,
+                CommandId,
+                timestamp(epoch=now(ns=TRUE)) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
          FROM scope()
       }, b=Result)
 

--- a/artifacts/definitions/Windows/System/CmdShell.yaml
+++ b/artifacts/definitions/Windows/System/CmdShell.yaml
@@ -69,8 +69,13 @@ sources:
 
       // Always send the command id to ack we received the command.
       SELECT * FROM chain(a={
-         SELECT CommandId,
-                timestamp(epoch=now(ns=TRUE)) AS Timestamp
+         SELECT "" AS Command,
+                CommandId,
+                timestamp(epoch=now(ns=TRUE)) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
          FROM scope()
       }, b=Result)
 

--- a/artifacts/definitions/Windows/System/PowerShell.yaml
+++ b/artifacts/definitions/Windows/System/PowerShell.yaml
@@ -80,8 +80,13 @@ sources:
 
       // Always send the command id to ack we received the command.
       SELECT * FROM chain(a={
-         SELECT CommandId,
-                timestamp(epoch=now(ns=TRUE)) AS Timestamp
+         SELECT "" AS Command,
+                CommandId,
+                timestamp(epoch=now(ns=TRUE)) AS Timestamp,
+                "" AS Stdout,
+                NULL AS StdoutUpload,
+                "" AS Stderr,
+                NULL AS StderrUpload
          FROM scope()
       }, b=Result)
 


### PR DESCRIPTION
Fixes #4914. Stateful shell session path lacked Stdout/Stderr columns, causing transcript notebook to fail with Symbol not found. Added placeholder columns to all 3 shell artifacts.