### PR TITLE
fix: ArpCache - no additional encoding needed for State

### DIFF
--- a/artifacts/definitions/Windows/Network/ArpCache.yaml
+++ b/artifacts/definitions/Windows/Network/ArpCache.yaml
@@ -45,8 +45,8 @@ sources:
                     then="Active",
                   else="?")) as Store,
 
-               get(item=parse_json(data=kMapOfState),
-                   member=encode(string=State, type='string')) AS State,
+               get(item=parse_json(data=kMapOfState), member=State) AS State,
+
                InterfaceIndex, IPAddress,
                InterfaceAlias, LinkLayerAddress
             FROM wmi(query=wmiQuery, namespace=wmiNamespace)

--- a/artifacts/definitions/Windows/Network/ArpCache.yaml
+++ b/artifacts/definitions/Windows/Network/ArpCache.yaml
@@ -45,7 +45,8 @@ sources:
                     then="Active",
                   else="?")) as Store,
 
-               get(item=parse_json(data=kMapOfState), member=State) AS State,
+               get(item=parse_json(data=kMapOfState), 
+                   member=str(str=State)) AS State,
 
                InterfaceIndex, IPAddress,
                InterfaceAlias, LinkLayerAddress


### PR DESCRIPTION
This Artifact fails in with its current definition. Per the documentation, the function "encode" does not support any type "string". 
Since the State is always as uint8, the function does not seem necessary. 

Tested on Win11.