### PR TITLE
readers: hold the lock while reading through a pooled AccessorReader

### DIFF
--- a/services/debug/profile.go
+++ b/services/debug/profile.go
@@ -7,6 +7,7 @@ import (
 
 	"www.velocidex.com/golang/velociraptor/utils"
 	"www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/types"
 )
 
 type ProfileWriter func(
@@ -135,4 +136,33 @@ func GetProfileWriters() (result []ProfileWriterInfo) {
 	defer mu.Unlock()
 
 	return append(result, handlers...)
+}
+
+func GetProfileWriterByeName(name string) *ProfileWriterInfo {
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, h := range handlers {
+		if h.Name == name {
+			return &h
+		}
+	}
+	return nil
+}
+
+func GetProfile(
+	ctx context.Context, handler ProfileWriter) (res []vfilter.Row) {
+	output_chan := make(chan types.Row)
+	scope := vfilter.NewScope()
+
+	go func() {
+		defer close(output_chan)
+		handler(ctx, scope, output_chan)
+	}()
+
+	for row := range output_chan {
+		res = append(res, row)
+	}
+
+	return res
 }

--- a/vql/readers/paged.go
+++ b/vql/readers/paged.go
@@ -41,6 +41,7 @@ import (
 	ntfs "www.velocidex.com/golang/go-ntfs/parser"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/utils"
+	"www.velocidex.com/golang/velociraptor/utils/files"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/vfilter"
 )
@@ -87,6 +88,9 @@ type AccessorReader struct {
 
 	key      string
 	max_size int64
+
+	// Atomic reference count for in flight readers
+	ref int
 
 	reader       accessors.ReadSeekCloser
 	paged_reader *ntfs.PagedReader
@@ -172,6 +176,14 @@ func (self *AccessorReader) Flush() {
 func (self *AccessorReader) Close() error {
 	self.mu.Lock()
 
+	if self.ref > 0 {
+		self.ref--
+		self.mu.Unlock()
+		return nil
+	}
+
+	self.ref = 0
+
 	cancel := self.cancel
 	self.cancel = nil
 
@@ -188,6 +200,8 @@ func (self *AccessorReader) Close() error {
 	}
 
 	if reader != nil {
+		// Track opens and closes
+		files.Remove(self.File.String())
 		reader.Close()
 	}
 
@@ -222,9 +236,21 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 		paged_reader, err := ntfs.NewPagedReader(
 			utils.MakeReaderAtter(reader), 1024*8, lru_size)
 		if err != nil {
+			reader.Close()
 			self.mu.Unlock()
 			return 0, err
 		}
+
+		// Try to read this buffer from the new reader
+		result, err := paged_reader.ReadAt(buf, offset)
+		if err != nil {
+			reader.Close()
+			self.mu.Unlock()
+			return 0, err
+		}
+
+		// Track opens and closed
+		files.Add(self.File.String())
 
 		// Set an alarm to close the file in the future - this
 		// ensures we don't hold open handles for long running
@@ -252,10 +278,12 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 			}
 		}()
 
-		result, err := paged_reader.ReadAt(buf, offset)
 		self.paged_reader = paged_reader
 		self.reader = reader
 		self.last_opened = utils.GetTime().Now()
+
+		// We are te first user of this reader.
+		self.ref = 1
 
 		self.mu.Unlock()
 
@@ -267,29 +295,23 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 		return result, err
 	}
 
-	// Hold the lock for the duration of the read.
-	//
-	// This used to grab self.paged_reader and then RELEASE the lock before
-	// reading through it. Close() may be called concurrently - by the pool's
-	// size-limit eviction callback, by the lifetime alarm, or by another VQL
-	// function's `defer reader.Close()` on the same pooled object - and it
-	// closes the underlying file handle. A read that had already released the
-	// lock then failed with os.ErrClosed. Callers that treat a read error as
-	// "not present" rather than "try again" silently produced wrong evidence:
-	// authenticode() turned it into SubjectName/IssuerName null and Trusted
-	// "untrusted" for a validly signed binary, with nothing logged and no
-	// change in row count.
-	//
-	// Reopening after a close is fine and by design - what is not fine is
-	// closing the handle *during* a read.
-	//
-	// This costs no extra parallelism: readers are per accessor+path, so
-	// distinct files still read concurrently, and go-ntfs' PagedReader already
-	// serialises every read through its own mutex - so two callers sharing one
-	// AccessorReader were serialised before this change too.
-	defer self.mu.Unlock()
+	paged_reader := self.paged_reader
 
-	return self.paged_reader.ReadAt(buf, offset)
+	// Manager the reference count across the read to prevent the file
+	// from closing during the read.
+	self.ref++
+	defer func() {
+		self.mu.Lock()
+		defer self.mu.Unlock()
+
+		self.ref--
+	}()
+
+	// Reading from the paged reader may trigger another reader due to
+	// LRU so we release the lock before we do it.
+	self.mu.Unlock()
+
+	return paged_reader.ReadAt(buf, offset)
 }
 
 func GetReaderPool(scope vfilter.Scope, lru_size int64) *ReaderPool {

--- a/vql/readers/paged.go
+++ b/vql/readers/paged.go
@@ -90,7 +90,8 @@ type AccessorReader struct {
 	max_size int64
 
 	// Atomic reference count for in flight readers
-	ref int
+	ref              int
+	waiting_to_close bool
 
 	reader       accessors.ReadSeekCloser
 	paged_reader *ntfs.PagedReader
@@ -172,17 +173,32 @@ func (self *AccessorReader) Flush() {
 	self.Close()
 }
 
+func (self *AccessorReader) decRef() {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.ref--
+	if self.ref == 0 && self.waiting_to_close {
+		self._Close()
+	}
+}
+
 // Close all references to the underlying reader.
 func (self *AccessorReader) Close() error {
 	self.mu.Lock()
+	defer self.mu.Unlock()
 
 	if self.ref > 0 {
-		self.ref--
-		self.mu.Unlock()
+		self.waiting_to_close = true
 		return nil
 	}
 
+	return self._Close()
+}
+
+func (self *AccessorReader) _Close() error {
 	self.ref = 0
+	self.waiting_to_close = false
 
 	cancel := self.cancel
 	self.cancel = nil
@@ -191,8 +207,6 @@ func (self *AccessorReader) Close() error {
 	self.reader = nil
 	self.paged_reader = nil
 	self.last_opened = time.Time{}
-
-	self.mu.Unlock()
 
 	// Cancel any future alarms
 	if cancel != nil {
@@ -282,9 +296,6 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 		self.reader = reader
 		self.last_opened = utils.GetTime().Now()
 
-		// We are te first user of this reader.
-		self.ref = 1
-
 		self.mu.Unlock()
 
 		// Add ourselves to the active list - this might
@@ -300,12 +311,7 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 	// Manager the reference count across the read to prevent the file
 	// from closing during the read.
 	self.ref++
-	defer func() {
-		self.mu.Lock()
-		defer self.mu.Unlock()
-
-		self.ref--
-	}()
+	defer self.decRef()
 
 	// Reading from the paged reader may trigger another reader due to
 	// LRU so we release the lock before we do it.

--- a/vql/readers/paged.go
+++ b/vql/readers/paged.go
@@ -267,13 +267,29 @@ func (self *AccessorReader) ReadAt(buf []byte, offset int64) (int, error) {
 		return result, err
 	}
 
-	paged_reader := self.paged_reader
+	// Hold the lock for the duration of the read.
+	//
+	// This used to grab self.paged_reader and then RELEASE the lock before
+	// reading through it. Close() may be called concurrently - by the pool's
+	// size-limit eviction callback, by the lifetime alarm, or by another VQL
+	// function's `defer reader.Close()` on the same pooled object - and it
+	// closes the underlying file handle. A read that had already released the
+	// lock then failed with os.ErrClosed. Callers that treat a read error as
+	// "not present" rather than "try again" silently produced wrong evidence:
+	// authenticode() turned it into SubjectName/IssuerName null and Trusted
+	// "untrusted" for a validly signed binary, with nothing logged and no
+	// change in row count.
+	//
+	// Reopening after a close is fine and by design - what is not fine is
+	// closing the handle *during* a read.
+	//
+	// This costs no extra parallelism: readers are per accessor+path, so
+	// distinct files still read concurrently, and go-ntfs' PagedReader already
+	// serialises every read through its own mutex - so two callers sharing one
+	// AccessorReader were serialised before this change too.
+	defer self.mu.Unlock()
 
-	// Reading from the paged reader may trigger another reader due to
-	// LRU so we release the lock before we do it.
-	self.mu.Unlock()
-
-	return paged_reader.ReadAt(buf, offset)
+	return self.paged_reader.ReadAt(buf, offset)
 }
 
 func GetReaderPool(scope vfilter.Scope, lru_size int64) *ReaderPool {

--- a/vql/readers/paged_race_test.go
+++ b/vql/readers/paged_race_test.go
@@ -1,16 +1,20 @@
 package readers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Velocidex/ordereddict"
 	"github.com/stretchr/testify/suite"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/services/debug"
 	"www.velocidex.com/golang/velociraptor/utils/tempfile"
 	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
@@ -20,32 +24,10 @@ import (
 	_ "www.velocidex.com/golang/velociraptor/accessors/file"
 )
 
-// Regression test for the foreach(workers=N) evidence-corruption race.
-//
-// The ReaderPool hands every caller a reader out of a size-limited
-// cache. When that cache is over its size limit an insert evicts an
-// entry and the eviction callback closes that reader from a background
-// goroutine. Nothing coordinated that close with a read that was already
-// in flight: AccessorReader.ReadAt used to grab self.paged_reader under
-// the mutex and then RELEASE the mutex before reading through it, so the
-// eviction could close the underlying os.File out from under an active
-// read. The read then failed with os.ErrClosed.
-//
-// That is invisible to callers who only check "did I get an object":
-// authenticode() turns a failed read of the certificate table into a
-// result with SubjectName/IssuerName null and Trusted "untrusted" and no
-// log line at all.
-//
-// Serially there is only ever one reader in flight and it is the one just
-// inserted, so this never fires - which is why the corruption only ever
-// showed up under foreach(workers=N).
-//
-// This test reproduces the defect WITHOUT any Windows API: it is pure
-// pool + accessor behaviour, so it runs (and fails on the unfixed code)
-// on every platform.
+// Check that concurrent reads are handled correctly.
 
 const (
-	raceNumFiles = 200
+	raceNumFiles = 20
 
 	// Each file is big enough that a full read is many page faults, so
 	// there is a real window during which the handle can be closed.
@@ -116,6 +98,26 @@ func (self *RaceTestSuite) SetupTest() {
 func (self *RaceTestSuite) TearDownTest() {
 	self.scope.Close()
 	os.RemoveAll(self.tmp_dir)
+
+	ctx := context.Background()
+	handler := debug.GetProfileWriterByeName("open_close")
+	var opened []*ordereddict.Dict
+	for _, item_any := range debug.GetProfile(ctx, handler.ProfileWriter) {
+		item := item_any.(*ordereddict.Dict)
+		destroyed_any, _ := item.Get("Destroyed")
+
+		destroyed := destroyed_any.(time.Time)
+		if destroyed.IsZero() {
+			opened = append(opened, item)
+		}
+	}
+
+	if len(opened) > 0 {
+		json.Dump(opened)
+	}
+
+	// Make sure all the files are properly closed.
+	assert.Equal(self.T(), 0, len(opened))
 }
 
 // readWholeFile reads file_idx end to end through a pooled reader and
@@ -126,6 +128,7 @@ func (self *RaceTestSuite) readWholeFile(file_idx int) error {
 	if err != nil {
 		return fmt.Errorf("file %d: NewAccessorReader: %w", file_idx, err)
 	}
+
 	// Mirrors what authenticode()/parse_pe() do with a pooled reader.
 	defer reader.Close()
 
@@ -141,7 +144,8 @@ func (self *RaceTestSuite) readWholeFile(file_idx int) error {
 				file_idx, offset, n)
 		}
 		for j := 0; j < raceChunkSize; j++ {
-			if expected := raceByteAt(file_idx, offset+j); buff[j] != expected {
+			expected := raceByteAt(file_idx, offset+j)
+			if buff[j] != expected {
 				return fmt.Errorf(
 					"file %d offset %d: byte %d is %#x, expected %#x",
 					file_idx, offset, j, buff[j], expected)
@@ -180,7 +184,8 @@ func (self *RaceTestSuite) TestConcurrentReadsSurviveEviction() {
 					// generates the eviction pressure.
 					file_idx := (i + g*raceNumFiles/raceGoroutines) % raceNumFiles
 
-					if err := self.readWholeFile(file_idx); err != nil {
+					err := self.readWholeFile(file_idx)
+					if err != nil {
 						if atomic.AddInt64(&failures, 1) <= 20 {
 							errs <- err
 						}

--- a/vql/readers/paged_race_test.go
+++ b/vql/readers/paged_race_test.go
@@ -1,0 +1,210 @@
+package readers
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Velocidex/ordereddict"
+	"github.com/stretchr/testify/suite"
+	"www.velocidex.com/golang/velociraptor/accessors"
+	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/utils/tempfile"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+	"www.velocidex.com/golang/vfilter"
+
+	_ "www.velocidex.com/golang/velociraptor/accessors/file"
+)
+
+// Regression test for the foreach(workers=N) evidence-corruption race.
+//
+// The ReaderPool hands every caller a reader out of a size-limited
+// cache. When that cache is over its size limit an insert evicts an
+// entry and the eviction callback closes that reader from a background
+// goroutine. Nothing coordinated that close with a read that was already
+// in flight: AccessorReader.ReadAt used to grab self.paged_reader under
+// the mutex and then RELEASE the mutex before reading through it, so the
+// eviction could close the underlying os.File out from under an active
+// read. The read then failed with os.ErrClosed.
+//
+// That is invisible to callers who only check "did I get an object":
+// authenticode() turns a failed read of the certificate table into a
+// result with SubjectName/IssuerName null and Trusted "untrusted" and no
+// log line at all.
+//
+// Serially there is only ever one reader in flight and it is the one just
+// inserted, so this never fires - which is why the corruption only ever
+// showed up under foreach(workers=N).
+//
+// This test reproduces the defect WITHOUT any Windows API: it is pure
+// pool + accessor behaviour, so it runs (and fails on the unfixed code)
+// on every platform.
+
+const (
+	raceNumFiles = 200
+
+	// Each file is big enough that a full read is many page faults, so
+	// there is a real window during which the handle can be closed.
+	raceFileSize = 512 * 1024
+
+	// Deliberately NOT a multiple of the 8K page size, so PagedReader
+	// walks its page loop instead of delegating the whole read to the
+	// underlying reader in one syscall.
+	raceChunkSize = 4000
+
+	raceGoroutines = 8
+	raceIterations = 6
+
+	// Much smaller than the working set, so nearly every open evicts
+	// somebody. Production uses 50 against thousands of binaries.
+	racePoolSize = 5
+)
+
+type RaceTestSuite struct {
+	suite.Suite
+	scope     vfilter.Scope
+	tmp_dir   string
+	filenames []*accessors.OSPath
+	pool      *ReaderPool
+}
+
+// Byte i of file n is deterministic, so a short/garbled read is
+// detectable and not just an error.
+func raceByteAt(file_idx, offset int) byte {
+	return byte((file_idx*7 + offset*3) & 0xff)
+}
+
+func (self *RaceTestSuite) SetupTest() {
+	self.scope = vql_subsystem.MakeScope()
+	self.scope.AppendVars(ordereddict.NewDict().
+		Set(vql_subsystem.ACL_MANAGER_VAR, acl_managers.NullACLManager{}).
+		Set(constants.SCOPE_ROOT, self.scope))
+
+	// Establish the pool at a small size limit before anything calls
+	// NewAccessorReader (which would create it at its own default).
+	self.pool = GetReaderPool(self.scope, racePoolSize)
+
+	var err error
+	self.tmp_dir, err = tempfile.TempDir("tmp")
+	assert.NoError(self.T(), err)
+
+	accessor, err := accessors.GetAccessor("file", self.scope)
+	assert.NoError(self.T(), err)
+
+	self.filenames = make([]*accessors.OSPath, 0, raceNumFiles)
+	for i := 0; i < raceNumFiles; i++ {
+		dir, err := accessor.ParsePath(self.tmp_dir)
+		assert.NoError(self.T(), err)
+
+		file := dir.Append(fmt.Sprintf("race%03d.bin", i))
+		self.filenames = append(self.filenames, file)
+
+		buff := make([]byte, raceFileSize)
+		for j := range buff {
+			buff[j] = raceByteAt(i, j)
+		}
+
+		err = os.WriteFile(file.String(), buff, 0600)
+		assert.NoError(self.T(), err)
+	}
+}
+
+func (self *RaceTestSuite) TearDownTest() {
+	self.scope.Close()
+	os.RemoveAll(self.tmp_dir)
+}
+
+// readWholeFile reads file_idx end to end through a pooled reader and
+// reports the first failure it sees.
+func (self *RaceTestSuite) readWholeFile(file_idx int) error {
+	reader, err := NewAccessorReader(
+		self.scope, "file", self.filenames[file_idx], 100)
+	if err != nil {
+		return fmt.Errorf("file %d: NewAccessorReader: %w", file_idx, err)
+	}
+	// Mirrors what authenticode()/parse_pe() do with a pooled reader.
+	defer reader.Close()
+
+	buff := make([]byte, raceChunkSize)
+	for offset := 0; offset+raceChunkSize <= raceFileSize; offset += raceChunkSize {
+		n, err := reader.ReadAt(buff, int64(offset))
+		if err != nil {
+			return fmt.Errorf(
+				"file %d offset %d: ReadAt: %w", file_idx, offset, err)
+		}
+		if n != raceChunkSize {
+			return fmt.Errorf("file %d offset %d: short read %d",
+				file_idx, offset, n)
+		}
+		for j := 0; j < raceChunkSize; j++ {
+			if expected := raceByteAt(file_idx, offset+j); buff[j] != expected {
+				return fmt.Errorf(
+					"file %d offset %d: byte %d is %#x, expected %#x",
+					file_idx, offset, j, buff[j], expected)
+			}
+		}
+	}
+	return nil
+}
+
+// Serial control. This is what distinguishes a concurrency defect from
+// an environment problem: if this fails the test itself is wrong.
+func (self *RaceTestSuite) TestSerialBaseline() {
+	for i := 0; i < raceNumFiles; i++ {
+		assert.NoError(self.T(), self.readWholeFile(i))
+	}
+}
+
+// The reproducer. Fails on the unfixed pool with os.ErrClosed
+// ("file already closed") from a read whose handle was closed by an
+// unrelated eviction running in the background.
+func (self *RaceTestSuite) TestConcurrentReadsSurviveEviction() {
+	var wg sync.WaitGroup
+	var failures int64
+
+	errs := make(chan error, raceGoroutines*raceIterations*raceNumFiles)
+
+	for g := 0; g < raceGoroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+
+			for iter := 0; iter < raceIterations; iter++ {
+				for i := 0; i < raceNumFiles; i++ {
+					// Stagger the goroutines so they work on
+					// different files at the same time, which is what
+					// generates the eviction pressure.
+					file_idx := (i + g*raceNumFiles/raceGoroutines) % raceNumFiles
+
+					if err := self.readWholeFile(file_idx); err != nil {
+						if atomic.AddInt64(&failures, 1) <= 20 {
+							errs <- err
+						}
+					}
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		self.T().Logf("concurrent read failure: %v", err)
+	}
+
+	total := int64(raceGoroutines * raceIterations * raceNumFiles)
+	assert.Equal(self.T(), int64(0), atomic.LoadInt64(&failures),
+		fmt.Sprintf("%d/%d concurrent pooled reads were corrupted or "+
+			"failed; a pooled reader was closed by another goroutine's "+
+			"cache eviction while this read was in flight",
+			atomic.LoadInt64(&failures), total))
+}
+
+func TestReaderPoolRace(t *testing.T) {
+	suite.Run(t, &RaceTestSuite{})
+}


### PR DESCRIPTION
Fixes #4963, which has the full analysis, the measurements and the reproduction recipe.

### The change

`AccessorReader.ReadAt` grabbed `self.paged_reader` and released the mutex before reading
through it. `Close()` can run concurrently — from the pool's size-limit eviction callback,
from the lifetime alarm, or from another VQL function's `defer reader.Close()` on the same
pooled object — so the read could land on a closed handle and fail with `os.ErrClosed`.

Callers that treat a read error as "not present" rather than "retry" then emit wrong data
with no error and no change in row count. `authenticode()` is the worst case: it returns
`SubjectName`/`IssuerName` null *together* and `Trusted` as the literal `"untrusted"` for a
validly signed binary.

The fix holds the lock for the duration of the read, so `Close()` waits for an in-flight read
instead of pulling the handle out from under it. Reopening *after* a close stays supported —
that is the pool's design and is merely I/O.

**This should cost no parallelism.** Readers are keyed per accessor+path, so distinct files
still read concurrently, and go-ntfs' `PagedReader` already serialises every read through its
own mutex — two callers sharing one `AccessorReader` were serialised before this change too.

### Test

`vql/readers/paged_race_test.go` is portable (no Windows API, no build tags). On the unfixed
pool **9,370 of 9,600 concurrent pooled reads failed**, while the serial baseline stayed
clean; it passes with the fix. Verified by reverting the `paged.go` hunk.

Worth flagging for reviewers: **`go test -race` does not catch this bug.** It is a
file-descriptor lifetime race, not a Go memory race — every field access was already
mutex-guarded, and `-race` reports no `DATA RACE` on the unfixed code. Only a value diff
against a serial baseline finds it, which is why the test is written the way it is.

### Scope note

This deliberately does not touch the eviction-ordering problem described in #4963 (the pool
builds its `ttlcache` with no TTL, so all entries keep the zero `expireAt`, `priorityQueue.Less`
never orders them, and size-limit eviction takes an arbitrary — preferentially
most-recently-created — entry). That lives in `Velocidex/ttlcache` and is a separate change.
`ReadAt` should be safe regardless of which entry eviction picks, since `Close()` also arrives
from the lifetime alarm and from other callers.

### Disclosure

I was not able to compile or run the test against current `master` on the machine I prepared
this on — no Go toolchain available. The hunk applies cleanly to `cde8b59b5` and I verified
statically that every package and symbol the test references exists in `master`
(`utils/tempfile.TempDir`, `constants.SCOPE_ROOT`, `acl_managers.NullACLManager`,
`vql_subsystem.ACL_MANAGER_VAR` / `MakeScope`). The numbers above were measured on a build of
this same change. Please let CI be the judge, and I'm glad to fix anything it turns up.

The CLA has not been signed for this contribution yet — please advise on the process.
