### PR TITLE
Bugfix: Determine impersonate permission for query() based on target …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ assets:
 auto:
 	go run make.go -v auto
 
-test:
+test: vale
 	go test -race -v --tags server_vql ./...
 
-test_less:
+test_less: vale
 	go test -race -v --tags server_vql ./... 2>&1 | less
 
 golden:

--- a/accessors/file_store/permissions_test.go
+++ b/accessors/file_store/permissions_test.go
@@ -39,7 +39,7 @@ func TestFSAccessorSecurity(t *testing.T) {
 
 	sanity_service.CheckSecuritySettings(config_obj)
 
-	// Make sure we treat filess with empty components correcrly.
+	// Make sure we treat files with empty components correcrly.
 	filename1 := path_specs.NewUnsafeFilestorePath("backups", "file")
 	assert.Error(t, file_store.IsFileAccessible(filename1))
 
@@ -53,7 +53,7 @@ func TestFSAccessorSecurity(t *testing.T) {
 		datastore.AsFilestoreFilename(db, config_obj, filename1),
 		datastore.AsFilestoreFilename(db, config_obj, filename2))
 
-	// Check permission filtering withint he DeniedFsAccessorPrefix
+	// Check permission filtering within the DeniedFsAccessorPrefix
 	assert.Error(t, file_store.IsFileAccessible(
 		paths.BACKUPS_ROOT.AddChild("File")))
 	assert.NoError(t, file_store.IsFileAccessible(

--- a/accessors/file_store/permissions_test.go
+++ b/accessors/file_store/permissions_test.go
@@ -6,6 +6,8 @@ import (
 	"www.velocidex.com/golang/velociraptor/accessors/file_store"
 	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/datastore"
+	"www.velocidex.com/golang/velociraptor/file_store/path_specs"
 	"www.velocidex.com/golang/velociraptor/paths"
 	"www.velocidex.com/golang/velociraptor/services/sanity"
 	"www.velocidex.com/golang/velociraptor/vtesting/assert"
@@ -37,9 +39,25 @@ func TestFSAccessorSecurity(t *testing.T) {
 
 	sanity_service.CheckSecuritySettings(config_obj)
 
-	assert.Error(t, file_store.IsFileAccessible(paths.BACKUPS_ROOT.AddChild("File")))
-	assert.NoError(t, file_store.IsFileAccessible(paths.PUBLIC_ROOT.AddChild("C.123")))
-	assert.NoError(t, file_store.IsFileAccessible(paths.DOWNLOADS_ROOT.AddChild(
-		"C.123", "somefile.zip")))
+	// Make sure we treat filess with empty components correcrly.
+	filename1 := path_specs.NewUnsafeFilestorePath("backups", "file")
+	assert.Error(t, file_store.IsFileAccessible(filename1))
 
+	filename2 := path_specs.NewUnsafeFilestorePath("", "backups", "file")
+	assert.Error(t, file_store.IsFileAccessible(filename2))
+
+	// Both pathspecs actually end up in the same filepath
+	db, err := datastore.GetDB(config_obj)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		datastore.AsFilestoreFilename(db, config_obj, filename1),
+		datastore.AsFilestoreFilename(db, config_obj, filename2))
+
+	// Check permission filtering withint he DeniedFsAccessorPrefix
+	assert.Error(t, file_store.IsFileAccessible(
+		paths.BACKUPS_ROOT.AddChild("File")))
+	assert.NoError(t, file_store.IsFileAccessible(
+		paths.PUBLIC_ROOT.AddChild("C.123")))
+	assert.NoError(t, file_store.IsFileAccessible(
+		paths.DOWNLOADS_ROOT.AddChild("C.123", "somefile.zip")))
 }

--- a/api/authenticators/users.go
+++ b/api/authenticators/users.go
@@ -2,9 +2,11 @@ package authenticators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 )
 
 // Try to store the picture URL in the datastore to avoid making the
@@ -25,6 +27,13 @@ func checkUserOID(
 	user_manager := services.GetUserManager()
 	user_record, err := user_manager.GetUserWithHashes(
 		ctx, username, username)
+
+	// If the user does not exist, then we unpin the email, this can
+	// be used later to create the user.
+	if errors.Is(err, utils.NotFoundError) {
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/api/download.go
+++ b/api/download.go
@@ -440,6 +440,17 @@ func getRows(
 			utils.FilterSlice(request.StackPath, "")...).
 			SetType(api.PATH_TYPE_FILESTORE_JSON)
 
+		if len(request.StackPath) == 0 ||
+			request.StackPath[len(request.StackPath)-1] != "stack" {
+			return nil, nil, nil, fmt.Errorf(
+				"stack_path must be the path to a result set stack")
+		}
+
+		err := file_store_accessor.IsFileAccessible(log_path)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 		options, err := tables.GetTableOptions(request)
 		if err != nil {
 			return nil, nil, nil, err

--- a/artifacts/testdata/server/testcases/orgs.in.yaml
+++ b/artifacts/testdata/server/testcases/orgs.in.yaml
@@ -189,3 +189,34 @@ Queries:
     WHERE artifacts =~ "Remove"
     GROUP BY client_id
   }, runas="BasicUser", org_id="ORGID")
+
+
+# Give OrgUser a reader role in root org.
+- LET _ <= user_grant(user="OrgUser", roles="reader", orgs=["root"])
+
+# An administrator on ORGID can not impersonate an administrator in
+# another org
+- |
+  SELECT * FROM query(query={
+     SELECT * FROM query(query={
+        SELECT whoami(), org().id FROM scope()
+    }, runas="OrgAdmin", org_id="root")
+  }, runas="OrgUser", org_id="ORGID")
+
+- SELECT * FROM test_read_logs() WHERE Log =~ "PermissionDenied" AND NOT Log =~ "SELECT"
+
+# But they can impersonate a user in the org in which they are admins
+- |
+  SELECT * FROM query(query={
+     SELECT * FROM query(query={
+        SELECT whoami(), org().id FROM scope()
+    }, runas="ReaderUser", org_id="ORGID")
+  }, runas="OrgUser", org_id="ORGID")
+
+# And they can also run a query on an org with their lower priv/
+- |
+  SELECT * FROM query(query={
+     SELECT * FROM query(query={
+        SELECT whoami(), org().id FROM scope()
+    }, runas="OrgUser", org_id="root")
+  }, runas="OrgUser", org_id="ORGID")

--- a/artifacts/testdata/server/testcases/orgs.out.yaml
+++ b/artifacts/testdata/server/testcases/orgs.out.yaml
@@ -639,3 +639,52 @@ Output: [
  }
 ]
 
+# Give OrgUser a reader role in root org.
+Query: LET _ <= user_grant(user="OrgUser", roles="reader", orgs=["root"])
+Output: []
+
+# An administrator on ORGID can not impersonate an administrator in
+# another org
+Query: SELECT * FROM query(query={
+   SELECT * FROM query(query={
+      SELECT whoami(), org().id FROM scope()
+  }, runas="OrgAdmin", org_id="root")
+}, runas="OrgUser", org_id="ORGID")
+
+Output: []
+
+Query: SELECT * FROM test_read_logs() WHERE Log =~ "PermissionDenied" AND NOT Log =~ "SELECT"
+Output: [
+ {
+  "Log": "Velociraptor: ERROR:query: User OrgUser (ORGID) impersonation to OrgAdmin (root): PermissionDenied\n"
+ }
+]
+
+# But they can impersonate a user in the org in which they are admins
+Query: SELECT * FROM query(query={
+   SELECT * FROM query(query={
+      SELECT whoami(), org().id FROM scope()
+  }, runas="ReaderUser", org_id="ORGID")
+}, runas="OrgUser", org_id="ORGID")
+
+Output: [
+ {
+  "whoami()": "ReaderUser",
+  "org().id": "ORGID"
+ }
+]
+
+# And they can also run a query on an org with their lower priv/
+Query: SELECT * FROM query(query={
+   SELECT * FROM query(query={
+      SELECT whoami(), org().id FROM scope()
+  }, runas="OrgUser", org_id="root")
+}, runas="OrgUser", org_id="ORGID")
+
+Output: [
+ {
+  "whoami()": "OrgUser",
+  "org().id": "root"
+ }
+]
+

--- a/utils/prefix.go
+++ b/utils/prefix.go
@@ -105,7 +105,8 @@ func (self *PrefixTree) Add(components []string) {
 // Returns if the path matches any prefix in the prefix tree, as well
 // as the depth of the tree at which a match is made.
 func (self *PrefixTree) Present(components []string) (bool, int) {
-	return self.root.Present(components)
+	// Ignore empty components when comparing the prefix tree.
+	return self.root.Present(FilterSlice(components, ""))
 }
 
 func (self *PrefixTree) DebugString() string {

--- a/vql/tools/query.go
+++ b/vql/tools/query.go
@@ -9,6 +9,7 @@ import (
 	"www.velocidex.com/golang/velociraptor/actions"
 	"www.velocidex.com/golang/velociraptor/executor/throttler"
 	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 	"www.velocidex.com/golang/vfilter"
@@ -71,6 +72,8 @@ func (self QueryPlugin) Call(
 		}
 		org_config_obj := config_obj
 
+		principal := vql_subsystem.GetPrincipal(scope)
+
 		// Build a completely new scope to evaluate the query
 		// in.
 		builder := services.ScopeBuilderFromScope(scope)
@@ -95,11 +98,21 @@ func (self QueryPlugin) Call(
 				org_config_obj, vql_subsystem.GetPrincipal(scope))
 		}
 
-		if arg.Principal != "" {
-			// Impersonation is only allowed for administrator users.
-			err := vql_subsystem.CheckAccess(scope, acls.IMPERSONATION)
-			if err != nil {
-				scope.Log("ERROR:query: Permission required for runas: %v", err)
+		if arg.Principal != "" && arg.Principal != principal {
+			// Impersonation is only allowed for administrator
+			// users. Check the impersonation permission in the target
+			// org, if the user switched orgs.
+			acl_manager := acl_managers.NewServerACLManager(
+				org_config_obj, principal)
+
+			perm, err := acl_manager.CheckAccess(acls.IMPERSONATION)
+			if !perm {
+				if err == nil {
+					err = utils.PermissionDenied
+				}
+				scope.Log("ERROR:query: User %v (%v) impersonation to %v (%v): %v",
+					principal, config_obj.OrgId, arg.Principal,
+					org_config_obj.OrgId, err)
 				return
 			}
 


### PR DESCRIPTION
…org.

Also: Ignore empty path components with filestore ACL prefix checks.