### PR TITLE
Add Azure Monitor (Log Analytics) upload plugin and artifact

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,3 +12,7 @@ lsp
 opencode
 upcase
 emacs
+
+Entra
+azidentity
+unparseable

--- a/artifacts/definitions/Azure/Monitor/Upload.yaml
+++ b/artifacts/definitions/Azure/Monitor/Upload.yaml
@@ -1,0 +1,190 @@
+name: Azure.Monitor.Upload
+description: |
+  This server-side event monitoring artifact waits for new artifacts to
+  be collected from endpoints and automatically uploads those to an
+  Azure Log Analytics workspace using the **Azure Monitor Logs Ingestion
+  API** (the modern Data Collection Rule based API).
+
+  Although Azure Data Explorer (ADX) and Log Analytics share the Kusto
+  (KQL) query engine, they use completely different *ingestion* APIs and
+  the `ADX.Flows.Upload` artifact can NOT be pointed at a Log Analytics
+  workspace. This artifact uses the dedicated Logs Ingestion path
+  instead.
+
+  Each row is uploaded with structured metadata columns and a `RawData`
+  column containing the full event, allowing efficient queries on the
+  structured columns while keeping full flexibility via `RawData`.
+
+  ## 1. Create the custom table
+
+  In the Log Analytics workspace create a custom table (the name must end
+  in `_CL`) with this schema (every Log Analytics table requires a
+  `TimeGenerated` column):
+
+  ```
+  TimeGenerated:  datetime
+  Artifact:       string
+  ClientId:       string
+  FlowId:         string
+  Organization:   string
+  Hostname:       string
+  RawData:        dynamic
+  ```
+
+  ## 2. Create a Data Collection Rule (DCR)
+
+  Create a DCR that declares an input **stream** named
+  `Custom-RawVelociraptorEvents_CL` (stream names must start with
+  `Custom-`) whose schema matches the table, and routes it to the table.
+  Note the DCR's **immutableId** (e.g. `dcr-xxxxxxxxxxxxxxxx`) and its
+  **logs ingestion endpoint** (`logsIngestion.endpoint`), or attach a
+  Data Collection Endpoint (DCE) and use its URI.
+
+  ## 3. Configure authentication
+
+  Several options are supported:
+
+  - **Service principal** - create an Entra app registration with a
+    client secret and supply `TenantID`, `ClientID`, `ClientSecret`.
+  - **Environment variables** - leave the service principal fields empty
+    and set `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
+    in the server's environment (the SDK `EnvironmentCredential`
+    behaviour). This path still honors the server's proxy / CA settings.
+  - **Managed identity** - set `ManagedIdentity` to TRUE (server must run
+    in Azure; requires a `sumo` build).
+  - **Default credential chain** - set `DefaultCredential` to TRUE to use
+    the Azure SDK `DefaultAzureCredential` (env vars, workload identity,
+    managed identity, Azure CLI; requires a `sumo` build).
+
+  Whichever identity is used, assign it the **Monitoring Metrics
+  Publisher** role on the **DCR** (scope = the DCR resource).
+
+  Credentials may also be stored in the secrets service as a secret of
+  type `Azure Monitor Creds` and referenced via the `Secret` parameter.
+
+  ## Notes
+
+  - `StreamName` MUST exactly match the DCR's declared input stream name.
+  - The Logs Ingestion API caps a single request at ~1MB uncompressed;
+    `MaxMemoryBuffer` defaults well under that.
+
+type: SERVER_EVENT
+
+parameters:
+  - name: ArtifactNameRegex
+    default: .
+    type: regex
+    description: Only upload these artifacts to Azure Monitor.
+  - name: LogsIngestionEndpoint
+    default: https://your-dce-or-dcr.region.ingest.monitor.azure.com
+    description: |
+      The Logs Ingestion endpoint URI of the Data Collection Rule (or a
+      Data Collection Endpoint).
+  - name: DCRImmutableID
+    description: The immutable ID of the Data Collection Rule (e.g. dcr-xxxxxxxx).
+  - name: StreamName
+    default: Custom-RawVelociraptorEvents_CL
+    description: |
+      The DCR input stream name. Must match the stream declared in the
+      DCR exactly.
+  - name: Table
+    default: RawVelociraptorEvents_CL
+    description: |
+      Only used to derive StreamName as 'Custom-<Table>' when StreamName
+      is left empty. Ignored otherwise.
+  - name: TenantID
+    description: Azure Service Principal Tenant ID (or set AZURE_TENANT_ID).
+  - name: ClientID
+    description: Azure Service Principal Client ID (or set AZURE_CLIENT_ID).
+  - name: ClientSecret
+    description: Azure Service Principal Client Secret (or set AZURE_CLIENT_SECRET).
+  - name: ManagedIdentity
+    type: bool
+    description: |
+      Use an Azure managed identity instead of a service principal
+      (requires a 'sumo' build and that the server runs in Azure).
+  - name: ManagedIdentityClientID
+    description: Optional client ID of a user-assigned managed identity.
+  - name: DefaultCredential
+    type: bool
+    description: |
+      Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars,
+      workload identity, managed identity, Azure CLI). Requires a 'sumo'
+      build.
+  - name: Threads
+    type: int
+    default: 1
+    description: Number of threads to upload with.
+  - name: ChunkSize
+    type: int
+    default: 1000
+    description: Batch this many rows for each upload.
+  - name: WaitTime
+    type: int
+    default: 5
+    description: |
+      Maximum time in seconds to wait before flushing buffered rows.
+  - name: MaxMemoryBuffer
+    type: hidden
+    default: 921600
+    description: |
+      Maximum uncompressed request body in bytes before forcing an
+      upload. Keep under the ~1MB Azure limit. Default is 900KB.
+  - name: MaxRetries
+    type: int
+    default: 3
+    description: Maximum number of retries for failed uploads.
+  - name: RetryWait
+    type: int
+    default: 2
+    description: Base wait time in seconds for exponential backoff between retries.
+  - name: Secret
+    type: hidden
+    description: |
+      Alternatively use a secret from the secrets service. Secret must be
+      of type 'Azure Monitor Creds'.
+
+sources:
+  - query: |
+      LET completions = SELECT * FROM watch_monitoring(
+               artifact="System.Flow.Completion")
+               WHERE Flow.artifacts_with_results =~ ArtifactNameRegex
+      LET organization <= org().name
+
+      LET documents = SELECT * FROM foreach(row=completions,
+          query={
+             SELECT * FROM foreach(
+                 row=Flow.artifacts_with_results,
+                 query={
+                     SELECT *, _value AS _Artifact,
+                            client_info(client_id=ClientId).os_info.hostname AS _Hostname,
+                            timestamp(epoch=now()) AS _timestamp,
+                            ClientId AS _ClientId,
+                            Flow.session_id AS _FlowId,
+                            organization as _Organization
+                     FROM source(
+                        client_id=ClientId,
+                        flow_id=Flow.session_id,
+                        artifact=_value)
+                 })
+          })
+
+      SELECT * FROM azure_monitor_upload(
+            query=documents,
+            threads=Threads,
+            chunk_size=ChunkSize,
+            wait_time=WaitTime,
+            max_memory_buffer=int(int=MaxMemoryBuffer),
+            max_retries=MaxRetries,
+            retry_wait=RetryWait,
+            logs_ingestion_endpoint=LogsIngestionEndpoint,
+            dcr_immutable_id=DCRImmutableID,
+            stream_name=StreamName,
+            table=Table,
+            tenant_id=TenantID,
+            client_id=ClientID,
+            client_secret=ClientSecret,
+            managed_identity=ManagedIdentity,
+            managed_identity_client_id=ManagedIdentityClientID,
+            default_credential=DefaultCredential,
+            secret=Secret)

--- a/artifacts/definitions/Azure/Monitor/Upload.yaml
+++ b/artifacts/definitions/Azure/Monitor/Upload.yaml
@@ -66,7 +66,7 @@ description: |
   - **Environment variables** - leave the service principal fields empty
     and set `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
     in the server's environment (the SDK `EnvironmentCredential`
-    behaviour). This path still honors the server's proxy / CA settings.
+    behavior). This path still honors the server's proxy / CA settings.
   - **Managed identity** - set `ManagedIdentity` to TRUE (server must run
     in Azure).
   - **Default credential chain** - set `DefaultCredential` to TRUE to use

--- a/artifacts/definitions/Azure/Monitor/Upload.yaml
+++ b/artifacts/definitions/Azure/Monitor/Upload.yaml
@@ -15,6 +15,14 @@ description: |
   column containing the full event, allowing efficient queries on the
   structured columns while keeping full flexibility via `RawData`.
 
+  ## Requirements
+
+  This artifact needs the `azure_monitor_upload()` plugin, which is only
+  compiled into Velociraptor builds made with the `sumo` build tag - the
+  official Docker image, or a release binary with `sumo` in its name.
+  Standard builds do not include it (the Azure SDK it depends on is a
+  heavy dependency, so it is excluded the same way `adx_upload()` is).
+
   ## 1. Create the custom table
 
   In the Log Analytics workspace create a custom table (the name must end
@@ -23,6 +31,7 @@ description: |
 
   ```
   TimeGenerated:  datetime
+  EventTime:      datetime
   Artifact:       string
   ClientId:       string
   FlowId:         string
@@ -30,6 +39,14 @@ description: |
   Hostname:       string
   RawData:        dynamic
   ```
+
+  `TimeGenerated` is the *ingestion* time. Log Analytics uses it as the
+  partition key and only accepts values in a narrow window around now
+  (roughly not older than 2 days, and not far into the future), so the
+  event's own time cannot go there - rows from forensic artifacts would
+  be re-stamped or rejected. That event time is uploaded as `EventTime`
+  instead, taken from the artifact's `Timestamp` column and simply
+  absent for artifacts that have none. It also remains inside `RawData`.
 
   ## 2. Create a Data Collection Rule (DCR)
 
@@ -51,10 +68,10 @@ description: |
     in the server's environment (the SDK `EnvironmentCredential`
     behaviour). This path still honors the server's proxy / CA settings.
   - **Managed identity** - set `ManagedIdentity` to TRUE (server must run
-    in Azure; requires a `sumo` build).
+    in Azure).
   - **Default credential chain** - set `DefaultCredential` to TRUE to use
     the Azure SDK `DefaultAzureCredential` (env vars, workload identity,
-    managed identity, Azure CLI; requires a `sumo` build).
+    managed identity, Azure CLI).
 
   Whichever identity is used, assign it the **Monitoring Metrics
   Publisher** role on the **DCR** (scope = the DCR resource).
@@ -102,15 +119,14 @@ parameters:
     type: bool
     description: |
       Use an Azure managed identity instead of a service principal
-      (requires a 'sumo' build and that the server runs in Azure).
+      (requires that the server runs in Azure).
   - name: ManagedIdentityClientID
     description: Optional client ID of a user-assigned managed identity.
   - name: DefaultCredential
     type: bool
     description: |
       Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars,
-      workload identity, managed identity, Azure CLI). Requires a 'sumo'
-      build.
+      workload identity, managed identity, Azure CLI).
   - name: Threads
     type: int
     default: 1
@@ -145,7 +161,21 @@ parameters:
       of type 'Azure Monitor Creds'.
 
 sources:
-  - query: |
+  - precondition: |
+      SELECT * FROM info()
+      WHERE version(plugin="azure_monitor_upload") >= 1
+
+    query: |
+      -- azure_monitor_upload() only exists in 'sumo' builds. Server
+      -- monitoring does not evaluate the precondition above, so also
+      -- log an actionable message here rather than leaving the user
+      -- with a bare "plugin not found".
+      LET _ <= if(condition=NOT version(plugin="azure_monitor_upload"),
+          then=log(level="ERROR", dedup=-1,
+                   message="Azure.Monitor.Upload requires a Velociraptor " +
+                     "build with the 'sumo' tag (the official Docker image, " +
+                     "or a release binary with 'sumo' in its name)."))
+
       LET completions = SELECT * FROM watch_monitoring(
                artifact="System.Flow.Completion")
                WHERE Flow.artifacts_with_results =~ ArtifactNameRegex

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -199,14 +199,15 @@ const (
 	DISABLE_DANGEROUS_API_CALLS = "DISABLE_DANGEROUS_API_CALLS"
 
 	// Fixed secret types - definitions in the sanity service
-	AWS_S3_CREDS    = "AWS S3 Creds"
-	SSH_PRIVATE_KEY = "SSH PrivateKey"
-	HTTP_SECRETS    = "HTTP Secrets"
-	SPLUNK_CREDS    = "Splunk Creds"
-	ELASTIC_CREDS   = "Elastic Creds"
-	ADX_CREDS       = "ADX Creds"
-	SMTP_CREDS      = "SMTP Creds"
-	EXECVE_SECRET   = "Execve Secrets"
+	AWS_S3_CREDS        = "AWS S3 Creds"
+	SSH_PRIVATE_KEY     = "SSH PrivateKey"
+	HTTP_SECRETS        = "HTTP Secrets"
+	SPLUNK_CREDS        = "Splunk Creds"
+	ELASTIC_CREDS       = "Elastic Creds"
+	ADX_CREDS           = "ADX Creds"
+	AZURE_MONITOR_CREDS = "Azure Monitor Creds"
+	SMTP_CREDS          = "SMTP Creds"
+	EXECVE_SECRET       = "Execve Secrets"
 
 	// The name of the annotation timeline
 	TIMELINE_ANNOTATION      = "Annotation"

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -540,14 +540,14 @@
   - name: managed_identity
     type: bool
     description: Use an Azure managed identity instead of a service principal (requires
-      a 'sumo' build and that the server runs in Azure).
+      that the server runs in Azure).
   - name: managed_identity_client_id
     type: string
     description: Optional client ID of a user-assigned managed identity.
   - name: default_credential
     type: bool
     description: Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars,
-      workload identity, managed identity, Azure CLI). Requires a 'sumo' build.
+      workload identity, managed identity, Azure CLI).
   - name: chunk_size
     type: int64
     description: The number of rows to send at a time.

--- a/docs/references/vql.yaml
+++ b/docs/references/vql.yaml
@@ -500,6 +500,90 @@
   - linux_amd64_cgo
   - windows_386_cgo
   - windows_amd64_cgo
+- name: azure_monitor_upload
+  description: Upload rows to Azure Monitor / Log Analytics via the Logs Ingestion
+    API (Data Collection Rule).
+  type: Plugin
+  version: 1
+  args:
+  - name: query
+    type: StoredQuery
+    description: Source for rows to upload.
+    required: true
+  - name: threads
+    type: int64
+    description: How many threads to use.
+  - name: logs_ingestion_endpoint
+    type: string
+    description: The Logs Ingestion endpoint URI of the Data Collection Rule (or a
+      Data Collection Endpoint).
+  - name: dcr_immutable_id
+    type: string
+    description: The immutable ID of the Data Collection Rule (e.g. dcr-xxxxxxxx).
+  - name: stream_name
+    type: string
+    description: The DCR input stream name (e.g. Custom-RawVelociraptorEvents_CL).
+      If empty it is derived from table as 'Custom-<table>'.
+  - name: table
+    type: string
+    description: Used to derive stream_name as 'Custom-<table>' when stream_name is
+      not set. Unused otherwise.
+  - name: tenant_id
+    type: string
+    description: Azure Service Principal Tenant ID.
+  - name: client_id
+    type: string
+    description: Azure Service Principal Client ID.
+  - name: client_secret
+    type: string
+    description: Azure Service Principal Client Secret.
+  - name: managed_identity
+    type: bool
+    description: Use an Azure managed identity instead of a service principal (requires
+      a 'sumo' build and that the server runs in Azure).
+  - name: managed_identity_client_id
+    type: string
+    description: Optional client ID of a user-assigned managed identity.
+  - name: default_credential
+    type: bool
+    description: Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars,
+      workload identity, managed identity, Azure CLI). Requires a 'sumo' build.
+  - name: chunk_size
+    type: int64
+    description: The number of rows to send at a time.
+  - name: wait_time
+    type: int64
+    description: Batch upload at most this long in seconds (default 5).
+  - name: max_memory_buffer
+    type: uint64
+    description: Max uncompressed request body in bytes; keep under the ~1MB Azure
+      limit (default 900KB).
+  - name: skip_verify
+    type: bool
+    description: 'Skip TLS verification (default: False).'
+  - name: root_ca
+    type: string
+    description: As a better alternative to skip_verify, allows root ca certs to be
+      added here.
+  - name: max_retries
+    type: int64
+    description: 'Maximum number of retries for failed uploads (default: 3).'
+  - name: retry_wait
+    type: int64
+    description: 'Base wait time in seconds for exponential backoff between retries
+      (default: 2).'
+  - name: secret
+    type: string
+    description: Alternatively use a secret from the secrets service. Secret must
+      be of type 'Azure Monitor Creds'.
+  metadata:
+    permissions: NETWORK
+  platforms:
+  - darwin_amd64_cgo
+  - darwin_arm64_cgo
+  - linux_amd64_cgo
+  - windows_386_cgo
+  - windows_amd64_cgo
 - name: background
   description: |
     Run a query in the background.

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,8 @@ require (
 require (
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.2
 	github.com/Azure/azure-kusto-go/azkustoingest v1.2.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Masterminds/sprig/v3 v3.2.2
@@ -179,8 +181,6 @@ require (
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/pubsub/v2 v2.3.0 // indirect
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.4.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect

--- a/services/secrets/initialize.go
+++ b/services/secrets/initialize.go
@@ -129,6 +129,33 @@ var (
 			"table":       "RawVelociraptorEvents",
 		},
 	}, {
+		TypeName:    constants.AZURE_MONITOR_CREDS,
+		Description: "Credentials to be used in azure_monitor_upload() calls.",
+		// Credentials are optional in the secret - they may instead come from
+		// AZURE_* environment variables, a managed identity or the default
+		// credential chain. Only the ingestion destination is mandatory.
+		Verifier: `x=>x.logs_ingestion_endpoint AND x.dcr_immutable_id`,
+		Fields: []string{
+			"logs_ingestion_endpoint",
+			"dcr_immutable_id",
+			"stream_name",
+			"table",
+			"client_id",
+			"client_secret",
+			"tenant_id",
+			"managed_identity",
+			"managed_identity_client_id",
+			"default_credential",
+			"skip_verify",
+			"root_ca",
+		},
+		Template: map[string]string{
+			"logs_ingestion_endpoint": "https://your-dce-or-dcr.region.ingest.monitor.azure.com",
+			"stream_name":             "Custom-RawVelociraptorEvents_CL",
+			"table":                   "RawVelociraptorEvents_CL",
+			"skip_verify":             "FALSE",
+		},
+	}, {
 		TypeName:    constants.SMTP_CREDS,
 		Verifier:    "x=>x.server && x.server_port",
 		Description: "Credentials to be used in mail() plugin.",

--- a/vql/server/azure_monitor.go
+++ b/vql/server/azure_monitor.go
@@ -1,3 +1,6 @@
+//go:build sumo
+// +build sumo
+
 /*
    Velociraptor - Dig Deeper
    Copyright (C) 2019-2025 Rapid7 Inc.
@@ -30,10 +33,12 @@ stream, authenticated with an Entra (Azure AD) OAuth2 bearer token. The service
 principal or managed identity must hold the "Monitoring Metrics Publisher" role
 on the DCR.
 
-The service-principal auth path uses only the standard library plus
-golang.org/x/oauth2 so this file carries no build tag and is compiled into every
-build (like elastic.go / splunk.go). The managed-identity path pulls in the
-azidentity SDK and therefore lives in azure_monitor_mi.go behind the "sumo" tag.
+Like the ADX plugin, this plugin is compiled only under the "sumo" build tag
+because its managed-identity and default-credential auth paths pull in the
+azidentity SDK (a fat dependency shared with ADX). Builds without the tag do not
+register azure_monitor_upload at all, so callers can detect it with
+version(plugin="azure_monitor_upload"). The azidentity-backed token sources live
+in azure_monitor_mi.go.
 */
 package server
 
@@ -84,39 +89,15 @@ const azureMonitorMaxBuffer = uint64(1024 * 1024)
 // configuration comes near this.
 const azureMonitorMaxChunkSize = int64(100000)
 
+// An error response body is only ever used for a log line and the Response
+// column of a result row, so a few KB is plenty. Reading more lets a
+// misconfigured endpoint (a proxy or WAF error page) push megabytes into the
+// server monitoring logs on every retry of every failed batch.
+const azureMonitorMaxRespBody = 8 * 1024
+
 // Never honor a Retry-After longer than this - a misconfigured (or hostile)
 // server should not be able to park an upload worker for hours.
 const azureMonitorMaxRetryAfter = 5 * time.Minute
-
-// azureTokenSourceFunc builds an OAuth2 token source from the Azure identity
-// SDK. The managed-identity and default-credential implementations pull in the
-// azidentity SDK and are therefore provided by an init() in azure_monitor_mi.go,
-// compiled only under the "sumo" build tag. In builds without that tag these
-// modes are unavailable and the stubs below return an explanatory error.
-//
-// Note the plain service-principal path (including AZURE_* environment variable
-// credentials) does NOT use these - it uses golang.org/x/oauth2 directly and is
-// always compiled.
-type azureTokenSourceFunc func(
-	ctx context.Context, scope vfilter.Scope,
-	transport *http.Transport,
-	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error)
-
-var azureMonitorMITokenSource azureTokenSourceFunc = func(
-	ctx context.Context, scope vfilter.Scope,
-	transport *http.Transport,
-	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
-	return nil, errors.New(
-		"managed_identity requires a Velociraptor build with the 'sumo' tag")
-}
-
-var azureMonitorDefaultTokenSource azureTokenSourceFunc = func(
-	ctx context.Context, scope vfilter.Scope,
-	transport *http.Transport,
-	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
-	return nil, errors.New(
-		"default_credential requires a Velociraptor build with the 'sumo' tag")
-}
 
 type _AzureMonitorPluginArgs struct {
 	Query                 vfilter.StoredQuery `vfilter:"required,field=query,doc=Source for rows to upload."`
@@ -128,9 +109,9 @@ type _AzureMonitorPluginArgs struct {
 	TenantID              string              `vfilter:"optional,field=tenant_id,doc=Azure Service Principal Tenant ID."`
 	ClientID              string              `vfilter:"optional,field=client_id,doc=Azure Service Principal Client ID."`
 	ClientSecret          string              `vfilter:"optional,field=client_secret,doc=Azure Service Principal Client Secret."`
-	ManagedIdentity       bool                `vfilter:"optional,field=managed_identity,doc=Use an Azure managed identity instead of a service principal (requires a 'sumo' build and that the server runs in Azure)."`
+	ManagedIdentity       bool                `vfilter:"optional,field=managed_identity,doc=Use an Azure managed identity instead of a service principal (requires that the server runs in Azure)."`
 	ManagedIdentityClient string              `vfilter:"optional,field=managed_identity_client_id,doc=Optional client ID of a user-assigned managed identity."`
-	DefaultCredential     bool                `vfilter:"optional,field=default_credential,doc=Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars, workload identity, managed identity, Azure CLI). Requires a 'sumo' build."`
+	DefaultCredential     bool                `vfilter:"optional,field=default_credential,doc=Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars, workload identity, managed identity, Azure CLI)."`
 	ChunkSize             int64               `vfilter:"optional,field=chunk_size,doc=The number of rows to send at a time."`
 	WaitTime              int64               `vfilter:"optional,field=wait_time,doc=Batch upload at most this long in seconds (default 5)."`
 	MaxMemoryBuffer       uint64              `vfilter:"optional,field=max_memory_buffer,doc=Max uncompressed request body in bytes; keep under the ~1MB Azure limit (default 900KB)."`
@@ -292,9 +273,8 @@ func (self _AzureMonitorPlugin) Call(ctx context.Context,
 
 		// One token source shared by all threads - the underlying sources
 		// cache and refresh tokens safely across goroutines. Creating it up
-		// front also fails fast (before the source query starts) when
-		// managed_identity or default_credential is requested on a build
-		// without the 'sumo' tag.
+		// front also fails fast, before the source query starts, if the
+		// requested credential cannot be constructed.
 		tokenSource, err := getAzureMonitorTokenSource(ctx, scope, transport, arg)
 		if err != nil {
 			scope.Log("azure_monitor_upload: %v", err)
@@ -437,8 +417,9 @@ func _upload_rows_azure(
 
 // marshal_azure_row shapes a VQL row into the JSON object expected by the DCR
 // stream. Every Log Analytics table requires a TimeGenerated column, so we
-// always populate it. The remaining metadata is lifted into structured columns
-// and the original row is preserved under RawData.
+// always populate it - with the ingestion time, see below. The row's own event
+// time is carried separately in EventTime. The remaining metadata is lifted
+// into structured columns and the original row is preserved under RawData.
 func marshal_azure_row(
 	ctx context.Context,
 	scope vfilter.Scope,
@@ -461,19 +442,28 @@ func marshal_azure_row(
 	organization, _ := row_dict.GetString("_Organization")
 	hostname, _ := row_dict.GetString("_Hostname")
 
-	// Prefer the artifact's own Timestamp column, fall back to the injected
-	// _timestamp, otherwise default to now.
+	// TimeGenerated is the Log Analytics partition / retention key and Azure
+	// only accepts a narrow window around the moment of ingestion (roughly the
+	// last 2 days, and not far into the future), so it must hold the ingestion
+	// time rather than the event time. Rows from forensic artifacts routinely
+	// carry historical Timestamps which Azure would re-stamp or reject - those
+	// go into EventTime below instead. Use the injected _timestamp, falling
+	// back to now for callers that do not supply one.
 	timeGenerated := ""
-	if ts, pres := row_dict.Get("Timestamp"); pres && !utils.IsNil(ts) {
+	if ts, pres := row_dict.Get("_timestamp"); pres && !utils.IsNil(ts) {
 		timeGenerated = formatAzureTime(ctx, scope, ts)
 	}
 	if timeGenerated == "" {
-		if ts, pres := row_dict.Get("_timestamp"); pres && !utils.IsNil(ts) {
-			timeGenerated = formatAzureTime(ctx, scope, ts)
-		}
-	}
-	if timeGenerated == "" {
 		timeGenerated = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	// The artifact's own event time, when it has one. The key is omitted
+	// entirely when the column is absent or unparseable - formatAzureTime
+	// returns "" for those, and an empty string does not parse as a datetime
+	// column in the DCR.
+	eventTime := ""
+	if ts, pres := row_dict.Get("Timestamp"); pres && !utils.IsNil(ts) {
+		eventTime = formatAzureTime(ctx, scope, ts)
 	}
 
 	// Remove the injected metadata fields before storing the row as RawData
@@ -486,8 +476,11 @@ func marshal_azure_row(
 	row_dict.Delete("_timestamp")
 
 	out := ordereddict.NewDict().
-		Set("TimeGenerated", timeGenerated).
-		Set("Artifact", artifact).
+		Set("TimeGenerated", timeGenerated)
+	if eventTime != "" {
+		out.Set("EventTime", eventTime)
+	}
+	out.Set("Artifact", artifact).
 		Set("ClientId", clientId).
 		Set("FlowId", flowId).
 		Set("Organization", organization).
@@ -640,11 +633,17 @@ func post_azure_batch(
 			lastStatus = 0
 			lastBody = ""
 		} else {
-			body, read_err := utils.ReadAllWithLimit(resp.Body, constants.MAX_MEMORY)
+			// Deliberately not draining the rest of the body before closing:
+			// losing connection reuse on an error response is cheaper than
+			// reading an arbitrarily large one.
+			body, read_err := utils.ReadAllWithLimit(
+				resp.Body, azureMonitorMaxRespBody)
 			resp.Body.Close()
 			lastStatus = resp.StatusCode
 			lastBody = string(body)
-			if read_err != nil {
+			if errors.Is(read_err, utils.MemoryBufferExceeded) {
+				lastBody += " ...(truncated)"
+			} else if read_err != nil {
 				scope.Log("azure_monitor_upload: error reading response body (status %d): %v",
 					resp.StatusCode, read_err)
 			}

--- a/vql/server/azure_monitor.go
+++ b/vql/server/azure_monitor.go
@@ -1,0 +1,882 @@
+/*
+   Velociraptor - Dig Deeper
+   Copyright (C) 2019-2025 Rapid7 Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+Plugin Azure Monitor (Log Analytics).
+
+Uploads rows to an Azure Log Analytics workspace using the Azure Monitor Logs
+Ingestion API (the modern Data Collection Rule based API which superseded the
+deprecated HTTP Data Collector API).
+
+Unlike the ADX plugin (which talks to a Kusto cluster's Data Management endpoint
+via the Azure Kusto SDK), Log Analytics does not expose a Kusto ingestion
+endpoint. Data is instead POSTed as a JSON array to a Data Collection Rule (DCR)
+stream, authenticated with an Entra (Azure AD) OAuth2 bearer token. The service
+principal or managed identity must hold the "Monitoring Metrics Publisher" role
+on the DCR.
+
+The service-principal auth path uses only the standard library plus
+golang.org/x/oauth2 so this file carries no build tag and is compiled into every
+build (like elastic.go / splunk.go). The managed-identity path pulls in the
+azidentity SDK and therefore lives in azure_monitor_mi.go behind the "sumo" tag.
+*/
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"golang.org/x/oauth2/microsoft"
+	"www.velocidex.com/golang/velociraptor/acls"
+	"www.velocidex.com/golang/velociraptor/artifacts"
+	"www.velocidex.com/golang/velociraptor/constants"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/velociraptor/vql/functions"
+	"www.velocidex.com/golang/velociraptor/vql/networking"
+	vfilter "www.velocidex.com/golang/vfilter"
+	"www.velocidex.com/golang/vfilter/arg_parser"
+)
+
+// The OAuth2 scope used to obtain a token for the Logs Ingestion API.
+const azureMonitorScope = "https://monitor.azure.com/.default"
+
+// The Logs Ingestion API caps a single request at ~1MB uncompressed. We default
+// the buffer well under that to leave headroom for the JSON array framing.
+const azureMonitorDefaultMaxBuffer = uint64(900 * 1024)
+
+// The hard ceiling for max_memory_buffer - the documented Logs Ingestion
+// request cap. Anything above this is guaranteed to be rejected with a 413.
+const azureMonitorMaxBuffer = uint64(1024 * 1024)
+
+// chunk_size sizes an allocation, so it needs an upper bound as well as a lower
+// one. A batch must fit under max_memory_buffer anyway, so no legitimate
+// configuration comes near this.
+const azureMonitorMaxChunkSize = int64(100000)
+
+// Never honor a Retry-After longer than this - a misconfigured (or hostile)
+// server should not be able to park an upload worker for hours.
+const azureMonitorMaxRetryAfter = 5 * time.Minute
+
+// azureTokenSourceFunc builds an OAuth2 token source from the Azure identity
+// SDK. The managed-identity and default-credential implementations pull in the
+// azidentity SDK and are therefore provided by an init() in azure_monitor_mi.go,
+// compiled only under the "sumo" build tag. In builds without that tag these
+// modes are unavailable and the stubs below return an explanatory error.
+//
+// Note the plain service-principal path (including AZURE_* environment variable
+// credentials) does NOT use these - it uses golang.org/x/oauth2 directly and is
+// always compiled.
+type azureTokenSourceFunc func(
+	ctx context.Context, scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error)
+
+var azureMonitorMITokenSource azureTokenSourceFunc = func(
+	ctx context.Context, scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+	return nil, errors.New(
+		"managed_identity requires a Velociraptor build with the 'sumo' tag")
+}
+
+var azureMonitorDefaultTokenSource azureTokenSourceFunc = func(
+	ctx context.Context, scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+	return nil, errors.New(
+		"default_credential requires a Velociraptor build with the 'sumo' tag")
+}
+
+type _AzureMonitorPluginArgs struct {
+	Query                 vfilter.StoredQuery `vfilter:"required,field=query,doc=Source for rows to upload."`
+	Threads               int64               `vfilter:"optional,field=threads,doc=How many threads to use."`
+	LogsIngestionEndpoint string              `vfilter:"optional,field=logs_ingestion_endpoint,doc=The Logs Ingestion endpoint URI of the Data Collection Rule (or a Data Collection Endpoint)."`
+	DCRImmutableID        string              `vfilter:"optional,field=dcr_immutable_id,doc=The immutable ID of the Data Collection Rule (e.g. dcr-xxxxxxxx)."`
+	StreamName            string              `vfilter:"optional,field=stream_name,doc=The DCR input stream name (e.g. Custom-RawVelociraptorEvents_CL). If empty it is derived from table as 'Custom-<table>'."`
+	Table                 string              `vfilter:"optional,field=table,doc=Used to derive stream_name as 'Custom-<table>' when stream_name is not set. Unused otherwise."`
+	TenantID              string              `vfilter:"optional,field=tenant_id,doc=Azure Service Principal Tenant ID."`
+	ClientID              string              `vfilter:"optional,field=client_id,doc=Azure Service Principal Client ID."`
+	ClientSecret          string              `vfilter:"optional,field=client_secret,doc=Azure Service Principal Client Secret."`
+	ManagedIdentity       bool                `vfilter:"optional,field=managed_identity,doc=Use an Azure managed identity instead of a service principal (requires a 'sumo' build and that the server runs in Azure)."`
+	ManagedIdentityClient string              `vfilter:"optional,field=managed_identity_client_id,doc=Optional client ID of a user-assigned managed identity."`
+	DefaultCredential     bool                `vfilter:"optional,field=default_credential,doc=Use the Azure SDK DefaultAzureCredential chain (AZURE_* env vars, workload identity, managed identity, Azure CLI). Requires a 'sumo' build."`
+	ChunkSize             int64               `vfilter:"optional,field=chunk_size,doc=The number of rows to send at a time."`
+	WaitTime              int64               `vfilter:"optional,field=wait_time,doc=Batch upload at most this long in seconds (default 5)."`
+	MaxMemoryBuffer       uint64              `vfilter:"optional,field=max_memory_buffer,doc=Max uncompressed request body in bytes; keep under the ~1MB Azure limit (default 900KB)."`
+	SkipVerify            bool                `vfilter:"optional,field=skip_verify,doc=Skip TLS verification (default: False)."`
+	RootCerts             string              `vfilter:"optional,field=root_ca,doc=As a better alternative to skip_verify, allows root ca certs to be added here."`
+	MaxRetries            int64               `vfilter:"optional,field=max_retries,doc=Maximum number of retries for failed uploads (default: 3)."`
+	RetryWait             int64               `vfilter:"optional,field=retry_wait,doc=Base wait time in seconds for exponential backoff between retries (default: 2)."`
+	Secret                string              `vfilter:"optional,field=secret,doc=Alternatively use a secret from the secrets service. Secret must be of type 'Azure Monitor Creds'."`
+}
+
+type _AzureMonitorPlugin struct{}
+
+func (self _AzureMonitorPlugin) Call(ctx context.Context,
+	scope vfilter.Scope,
+	args *ordereddict.Dict) <-chan vfilter.Row {
+	output_chan := make(chan vfilter.Row)
+
+	go func() {
+		defer close(output_chan)
+		defer vql_subsystem.RegisterMonitor(ctx, "azure_monitor_upload", args)()
+
+		err := vql_subsystem.CheckAccess(scope, acls.NETWORK)
+		if err != nil {
+			scope.Log("azure_monitor_upload: %v", err)
+			return
+		}
+
+		arg := &_AzureMonitorPluginArgs{}
+		err = arg_parser.ExtractArgsWithContext(ctx, scope, args, arg)
+		if err != nil {
+			scope.Log("azure_monitor_upload: %v", err)
+			return
+		}
+
+		err = self.maybeForceSecrets(ctx, scope, arg)
+		if err != nil {
+			scope.Log("azure_monitor_upload: %v", err)
+			return
+		}
+
+		if arg.Secret != "" {
+			err := mergeSecretAzureMonitor(ctx, scope, arg)
+			if err != nil {
+				scope.Log("azure_monitor_upload: %v", err)
+				return
+			}
+		}
+
+		if arg.LogsIngestionEndpoint == "" {
+			scope.Log("azure_monitor_upload: field logs_ingestion_endpoint is required")
+			return
+		}
+
+		// url.Parse accepts almost anything, so check the parts we actually
+		// need. A missing host can only ever produce a broken request URL.
+		endpoint_url, err := url.Parse(arg.LogsIngestionEndpoint)
+		if err != nil {
+			scope.Log("azure_monitor_upload: invalid logs_ingestion_endpoint: %v", err)
+			return
+		}
+		if endpoint_url.Host == "" {
+			scope.Log("azure_monitor_upload: invalid logs_ingestion_endpoint %q: no host - expected e.g. https://<dce>.<region>.ingest.monitor.azure.com",
+				arg.LogsIngestionEndpoint)
+			return
+		}
+		// The oauth2 transport attaches the Entra bearer token to every
+		// request, so a non-https endpoint puts a live token on the wire.
+		if endpoint_url.Scheme != "https" {
+			scope.Log("azure_monitor_upload: logs_ingestion_endpoint %q is not https - the Azure access token will be sent in cleartext",
+				arg.LogsIngestionEndpoint)
+		}
+
+		if arg.DCRImmutableID == "" {
+			scope.Log("azure_monitor_upload: field dcr_immutable_id is required")
+			return
+		}
+
+		// Resolve the stream name from table if not given explicitly.
+		if arg.StreamName == "" {
+			if arg.Table == "" {
+				scope.Log("azure_monitor_upload: either stream_name or table is required")
+				return
+			}
+			arg.StreamName = "Custom-" + arg.Table
+		}
+
+		// Allow credentials to come from the standard Azure environment
+		// variables (as the Azure SDKs do by default) when they are not
+		// supplied explicitly. This still uses the proxy / CA aware
+		// client-credentials flow below.
+		if arg.ClientID == "" {
+			arg.ClientID = os.Getenv("AZURE_CLIENT_ID")
+		}
+		if arg.ClientSecret == "" {
+			arg.ClientSecret = os.Getenv("AZURE_CLIENT_SECRET")
+		}
+		if arg.TenantID == "" {
+			arg.TenantID = os.Getenv("AZURE_TENANT_ID")
+		}
+
+		// Credentials: a managed identity, the default credential chain, or a
+		// full service principal (from args, a secret, or AZURE_* env vars).
+		if !arg.ManagedIdentity && !arg.DefaultCredential {
+			if arg.ClientID == "" || arg.ClientSecret == "" || arg.TenantID == "" {
+				scope.Log("azure_monitor_upload: no credentials found - supply client_id/client_secret/tenant_id (or set the AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID env vars), or set managed_identity=TRUE or default_credential=TRUE")
+				return
+			}
+		}
+
+		if arg.Threads <= 0 {
+			arg.Threads = 1
+		}
+		if arg.ChunkSize <= 0 {
+			arg.ChunkSize = 1000
+		} else if arg.ChunkSize > azureMonitorMaxChunkSize {
+			scope.Log("azure_monitor_upload: chunk_size %d exceeds the maximum of %d - clamping",
+				arg.ChunkSize, azureMonitorMaxChunkSize)
+			arg.ChunkSize = azureMonitorMaxChunkSize
+		}
+		if arg.WaitTime <= 0 {
+			arg.WaitTime = 5
+		}
+		if arg.MaxRetries <= 0 {
+			arg.MaxRetries = 3
+		}
+		if arg.RetryWait <= 0 {
+			arg.RetryWait = 2
+		}
+		// Note a negative value from VQL arrives here as a huge uint64 (the
+		// arg parser converts through int64), so the upper clamp is what
+		// rejects it - it must not be allowed to disable the size guards.
+		if arg.MaxMemoryBuffer == 0 {
+			arg.MaxMemoryBuffer = azureMonitorDefaultMaxBuffer
+		} else if arg.MaxMemoryBuffer > azureMonitorMaxBuffer {
+			scope.Log("azure_monitor_upload: max_memory_buffer %d exceeds the Azure request limit - clamping to %d",
+				arg.MaxMemoryBuffer, azureMonitorMaxBuffer)
+			arg.MaxMemoryBuffer = azureMonitorMaxBuffer
+		}
+
+		config_obj, _ := artifacts.GetConfig(scope)
+
+		// Build a single transport honoring proxy / CA / skip_verify
+		// settings, shared by all upload threads. GetNewHttpTransport
+		// returns a clone, so it is safe to mutate its TLS config (unlike
+		// the cached GetHttpTransport).
+		transport, err := networking.GetNewHttpTransport(config_obj, arg.RootCerts)
+		if err != nil {
+			scope.Log("azure_monitor_upload: cannot create http transport: %v", err)
+			return
+		}
+
+		if arg.SkipVerify {
+			if err := networking.EnableSkipVerify(
+				transport.TLSClientConfig, config_obj); err != nil {
+				scope.Log("azure_monitor_upload: cannot disable SSL security: %v", err)
+				return
+			}
+		}
+
+		// One token source shared by all threads - the underlying sources
+		// cache and refresh tokens safely across goroutines. Creating it up
+		// front also fails fast (before the source query starts) when
+		// managed_identity or default_credential is requested on a build
+		// without the 'sumo' tag.
+		tokenSource, err := getAzureMonitorTokenSource(ctx, scope, transport, arg)
+		if err != nil {
+			scope.Log("azure_monitor_upload: %v", err)
+			return
+		}
+
+		// The oauth2 transport injects (and transparently refreshes) the
+		// bearer token, and sends the data request through our Base
+		// transport.
+		httpClient := &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &oauth2.Transport{
+				Base:   transport,
+				Source: tokenSource,
+			},
+		}
+
+		uploadURL := buildIngestionURL(
+			arg.LogsIngestionEndpoint, arg.DCRImmutableID, arg.StreamName)
+
+		wg := sync.WaitGroup{}
+		row_chan := arg.Query.Eval(ctx, scope)
+		for i := 0; i < int(arg.Threads); i++ {
+			wg.Add(1)
+
+			// Start an uploader on a thread.
+			go _upload_rows_azure(ctx, scope, output_chan,
+				row_chan, &wg, httpClient, uploadURL, arg)
+		}
+
+		wg.Wait()
+	}()
+	return output_chan
+}
+
+// Copy rows from row_chan into a local batch and POST them to the Logs
+// Ingestion API.
+func _upload_rows_azure(
+	ctx context.Context,
+	scope vfilter.Scope,
+	output_chan chan vfilter.Row,
+	row_chan <-chan vfilter.Row,
+	wg *sync.WaitGroup,
+	httpClient *http.Client,
+	uploadURL string,
+	arg *_AzureMonitorPluginArgs) {
+	defer wg.Done()
+
+	var rowCount int64
+	var byteEstimate int
+	buf := make([][]byte, 0, arg.ChunkSize)
+	var batchStart time.Time
+
+	opts := vql_subsystem.EncOptsFromScope(scope)
+
+	flushBuffer := func(reason string) {
+		if rowCount > 0 {
+			send_to_azure_monitor(ctx, scope, output_chan, httpClient,
+				uploadURL, buf, rowCount, byteEstimate, arg, reason, batchStart)
+		}
+		buf = buf[:0]
+		rowCount = 0
+		byteEstimate = 0
+		batchStart = time.Time{}
+	}
+	defer func() {
+		flushBuffer("shutdown")
+	}()
+
+	wait_time := time.Duration(arg.WaitTime) * time.Second
+	timer := time.NewTimer(wait_time)
+	defer timer.Stop()
+
+	// resetTimer safely drains and resets the timer.
+	resetTimer := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(wait_time)
+	}
+
+	// Batch sending: flush when we reach chunk_size, when the buffer would
+	// exceed max_memory_buffer, or when wait_time elapses - whichever first.
+	for {
+		select {
+		case <-ctx.Done():
+			flushBuffer("context_cancelled")
+			return
+
+		case row, ok := <-row_chan:
+			if !ok {
+				flushBuffer("channel_closed")
+				return
+			}
+
+			data, err := marshal_azure_row(ctx, scope, row, opts)
+			if err != nil {
+				scope.Log("azure_monitor_upload: failed to process row: %v", err)
+				continue
+			}
+
+			// A single row larger than the request cap could never be
+			// ingested - drop it with a warning rather than wedging the
+			// worker into endless rejections.
+			if uint64(len(data)) > arg.MaxMemoryBuffer {
+				scope.Log("azure_monitor_upload: dropping oversized row (%d bytes > max_memory_buffer %d)",
+					len(data), arg.MaxMemoryBuffer)
+				continue
+			}
+
+			// Flush first if appending this row would exceed the cap.
+			if rowCount > 0 &&
+				uint64(byteEstimate+len(data)+1) > arg.MaxMemoryBuffer {
+				flushBuffer("max_memory_buffer")
+				resetTimer()
+			}
+
+			if batchStart.IsZero() {
+				batchStart = time.Now()
+			}
+
+			buf = append(buf, data)
+			byteEstimate += len(data) + 1 // +1 for the array separator
+			rowCount++
+
+			if rowCount >= arg.ChunkSize {
+				flushBuffer("chunk_size")
+				resetTimer()
+			}
+
+		case <-timer.C:
+			flushBuffer("wait_time")
+			timer.Reset(wait_time)
+		}
+	}
+}
+
+// marshal_azure_row shapes a VQL row into the JSON object expected by the DCR
+// stream. Every Log Analytics table requires a TimeGenerated column, so we
+// always populate it. The remaining metadata is lifted into structured columns
+// and the original row is preserved under RawData.
+func marshal_azure_row(
+	ctx context.Context,
+	scope vfilter.Scope,
+	row vfilter.Row,
+	opts *json.EncOpts) ([]byte, error) {
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	row_dict := vfilter.RowToDict(ctx, scope, row)
+
+	// Extract metadata fields (prefixed with _ to avoid collisions with
+	// artifact columns).
+	artifact, _ := row_dict.GetString("_Artifact")
+	clientId, _ := row_dict.GetString("_ClientId")
+	flowId, _ := row_dict.GetString("_FlowId")
+	organization, _ := row_dict.GetString("_Organization")
+	hostname, _ := row_dict.GetString("_Hostname")
+
+	// Prefer the artifact's own Timestamp column, fall back to the injected
+	// _timestamp, otherwise default to now.
+	timeGenerated := ""
+	if ts, pres := row_dict.Get("Timestamp"); pres && !utils.IsNil(ts) {
+		timeGenerated = formatAzureTime(ctx, scope, ts)
+	}
+	if timeGenerated == "" {
+		if ts, pres := row_dict.Get("_timestamp"); pres && !utils.IsNil(ts) {
+			timeGenerated = formatAzureTime(ctx, scope, ts)
+		}
+	}
+	if timeGenerated == "" {
+		timeGenerated = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	// Remove the injected metadata fields before storing the row as RawData
+	// (but keep the artifact's own Timestamp column intact).
+	row_dict.Delete("_Artifact")
+	row_dict.Delete("_ClientId")
+	row_dict.Delete("_FlowId")
+	row_dict.Delete("_Organization")
+	row_dict.Delete("_Hostname")
+	row_dict.Delete("_timestamp")
+
+	out := ordereddict.NewDict().
+		Set("TimeGenerated", timeGenerated).
+		Set("Artifact", artifact).
+		Set("ClientId", clientId).
+		Set("FlowId", flowId).
+		Set("Organization", organization).
+		Set("Hostname", hostname).
+		Set("RawData", row_dict)
+
+	return json.MarshalWithOptions(out, opts)
+}
+
+func formatAzureTime(
+	ctx context.Context, scope vfilter.Scope, ts interface{}) string {
+	t, err := functions.TimeFromAny(ctx, scope, ts)
+
+	// TimeFromAny returns the zero time with a *nil* error for an empty
+	// string, for a zero epoch, and for any repeat of an unparseable string
+	// (ParseTimeFromString caches the failed parse and later returns it as a
+	// hit). Checking err alone would let those through as year 0001, which
+	// Azure silently drops - report "no timestamp" so the caller falls back.
+	if err != nil || t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func send_to_azure_monitor(
+	ctx context.Context,
+	scope vfilter.Scope,
+	output_chan chan vfilter.Row,
+	httpClient *http.Client,
+	uploadURL string,
+	buf [][]byte,
+	rowCount int64,
+	byteEstimate int,
+	arg *_AzureMonitorPluginArgs,
+	flushReason string,
+	batchStart time.Time) {
+
+	if rowCount == 0 || len(buf) == 0 {
+		return
+	}
+
+	// Assemble the JSON array body.
+	var body bytes.Buffer
+	body.Grow(byteEstimate + 2)
+	body.WriteByte('[')
+	for i, r := range buf {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		body.Write(r)
+	}
+	body.WriteByte(']')
+
+	uncompressedSize := body.Len()
+
+	// gzip the payload to reduce egress. Note the ~1MB Azure limit is on the
+	// uncompressed body, which we already bound via max_memory_buffer.
+	var gzBuf bytes.Buffer
+	gz := gzip.NewWriter(&gzBuf)
+	_, err := gz.Write(body.Bytes())
+	if err == nil {
+		err = gz.Close()
+	}
+	if err != nil {
+		scope.Log("azure_monitor_upload: gzip failed: %v", err)
+		return
+	}
+
+	var duration time.Duration
+	if !batchStart.IsZero() {
+		duration = time.Since(batchStart)
+	}
+
+	// If the caller's context is already cancelled (final flush on shutdown),
+	// use a short-lived background context so the last batch is not dropped.
+	uploadCtx := ctx
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		uploadCtx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+	}
+
+	status, respBody, err := post_azure_batch(
+		uploadCtx, scope, httpClient, uploadURL, gzBuf.Bytes(), arg)
+
+	if err != nil {
+		scope.Log("azure_monitor_upload: failed to upload %d rows (%d bytes) (reason=%s duration=%v): %v",
+			rowCount, uncompressedSize, flushReason, duration, err)
+		// Guard on the caller's ctx, not uploadCtx: once the query is
+		// cancelled nobody reads output_chan, so the result row is dropped
+		// instead of blocking until uploadCtx times out.
+		select {
+		case <-ctx.Done():
+		case output_chan <- ordereddict.NewDict().
+			Set("Rows", rowCount).
+			Set("Bytes", uncompressedSize).
+			Set("DurationMs", duration.Milliseconds()).
+			Set("FlushReason", flushReason).
+			Set("Status", "Error").
+			Set("StatusCode", status).
+			Set("Response", responseOrError(respBody, err)):
+		}
+		return
+	}
+
+	scope.Log("azure_monitor_upload: uploaded %d rows (%d bytes) to stream %s (reason=%s duration=%v)",
+		rowCount, uncompressedSize, arg.StreamName, flushReason, duration)
+	select {
+	case <-ctx.Done():
+	case output_chan <- ordereddict.NewDict().
+		Set("Rows", rowCount).
+		Set("Bytes", uncompressedSize).
+		Set("DurationMs", duration.Milliseconds()).
+		Set("FlushReason", flushReason).
+		Set("Status", "Success").
+		Set("StatusCode", status).
+		Set("StreamName", arg.StreamName).
+		Set("Response", "Ingestion accepted"):
+	}
+}
+
+// post_azure_batch performs the HTTPS POST with retry/backoff. It honors
+// Retry-After on 429 and retries transient 5xx errors; 4xx client errors are
+// returned immediately since they will not fix themselves.
+func post_azure_batch(
+	ctx context.Context,
+	scope vfilter.Scope,
+	httpClient *http.Client,
+	uploadURL string,
+	gzBody []byte,
+	arg *_AzureMonitorPluginArgs) (int, string, error) {
+
+	var lastErr error
+	var lastStatus int
+	var lastBody string
+
+	for attempt := int64(0); attempt <= arg.MaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(
+			ctx, "POST", uploadURL, bytes.NewReader(gzBody))
+		if err != nil {
+			// A malformed request will never succeed.
+			return 0, "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Encoding", "gzip")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			lastStatus = 0
+			lastBody = ""
+		} else {
+			body, read_err := utils.ReadAllWithLimit(resp.Body, constants.MAX_MEMORY)
+			resp.Body.Close()
+			lastStatus = resp.StatusCode
+			lastBody = string(body)
+			if read_err != nil {
+				scope.Log("azure_monitor_upload: error reading response body (status %d): %v",
+					resp.StatusCode, read_err)
+			}
+
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return resp.StatusCode, lastBody, nil
+			}
+
+			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, lastBody)
+
+			// Only retry on throttling (429) or transient server errors.
+			if resp.StatusCode != http.StatusTooManyRequests &&
+				resp.StatusCode < 500 {
+				return resp.StatusCode, lastBody, lastErr
+			}
+
+			// Honor Retry-After on 429 if present, but never on the last
+			// attempt - sleeping there just parks the worker (and stalls
+			// row_chan) before returning the error we already have.
+			if resp.StatusCode == http.StatusTooManyRequests &&
+				attempt < arg.MaxRetries {
+				if wait := parseRetryAfter(resp.Header.Get("Retry-After")); wait > 0 {
+					scope.Log("azure_monitor_upload: throttled (429), waiting %v (Retry-After)...", wait)
+					if !sleepCtx(ctx, wait) {
+						return lastStatus, lastBody, lastErr
+					}
+					continue
+				}
+			}
+		}
+
+		// Exponential backoff before the next attempt.
+		if attempt < arg.MaxRetries {
+			backoff := azureMonitorBackoff(arg.RetryWait, attempt)
+			scope.Log("azure_monitor_upload: attempt %d failed: %v, retrying in %v...",
+				attempt+1, lastErr, backoff)
+			if !sleepCtx(ctx, backoff) {
+				return lastStatus, lastBody, lastErr
+			}
+		}
+	}
+
+	return lastStatus, lastBody, lastErr
+}
+
+// buildIngestionURL constructs the Logs Ingestion API URL for a DCR stream.
+func buildIngestionURL(endpoint, dcr, stream string) string {
+	return strings.TrimRight(endpoint, "/") +
+		"/dataCollectionRules/" + url.PathEscape(dcr) +
+		"/streams/" + url.PathEscape(stream) +
+		"?api-version=2023-01-01"
+}
+
+// getAzureMonitorTokenSource returns an OAuth2 token source for either a service
+// principal (client-credentials flow) or a managed identity.
+func getAzureMonitorTokenSource(
+	ctx context.Context,
+	scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+
+	if arg.ManagedIdentity {
+		return azureMonitorMITokenSource(ctx, scope, transport, arg)
+	}
+
+	if arg.DefaultCredential {
+		return azureMonitorDefaultTokenSource(ctx, scope, transport, arg)
+	}
+
+	conf := &clientcredentials.Config{
+		ClientID:     arg.ClientID,
+		ClientSecret: arg.ClientSecret,
+		TokenURL:     microsoft.AzureADEndpoint(arg.TenantID).TokenURL,
+		Scopes:       []string{azureMonitorScope},
+	}
+
+	// Reach the token endpoint through the same transport (proxy / CA /
+	// skip_verify) as the data plane. We use a background context carrying the
+	// http client so token refresh still works during the shutdown flush. The
+	// client carries its own timeout because the background context has no
+	// deadline and the data-plane client's timeout does not cover token
+	// acquisition - without it a hung token endpoint would wedge the uploader.
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Transport: transport, Timeout: 30 * time.Second})
+
+	return conf.TokenSource(tokenCtx), nil
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// azureMonitorBackoff computes exponential backoff for a retry attempt,
+// capped at azureMonitorMaxRetryAfter. The cap also guards against int64
+// overflow in retryWaitSecs*2^attempt when attempt or retry_wait is large.
+func azureMonitorBackoff(retryWaitSecs, attempt int64) time.Duration {
+	if attempt > 30 {
+		attempt = 30
+	}
+	backoff := time.Duration(retryWaitSecs) * time.Second * time.Duration(int64(1)<<uint(attempt))
+	if backoff <= 0 || backoff > azureMonitorMaxRetryAfter {
+		return azureMonitorMaxRetryAfter
+	}
+	return backoff
+}
+
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+
+	var d time.Duration
+
+	// Retry-After may be a number of seconds.
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs > 0 {
+			d = time.Duration(secs) * time.Second
+		}
+	} else if t, err := http.ParseTime(v); err == nil {
+		// Or an HTTP date.
+		d = time.Until(t)
+	}
+
+	if d < 0 {
+		return 0
+	}
+	if d > azureMonitorMaxRetryAfter {
+		return azureMonitorMaxRetryAfter
+	}
+	return d
+}
+
+func responseOrError(body string, err error) string {
+	if body != "" {
+		return body
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func (self _AzureMonitorPlugin) maybeForceSecrets(
+	ctx context.Context, scope vfilter.Scope, arg *_AzureMonitorPluginArgs) error {
+
+	// Not running on the server, secrets don't work.
+	config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		return nil
+	}
+
+	if config_obj.Security == nil {
+		return nil
+	}
+
+	if !config_obj.Security.VqlMustUseSecrets {
+		return nil
+	}
+
+	// If an explicit secret is defined let it provide the credentials.
+	if arg.Secret != "" {
+		return nil
+	}
+
+	return utils.SecretsEnforced
+}
+
+func mergeSecretAzureMonitor(
+	ctx context.Context, scope vfilter.Scope, arg *_AzureMonitorPluginArgs) error {
+	config_obj, ok := vql_subsystem.GetServerConfig(scope)
+	if !ok {
+		return errors.New("azure_monitor_upload: Secrets may only be used on the server")
+	}
+
+	secrets_service, err := services.GetSecretsService(config_obj)
+	if err != nil {
+		return err
+	}
+
+	principal := vql_subsystem.GetPrincipal(scope)
+
+	s, err := secrets_service.GetSecret(ctx, principal,
+		constants.AZURE_MONITOR_CREDS, arg.Secret)
+	if err != nil {
+		return err
+	}
+
+	// Allow the user to override these fields.
+	s.UpdateString("logs_ingestion_endpoint", &arg.LogsIngestionEndpoint)
+	s.UpdateString("dcr_immutable_id", &arg.DCRImmutableID)
+	s.UpdateString("stream_name", &arg.StreamName)
+	s.UpdateString("table", &arg.Table)
+
+	// Credentials come from the secret when it carries them. Unlike ADX_CREDS
+	// (whose verifier requires all three, so mergeSecretADX can assign
+	// unconditionally), the AZURE_MONITOR_CREDS verifier makes credentials
+	// optional - auth may instead be a managed identity, the default
+	// credential chain or the AZURE_* env vars. So a destination-only secret
+	// must leave any credentials the caller supplied alone rather than
+	// blanking them. A secret that does carry credentials still wins.
+	s.UpdateString("client_id", &arg.ClientID)
+	s.UpdateString("client_secret", &arg.ClientSecret)
+	s.UpdateString("tenant_id", &arg.TenantID)
+	s.UpdateBool("managed_identity", &arg.ManagedIdentity)
+	s.UpdateString("managed_identity_client_id", &arg.ManagedIdentityClient)
+	s.UpdateBool("default_credential", &arg.DefaultCredential)
+	s.UpdateString("root_ca", &arg.RootCerts)
+	s.UpdateBool("skip_verify", &arg.SkipVerify)
+
+	return nil
+}
+
+func (self _AzureMonitorPlugin) Info(
+	scope vfilter.Scope,
+	type_map *vfilter.TypeMap) *vfilter.PluginInfo {
+	return &vfilter.PluginInfo{
+		Name:     "azure_monitor_upload",
+		Doc:      "Upload rows to Azure Monitor / Log Analytics via the Logs Ingestion API (Data Collection Rule).",
+		ArgType:  type_map.AddType(scope, &_AzureMonitorPluginArgs{}),
+		Metadata: vql_subsystem.VQLMetadata().Permissions(acls.NETWORK).Build(),
+		Version:  1,
+	}
+}
+
+func init() {
+	vql_subsystem.RegisterPlugin(&_AzureMonitorPlugin{})
+}

--- a/vql/server/azure_monitor_mi.go
+++ b/vql/server/azure_monitor_mi.go
@@ -22,12 +22,10 @@
 /*
 Azure Monitor managed-identity / default-credential auth.
 
-This file is compiled only under the "sumo" build tag because it pulls in the
-azidentity SDK (which is also used by the ADX plugin). It provides the
-azidentity-backed token sources for the managed_identity and default_credential
-auth modes of azure_monitor_upload(). The service-principal path (including
-AZURE_* environment variable credentials) lives in azure_monitor.go and is
-always compiled.
+The azidentity-backed token sources for the managed_identity and
+default_credential auth modes of azure_monitor_upload(). The service-principal
+path (including AZURE_* environment variable credentials) uses
+golang.org/x/oauth2 directly and lives in azure_monitor.go.
 
 Note: azidentity manages its own HTTP stack for token acquisition (IMDS for
 managed identity, the Entra endpoints for the default credential chain), so the
@@ -49,40 +47,40 @@ import (
 	vfilter "www.velocidex.com/golang/vfilter"
 )
 
-func init() {
-	// Managed identity (optionally user-assigned via managed_identity_client_id).
-	azureMonitorMITokenSource = func(
-		ctx context.Context, scope vfilter.Scope,
-		transport *http.Transport,
-		arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+// azureMonitorMITokenSource authenticates with a managed identity (optionally
+// user-assigned via managed_identity_client_id).
+func azureMonitorMITokenSource(
+	ctx context.Context, scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
 
-		options := &azidentity.ManagedIdentityCredentialOptions{}
-		if arg.ManagedIdentityClient != "" {
-			options.ID = azidentity.ClientID(arg.ManagedIdentityClient)
-		}
-
-		cred, err := azidentity.NewManagedIdentityCredential(options)
-		if err != nil {
-			return nil, err
-		}
-
-		return newAzureADTokenSource(cred), nil
+	options := &azidentity.ManagedIdentityCredentialOptions{}
+	if arg.ManagedIdentityClient != "" {
+		options.ID = azidentity.ClientID(arg.ManagedIdentityClient)
 	}
 
-	// DefaultAzureCredential chain: AZURE_* env vars, workload identity,
-	// managed identity, Azure CLI - auto-detected by the SDK.
-	azureMonitorDefaultTokenSource = func(
-		ctx context.Context, scope vfilter.Scope,
-		transport *http.Transport,
-		arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
-
-		cred, err := azidentity.NewDefaultAzureCredential(nil)
-		if err != nil {
-			return nil, err
-		}
-
-		return newAzureADTokenSource(cred), nil
+	cred, err := azidentity.NewManagedIdentityCredential(options)
+	if err != nil {
+		return nil, err
 	}
+
+	return newAzureADTokenSource(cred), nil
+}
+
+// azureMonitorDefaultTokenSource authenticates with the DefaultAzureCredential
+// chain: AZURE_* env vars, workload identity, managed identity, Azure CLI -
+// auto-detected by the SDK.
+func azureMonitorDefaultTokenSource(
+	ctx context.Context, scope vfilter.Scope,
+	transport *http.Transport,
+	arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return newAzureADTokenSource(cred), nil
 }
 
 // azureADCredTokenSource adapts an azcore.TokenCredential to an

--- a/vql/server/azure_monitor_mi.go
+++ b/vql/server/azure_monitor_mi.go
@@ -1,0 +1,125 @@
+//go:build sumo
+// +build sumo
+
+/*
+   Velociraptor - Dig Deeper
+   Copyright (C) 2019-2025 Rapid7 Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+Azure Monitor managed-identity / default-credential auth.
+
+This file is compiled only under the "sumo" build tag because it pulls in the
+azidentity SDK (which is also used by the ADX plugin). It provides the
+azidentity-backed token sources for the managed_identity and default_credential
+auth modes of azure_monitor_upload(). The service-principal path (including
+AZURE_* environment variable credentials) lives in azure_monitor.go and is
+always compiled.
+
+Note: azidentity manages its own HTTP stack for token acquisition (IMDS for
+managed identity, the Entra endpoints for the default credential chain), so the
+plugin's proxy / custom-CA / skip_verify settings do not apply to token
+acquisition on these paths. Use the explicit service-principal path (or AZURE_*
+env vars) if token acquisition must traverse a proxy or trust a custom CA.
+*/
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"golang.org/x/oauth2"
+	vfilter "www.velocidex.com/golang/vfilter"
+)
+
+func init() {
+	// Managed identity (optionally user-assigned via managed_identity_client_id).
+	azureMonitorMITokenSource = func(
+		ctx context.Context, scope vfilter.Scope,
+		transport *http.Transport,
+		arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+
+		options := &azidentity.ManagedIdentityCredentialOptions{}
+		if arg.ManagedIdentityClient != "" {
+			options.ID = azidentity.ClientID(arg.ManagedIdentityClient)
+		}
+
+		cred, err := azidentity.NewManagedIdentityCredential(options)
+		if err != nil {
+			return nil, err
+		}
+
+		return newAzureADTokenSource(cred), nil
+	}
+
+	// DefaultAzureCredential chain: AZURE_* env vars, workload identity,
+	// managed identity, Azure CLI - auto-detected by the SDK.
+	azureMonitorDefaultTokenSource = func(
+		ctx context.Context, scope vfilter.Scope,
+		transport *http.Transport,
+		arg *_AzureMonitorPluginArgs) (oauth2.TokenSource, error) {
+
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, err
+		}
+
+		return newAzureADTokenSource(cred), nil
+	}
+}
+
+// azureADCredTokenSource adapts an azcore.TokenCredential to an
+// oauth2.TokenSource so it can be plugged into the same oauth2.Transport as the
+// service-principal path.
+type azureADCredTokenSource struct {
+	cred azcore.TokenCredential
+}
+
+// newAzureADTokenSource wraps the credential in a caching token source.
+// oauth2.Transport calls Token() on every single request and does no expiry
+// caching of its own, so without ReuseTokenSource each upload would re-enter
+// azidentity (for DefaultAzureCredential, the whole credential chain). This
+// matches what clientcredentials.Config.TokenSource gives the
+// service-principal path in azure_monitor.go for free.
+func newAzureADTokenSource(cred azcore.TokenCredential) oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, &azureADCredTokenSource{cred: cred})
+}
+
+func (self *azureADCredTokenSource) Token() (*oauth2.Token, error) {
+	// Like the service-principal path in azure_monitor.go, this must not be
+	// tied to the caller's context - token refresh still needs to succeed
+	// during the shutdown flush, after that context is already cancelled.
+	// A bounded timeout instead ensures a hung IMDS/Entra endpoint cannot
+	// wedge the uploader forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tk, err := self.cred.GetToken(ctx,
+		policy.TokenRequestOptions{Scopes: []string{azureMonitorScope}})
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth2.Token{
+		AccessToken: tk.Token,
+		Expiry:      tk.ExpiresOn,
+		TokenType:   "Bearer",
+	}, nil
+}

--- a/vql/server/azure_monitor_test.go
+++ b/vql/server/azure_monitor_test.go
@@ -1,8 +1,14 @@
+//go:build sumo
+// +build sumo
+
 package server
 
 import (
 	"context"
 	stdjson "encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,16 +109,21 @@ func TestMarshalAzureRow(t *testing.T) {
 	if _, pres := raw["Name"]; !pres {
 		t.Errorf("RawData should contain the original Name column: %s", out["RawData"])
 	}
+
+	// The row has no Timestamp column, so there is no event time to report.
+	if _, pres := out["EventTime"]; pres {
+		t.Errorf("EventTime should be omitted when the row has no Timestamp: %s", data)
+	}
 }
 
-func TestMarshalAzureRowPrefersTimestampColumn(t *testing.T) {
+// TimeGenerated must be the ingestion time (Azure only accepts a narrow window
+// around it), while the artifact's own event time goes to EventTime.
+func TestMarshalAzureRowSplitsEventTime(t *testing.T) {
 	scope := vql_subsystem.MakeScope()
 	defer scope.Close()
 	ctx := context.Background()
 	opts := vql_subsystem.EncOptsFromScope(scope)
 
-	// When both Timestamp and _timestamp are present, the artifact's own
-	// Timestamp column wins.
 	row := ordereddict.NewDict().
 		Set("Timestamp", time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC)).
 		Set("_timestamp", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC))
@@ -129,8 +140,23 @@ func TestMarshalAzureRowPrefersTimestampColumn(t *testing.T) {
 
 	var tg string
 	_ = stdjson.Unmarshal(out["TimeGenerated"], &tg)
-	if len(tg) < 4 || tg[:4] != "2021" {
-		t.Errorf("TimeGenerated = %q, want it derived from the Timestamp column (2021...)", tg)
+	if len(tg) < 4 || tg[:4] != "2024" {
+		t.Errorf("TimeGenerated = %q, want it derived from _timestamp (2024...)", tg)
+	}
+
+	var et string
+	_ = stdjson.Unmarshal(out["EventTime"], &et)
+	if len(et) < 4 || et[:4] != "2021" {
+		t.Errorf("EventTime = %q, want it derived from the Timestamp column (2021...)", et)
+	}
+
+	// The event time also stays in RawData, as the artifact emitted it.
+	raw := map[string]stdjson.RawMessage{}
+	if err := stdjson.Unmarshal(out["RawData"], &raw); err != nil {
+		t.Fatalf("RawData is not an object: %v", err)
+	}
+	if _, pres := raw["Timestamp"]; !pres {
+		t.Errorf("RawData should retain the original Timestamp column: %s", out["RawData"])
 	}
 }
 
@@ -161,8 +187,9 @@ func TestFormatAzureTimeZeroValues(t *testing.T) {
 	}
 }
 
-// An empty Timestamp column must not shadow the injected _timestamp.
-func TestMarshalAzureRowEmptyTimestampFallsBack(t *testing.T) {
+// An empty Timestamp column yields no EventTime at all, and leaves the
+// injected _timestamp as TimeGenerated.
+func TestMarshalAzureRowEmptyTimestampHasNoEventTime(t *testing.T) {
 	scope := vql_subsystem.MakeScope()
 	defer scope.Close()
 	ctx := context.Background()
@@ -172,14 +199,20 @@ func TestMarshalAzureRowEmptyTimestampFallsBack(t *testing.T) {
 		Set("Timestamp", "").
 		Set("_timestamp", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC))
 
-	tg := marshalAndGetTimeGenerated(t, ctx, scope, row, opts)
+	out := marshalAzureRowForTest(t, ctx, scope, row, opts)
+
+	var tg string
+	_ = stdjson.Unmarshal(out["TimeGenerated"], &tg)
 	if len(tg) < 4 || tg[:4] != "2024" {
 		t.Errorf("TimeGenerated = %q, want it derived from _timestamp (2024...)", tg)
 	}
+	if _, pres := out["EventTime"]; pres {
+		t.Errorf("EventTime should be omitted for an empty Timestamp: %s", out["EventTime"])
+	}
 }
 
-// With neither a usable Timestamp nor a _timestamp, TimeGenerated falls all
-// the way back to now - never to the zero time.
+// Without a _timestamp, TimeGenerated falls all the way back to now - never to
+// the zero time - and an unparseable Timestamp produces no EventTime.
 func TestMarshalAzureRowUnparseableTimestampFallsBackToNow(t *testing.T) {
 	scope := vql_subsystem.MakeScope()
 	defer scope.Close()
@@ -192,7 +225,12 @@ func TestMarshalAzureRowUnparseableTimestampFallsBackToNow(t *testing.T) {
 
 	// Marshal twice: the second row exercises the cached-failed-parse path.
 	for i := 0; i < 2; i++ {
-		tg := marshalAndGetTimeGenerated(t, ctx, scope, row, opts)
+		out := marshalAzureRowForTest(t, ctx, scope, row, opts)
+
+		var tg string
+		if err := stdjson.Unmarshal(out["TimeGenerated"], &tg); err != nil {
+			t.Fatalf("row %d: TimeGenerated is not a JSON string: %v", i, err)
+		}
 		parsed, err := time.Parse(time.RFC3339Nano, tg)
 		if err != nil {
 			t.Fatalf("row %d: TimeGenerated %q is not RFC3339: %v", i, tg, err)
@@ -200,12 +238,50 @@ func TestMarshalAzureRowUnparseableTimestampFallsBackToNow(t *testing.T) {
 		if parsed.Year() < 2024 {
 			t.Errorf("row %d: TimeGenerated = %q, want the time.Now() fallback", i, tg)
 		}
+		if _, pres := out["EventTime"]; pres {
+			t.Errorf("row %d: EventTime should be omitted for an unparseable Timestamp: %s",
+				i, out["EventTime"])
+		}
 	}
 }
 
-func marshalAndGetTimeGenerated(
+// An error response body must not be relayed to the logs and the result row in
+// its entirety - a broken endpoint can return an arbitrarily large error page.
+func TestPostAzureBatchTruncatesResponse(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+
+	huge := strings.Repeat("A", 1024*1024)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(huge))
+		}))
+	defer server.Close()
+
+	arg := &_AzureMonitorPluginArgs{MaxRetries: 0, RetryWait: 1}
+	status, body, err := post_azure_batch(context.Background(), scope,
+		server.Client(), server.URL, []byte("ignored"), arg)
+
+	if err == nil {
+		t.Fatalf("expected an error for a 400 response")
+	}
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	if len(body) > azureMonitorMaxRespBody+64 {
+		t.Errorf("response body is %d bytes, want it capped near %d",
+			len(body), azureMonitorMaxRespBody)
+	}
+	if !strings.HasSuffix(body, "...(truncated)") {
+		t.Errorf("a capped body should be marked truncated, got %d bytes ending %q",
+			len(body), body[max(0, len(body)-20):])
+	}
+}
+
+func marshalAzureRowForTest(
 	t *testing.T, ctx context.Context, scope vfilter.Scope,
-	row *ordereddict.Dict, opts *json.EncOpts) string {
+	row *ordereddict.Dict, opts *json.EncOpts) map[string]stdjson.RawMessage {
 	t.Helper()
 
 	data, err := marshal_azure_row(ctx, scope, row, opts)
@@ -217,12 +293,7 @@ func marshalAndGetTimeGenerated(
 	if err := stdjson.Unmarshal(data, &out); err != nil {
 		t.Fatalf("output is not valid JSON: %v (%s)", err, data)
 	}
-
-	var tg string
-	if err := stdjson.Unmarshal(out["TimeGenerated"], &tg); err != nil {
-		t.Fatalf("TimeGenerated is not a JSON string: %v (%s)", err, data)
-	}
-	return tg
+	return out
 }
 
 func assertJSONString(t *testing.T, m map[string]stdjson.RawMessage, key, want string) {

--- a/vql/server/azure_monitor_test.go
+++ b/vql/server/azure_monitor_test.go
@@ -1,0 +1,243 @@
+package server
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/velociraptor/json"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	vfilter "www.velocidex.com/golang/vfilter"
+)
+
+func TestBuildIngestionURL(t *testing.T) {
+	const want = "https://x.region.ingest.monitor.azure.com/dataCollectionRules/dcr-abc123/streams/Custom-Foo_CL?api-version=2023-01-01"
+
+	cases := []struct {
+		name, endpoint, dcr, stream string
+	}{
+		{"plain", "https://x.region.ingest.monitor.azure.com", "dcr-abc123", "Custom-Foo_CL"},
+		{"trailing slash trimmed", "https://x.region.ingest.monitor.azure.com/", "dcr-abc123", "Custom-Foo_CL"},
+	}
+
+	for _, c := range cases {
+		got := buildIngestionURL(c.endpoint, c.dcr, c.stream)
+		if got != want {
+			t.Errorf("%s: buildIngestionURL(%q,%q,%q) = %q, want %q",
+				c.name, c.endpoint, c.dcr, c.stream, got, want)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"5", 5 * time.Second},
+		{" 5 ", 5 * time.Second},
+		{"", 0},
+		{"0", 0},
+		{"-3", 0},
+		{"garbage", 0},
+	}
+	for _, c := range cases {
+		if got := parseRetryAfter(c.in); got != c.want {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMarshalAzureRow(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+	ctx := context.Background()
+	opts := vql_subsystem.EncOptsFromScope(scope)
+
+	row := ordereddict.NewDict().
+		Set("_Artifact", "Windows.System.Pslist").
+		Set("_ClientId", "C.1234").
+		Set("_FlowId", "F.5678").
+		Set("_Organization", "root").
+		Set("_Hostname", "HOST-1").
+		Set("_timestamp", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)).
+		Set("Pid", 4321).
+		Set("Name", "evil.exe")
+
+	data, err := marshal_azure_row(ctx, scope, row, opts)
+	if err != nil {
+		t.Fatalf("marshal_azure_row: %v", err)
+	}
+
+	var out map[string]stdjson.RawMessage
+	if err := stdjson.Unmarshal(data, &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, data)
+	}
+
+	// Structured metadata columns are lifted out of the raw row.
+	assertJSONString(t, out, "Artifact", "Windows.System.Pslist")
+	assertJSONString(t, out, "ClientId", "C.1234")
+	assertJSONString(t, out, "FlowId", "F.5678")
+	assertJSONString(t, out, "Organization", "root")
+	assertJSONString(t, out, "Hostname", "HOST-1")
+
+	// TimeGenerated is mandatory for every Log Analytics table.
+	var tg string
+	_ = stdjson.Unmarshal(out["TimeGenerated"], &tg)
+	if tg == "" {
+		t.Errorf("TimeGenerated missing/empty: %s", data)
+	}
+
+	// RawData holds the original row minus the injected metadata fields.
+	raw := map[string]stdjson.RawMessage{}
+	if err := stdjson.Unmarshal(out["RawData"], &raw); err != nil {
+		t.Fatalf("RawData is not an object: %v", err)
+	}
+	for _, k := range []string{"_Artifact", "_ClientId", "_FlowId", "_Organization", "_Hostname", "_timestamp"} {
+		if _, pres := raw[k]; pres {
+			t.Errorf("RawData should not contain injected metadata %q: %s", k, out["RawData"])
+		}
+	}
+	if _, pres := raw["Name"]; !pres {
+		t.Errorf("RawData should contain the original Name column: %s", out["RawData"])
+	}
+}
+
+func TestMarshalAzureRowPrefersTimestampColumn(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+	ctx := context.Background()
+	opts := vql_subsystem.EncOptsFromScope(scope)
+
+	// When both Timestamp and _timestamp are present, the artifact's own
+	// Timestamp column wins.
+	row := ordereddict.NewDict().
+		Set("Timestamp", time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC)).
+		Set("_timestamp", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC))
+
+	data, err := marshal_azure_row(ctx, scope, row, opts)
+	if err != nil {
+		t.Fatalf("marshal_azure_row: %v", err)
+	}
+
+	var out map[string]stdjson.RawMessage
+	if err := stdjson.Unmarshal(data, &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, data)
+	}
+
+	var tg string
+	_ = stdjson.Unmarshal(out["TimeGenerated"], &tg)
+	if len(tg) < 4 || tg[:4] != "2021" {
+		t.Errorf("TimeGenerated = %q, want it derived from the Timestamp column (2021...)", tg)
+	}
+}
+
+// TimeFromAny returns the zero time with a nil error for several inputs.
+// formatAzureTime must report those as "" so marshal_azure_row falls back
+// rather than emitting a year-0001 TimeGenerated that Azure drops.
+func TestFormatAzureTimeZeroValues(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		in   interface{}
+	}{
+		{"empty string", ""},
+		{"zero epoch", 0},
+		// The timestamp LRU caches failed parses too, so a repeated
+		// unparseable string comes back as a hit with a nil error.
+		{"unparseable string", "not a timestamp"},
+		{"unparseable string repeated", "not a timestamp"},
+	}
+
+	for _, c := range cases {
+		if got := formatAzureTime(ctx, scope, c.in); got != "" {
+			t.Errorf("%s: formatAzureTime(%#v) = %q, want \"\"", c.name, c.in, got)
+		}
+	}
+}
+
+// An empty Timestamp column must not shadow the injected _timestamp.
+func TestMarshalAzureRowEmptyTimestampFallsBack(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+	ctx := context.Background()
+	opts := vql_subsystem.EncOptsFromScope(scope)
+
+	row := ordereddict.NewDict().
+		Set("Timestamp", "").
+		Set("_timestamp", time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC))
+
+	tg := marshalAndGetTimeGenerated(t, ctx, scope, row, opts)
+	if len(tg) < 4 || tg[:4] != "2024" {
+		t.Errorf("TimeGenerated = %q, want it derived from _timestamp (2024...)", tg)
+	}
+}
+
+// With neither a usable Timestamp nor a _timestamp, TimeGenerated falls all
+// the way back to now - never to the zero time.
+func TestMarshalAzureRowUnparseableTimestampFallsBackToNow(t *testing.T) {
+	scope := vql_subsystem.MakeScope()
+	defer scope.Close()
+	ctx := context.Background()
+	opts := vql_subsystem.EncOptsFromScope(scope)
+
+	row := ordereddict.NewDict().
+		Set("Timestamp", "not a timestamp").
+		Set("Name", "evil.exe")
+
+	// Marshal twice: the second row exercises the cached-failed-parse path.
+	for i := 0; i < 2; i++ {
+		tg := marshalAndGetTimeGenerated(t, ctx, scope, row, opts)
+		parsed, err := time.Parse(time.RFC3339Nano, tg)
+		if err != nil {
+			t.Fatalf("row %d: TimeGenerated %q is not RFC3339: %v", i, tg, err)
+		}
+		if parsed.Year() < 2024 {
+			t.Errorf("row %d: TimeGenerated = %q, want the time.Now() fallback", i, tg)
+		}
+	}
+}
+
+func marshalAndGetTimeGenerated(
+	t *testing.T, ctx context.Context, scope vfilter.Scope,
+	row *ordereddict.Dict, opts *json.EncOpts) string {
+	t.Helper()
+
+	data, err := marshal_azure_row(ctx, scope, row, opts)
+	if err != nil {
+		t.Fatalf("marshal_azure_row: %v", err)
+	}
+
+	var out map[string]stdjson.RawMessage
+	if err := stdjson.Unmarshal(data, &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, data)
+	}
+
+	var tg string
+	if err := stdjson.Unmarshal(out["TimeGenerated"], &tg); err != nil {
+		t.Fatalf("TimeGenerated is not a JSON string: %v (%s)", err, data)
+	}
+	return tg
+}
+
+func assertJSONString(t *testing.T, m map[string]stdjson.RawMessage, key, want string) {
+	t.Helper()
+	raw, pres := m[key]
+	if !pres {
+		t.Errorf("missing key %q", key)
+		return
+	}
+	var got string
+	if err := stdjson.Unmarshal(raw, &got); err != nil {
+		t.Errorf("key %q is not a JSON string: %v", key, err)
+		return
+	}
+	if got != want {
+		t.Errorf("key %q = %q, want %q", key, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `azure_monitor_upload()`, a new VQL plugin that uploads rows to an Azure Log Analytics workspace via the Logs Ingestion API (Data Collection Rule based), since the existing `adx_upload()` plugin talks to ADX's Kusto ingestion endpoint and cannot be pointed at Log Analytics.
- Adds the `Azure.Monitor.Upload` server-event artifact that watches completed flows and streams matching results to the new plugin.
- Supports service principal, `AZURE_*` environment variables, managed identity, and the Azure SDK default credential chain (the last two gated behind a `sumo` build tag to keep the `azidentity` SDK out of default builds).
- Adds an `Azure Monitor Creds` secret type so credentials/destination can be stored in the secrets service instead of the artifact.

## Test plan
- [x] Unit tests in `vql/server/azure_monitor_test.go` (URL building, retry-after parsing, row marshaling, timestamp fallback edge cases)
- [x] Manual end-to-end run against a real Log Analytics workspace + DCR
