### PR TITLE
fix: refresh cached tool hashes

### DIFF
--- a/services/inventory/fixtures/TestGihubToolServedLocally.golden
+++ b/services/inventory/fixtures/TestGihubToolServedLocally.golden
@@ -10,6 +10,9 @@
     "value": "file.exe"
    },
    {
+    "key": "Tool_SampleTool_VERSION"
+   },
+   {
     "key": "Tool_SampleTool_URL",
     "value": "https://localhost:8000/public/dbdbc5e2ae775342ae9189803757a07b20daf0b04a25cda9d97a99785d75ec3b"
    },

--- a/services/inventory/fixtures/TestGihubTools.golden
+++ b/services/inventory/fixtures/TestGihubTools.golden
@@ -30,6 +30,9 @@
     "value": "file.exe"
    },
    {
+    "key": "Tool_SampleTool_VERSION"
+   },
+   {
     "key": "Tool_SampleTool_URL",
     "value": "htttp://www.example.com/file.exe"
    },

--- a/services/inventory/fixtures/TestGihubToolsUninitialized.golden
+++ b/services/inventory/fixtures/TestGihubToolsUninitialized.golden
@@ -10,6 +10,9 @@
     "value": "file.exe"
    },
    {
+    "key": "Tool_SampleTool_VERSION"
+   },
+   {
     "key": "Tool_SampleTool_URL",
     "value": "htttp://www.example.com/file.exe"
    },

--- a/services/inventory/fixtures/TestMultipleSemanticVersions.golden
+++ b/services/inventory/fixtures/TestMultipleSemanticVersions.golden
@@ -4,7 +4,7 @@
   "url": "http://www.example.com/SampleTool0.6.5-rc2.exe",
   "version": "0.6.5-rc2",
   "artifact": "TestArtifactSemver2",
-  "filestore_path": "2f30b410203dd2aec421b39bad6e2d4f998d8087756d171c22538d40f8a8f559",
+  "filestore_path": "dcd615de21e82e31fbe4b3207971dbd61cc98a5d3a8f5e594ceef41c83c2c868",
   "serve_url": "http://www.example.com/SampleTool0.6.5-rc2.exe",
   "serve_urls": [
    "http://www.example.com/SampleTool0.6.5-rc2.exe"
@@ -31,7 +31,7 @@
   "url": "http://www.example.com/ConflictingVersion.exe",
   "version": "0.6.5-rc2",
   "artifact": "TestArtifactConflictingVersion",
-  "filestore_path": "2f30b410203dd2aec421b39bad6e2d4f998d8087756d171c22538d40f8a8f559",
+  "filestore_path": "dcd615de21e82e31fbe4b3207971dbd61cc98a5d3a8f5e594ceef41c83c2c868",
   "serve_url": "http://www.example.com/ConflictingVersion.exe",
   "serve_urls": [
    "http://www.example.com/ConflictingVersion.exe"

--- a/services/inventory/inventory.go
+++ b/services/inventory/inventory.go
@@ -532,7 +532,12 @@ func (self *InventoryService) AddTool(
 	// Obfuscate the public directory path.
 	// Make a copy to work on.
 	tool := proto.Clone(tool_request).(*artifacts_proto.Tool)
-	tool.FilestorePath = paths.ObfuscateName(config_obj, tool.Name)
+
+	if tool.Version == "" {
+		tool.FilestorePath = paths.ObfuscateName(config_obj, tool.Name)
+	} else {
+		tool.FilestorePath = paths.ObfuscateName(config_obj, fmt.Sprintf("%s:%s", tool.Name, tool.Version))
+	}
 
 	// No client config so we don't know any server urls - therefore we
 	// can not serve locally at all.

--- a/services/inventory/inventory_test.go
+++ b/services/inventory/inventory_test.go
@@ -194,8 +194,8 @@ tools:
 	assert.Equal(self.T(), "TestArtifact", tool.Versions[0].Artifact)
 
 	// Make sure the tool is served directly from upstream.
-	assert.Equal(self.T(), response[0].Env[2].Key, "Tool_SampleTool_URL")
-	assert.Equal(self.T(), response[0].Env[2].Value, "htttp://www.example.com/file.exe")
+	assert.Equal(self.T(), response[0].Env[3].Key, "Tool_SampleTool_URL")
+	assert.Equal(self.T(), response[0].Env[3].Value, "htttp://www.example.com/file.exe")
 
 	assert.Equal(self.T(), response[0].Env[0].Key, "Tool_SampleTool_HASH")
 	assert.Equal(self.T(), response[0].Env[0].Value,
@@ -355,8 +355,8 @@ tools:
 	assert.NoError(self.T(), err)
 
 	// Make sure the tool is served directly from the public directory.
-	assert.Equal(self.T(), response[0].Env[2].Key, "Tool_SampleTool_URL")
-	assert.Contains(self.T(), response[0].Env[2].Value, "https://localhost:8000/")
+	assert.Equal(self.T(), response[0].Env[3].Key, "Tool_SampleTool_URL")
+	assert.Contains(self.T(), response[0].Env[3].Value, "https://localhost:8000/")
 
 	inventory_service, err := services.GetInventory(self.ConfigObj)
 	assert.NoError(self.T(), err)
@@ -764,7 +764,7 @@ tools:
 
 	assert.Equal(self.T(), response[0].Env[0].Value,
 		getHash("File Content 1"))
-	assert.Equal(self.T(), response[0].Env[2].Value,
+	assert.Equal(self.T(), response[0].Env[3].Value,
 		"http://www.example.com/SampleTool1.exe")
 
 	response, err = launcher.CompileCollectorArgs(
@@ -777,7 +777,7 @@ tools:
 
 	assert.Equal(self.T(), response[0].Env[0].Value,
 		getHash("File Content 2"))
-	assert.Equal(self.T(), response[0].Env[2].Value,
+	assert.Equal(self.T(), response[0].Env[3].Value,
 		"http://www.example.com/SampleTool2.exe")
 }
 

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -534,18 +534,6 @@ func (self *Launcher) EnsureToolsDeclared(
 	return nil
 }
 
-// Update an existing VQLEnv if it exists, otherwise append it.
-func upsertVqlEnv(existing []*actions_proto.VQLEnv, env *actions_proto.VQLEnv) []*actions_proto.VQLEnv {
-	for idx, item := range existing {
-		if item.Key == env.Key {
-			existing[idx] = env
-			return existing
-		}
-	}
-
-	return append(existing, env)
-}
-
 func AddToolDependency(
 	ctx context.Context,
 	config_obj *config_proto.Config,
@@ -560,43 +548,43 @@ func AddToolDependency(
 		return err
 	}
 
-	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+	vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 		Key:   fmt.Sprintf("Tool_%v_HASH", tool_info.Name),
 		Value: tool_info.Hash,
 	})
 
-	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+	vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 		Key:   fmt.Sprintf("Tool_%v_FILENAME", tool_info.Name),
 		Value: tool_info.Filename,
 	})
 
 	// Support local filesystem access for local tools.
 	if tool_info.ServePath != "" {
-		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_PATH", tool_info.Name),
 			Value: tool_info.ServePath,
 		})
 
 	} else if len(tool_info.ServeUrls) > 0 {
-		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URL", tool_info.Name),
 			Value: tool_info.ServeUrls[0],
 		})
 
 		serialized_urls := json.MustMarshalString(tool_info.ServeUrls)
-		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URLs", tool_info.Name),
 			Value: serialized_urls,
 		})
 
 	} else if tool_info.Url != "" {
-		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URL", tool_info.Name),
 			Value: tool_info.Url,
 		})
 
 		serialized_urls := json.MustMarshalString([]string{tool_info.Url})
-		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URLs", tool_info.Name),
 			Value: serialized_urls,
 		})
@@ -635,21 +623,6 @@ func (self *Launcher) ScheduleArtifactCollection(
 			return "", err
 		}
 		args = append(args, compiled...)
-	} else {
-		// Collector args are cached for performance but may contain stale tool information.
-		// This ensures that before an artifact is scheduled, it has the most up-to-date tool data.
-		for idx, arg := range args {
-			_artifacts := arg.GetArtifacts()
-
-			for _, artifact := range _artifacts {
-				for _, tool := range artifact.Tools {
-					err := AddToolDependency(ctx, config_obj, tool.Name, tool.Version, args[idx])
-					if err != nil {
-						return "", err
-					}
-				}
-			}
-		}
 	}
 
 	return self.WriteArtifactCollectionRecord(

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -534,6 +534,18 @@ func (self *Launcher) EnsureToolsDeclared(
 	return nil
 }
 
+// Update an existing VQLEnv if it exists, otherwise append it.
+func upsertVqlEnv(existing []*actions_proto.VQLEnv, env *actions_proto.VQLEnv) []*actions_proto.VQLEnv {
+	for idx, item := range existing {
+		if item.Key == env.Key {
+			existing[idx] = env
+			return existing
+		}
+	}
+
+	return append(existing, env)
+}
+
 func AddToolDependency(
 	ctx context.Context,
 	config_obj *config_proto.Config,
@@ -548,43 +560,48 @@ func AddToolDependency(
 		return err
 	}
 
-	vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 		Key:   fmt.Sprintf("Tool_%v_HASH", tool_info.Name),
 		Value: tool_info.Hash,
 	})
 
-	vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
+		Key:   fmt.Sprintf("Tool_%v_HASH", tool_info.Name),
+		Value: tool_info.Hash,
+	})
+
+	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 		Key:   fmt.Sprintf("Tool_%v_FILENAME", tool_info.Name),
 		Value: tool_info.Filename,
 	})
 
 	// Support local filesystem access for local tools.
 	if tool_info.ServePath != "" {
-		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_PATH", tool_info.Name),
 			Value: tool_info.ServePath,
 		})
 
 	} else if len(tool_info.ServeUrls) > 0 {
-		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URL", tool_info.Name),
 			Value: tool_info.ServeUrls[0],
 		})
 
 		serialized_urls := json.MustMarshalString(tool_info.ServeUrls)
-		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URLs", tool_info.Name),
 			Value: serialized_urls,
 		})
 
 	} else if tool_info.Url != "" {
-		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URL", tool_info.Name),
 			Value: tool_info.Url,
 		})
 
 		serialized_urls := json.MustMarshalString([]string{tool_info.Url})
-		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 			Key:   fmt.Sprintf("Tool_%v_URLs", tool_info.Name),
 			Value: serialized_urls,
 		})
@@ -623,6 +640,21 @@ func (self *Launcher) ScheduleArtifactCollection(
 			return "", err
 		}
 		args = append(args, compiled...)
+	} else {
+		// Collector args are cached for performance but may contain stale tool information.
+		// This ensures that before an artifact is scheduled, it has the most up-to-date tool data.
+		for idx, arg := range args {
+			_artifacts := arg.GetArtifacts()
+
+			for _, artifact := range _artifacts {
+				for _, tool := range artifact.Tools {
+					err := AddToolDependency(ctx, config_obj, tool.Name, tool.Version, args[idx])
+					if err != nil {
+						return "", err
+					}
+				}
+			}
+		}
 	}
 
 	return self.WriteArtifactCollectionRecord(

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -558,6 +558,11 @@ func AddToolDependency(
 		Value: tool_info.Filename,
 	})
 
+	vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{
+		Key:   fmt.Sprintf("Tool_%v_VERSION", tool_info.Name),
+		Value: tool_info.Version,
+	})
+
 	// Support local filesystem access for local tools.
 	if tool_info.ServePath != "" {
 		vql_collector_args.Env = append(vql_collector_args.Env, &actions_proto.VQLEnv{

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -566,11 +566,6 @@ func AddToolDependency(
 	})
 
 	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
-		Key:   fmt.Sprintf("Tool_%v_HASH", tool_info.Name),
-		Value: tool_info.Hash,
-	})
-
-	vql_collector_args.Env = upsertVqlEnv(vql_collector_args.Env, &actions_proto.VQLEnv{
 		Key:   fmt.Sprintf("Tool_%v_FILENAME", tool_info.Name),
 		Value: tool_info.Filename,
 	})

--- a/services/notebook/fixtures/TestNotebookFromTemplate.golden
+++ b/services/notebook/fixtures/TestNotebookFromTemplate.golden
@@ -60,6 +60,9 @@
       "value": "www.google.com"
      },
      {
+      "key": "Tool_SomeTool_VERSION"
+     },
+     {
       "key": "Tool_SomeTool_URL",
       "value": "https://localhost:8000/public/152038a5bc46cb8fc68ee6eac0269c6a3fba574c4a96a650ed26aa9b02b1cb64"
      },
@@ -171,6 +174,9 @@
      {
       "key": "Tool_SomeTool_FILENAME",
       "value": "www.google.com"
+     },
+     {
+      "key": "Tool_SomeTool_VERSION"
      },
      {
       "key": "Tool_SomeTool_URL",


### PR DESCRIPTION
This pull request addresses an edge case that we encountered recently where a hunt was scheduled with an artifact containing a tool definition, but the tool definition was changed before the collection was scheduled on the host. This led to a hash mismatch when the tool was fetched on a client and subsequently caused the collection to fail.

My proposed solution to this scenario is to refresh the tool dependencies when a collection is scheduled and the request contains pre-compiled collector args. Of course this comes with a slight overhead of having to query the inventory and update the request, but hopefully this shouldn't slow down the scheduling process too much.

I have also added an `upsertVqlEnv` helper function to prevent code duplication when refreshing the tool dependencies in `ScheduleArtifactCollection` and to ensure that the `VQLEnv` is only added once.

Let me know if I've overlooked anything or this causes any unintended side-effects.

