### PR TITLE
Bugfix: Only set ORG_ADMIN permission on the root org.

### DIFF
--- a/api/tables/table.go
+++ b/api/tables/table.go
@@ -235,6 +235,17 @@ func getStackTable(
 		in.Rows = 100
 	}
 
+	// The caller asked for rows after the last one. We don't really
+	// know the columns because reading past the end of the table will
+	// give no rows. So for this case we read the first row and return
+	// the columns from there.
+	if in.StartRow > uint64(result.TotalRows) {
+		res := ConvertRowsToTableResponse(
+			rs_reader.Rows(ctx), result, in.Timezone, 1)
+		res.Rows = nil
+		return res, nil
+	}
+
 	// Seek to the row we need.
 	err = rs_reader.SeekToRow(int64(in.StartRow))
 	if errors.Is(err, io.EOF) {

--- a/docs/references/server.config.yaml
+++ b/docs/references/server.config.yaml
@@ -1051,7 +1051,7 @@ Datastore:
   # The maximum size of stored objects in the datastore. The Datastore
   # is assumed to contain smallish objects which are read and written
   # atomically. This setting places a limit on the size of these
-  # objects to mainain efficiency and speed. If you hit this limit it
+  # objects to maintain efficiency and speed. If you hit this limit it
   # means that you need to rethink your approach. See
   # https:docs.velociraptor.app/knowledge_base/tips/grpc_errors/ The
   # default size is 4Mb.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -407,7 +407,7 @@ func (self *ExecutorTestSuite) TestLogMessages() {
 	// collect the log messages and ensure they are all batched in one response.
 	log_messages := []*crypto_proto.LogMessage{}
 
-	vtesting.WaitUntil(2*time.Second, self.T(), func() bool {
+	vtesting.WaitUntilWithError(2*time.Second, self.T(), func() bool {
 		var total_messages uint64
 		log_messages = nil
 
@@ -423,6 +423,8 @@ func (self *ExecutorTestSuite) TestLogMessages() {
 		}
 
 		return total_messages > 10
+	}, func() string {
+		return string(json.MustMarshalIndent(collector.Messages()))
 	})
 
 	// Log messages should be combined into few messages.

--- a/gui/velociraptor/src/components/core/api-service.jsx
+++ b/gui/velociraptor/src/components/core/api-service.jsx
@@ -326,6 +326,18 @@ const href = function(url, params, options) {
 
     let parsed = parse_url(url);
 
+    // Only support http and https schemes.
+    switch(parsed.protocol) {
+    case "":
+    case "http:":
+    case "https:":
+        break;
+
+        // Unsupported protocols.
+    default:
+        return "#";
+    }
+
     // The params form the query string (after ? and before #)
     params = Object.assign(parsed.params, params || {});
 

--- a/gui/velociraptor/src/components/core/paged-table.jsx
+++ b/gui/velociraptor/src/components/core/paged-table.jsx
@@ -327,7 +327,8 @@ export class TablePaginationControl extends React.Component {
         // The current cursor points beyond the end of the table, seek
         // to the last page. This can happen if the table suddenly
         // shrinks.
-        if (this.props.start_row > this.props.total_size) {
+        if (this.props.total_size >= 0 &&
+            this.props.start_row > this.props.total_size) {
             let last_page = this.getLastPage();
             let last_row = last_page * this.props.page_size;
             if(last_row !== this.props.start_row) {
@@ -407,7 +408,8 @@ export class TablePaginationControl extends React.Component {
                                variant="default"
                                key={i}
                                active={i === current_page}
-                               onClick={ () => this.props.onRowChange(row_offset)} >
+                               onClick={ () => this.props.onRowChange(
+                                   row_offset)} >
                   { row_offset }
                 </Dropdown.Item>);
         };
@@ -568,6 +570,7 @@ class VeloPagedTable extends Component {
         selectRow: PropTypes.object,
 
         initial_page_size: PropTypes.number,
+        initial_start_row: PropTypes.number,
 
         // Additional columns to add (should be formatted with a
         // custom renderer).
@@ -605,7 +608,8 @@ class VeloPagedTable extends Component {
         // If the table has an index this will be the total number of
         // rows in the table. If it is -1 then we don't know the total
         // number.
-        total_size: 0,
+        total_size: -1,   // Initialize to -1 because we don't know the
+                          // size until the first API call.
         loading: true,
 
         // A transform applied on the basic table.
@@ -614,6 +618,8 @@ class VeloPagedTable extends Component {
         last_data: [],
 
         stack_path: [],
+        stack_start_row: 0,
+        stack_page_size: 10,
 
         showStackDialog: false,
 
@@ -632,11 +638,15 @@ class VeloPagedTable extends Component {
         // Maintain the page size in the state as well to get
         // react to refresh when changed.
         page_size: 10,
+
+        // Set to true when the user updated the paginator - in this
+        // case we ignore the initial_start_row.
+        paginator_chaged_row: false,
     }
 
     componentDidMount = () => {
         this.source = CancelToken.source();
-        if(this.props.initial_page_size>0) {
+        if(this.props.initial_page_size > 0) {
             setItem(schema.CurrentPageSizeKey,
                     this.props.initial_page_size);
         }
@@ -728,7 +738,12 @@ class VeloPagedTable extends Component {
         }
         return <TransformViewer
                  transform={transform}
-                 setTransform={t=>this.setState({transform: t})}
+                 setTransform={t=>{
+                     this.setState({transform: t});
+                     if(this.props.setTransform) {
+                         this.props.setTransform(t);
+                     };
+                 }}
                />;
     }
 
@@ -747,6 +762,18 @@ class VeloPagedTable extends Component {
 
         Object.assign(params, transform);
         params.start_row = this.state.start_row || 0;
+
+        // Set the start row to the initial_start_row if the user had
+        // not updated the page yet.
+        if(!this.state.paginator_chaged_row &&
+           this.props.initial_start_row > 0 &&
+           this.props.initial_start_row != params.start_row) {
+            this.setState({
+                start_row: this.props.initial_start_row,
+            });
+            params.start_row = this.props.initial_start_row;
+        }
+
         if (params.start_row < 0) {
             params.start_row = 0;
         }
@@ -764,11 +791,10 @@ class VeloPagedTable extends Component {
             if (response.cancel) {
                 return;
             }
-
             let stack_path = response.data && response.data.stack_path;
             let pageData = PrepareData(response.data);
             let toggles = Object.assign({}, this.state.toggles);
-            let columns = pageData.columns;
+            let columns = pageData.columns || [];
             if (this.props.extra_columns) {
                 columns = columns.concat(this.props.extra_columns);
             };
@@ -800,8 +826,18 @@ class VeloPagedTable extends Component {
                 pageData.rows = _.map(pageData.rows, this.props.row_filter);
             }
 
+            // We are trying to seek past the end of the table, reset
+            // to the start.
+            let total_size = parseInt(response.data.total_rows || 0);
+            if(total_size < params.start_row) {
+                this.setState({start_row: 0});
+                if(this.props.setPageState) {
+                    this.props.setPageState({start_row: 0});
+                }
+            }
+
             this.setState({loading: false,
-                           total_size: parseInt(response.data.total_rows || 0),
+                           total_size: total_size,
                            rows: pageData.rows,
                            all_columns: pageData.columns,
                            toggles: toggles,
@@ -1144,7 +1180,9 @@ class VeloPagedTable extends Component {
                                   className="visible"
                                   target="_blank" rel="noopener noreferrer"
                                   onClick={e=>{
-                                      this.setState({showStackDialog: column});
+                                      this.setState({
+                                          showStackDialog: column,
+                                      });
                                       e.preventDefault();
                                       return false;
                                   }}>
@@ -1380,6 +1418,10 @@ class VeloPagedTable extends Component {
     }
 
     getLastPage = ()=>{
+        if(this.state.total_size < 0) {
+            return 0 ;
+        };
+
         let page_size = getItem(schema.CurrentPageSizeKey) || 10;
         let total_size = parseInt(this.state.total_size || 0);
         let total_pages = parseInt(total_size / page_size) + 1;
@@ -1521,7 +1563,14 @@ class VeloPagedTable extends Component {
                   start_row={this.state.start_row}
                   page_size={page_size || this.state.page_size}
                   current_page={this.state.start_row / page_size}
-                  onRowChange={row_offset=>this.setState({start_row: row_offset})}
+                  onRowChange={(row_offset)=>{
+                      if(this.state.start_row != row_offset) {
+                          this.setState({
+                              start_row: row_offset,
+                              paginator_chaged_row: true,
+                          });
+                      }
+                  }}
                   onPageSizeChange={size=>{
                       setItem(schema.CurrentPageSizeKey, size);
 
@@ -1567,8 +1616,12 @@ class VeloPagedTable extends Component {
               { this.state.showStackDialog &&
                 <StackDialog
                   name={this.state.showStackDialog}
-                  onClose={()=>this.setState({showStackDialog: false})}
-                  navigateToRow={row=>this.setState({start_row: row})}
+                  onClose={()=>this.setState({
+                      showStackDialog: false,
+                  })}
+                  navigateToRow={row=>this.setState({
+                      start_row: row,
+                  })}
                   stack_path={this.state.stack_path}
 
                   transform={this.state.stack_transforms[
@@ -1578,6 +1631,14 @@ class VeloPagedTable extends Component {
                       stack_transforms[this.state.showStackDialog] = t;
                       this.setState({stack_transforms: stack_transforms});
                   }}
+                  setPageState={x=>{
+                      this.setState({
+                          stack_start_row: x.start_row,
+                          stack_page_size: x.page_size,
+                      });
+                  }}
+                  start_row={this.state.stack_start_row}
+                  page_size={this.state.stack_page_size}
                 />
               }
             </>

--- a/gui/velociraptor/src/components/core/stack.jsx
+++ b/gui/velociraptor/src/components/core/stack.jsx
@@ -18,6 +18,11 @@ export default class StackDialog extends Component {
         // Save the transform in our parent so we can resume easily.
         transform: PropTypes.object,
         setTransform: PropTypes.func,
+        setPageSize: PropTypes.func,
+
+        // Start the stack table at this initial row.
+        start_row: PropTypes.number,
+        page_size: PropTypes.number,
     }
 
     navigate = row=>{
@@ -41,7 +46,6 @@ export default class StackDialog extends Component {
             idx: {text: T("Row Index")},
             c:{text: T("Count")},
         };
-
         return (
             <>
               <Modal show={true}
@@ -55,6 +59,7 @@ export default class StackDialog extends Component {
                 </Modal.Header>
                 <Modal.Body>
                   <VeloPagedTable
+                    name={(this.props.name || "") + "Stack" }
                     extra_columns={["Link"]}
                     columns={columns}
                     renderers={renderers}
@@ -63,6 +68,14 @@ export default class StackDialog extends Component {
                         stack_path: this.props.stack_path}}
                     transform={this.props.transform}
                     setTransform={this.props.setTransform}
+
+                    // Allow the caller to keep strack of the stack
+                    // table's paging.
+                    setPageState={this.props.setPageState}
+
+                    // Start the table with these parameters.
+                    initial_page_size={this.props.page_size}
+                    initial_start_row={this.props.start_row}
                   />
                 </Modal.Body>
               </Modal>

--- a/gui/velociraptor/src/components/users/user-inspector.jsx
+++ b/gui/velociraptor/src/components/users/user-inspector.jsx
@@ -137,6 +137,24 @@ class PermissionViewer extends Component {
         }
     }
 
+    // ORG_ADMIN role can only be set on the root org.
+    isRoleDisabled = role=>{
+        if(role === "org_admin") {
+            let org_id = this.props.org && this.props.org.id;
+            return org_id != "root";
+        }
+        return false;
+    }
+
+    // ORG_ADMIN permission can only be set on the root org.
+    isPermissionDisabled = perm=>{
+        if(perm === "ORG_ADMIN") {
+            let org_id = this.props.org && this.props.org.id;
+            return org_id != "root";
+        }
+        return false;
+    }
+
     render() {
         if (!this.props.username) {
             return <></>;
@@ -199,6 +217,7 @@ class PermissionViewer extends Component {
 
                           <div className="form-toggle-control">
                             <Form.Switch
+                              disabled={this.isRoleDisabled(role)}
                               id={"Role_" + role}
                               label={T("Role_" + role)}
                               checked={_.indexOf(this.props.acls.roles, role) >= 0}
@@ -262,8 +281,9 @@ class PermissionViewer extends Component {
                           <Form.Switch
                             id={"Perm2_" + perm}
                             label={T("Perm_" + perm)}
-                            disabled={_.indexOf(
-                                this.props.acls.effective_permissions, perm) >= 0}
+                            disabled={
+                                this.isPermissionDisabled(perm) ||
+                                _.indexOf(this.props.acls.effective_permissions, perm) >= 0}
                             checked={_.indexOf(
                                 this.props.acls.effective_permissions, perm) >= 0}
                             onChange={e=>this.changePermissions(

--- a/services/acl_manager/acl_manager.go
+++ b/services/acl_manager/acl_manager.go
@@ -182,6 +182,11 @@ func (self *ACLManager) GetEffectivePolicy(
 	// Reserved for the server itself - can not be set by normal means.
 	policy.SuperUser = false
 
+	// OrgAdmin is only relevant for the root org.
+	if !utils.IsRootOrg(config_obj.OrgId) {
+		policy.OrgAdmin = false
+	}
+
 	return policy, nil
 }
 
@@ -192,6 +197,15 @@ func (self *ACLManager) SetPolicy(
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	// Make a copy to set
+	acl_obj = proto.Clone(acl_obj).(*acl_proto.ApiClientACL)
+
+	// ORG_ADMIN can only be set on the root org.
+	if !utils.IsRootOrg(config_obj.OrgId) {
+		acl_obj.OrgAdmin = false
+		acl_obj.Roles = utils.FilterSlice(acl_obj.Roles, "org_admin")
+	}
+
 	// Normalize the username casing.
 	lower_user_name := utils.ToLower(principal)
 	cache, pres := self.cache[lower_user_name]
@@ -200,7 +214,7 @@ func (self *ACLManager) SetPolicy(
 	}
 
 	self.cache[lower_user_name] = &_CachedACLObject{
-		policy:   proto.Clone(acl_obj).(*acl_proto.ApiClientACL),
+		policy:   acl_obj,
 		username: principal,
 	}
 

--- a/vql/acl_managers/server.go
+++ b/vql/acl_managers/server.go
@@ -88,6 +88,22 @@ func (self *ServerACLManager) CheckAccess(
 	}
 
 	for _, permission := range permissions {
+		// The ORG_ADMIN permission in only meaningful when evaluated
+		// against the root org.
+		if permission == acls.ORG_ADMIN {
+			root_policy, err := self.GetPolicyInOrg(services.ROOT_ORG_ID)
+			if err != nil {
+				return false, acls.PermissionDenied
+			}
+
+			ok, err := services.CheckAccessWithToken(root_policy, permission)
+			if !ok || err != nil {
+				return ok, err
+			}
+			continue
+		}
+
+		// Other permissions are checked against the calling org.
 		ok, err := services.CheckAccessWithToken(policy, permission)
 		if !ok || err != nil {
 			return ok, err

--- a/vql/acl_managers/server_test.go
+++ b/vql/acl_managers/server_test.go
@@ -56,10 +56,69 @@ func (self *TestSuite) TestLockdown() {
 	err = sanity.NewSanityCheckService(self.Ctx, nil, self.ConfigObj)
 	assert.NoError(self.T(), err)
 
+	// Clear the lockdown once we are done here.
+	defer acls.SetLockdownToken(nil)
+
 	// Checking again should reject it due to lockdown.
 	ok, err = acl_manager.CheckAccess(acls.COLLECT_CLIENT)
 	assert.ErrorContains(self.T(), err, "Server locked down")
 	assert.False(self.T(), ok)
+}
+
+func (self *TestSuite) TestOrgAdmin() {
+	users_manager := services.GetUserManager()
+
+	// Create an admin user with administrator role.
+	err := users_manager.SetUser(self.Ctx, &api_proto.VelociraptorUser{
+		Name: "admin",
+	})
+	assert.NoError(self.T(), err)
+
+	org_manager, err := services.GetOrgManager()
+	assert.NoError(self.T(), err)
+
+	// Create a side org.
+	org_record, err := org_manager.CreateNewOrg("SideOrg", "OXYZ", "1234")
+	assert.NoError(self.T(), err)
+
+	org_config_obj, err := org_manager.GetOrgConfig(org_record.Id)
+	assert.NoError(self.T(), err)
+
+	// Assign the user an ORG_ADMIN on the child org only.
+	err = services.GrantRoles(org_config_obj, "admin",
+		[]string{"administrator", "org_admin"})
+	assert.NoError(self.T(), err)
+
+	// Even though we set the org admin role on the child org, the
+	// permission is missing because child orgs can not hold the org
+	// admin permission.
+	policy, err := services.GetEffectivePolicy(org_config_obj, "admin")
+	assert.NoError(self.T(), err)
+	assert.False(self.T(), policy.OrgAdmin)
+
+	// Check permissions inside the org.
+	acl_manager := acl_managers.NewServerACLManager(org_config_obj, "admin")
+
+	// Check the user has COLLECT_CLIENT
+	ok, err := acl_manager.CheckAccess(acls.SERVER_ADMIN)
+	assert.NoError(self.T(), err)
+	assert.True(self.T(), ok)
+
+	// But the user should not have ORG_ADMIN because this permission
+	// in only ever checked on the root org.
+	_, err = acl_manager.CheckAccess(acls.ORG_ADMIN)
+	assert.Error(self.T(), err)
+	assert.ErrorContains(self.T(), err, "PermissionDenied")
+
+	// Now let's give the user org admin in the root org.
+	// Assign the user an ORG_ADMIN on the side org only.
+	err = services.GrantRoles(self.ConfigObj, "admin", []string{"org_admin"})
+	assert.NoError(self.T(), err)
+
+	// Repeat the check in the child org, but this time it should pass.
+	ok, err = acl_manager.CheckAccess(acls.ORG_ADMIN)
+	assert.NoError(self.T(), err)
+	assert.True(self.T(), ok)
 }
 
 func TestServerACLManager(t *testing.T) {


### PR DESCRIPTION
Also ensure it is only checked against the root org. The org_admin permission is only meaningful when attached to the root org as it allows the user to perform operations across orgs.

Also:
* Fixed persistence in stacking GUI - This was a regression when the stack table was reset to the start after showing it again from the main table.
* Restrict URLs to http and https method.