### PR TITLE
Bugfix: ntfs_vss accessor, support when a directory is missing

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,2 +1,3 @@
 Unindex
 Builtin
+vss

--- a/accessors/ntfs/vss.go
+++ b/accessors/ntfs/vss.go
@@ -116,15 +116,21 @@ func (self *WindowsVSSFileSystemAccessor) getVSSRoots(
 func (self *WindowsVSSFileSystemAccessor) ReadDirWithOSPath(
 	fullpath *accessors.OSPath) (res []accessors.FileInfo, err error) {
 
-	root_list, err := self.WindowsNTFSFileSystemAccessor.ReadDirWithOSPath(fullpath)
+	root_list, err := self.WindowsNTFSFileSystemAccessor.
+		ReadDirWithOSPath(fullpath)
 	if err != nil {
-		return nil, err
+		// We do not have any files in the top level drive but maybe
+		// there are files in the vss.
 	}
 
+	// The top level path represents all the drives. Return on the
+	// real drives (like \\.\C: )
 	if len(fullpath.Components) == 0 {
 		return root_list, nil
 	}
 
+	// Create a lookup list by mft id for all the files we found in
+	// the live device.
 	by_mft_id := make(map[string][]accessors.FileInfo)
 	for _, i := range root_list {
 		mft_id, pres := i.Data().GetString("mft")
@@ -138,9 +144,16 @@ func (self *WindowsVSSFileSystemAccessor) ReadDirWithOSPath(
 		}
 	}
 
-	// Now list each of the VSS and merge with the by_mft_id list.
+	// Now list each of the VSS and merge with the by_mft_id list only
+	// if the vss files do not exist in the live device.
+
+	// Take the relative path to the root device:
+	// [\\.\C: Windows System32] -> [Windows System32]
 	relative_path := fullpath.Components[1:]
 	for _, root := range self.vss_roots {
+
+		// root here is the device node for the vss device. Append the
+		// relative path to find the full path in the VSS device.
 		path := root.Append(relative_path...)
 
 		files, err := self.WindowsNTFSFileSystemAccessor.ReadDirWithOSPath(path)
@@ -150,10 +163,12 @@ func (self *WindowsVSSFileSystemAccessor) ReadDirWithOSPath(
 		}
 
 		for _, i := range files {
+			// Get the mft id and see if it is already in the known
+			// list. If it is not then we add it from the VSS.
 			mft_id, pres := i.Data().GetString("mft")
 			if pres {
-				existing, _ := by_mft_id[mft_id]
-				if !self.file_found(existing, i) {
+				existing, pres := by_mft_id[mft_id]
+				if !pres || !self.file_found(existing, i) {
 					existing = append(existing, VSSFileInfo{
 						FileInfo: i,
 						device:   root.Components[0],
@@ -166,12 +181,10 @@ func (self *WindowsVSSFileSystemAccessor) ReadDirWithOSPath(
 
 	result := make([]accessors.FileInfo, 0, len(by_mft_id))
 	for _, v := range by_mft_id {
-		for _, item := range v {
-			result = append(result, item)
-		}
+		result = append(result, v...)
 	}
 
-	return result, err
+	return result, nil
 }
 
 // Search for the file needle in the file haystack

--- a/datastore/filebased.go
+++ b/datastore/filebased.go
@@ -318,6 +318,10 @@ func writeContentToFile(
 	}
 
 	filename := AsDatastoreFilename(db, config_obj, urn)
+	err := checkPath(filename)
+	if err != nil {
+		return err
+	}
 
 	// Truncate the file immediately so we don't need to make a second
 	// syscall. Empirically on Linux, a truncate call always works,
@@ -362,7 +366,13 @@ func readContentFromFile(
 		return nil, datastoreNotConfiguredError
 	}
 
-	file, err := os.Open(AsDatastoreFilename(db, config_obj, urn))
+	filename := AsDatastoreFilename(db, config_obj, urn)
+	err := checkPath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(filename)
 	if err == nil {
 		defer file.Close()
 
@@ -450,4 +460,14 @@ func (self *FileBaseDataStore) SetBuffer(
 		completion()
 	}
 	return err
+}
+
+// Check for directory traversal sequences. These should never happen
+// but we have a second layer of defence here.
+func checkPath(path string) error {
+	if strings.Contains(path, "/../") {
+		return utils.Wrap(utils.InvalidArgError, "Directory traversal not supported")
+	}
+
+	return nil
 }

--- a/paths/inventory.go
+++ b/paths/inventory.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	artifacts_proto "www.velocidex.com/golang/velociraptor/artifacts/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
@@ -67,7 +68,12 @@ func (self InventoryPathManager) Path() (api.FSPathSpec, api.FileStore, error) {
 func NewInventoryPathManager(config_obj *config_proto.Config,
 	tool *artifacts_proto.Tool) *InventoryPathManager {
 	if tool.FilestorePath == "" {
-		tool.FilestorePath = ObfuscateName(config_obj, tool.Name)
+		if tool.Version == "" {
+			tool.FilestorePath = ObfuscateName(config_obj, tool.Name)
+		} else {
+			tool.FilestorePath = ObfuscateName(config_obj,
+				fmt.Sprintf("%s:%s", tool.Name, tool.Version))
+		}
 	}
 
 	return &InventoryPathManager{

--- a/paths/notebooks.go
+++ b/paths/notebooks.go
@@ -2,11 +2,16 @@ package paths
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/velociraptor/file_store/api"
 	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+var (
+	dirTraversalRegex = regexp.MustCompile(`\.\.+`)
 )
 
 type NotebookPathManager struct {
@@ -162,6 +167,9 @@ func rootPathFromNotebookID(notebook_id string) api.DSPathSpec {
 }
 
 func NewNotebookPathManager(notebook_id string) *NotebookPathManager {
+	// Do not allow directory traversal sequences in notebook ids so
+	// we can treat it as safe.
+	notebook_id = dirTraversalRegex.ReplaceAllLiteralString(notebook_id, ".")
 	return &NotebookPathManager{
 		notebook_id: notebook_id,
 		root:        rootPathFromNotebookID(notebook_id),

--- a/services/inventory/inventory.go
+++ b/services/inventory/inventory.go
@@ -536,7 +536,8 @@ func (self *InventoryService) AddTool(
 	if tool.Version == "" {
 		tool.FilestorePath = paths.ObfuscateName(config_obj, tool.Name)
 	} else {
-		tool.FilestorePath = paths.ObfuscateName(config_obj, fmt.Sprintf("%s:%s", tool.Name, tool.Version))
+		tool.FilestorePath = paths.ObfuscateName(config_obj,
+			fmt.Sprintf("%s:%s", tool.Name, tool.Version))
 	}
 
 	// No client config so we don't know any server urls - therefore we

--- a/vql/tools/gcs_pubsub_publish.go
+++ b/vql/tools/gcs_pubsub_publish.go
@@ -43,7 +43,7 @@ func (self *GCSPubsubPublishFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	err := vql_subsystem.CheckAccess(scope, acls.NETWORK)
+	err = vql_subsystem.CheckAccess(scope, acls.NETWORK)
 	if err != nil {
 		scope.Log("gcs_pubsub_publish: %v", err)
 		return vfilter.Null{}

--- a/vql/tools/gcs_upload.go
+++ b/vql/tools/gcs_upload.go
@@ -61,7 +61,7 @@ func (self *GCSUploadFunction) Call(ctx context.Context,
 		return vfilter.Null{}
 	}
 
-	err := vql_subsystem.CheckAccess(scope, acls.NETWORK)
+	err = vql_subsystem.CheckAccess(scope, acls.NETWORK)
 	if err != nil {
 		scope.Log("upload_gcs: %s", err)
 		return vfilter.Null{}


### PR DESCRIPTION
When a directory is missing from the live image but exists in the VSS only, it was not properly merged with the vss output. This failed in globs over the vss.

Also:
* Prevent notebook id from containing directory traversal sequences