### PR TITLE
Bugfix: Tag notebook cells with their artifact name

### DIFF
--- a/services/notebook/fixtures/TestInitialNotebook.golden
+++ b/services/notebook/fixtures/TestInitialNotebook.golden
@@ -17,7 +17,13 @@
     "notebook": [
      {
       "template": "# Welcome to Velociraptor notebooks!\n",
-      "type": "markdown"
+      "type": "markdown",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Notebooks.Default"
+       }
+      ]
      }
     ]
    }
@@ -64,7 +70,13 @@
     "notebook": [
      {
       "template": "\n/*\n# Generic.Client.Info\n*/\nSELECT * FROM source(artifact=\"Generic.Client.Info\")\nLIMIT 50\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Generic.Client.Info"
+       }
+      ]
      }
     ]
    },
@@ -122,7 +134,13 @@
     "notebook": [
      {
       "template": "# Custom.Generic.Client.Info template\n",
-      "type": "markdown"
+      "type": "markdown",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Custom.Generic.Client.Info"
+       }
+      ]
      }
     ]
    },
@@ -188,7 +206,13 @@
     "notebook": [
      {
       "template": "\n/*\n# Events from Generic.Events\n\nFrom {{ Scope \"StartTime\" }} to {{ Scope \"EndTime\" }}\n*/\n\nSELECT timestamp(epoch=_ts) AS ServerTime, *\n FROM source(start_time=StartTime, end_time=EndTime, artifact=\"Generic.Events\")\nLIMIT 50\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Generic.Events"
+       }
+      ]
      }
     ]
    }
@@ -256,7 +280,13 @@
     "notebook": [
      {
       "template": "\n/*\n# Events from Generic.Events\n\nFrom {{ Scope \"StartTime\" }} to {{ Scope \"EndTime\" }}\n*/\n\nSELECT timestamp(epoch=_ts) AS ServerTime, *\n FROM source(start_time=StartTime, end_time=EndTime, artifact=\"Generic.Events\")\nLIMIT 50\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Generic.Events"
+       }
+      ]
      }
     ]
    }
@@ -323,7 +353,13 @@
     "notebook": [
      {
       "template": "SELECT Arg1 FROM scope()\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "GlobalNotebook"
+       }
+      ]
      }
     ]
    }
@@ -376,7 +412,13 @@
     "notebook": [
      {
       "template": "\n/*\n# Generic.Client.Info\n*/\nSELECT * FROM source(artifact=\"Generic.Client.Info\")\nLIMIT 50\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Generic.Client.Info"
+       }
+      ]
      }
     ]
    },
@@ -422,7 +464,13 @@
     "notebook": [
      {
       "template": "SELECT NotebookExport, ArtifactExport FROM scope()",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "NotebookWithImport"
+       }
+      ]
      }
     ]
    }
@@ -455,17 +503,86 @@
      {
       "template": "SELECT * FROM info()",
       "type": "vql_suggestion",
-      "name": "A good suggestion."
+      "name": "A good suggestion.",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "NotebookWithSugegstions"
+       }
+      ]
      },
      {
       "template": "\n/*\n# NotebookWithSugegstions\n*/\nSELECT * FROM source(artifact=\"NotebookWithSugegstions\")\nLIMIT 50\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "NotebookWithSugegstions"
+       }
+      ]
      }
     ]
    }
   ]
  },
  "Notebook with suggestions Spec": {
+  "artifact": "PrivateNotebook",
+  "parameters": {}
+ },
+ "Multiple artifacts Request": {
+  "name": "Multiple artifacts",
+  "description": "Cells are tagged with the artifact they were created from",
+  "artifacts": [
+   "Generic.Client.Info",
+   "ArtifactWithCustomNotebook"
+  ]
+ },
+ "Multiple artifacts Response": {
+  "name": "PrivateNotebook",
+  "parameters": [
+   {
+    "name": "FirstParameter",
+    "default": "1982-12-10",
+    "type": "timestamp"
+   },
+   {
+    "name": "ArtifactName",
+    "default": "Generic.Client.Info",
+    "description": "Name of the artifact this notebook came from."
+   }
+  ],
+  "sources": [
+   {
+    "notebook": [
+     {
+      "template": "\n/*\n# Generic.Client.Info\n*/\nSELECT * FROM source(artifact=\"Generic.Client.Info\")\nLIMIT 50\n",
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "Generic.Client.Info"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "notebook": [
+     {
+      "template": "/*\n# ArtifactWithCustomNotebook\n*/\n\n// Deliberately no artifact specified here - the cell is\n// tagged with its own artifact by the notebook manager.\nSELECT * FROM source()\n",
+      "type": "vql",
+      "env": [
+       {
+        "key": "CellArtifactName",
+        "value": "ArtifactWithCustomNotebook"
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ },
+ "Multiple artifacts Spec": {
   "artifact": "PrivateNotebook",
   "parameters": {}
  }

--- a/services/notebook/fixtures/TestNotebookFromTemplate.golden
+++ b/services/notebook/fixtures/TestNotebookFromTemplate.golden
@@ -110,6 +110,12 @@
    "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":5,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
   ],
   "type": "vql",
+  "env": [
+   {
+    "key": "CellArtifactName",
+    "value": "Notebook.With.Parameters"
+   }
+  ],
   "current_version": "03",
   "available_versions": [
    "03"

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -87,6 +87,24 @@ import (
 	"www.velocidex.com/golang/velociraptor/vql/acl_managers"
 )
 
+// Notebook cells created from an artifact source are tagged with
+// this environment variable. The value is the fully qualified
+// artifact name (including any named source - e.g.
+// Custom.Artifact/Source). The source() plugin gives this tag
+// precedence over the notebook wide ArtifactName parameter (which
+// always refers to the first artifact in the collection), so bare
+// source() calls within a cell resolve to the artifact the cell
+// was created from. Tagging happens at notebook creation time so
+// it automatically follows artifact renames or copies.
+const CellArtifactNameEnv = "CellArtifactName"
+
+func cellArtifactEnv(source_name string) []*artifacts_proto.ArtifactEnv {
+	return []*artifacts_proto.ArtifactEnv{{
+		Key:   CellArtifactNameEnv,
+		Value: source_name,
+	}}
+}
+
 // Create the initial cells of the notebook.
 func (self *NotebookManager) CreateInitialNotebook(ctx context.Context,
 	config_obj *config_proto.Config,
@@ -310,6 +328,17 @@ func CalculateNotebookArtifact(
 
 			custom_cells := false
 			for _, n := range s.Notebook {
+				// Clone the cell before we modify it because the
+				// original belongs to the global repository cache.
+				n = proto.Clone(n).(*artifacts_proto.NotebookSourceCell)
+
+				// Tag the cell with the artifact it was created
+				// from. This allows source() calls within the cell
+				// that do not explicitly specify an artifact to
+				// resolve to this artifact, even when the notebook
+				// is created from multiple artifacts.
+				n.Env = append(n.Env, cellArtifactEnv(source_name)...)
+
 				new_source.Notebook = append(new_source.Notebook, n)
 				switch strings.ToLower(n.Type) {
 
@@ -339,6 +368,7 @@ func CalculateNotebookArtifact(
 						&artifacts_proto.NotebookSourceCell{
 							Type:   "vql",
 							Output: output,
+							Env:    cellArtifactEnv(source_name),
 							Template: fmt.Sprintf(`
 /*
 # Events from %v
@@ -357,6 +387,7 @@ LIMIT %v
 						&artifacts_proto.NotebookSourceCell{
 							Type:   "vql",
 							Output: output,
+							Env:    cellArtifactEnv(source_name),
 							Template: fmt.Sprintf(`
 /*
 # %v

--- a/services/notebook/initial_test.go
+++ b/services/notebook/initial_test.go
@@ -96,6 +96,22 @@ sources:
   - name: A good suggestion.
     type: vql_suggestion
     template: SELECT * FROM info()
+`, `
+name: ArtifactWithCustomNotebook
+type: CLIENT
+sources:
+- query: |
+    SELECT * FROM info()
+  notebook:
+  - type: vql
+    template: |
+      /*
+      # ArtifactWithCustomNotebook
+      */
+
+      // Deliberately no artifact specified here - the cell is
+      // tagged with its own artifact by the notebook manager.
+      SELECT * FROM source()
 `}
 
 type checker func(t *testing.T, response *artifacts_proto.Artifact, spec *flows_proto.ArtifactSpec)
@@ -283,6 +299,29 @@ func initialTestCases(client_id string) []notebookTestCase {
 				AssertDictRegex(t, "vql_suggestion", "Sources.0.Notebook.0.Type", artifact)
 				AssertDictRegex(t, "SELECT \\* FROM source", "Sources.0.Notebook.1.Template", artifact)
 				AssertDictRegex(t, "vql", "Sources.0.Notebook.1.Type", artifact)
+			},
+		},
+		{
+			req: &api_proto.NotebookMetadata{
+				Name:        "Multiple artifacts",
+				Description: "Cells are tagged with the artifact they were created from",
+				Artifacts:   []string{"Generic.Client.Info", "ArtifactWithCustomNotebook"},
+			},
+			check: func(t *testing.T, artifact *artifacts_proto.Artifact,
+				spec *flows_proto.ArtifactSpec) {
+
+				// The default cell of the first artifact is tagged
+				// with its own artifact name.
+				AssertDictRegex(t, "CellArtifactName", "Sources.0.Notebook.0.Env.0.Key", artifact)
+				AssertDictRegex(t, "Generic.Client.Info",
+					"Sources.0.Notebook.0.Env.0.Value", artifact)
+
+				// The custom cell (with a bare source()) of the
+				// second artifact is tagged with its own artifact -
+				// not the first one in the collection.
+				AssertDictRegex(t, "CellArtifactName", "Sources.1.Notebook.0.Env.0.Key", artifact)
+				AssertDictRegex(t, "ArtifactWithCustomNotebook",
+					"Sources.1.Notebook.0.Env.0.Value", artifact)
 			},
 		},
 	}

--- a/vql/server/flows/results.go
+++ b/vql/server/flows/results.go
@@ -414,7 +414,15 @@ func (self *SourcePluginArgs) ParseSourceArgsFromScope(scope vfilter.Scope) {
 	}
 
 	if self.Artifact == "" {
-		artifact_name, pres := scope.Resolve("ArtifactName")
+		// Cells created from an artifact source are tagged with the
+		// artifact they belong to (see notebook.CellArtifactNameEnv).
+		// This takes precedence over the notebook wide ArtifactName
+		// parameter which always refers to the first artifact in the
+		// collection.
+		artifact_name, pres := scope.Resolve("CellArtifactName")
+		if !pres {
+			artifact_name, pres = scope.Resolve("ArtifactName")
+		}
 		if pres {
 			artifact, ok := artifact_name.(string)
 			if ok {

--- a/vql/server/flows/results_test.go
+++ b/vql/server/flows/results_test.go
@@ -35,6 +35,21 @@ var (
 			Mode: MODE_HUNT_ARTIFACT,
 		},
 		{
+			// Cells created from an artifact source are tagged with
+			// CellArtifactName which takes precedence over the
+			// notebook wide ArtifactName (which refers to the first
+			// artifact in the collection).
+			Env: ordereddict.NewDict().
+				Set("CellArtifactName", "Windows.Search.FileFinder").
+				Set("ArtifactName", "Generic.Client.Info").
+				Set("HuntId", "H.123"),
+			Args: ordereddict.NewDict(),
+			Mode: MODE_HUNT_ARTIFACT,
+			Assertion: func(arg *SourcePluginArgs) bool {
+				return arg.Artifact == "Windows.Search.FileFinder"
+			},
+		},
+		{
 			// Client event notebook provides the following in env.
 			Env: ordereddict.NewDict().
 				Set("ArtifactName", "Server.Monitor.Health").


### PR DESCRIPTION
Proposed fix for https://github.com/Velocidex/velociraptor/issues/4987

When an artifact ships custom `notebook:` cells, those cells are created
verbatim and any bare `source()` inside them has no binding to the artifact
they belong to — it resolves through the notebook-wide `ArtifactName`
parameter, which always refers to the **first** artifact of the collection or
hunt. In multi-artifact collections this makes such cells display another
artifact's results (e.g. `Windows.Search.FileFinder`'s notebook pane showing a
different artifact's rows).

This change tags every initial notebook cell — custom and auto-generated —
with a `CellArtifactName` environment variable holding the fully qualified
`artifact[/source]` name, computed at cell creation time. The `source()`
plugin now prefers this tag over `ArtifactName` when resolving from scope.

Design notes:

- A new variable is used instead of overwriting `ArtifactName` because the
  worker applies the compiled request env *after* cell env, and the
  pseudo-artifact preamble carries `ArtifactName = first artifact`, which
  would clobber per-cell overrides. A distinct key means zero behavior change
  for existing notebooks.
- Custom cells are cloned before tagging, since they point into the global
  repository cache.
- Because the binding is computed at creation time it automatically follows
  artifact renames and copies — no hardcoded names in YAML.
- Notebooks created before this change keep their current behavior (tagging
  happens at creation); suggestion cells instantiated later degrade gracefully
  to today's resolution.

Note: this fix is AI-generated.
