### PR TITLE
Add Acronis Cyber Protect to Windows.System.CriticalServices

### DIFF
--- a/artifacts/definitions/Windows/System/CriticalServices.yaml
+++ b/artifacts/definitions/Windows/System/CriticalServices.yaml
@@ -24,6 +24,10 @@ parameters:
        SavService
        wscsvc
        wuauserv
+       AcronisCyberProtectionService
+       AcronisActiveProtectionService
+       aakore
+       AcrSch2Svc
 
 sources:
      - query: |


### PR DESCRIPTION
This artifact flags when a critical security service has stopped running, but the default lookup table only covers Defender, Symantec, and Sophos. Added Acronis Cyber Protect's current service names so a stopped Acronis agent gets flagged the same way:

- AcronisCyberProtectionService
- AcronisActiveProtectionService
- aakore
- AcrSch2Svc

Service names are from Acronis's own KB docs on Cyber Protect's installed services. Just a 4-line addition to the existing CSV lookup table, validated that the YAML still parses correctly.