### PR TITLE
fix: update artifact default timeout behaviour

### DIFF
--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -336,8 +336,8 @@ func (self *Launcher) CompileCollectorArgs(
 				vql_collector_args.IopsLimit = collector_request.IopsLimit
 			}
 
-			if vql_collector_args.Timeout == 0 &&
-				collector_request.Timeout > 0 {
+			// If there is a timeout set on the collection, use that, otherwise default to the artifact timeout.
+			if collector_request.Timeout > 0 {
 				vql_collector_args.Timeout = collector_request.Timeout
 			}
 

--- a/services/launcher/launcher_test.go
+++ b/services/launcher/launcher_test.go
@@ -1294,7 +1294,7 @@ sources:
 		services.CompilerOptions{}, request)
 	assert.NoError(self.T(), err)
 	assert.Equal(self.T(), getReqName(compiled[0]), "Test.Artifact.Timeout")
-	assert.Equal(self.T(), compiled[0].Timeout, uint64(5))
+	assert.Equal(self.T(), compiled[0].Timeout, uint64(20))
 
 	assert.Equal(self.T(), getReqName(compiled[1]), "Test.Artifact.MaxRows")
 	assert.Equal(self.T(), compiled[1].Timeout, uint64(20))


### PR DESCRIPTION
This pull request makes a minor change to the artifact timeout handling which brings its behaviour inline with user expectation that defining a timeout on a collection overrides any default timeouts defined on individual artifacts.

Currently, if a default timeout is specified on an artifact through its definition (such as below), any changes to the timeout specified by the user in the collection are not reflected in the request sent to the client.

```
resources:
  timeout: 3600
```

This leads to unexpected behaviour such as the query timing out after the timeout specified on the collection, or, if a longer timeout is specified on the collection, the query will timeout before the collection times out, shown below.

<img width="588" height="205" alt="image" src="https://github.com/user-attachments/assets/7268df0e-9ab7-40d0-889d-087d6ace9c36" />
<img width="547" height="206" alt="image" src="https://github.com/user-attachments/assets/c8ffd610-5bed-4893-91cd-01944410e2a8" />

The [resources documentation](https://docs.velociraptor.app/docs/artifacts/advanced_fields/#-resources-) describes these as "defaults", but as a user, I would expect that defining a timeout on the collection would override any default timeouts that are set on individual artifacts.

I can see the use case for defining these default timeouts for individual artifacts, but maybe there's a way that we can support both behaviours? Let me know your thoughts!