### PR TITLE
Use 0-based positions in the VQL language server

### DIFF
--- a/services/lsp/completion.go
+++ b/services/lsp/completion.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/participle/v2/lexer"
 	"go.lsp.dev/protocol"
 	api_proto "www.velocidex.com/golang/velociraptor/api/proto"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -22,8 +21,8 @@ import (
 //
 // If point is at the inner callsite we want to retrieve the most
 // specific callsite - in this case bar().
-func (self *Document) matchCallsite(line, column int) (
-	callsite *vfilter.CallSite, offset_at_point int, err error) {
+func (self *Document) matchCallsite(offset_at_point int) (
+	callsite *vfilter.CallSite, err error) {
 
 	type prospect_t struct {
 		distance int
@@ -33,23 +32,11 @@ func (self *Document) matchCallsite(line, column int) (
 	// Find potential overlapping callsites
 	var prospects []*prospect_t
 
-	offset_at_point = -1
-
 	for _, cs := range self.AnalysisState.Callsites {
 		cs_pos := cs.Pos
 
 		// Potential prospect - the point is inside the callsite.
-		if isPosBetween(cs_pos, line, column) {
-			if offset_at_point < 0 {
-				offset_at_point, err = getNextOffset(
-					self.Text, cs_pos.Pos, line, column)
-				if err != nil {
-					// If we can not get the exact offset, then the
-					// text does not match the offset.
-					break
-				}
-			}
-
+		if rngContains(cs_pos, offset_at_point) {
 			prospects = append(prospects, &prospect_t{
 				distance: offset_at_point - cs_pos.Pos.Offset,
 				cs:       &cs,
@@ -58,10 +45,10 @@ func (self *Document) matchCallsite(line, column int) (
 	}
 
 	if len(prospects) == 0 {
-		return nil, 0, utils.Wrap(
+		return nil, utils.Wrap(
 			utils.NotFoundError,
-			"matchCallsite: Coordinate %v,%v are not found in text",
-			line, column)
+			"matchCallsite: Offset %v is not found in text",
+			offset_at_point)
 	}
 
 	sort.Slice(prospects, func(i, j int) bool {
@@ -70,7 +57,7 @@ func (self *Document) matchCallsite(line, column int) (
 
 	// Minimize the distance
 	best_cs := prospects[0].cs
-	return best_cs, offset_at_point, nil
+	return best_cs, nil
 }
 
 // Complete possible function names on callsite.
@@ -98,7 +85,7 @@ func (self *LSPServer) complete_function_names(
 func (self *LSPServer) complete_arg_names(
 	doc *Document,
 	cs *vfilter.CallSite,
-	line, column, offset_at_point int) (items []protocol.CompletionItem) {
+	offset_at_point int) (items []protocol.CompletionItem) {
 
 	// Find the description for the function
 	desc := doc.getVQLFunctionDescription(cs)
@@ -175,10 +162,11 @@ func (self *LSPServer) Completion(
 	}
 
 	// Find the function at point
-	line := int(params.Position.Line)
-	column := int(params.Position.Character)
+	position_mapper := newPositionMapper(doc.Text)
+	offset_at_point := position_mapper.positionToOffset(
+		int(params.Position.Line), int(params.Position.Character))
 
-	cs, offset_at_point, err := doc.matchCallsite(line, column)
+	cs, err := doc.matchCallsite(offset_at_point)
 
 	// The position is sitting inside a call site.
 	// The call site covers the function name and arg list.
@@ -193,7 +181,7 @@ func (self *LSPServer) Completion(
 				cs, match)...)
 		} else {
 			items = append(items, self.complete_arg_names(
-				doc, cs, line, column, offset_at_point)...)
+				doc, cs, offset_at_point)...)
 		}
 	}
 	return items, nil
@@ -208,54 +196,6 @@ func getKind(desc *api_proto.Completion) protocol.CompletionItemKind {
 	default:
 		return protocol.CompletionItemKindText
 	}
-}
-
-func isPosBetween(rng vfilter.RangePosition, line, column int) bool {
-	left := rng.Pos
-	right := rng.EndPos
-
-	// Line falls outside the range of interest.
-	if left.Line < line || right.Line > line {
-		return false
-	}
-
-	// Falls to the left of the range.
-	if left.Line == line && left.Column > column {
-		return false
-	}
-
-	if right.Line == line && right.Column < column {
-		return false
-	}
-
-	return true
-}
-
-// Find the absolute offset in the text of the line and character
-// specified.
-func getNextOffset(
-	text string,
-	start lexer.Position,
-	line, column int) (offset int, err error) {
-
-	cur_line := start.Line
-	cur_col := start.Column
-	for idx, char := range text {
-		if char == '\n' {
-			cur_line++
-			cur_col = 0
-		}
-
-		if cur_col == column && cur_line == line {
-			return idx + 1 + start.Offset, nil
-		}
-
-		if cur_line > line {
-			break
-		}
-		cur_col++
-	}
-	return 0, utils.NotFoundError
 }
 
 func (self *Document) getVQLFunctionDescription(

--- a/services/lsp/completion_test.go
+++ b/services/lsp/completion_test.go
@@ -79,7 +79,7 @@ func (self *LSPTestSuite) TestCompletion() {
 					URI: doc,
 				},
 				Position: protocol.Position{
-					Line:      1,
+					Line:      0,
 					Character: tc.Column,
 				},
 			},

--- a/services/lsp/document.go
+++ b/services/lsp/document.go
@@ -32,21 +32,14 @@ func (self *Document) Debug() string {
 }
 
 func (self *Document) Diagnostics() (res []*protocol.Diagnostic) {
+	position_mapper := newPositionMapper(self.Text)
+
 	for _, verify_error := range self.Errors {
 		diag := &protocol.Diagnostic{
 			Severity: protocol.DiagnosticSeverityError,
 			Source:   protocol.NewOptional("vql"),
 			Message:  protocol.String(verify_error.Error()),
-			Range: protocol.Range{
-				Start: protocol.Position{
-					Line:      uint32(verify_error.Pos.Pos.Line),
-					Character: uint32(verify_error.Pos.Pos.Column),
-				},
-				End: protocol.Position{
-					Line:      uint32(verify_error.Pos.EndPos.Line),
-					Character: uint32(verify_error.Pos.EndPos.Column),
-				},
-			},
+			Range:    position_mapper.mapRange(verify_error.Pos),
 		}
 		res = append(res, diag)
 	}

--- a/services/lsp/fixtures/TestCompletion.golden
+++ b/services/lsp/fixtures/TestCompletion.golden
@@ -61,12 +61,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 21
+    "line": 0,
+    "character": 20
    }
   },
   "severity": 1,
@@ -140,12 +140,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 20
+    "line": 0,
+    "character": 19
    },
    "end": {
-    "line": 1,
-    "character": 30
+    "line": 0,
+    "character": 29
    }
   },
   "severity": 1,
@@ -155,12 +155,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 31
+    "line": 0,
+    "character": 30
    }
   },
   "severity": 1,
@@ -189,12 +189,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 20
+    "line": 0,
+    "character": 19
    },
    "end": {
-    "line": 1,
-    "character": 30
+    "line": 0,
+    "character": 29
    }
   },
   "severity": 1,
@@ -204,12 +204,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 48
+    "line": 0,
+    "character": 47
    }
   },
   "severity": 1,

--- a/services/lsp/fixtures/TestDidOpen.golden
+++ b/services/lsp/fixtures/TestDidOpen.golden
@@ -5,12 +5,12 @@ SELECT * FROM scopeXXX()
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 25
+    "line": 0,
+    "character": 24
    }
   },
   "severity": 1,
@@ -25,12 +25,12 @@ SELECT * FROM scope(Foo=1)
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 21
+    "line": 0,
+    "character": 20
    },
    "end": {
-    "line": 1,
-    "character": 26
+    "line": 0,
+    "character": 25
    }
   },
   "severity": 1,
@@ -69,12 +69,12 @@ SELECT * FROM parse_evtx()
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 27
+    "line": 0,
+    "character": 26
    }
   },
   "severity": 1,

--- a/services/lsp/fixtures/TestHover.golden
+++ b/services/lsp/fixtures/TestHover.golden
@@ -12,12 +12,12 @@ Hover:
  },
  "range": {
   "start": {
-   "line": 1,
-   "character": 8
+   "line": 0,
+   "character": 7
   },
   "end": {
-   "line": 1,
-   "character": 13
+   "line": 0,
+   "character": 12
   }
  }
 }
@@ -35,12 +35,12 @@ Hover:
  },
  "range": {
   "start": {
-   "line": 1,
-   "character": 15
+   "line": 0,
+   "character": 14
   },
   "end": {
-   "line": 1,
-   "character": 20
+   "line": 0,
+   "character": 19
   }
  }
 }
@@ -58,12 +58,12 @@ Hover:
  },
  "range": {
   "start": {
-   "line": 1,
-   "character": 26
+   "line": 0,
+   "character": 25
   },
   "end": {
-   "line": 1,
-   "character": 33
+   "line": 0,
+   "character": 32
   }
  }
 }
@@ -76,12 +76,12 @@ Diagnostics:
  {
   "range": {
    "start": {
-    "line": 1,
-    "character": 15
+    "line": 0,
+    "character": 14
    },
    "end": {
-    "line": 1,
-    "character": 21
+    "line": 0,
+    "character": 20
    }
   },
   "severity": 1,
@@ -107,12 +107,12 @@ Hover:
  },
  "range": {
   "start": {
-   "line": 1,
-   "character": 15
+   "line": 0,
+   "character": 14
   },
   "end": {
-   "line": 1,
-   "character": 19
+   "line": 0,
+   "character": 18
   }
  }
 }

--- a/services/lsp/hover.go
+++ b/services/lsp/hover.go
@@ -19,11 +19,13 @@ func (self *LSPServer) Hover(
 		return nil, utils.NotFoundError
 	}
 
-	// Find the function at point
-	line := int(params.Position.Line)
-	column := int(params.Position.Character)
+	position_mapper := newPositionMapper(doc.Text)
 
-	cs, offset_at_point, err := doc.matchCallsite(line, column)
+	// Find the function at point.
+	offset_at_point := position_mapper.positionToOffset(
+		int(params.Position.Line), int(params.Position.Character))
+
+	cs, err := doc.matchCallsite(offset_at_point)
 
 	// The position is sitting inside a call site.
 	// The call site covers the function name and arg list.
@@ -39,14 +41,9 @@ func (self *LSPServer) Hover(
 			// hover info about the function.
 			return &protocol.Hover{
 				Range: &protocol.Range{
-					Start: protocol.Position{
-						Line:      uint32(cs.Pos.Pos.Line),
-						Character: uint32(cs.Pos.Pos.Column),
-					},
-					End: protocol.Position{
-						Line:      uint32(cs.Pos.Pos.Line),
-						Character: uint32(cs.Pos.Pos.Column + len(cs.Name)),
-					},
+					Start: position_mapper.mapPos(cs.Pos.Pos),
+					End: position_mapper.mapOffset(
+						cs.Pos.Pos.Offset + len(cs.Name)),
 				},
 				Contents: &protocol.MarkupContent{
 					Kind:  protocol.MarkupKind(desc.Type),
@@ -63,19 +60,13 @@ func (self *LSPServer) Hover(
 					return &protocol.Hover{}, nil
 				}
 
-				if arg.Pos.Pos.Line == line &&
-					arg.Pos.Pos.Column <= column &&
-					column <= arg.Pos.Pos.Column+len(arg.Name) {
+				if offset_at_point >= arg.Pos.Pos.Offset &&
+					offset_at_point <= arg.Pos.Pos.Offset+len(arg.Name) {
 					return &protocol.Hover{
 						Range: &protocol.Range{
-							Start: protocol.Position{
-								Line:      uint32(cs.Pos.Pos.Line),
-								Character: uint32(cs.Pos.Pos.Column),
-							},
-							End: protocol.Position{
-								Line:      uint32(cs.Pos.Pos.Line),
-								Character: uint32(cs.Pos.Pos.Column + len(cs.Name)),
-							},
+							Start: position_mapper.mapPos(cs.Pos.Pos),
+							End: position_mapper.mapOffset(
+								cs.Pos.Pos.Offset + len(cs.Name)),
 						},
 						Contents: &protocol.MarkupContent{
 							Kind:  protocol.MarkupKind("Arg"),

--- a/services/lsp/hover_test.go
+++ b/services/lsp/hover_test.go
@@ -75,7 +75,7 @@ func (self *LSPTestSuite) TestHover() {
 					URI: doc,
 				},
 				Position: protocol.Position{
-					Line:      1,
+					Line:      0,
 					Character: tc.Column,
 				},
 			},

--- a/services/lsp/position.go
+++ b/services/lsp/position.go
@@ -1,0 +1,97 @@
+package lsp
+
+import (
+	"sort"
+
+	"github.com/alecthomas/participle/v2/lexer"
+	"go.lsp.dev/protocol"
+	"www.velocidex.com/golang/vfilter"
+)
+
+// positionMapper converts between byte offsets (as reported by the
+// participle lexer) and the 0 based line/column positions used by the
+// LSP protocol.
+//
+// participle uses 1 based line and column counters internally so we
+// never use them directly. Instead we convert only using the byte
+// offsets via the line start table of the document. Byte offsets are
+// unambiguous - they only depend on the document text itself.
+type positionMapper struct {
+	document    string
+	line_starts []int
+}
+
+func newPositionMapper(document string) *positionMapper {
+	res := &positionMapper{
+		document:    document,
+		line_starts: []int{0},
+	}
+
+	for idx, char := range document {
+		if char == '\n' {
+			res.line_starts = append(res.line_starts, idx+1)
+		}
+	}
+
+	return res
+}
+
+// mapPos converts a byte offset to a 0 based LSP position.
+func (self *positionMapper) mapOffset(offset int) protocol.Position {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(self.document) {
+		offset = len(self.document)
+	}
+
+	// Binary search for the line containing the offset.
+	line := sort.Search(len(self.line_starts), func(i int) bool {
+		return self.line_starts[i] > offset
+	}) - 1
+	if line < 0 {
+		line = 0
+	}
+
+	return protocol.Position{
+		Line:      uint32(line),
+		Character: uint32(offset - self.line_starts[line]),
+	}
+}
+
+// mapPos converts a participle position to a 0 based LSP position.
+func (self *positionMapper) mapPos(pos lexer.Position) protocol.Position {
+	return self.mapOffset(pos.Offset)
+}
+
+// mapRange converts a participle RangePosition to an LSP range.
+func (self *positionMapper) mapRange(rng vfilter.RangePosition) protocol.Range {
+	return protocol.Range{
+		Start: self.mapPos(rng.Pos),
+		End:   self.mapPos(rng.EndPos),
+	}
+}
+
+// positionToOffset converts a 0 based LSP position to a byte offset
+// in the document. Positions past the end of the document are clamped.
+func (self *positionMapper) positionToOffset(
+	line, column int) int {
+	if line < 0 || line >= len(self.line_starts) {
+		return len(self.document)
+	}
+
+	offset := self.line_starts[line] + column
+	if offset < 0 {
+		return 0
+	}
+	if offset > len(self.document) {
+		return len(self.document)
+	}
+	return offset
+}
+
+// rngContains reports whether the given byte offset is inside the
+// range (inclusive of both ends).
+func rngContains(rng vfilter.RangePosition, offset int) bool {
+	return offset >= rng.Pos.Offset && offset <= rng.EndPos.Offset
+}


### PR DESCRIPTION
Participle reports 1-based line and column numbers while the LSP protocol uses 0-based positions. Convert everything through a positionMapper that works from byte offsets so the existing off-by-one errors in diagnostics, hover and completion are eliminated.

Also regenerate the golden fixtures with the corrected positions.