### PR TITLE
Bugfix: Move ArtifactName from a parameter to a cell env.

### DIFF
--- a/bin/fixtures/TestLSPServer.golden
+++ b/bin/fixtures/TestLSPServer.golden
@@ -16,11 +16,29 @@ Test Case 1 Initialize call:
    "completionProvider": {
     "triggerCharacters": [
      ".",
-     "("
+     "(",
+     "?"
     ]
    },
    "hoverProvider": true,
    "documentSymbolProvider": true,
+   "semanticTokensProvider": {
+    "legend": {
+     "tokenTypes": [
+      "keyword",
+      "comment",
+      "string",
+      "number",
+      "operator",
+      "function",
+      "plugin",
+      "variable",
+      "property"
+     ],
+     "tokenModifiers": []
+    },
+    "full": true
+   },
    "diagnosticProvider": {
     "identifier": "vql",
     "interFileDependencies": false,
@@ -56,17 +74,17 @@ Test Case 2 Add doc:
    {
     "range": {
      "start": {
-      "line": 1,
-      "character": 15
+      "line": 0,
+      "character": 14
      },
      "end": {
-      "line": 1,
-      "character": 24
+      "line": 0,
+      "character": 23
      }
     },
     "severity": 1,
     "source": "vql",
-    "message": "unknown_plugin:Unknown plugin infoXXX()"
+    "message": "(1,15) unknown_plugin: Unknown plugin infoXXX()"
    }
   ]
  }

--- a/services/launcher/verifier.go
+++ b/services/launcher/verifier.go
@@ -79,7 +79,8 @@ func (self *AnalysisState) Debug() string {
 	}
 
 	res = append(res, "Definitions:")
-	for _, desc := range self.Definitions {
+	for _, key := range utils.Sort(self.Definitions) {
+		desc := self.Definitions[key]
 		res = append(res, fmt.Sprintf("(%d,%d)-(%d,%d) %s (%s)",
 			desc.Pos.Pos.Line, desc.Pos.Pos.Column,
 			desc.Pos.EndPos.Line, desc.Pos.EndPos.Column,

--- a/services/notebook/fixtures/TestInitialNotebook.golden
+++ b/services/notebook/fixtures/TestInitialNotebook.golden
@@ -5,19 +5,18 @@
  },
  "Unspecified Artifacts Response": {
   "name": "PrivateNotebook",
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "sources": [
    {
     "notebook": [
      {
       "template": "# Welcome to Velociraptor notebooks!\n",
-      "type": "markdown"
+      "type": "markdown",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "Notebooks.Default"
+       }
+      ]
      }
     ]
    }
@@ -42,11 +41,6 @@
     "name": "FirstParameter",
     "default": "1982-12-10",
     "type": "timestamp"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Generic.Client.Info",
-    "description": "Name of the artifact this notebook came from."
    },
    {
     "name": "ClientId",
@@ -102,11 +96,6 @@
   "name": "PrivateNotebook",
   "parameters": [
    {
-    "name": "ArtifactName",
-    "default": "Custom.Generic.Client.Info",
-    "description": "Name of the artifact this notebook came from."
-   },
-   {
     "name": "ClientId",
     "default": "C.1235",
     "description": "Implied client id from notebook"
@@ -122,7 +111,13 @@
     "notebook": [
      {
       "template": "# Custom.Generic.Client.Info template\n",
-      "type": "markdown"
+      "type": "markdown",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "Custom.Generic.Client.Info"
+       }
+      ]
      }
     ]
    },
@@ -161,11 +156,6 @@
    {
     "name": "Arg1",
     "default": "Foo"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Generic.Events",
-    "description": "Name of the artifact this notebook came from."
    },
    {
     "name": "ClientId",
@@ -229,11 +219,6 @@
    {
     "name": "Arg1",
     "default": "Foo"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Generic.Events",
-    "description": "Name of the artifact this notebook came from."
    },
    {
     "name": "ClientId",
@@ -311,11 +296,6 @@
    {
     "name": "Arg2",
     "default": "Bar"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "GlobalNotebook",
-    "description": "Name of the artifact this notebook came from."
    }
   ],
   "sources": [
@@ -323,7 +303,13 @@
     "notebook": [
      {
       "template": "SELECT Arg1 FROM scope()\n",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "GlobalNotebook"
+       }
+      ]
      }
     ]
    }
@@ -359,11 +345,6 @@
     "name": "FirstParameter",
     "default": "1982-12-10",
     "type": "timestamp"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Generic.Client.Info",
-    "description": "Name of the artifact this notebook came from."
    },
    {
     "name": "HuntId",
@@ -410,19 +391,18 @@
  },
  "Notebook with exports Response": {
   "name": "PrivateNotebook",
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "NotebookWithImport",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "sources": [
    {
     "notebook": [
      {
       "template": "SELECT NotebookExport, ArtifactExport FROM scope()",
-      "type": "vql"
+      "type": "vql",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "NotebookWithImport"
+       }
+      ]
      }
     ]
    }
@@ -442,13 +422,6 @@
  },
  "Notebook with suggestions Response": {
   "name": "PrivateNotebook",
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "NotebookWithSugegstions",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "sources": [
    {
     "notebook": [
@@ -466,6 +439,54 @@
   ]
  },
  "Notebook with suggestions Spec": {
+  "artifact": "PrivateNotebook",
+  "parameters": {}
+ },
+ "Notebook with multiple sources Request": {
+  "name": "Notebook with multiple sources",
+  "description": "Adding multiple sources and notebook should update ArtifactName for each source",
+  "artifacts": [
+   "MultipleNotebooks"
+  ]
+ },
+ "Notebook with multiple sources Response": {
+  "name": "PrivateNotebook",
+  "sources": [
+   {
+    "name": "Part1",
+    "notebook": [
+     {
+      "template": "SELECT * FROM info()\n",
+      "type": "vql",
+      "name": "Test1",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "MultipleNotebooks/Part1"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "name": "Part2",
+    "notebook": [
+     {
+      "template": "SELECT * FROM info()\n",
+      "type": "vql",
+      "name": "Test1",
+      "env": [
+       {
+        "key": "ArtifactName",
+        "value": "MultipleNotebooks/Part2"
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ },
+ "Notebook with multiple sources Spec": {
   "artifact": "PrivateNotebook",
   "parameters": {}
  }

--- a/services/notebook/fixtures/TestNotebookFromTemplate.golden
+++ b/services/notebook/fixtures/TestNotebookFromTemplate.golden
@@ -28,11 +28,6 @@
     "name": "StringArg",
     "default": "This is a test",
     "type": "string"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Notebook.With.Parameters",
-    "description": "Name of the artifact this notebook came from."
    }
   ],
   "requests": [
@@ -46,10 +41,6 @@
      {
       "key": "StringArg",
       "value": "Hello"
-     },
-     {
-      "key": "ArtifactName",
-      "value": "Notebook.With.Parameters"
      },
      {
       "key": "Tool_SomeTool_HASH",
@@ -110,6 +101,12 @@
    "DEBUG:Query Stats: {\"RowsScanned\":1,\"PluginsCalled\":1,\"FunctionsCalled\":5,\"ProtocolSearch\":0,\"ScopeCopy\":3}\n"
   ],
   "type": "vql",
+  "env": [
+   {
+    "key": "ArtifactName",
+    "value": "Notebook.With.Parameters"
+   }
+  ],
   "current_version": "03",
   "available_versions": [
    "03"
@@ -144,11 +141,6 @@
     "name": "StringArg",
     "default": "This is a test",
     "type": "string"
-   },
-   {
-    "name": "ArtifactName",
-    "default": "Notebook.With.Parameters",
-    "description": "Name of the artifact this notebook came from."
    }
   ],
   "requests": [
@@ -162,10 +154,6 @@
      {
       "key": "StringArg",
       "value": "Goodbye"
-     },
-     {
-      "key": "ArtifactName",
-      "value": "Notebook.With.Parameters"
      },
      {
       "key": "Tool_SomeTool_HASH",

--- a/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelineAnnotations.golden
@@ -5,22 +5,11 @@
   "artifacts": [
    "Notebooks.Default"
   ],
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "requests": [
    {
     "query_id": 1,
     "total_queries": 1,
     "env": [
-     {
-      "key": "ArtifactName",
-      "value": "Notebooks.Default"
-     },
      {
       "key": "ColumnTypes",
       "value": "{}"
@@ -51,22 +40,11 @@
   "artifacts": [
    "Notebooks.Default"
   ],
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "requests": [
    {
     "query_id": 1,
     "total_queries": 1,
     "env": [
-     {
-      "key": "ArtifactName",
-      "value": "Notebooks.Default"
-     },
      {
       "key": "ColumnTypes",
       "value": "{}"

--- a/services/notebook/fixtures/TestNotebookManagerTimelines.golden
+++ b/services/notebook/fixtures/TestNotebookManagerTimelines.golden
@@ -5,22 +5,11 @@
   "artifacts": [
    "Notebooks.Default"
   ],
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "requests": [
    {
     "query_id": 1,
     "total_queries": 1,
     "env": [
-     {
-      "key": "ArtifactName",
-      "value": "Notebooks.Default"
-     },
      {
       "key": "ColumnTypes",
       "value": "{}"

--- a/services/notebook/fixtures/TestNotebookManagerUpdateCell.golden
+++ b/services/notebook/fixtures/TestNotebookManagerUpdateCell.golden
@@ -6,22 +6,11 @@
   "artifacts": [
    "Notebooks.Default"
   ],
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "requests": [
    {
     "query_id": 1,
     "total_queries": 1,
     "env": [
-     {
-      "key": "ArtifactName",
-      "value": "Notebooks.Default"
-     },
      {
       "key": "ColumnTypes",
       "value": "{}"
@@ -88,22 +77,11 @@
   "artifacts": [
    "Notebooks.Default"
   ],
-  "parameters": [
-   {
-    "name": "ArtifactName",
-    "default": "Notebooks.Default",
-    "description": "Name of the artifact this notebook came from."
-   }
-  ],
   "requests": [
    {
     "query_id": 1,
     "total_queries": 1,
     "env": [
-     {
-      "key": "ArtifactName",
-      "value": "Notebooks.Default"
-     },
      {
       "key": "ColumnTypes",
       "value": "{}"

--- a/services/notebook/initial.go
+++ b/services/notebook/initial.go
@@ -309,7 +309,9 @@ func CalculateNotebookArtifact(
 			}
 
 			custom_cells := false
-			for _, n := range s.Notebook {
+			// Tag custom cells with the artifact name and the source
+			for _, n_orig := range s.Notebook {
+				n := proto.Clone(n_orig).(*artifacts_proto.NotebookSourceCell)
 				new_source.Notebook = append(new_source.Notebook, n)
 				switch strings.ToLower(n.Type) {
 
@@ -318,6 +320,10 @@ func CalculateNotebookArtifact(
 				// be used. This allows suppressing notebook cells for
 				// this source.
 				case "vql", "md", "markdown", "none":
+					n.Env = append(n.Env, &artifacts_proto.ArtifactEnv{
+						Key:   "ArtifactName",
+						Value: source_name,
+					})
 					custom_cells = true
 				}
 			}
@@ -368,15 +374,6 @@ LIMIT 50
 				}
 			}
 		}
-	}
-
-	if len(out.Artifacts) > 0 {
-		res.Parameters = append(res.Parameters,
-			&artifacts_proto.ArtifactParameter{
-				Name:        "ArtifactName",
-				Description: "Name of the artifact this notebook came from.",
-				Default:     out.Artifacts[0],
-			})
 	}
 
 	// Add any custom variables.
@@ -713,8 +710,6 @@ func updateNotebookRequests(
 // Get the initial cells from a notebook artifact. Each source should
 // contain a notebook clause.
 func getInitialCellsFromArtifacts(
-	ctx context.Context,
-	config_obj *config_proto.Config,
 	artifact *artifacts_proto.Artifact,
 	in *api_proto.NotebookMetadata) (
 	result []*api_proto.NotebookCellRequest, err error) {
@@ -788,7 +783,7 @@ func getInitialCells(
 		return nil, nil, err
 	}
 
-	cells, err := getInitialCellsFromArtifacts(ctx, config_obj, psuedo_artifact, out)
+	cells, err := getInitialCellsFromArtifacts(psuedo_artifact, out)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/notebook/initial_test.go
+++ b/services/notebook/initial_test.go
@@ -96,6 +96,23 @@ sources:
   - name: A good suggestion.
     type: vql_suggestion
     template: SELECT * FROM info()
+`, `
+name: MultipleNotebooks
+type: CLIENT
+sources:
+- name: Part1
+  notebook:
+  - name: Test1
+    type: vql
+    template: |
+       SELECT * FROM info()
+
+- name: Part2
+  notebook:
+  - name: Test1
+    type: vql
+    template: |
+       SELECT * FROM info()
 `}
 
 type checker func(t *testing.T, response *artifacts_proto.Artifact, spec *flows_proto.ArtifactSpec)
@@ -139,11 +156,11 @@ func initialTestCases(client_id string) []notebookTestCase {
 				AssertDictRegex(t, "1982-12-10", "Parameters.0.Default", artifact)
 
 				// ClientId and Flow ID are added
-				AssertDictRegex(t, "ClientId", "Parameters.2.Name", artifact)
-				AssertDictRegex(t, client_id, "Parameters.2.Default", artifact)
+				AssertDictRegex(t, "ClientId", "Parameters.1.Name", artifact)
+				AssertDictRegex(t, client_id, "Parameters.1.Default", artifact)
 
-				AssertDictRegex(t, "FlowId", "Parameters.3.Name", artifact)
-				AssertDictRegex(t, "F.1234", "Parameters.3.Default", artifact)
+				AssertDictRegex(t, "FlowId", "Parameters.2.Name", artifact)
+				AssertDictRegex(t, "F.1234", "Parameters.2.Default", artifact)
 
 				// But the spec contains the actual collected data
 				AssertDictRegex(t, "FirstParameter", "Parameters.Env.0.Key", spec)
@@ -177,8 +194,10 @@ func initialTestCases(client_id string) []notebookTestCase {
 				spec *flows_proto.ArtifactSpec) {
 
 				// StartTime and EndTime are added as parameters
-				AssertDictRegex(t, "StartTime", "Parameters.3.Name", artifact)
-				AssertDictRegex(t, "EndTime", "Parameters.4.Name", artifact)
+				AssertDictRegex(t, "Arg1", "Parameters.0.Name", artifact)
+				AssertDictRegex(t, "ClientId", "Parameters.1.Name", artifact)
+				AssertDictRegex(t, "StartTime", "Parameters.2.Name", artifact)
+				AssertDictRegex(t, "EndTime", "Parameters.3.Name", artifact)
 
 				// The Value of StartTime in the spec comes from the
 				// Env of the request.
@@ -248,12 +267,12 @@ func initialTestCases(client_id string) []notebookTestCase {
 				spec *flows_proto.ArtifactSpec) {
 
 				// HuntId is added
-				AssertDictRegex(t, "HuntId", "Parameters.2.Name", artifact)
-				AssertDictRegex(t, "H.1234", "Parameters.2.Default", artifact)
+				AssertDictRegex(t, "HuntId", "Parameters.1.Name", artifact)
+				AssertDictRegex(t, "H.1234", "Parameters.1.Default", artifact)
 
 				// Spec has the value from the hunt object
-				AssertDictRegex(t, "FirstParameter", "Parameters.Env.0.Key", spec)
-				AssertDictRegex(t, "2021-11", "Parameters.Env.0.Value", spec)
+				AssertDictRegex(t, "FirstParameter", "Parameters.Env.1.Key", spec)
+				AssertDictRegex(t, "2021-11", "Parameters.Env.1.Value", spec)
 
 			},
 		},
@@ -283,6 +302,13 @@ func initialTestCases(client_id string) []notebookTestCase {
 				AssertDictRegex(t, "vql_suggestion", "Sources.0.Notebook.0.Type", artifact)
 				AssertDictRegex(t, "SELECT \\* FROM source", "Sources.0.Notebook.1.Template", artifact)
 				AssertDictRegex(t, "vql", "Sources.0.Notebook.1.Type", artifact)
+			},
+		},
+		{
+			req: &api_proto.NotebookMetadata{
+				Name:        "Notebook with multiple sources",
+				Description: "Adding multiple sources and notebook should update ArtifactName for each source",
+				Artifacts:   []string{"MultipleNotebooks"},
 			},
 		},
 	}


### PR DESCRIPTION
This fixes a bug where ArtifactName would be set to the first artifact collected instead of referring to the custom cell rendered.

Fixes: #4987 