### PR TITLE
Windows.Forensics.Prefetch: read VolumeSerialNumber at offset 16, not 12

### DIFF
--- a/artifacts/definitions/Windows/Forensics/Prefetch.yaml
+++ b/artifacts/definitions/Windows/Forensics/Prefetch.yaml
@@ -274,7 +274,7 @@ export: |
           }],
           ["__DeviceSize", 4, "unsigned long"],
           ["DeviceCreationTime", 8, "WinFileTime"],
-          ["VolumeSerialNumber", 12, "unsigned long"],
+          ["VolumeSerialNumber", 16, "unsigned long"],
           ["VolumeSerialNumberHex", 0, Value, {
               value: "x=>format(format='%#x', args=x.VolumeSerialNumber)",
           }],

--- a/artifacts/testdata/server/testcases/prefetch.out.yaml
+++ b/artifacts/testdata/server/testcases/prefetch.out.yaml
@@ -266,8 +266,8 @@ Output: [
      {
       "DeviceName": "\\VOLUME{01d8236a6bef56c6-006c4c5d}",
       "DeviceCreationTime": "2022-02-16T19:21:39Z",
-      "VolumeSerialNumber": 30942058,
-      "VolumeSerialNumberHex": "0x1d8236a",
+      "VolumeSerialNumber": 7097437,
+      "VolumeSerialNumberHex": "0x6c4c5d",
       "Directories": [
        "\\VOLUME{01d8236a6bef56c6-006c4c5d}\\USERS",
        "\\VOLUME{01d8236a6bef56c6-006c4c5d}\\USERS\\TEST",
@@ -375,8 +375,8 @@ Output: [
    {
     "DeviceName": "\\VOLUME{01d8236a6bef56c6-006c4c5d}",
     "DeviceCreationTime": "2022-02-16T19:21:39Z",
-    "VolumeSerialNumber": 30942058,
-    "VolumeSerialNumberHex": "0x1d8236a",
+    "VolumeSerialNumber": 7097437,
+    "VolumeSerialNumberHex": "0x6c4c5d",
     "Directories": [
      "\\VOLUME{01d8236a6bef56c6-006c4c5d}\\USERS",
      "\\VOLUME{01d8236a6bef56c6-006c4c5d}\\USERS\\TEST",


### PR DESCRIPTION
`Windows.Forensics.Prefetch` reads `VolumeSerialNumber` at offset 12 of the
`VolumeInformation` struct. Offset 12 is inside the 8-byte volume creation
FILETIME at offset 8, so the field reports **the upper 4 bytes of the timestamp**
rather than the volume serial — on every prefetch record, on every format version.

The serial belongs at **offset 16**. This PR changes that one number and updates the
two golden values it affects.

### The spec

libscca — the reference this artifact already cites in its own `reference:` block —
places the volume serial number at offset 16 in the volume information entry, for
every version (17 / 23 / 26 / 30). Every other field in the profile already matches
that layout: 0, 4, 8, 20, 24, 28, 32. Offset 16 is the only slot the struct leaves
free, and offset 12 is not a field at all.

### The repo's own fixture demonstrates it

From `artifacts/testdata/files/VELOCIRAPTOR.EXE-DB95245D.pf`, the first 40 bytes of
the volume information entry:

```
60000000 22000000 c656ef6b 6a23d801 5d4c6c00 a8000000 80010000 28020000 07000000
^off 0   ^off 4   ^off 8 = FILETIME  ^off 16  ^off 20  ^off 24  ^off 28  ^off 32
```

| | |
| --- | --- |
| `DeviceName` | `\VOLUME{01d8236a6bef56c6-`**`006c4c5d`**`}` |
| FILETIME at offset 8 | `0x01d8236a6bef56c6` → `2022-02-16T19:21:39Z` |
| bytes 12..15 (read today) | `0x01d8236a` — the upper half of that same FILETIME |
| bytes 16..19 (libscca) | `0x006c4c5d` — matches the `DeviceName` serial exactly |

The remaining fields decode to sane values at the libscca offsets (`168`, `384`,
`552`, `7` for file-references offset, file-references size, directory-strings
offset and directory-string count), which confirms the rest of the struct is right
and isolates the defect to this one field.

### Why the golden test did not catch it

`prefetch.out.yaml` recorded `"VolumeSerialNumber": 30942058` — that is `0x01d8236a`,
the timestamp value — while `DeviceName` in the very same record says the serial is
`006c4c5d`. The baseline was generated from the parser it was meant to check
(#1585 added the profile, the fixture and the golden file together), so it locked
the bug in rather than catching it. Both occurrences are updated to `7097437` /
`0x6c4c5d`, which now agree with the `DeviceName` beside them.

### Impact

`VolumeSerialNumber` / `VolumeSerialNumberHex` are the natural join key for tying a
prefetch record to a volume — matching against `Win32_LogicalDisk`, `MountedDevices`,
or `EMDMgmt` for USB attribution. Today that join can never match anything, and it
fails *quietly*: the column is populated with a plausible-looking hex value, so it
reads as a working correlation that simply found nothing.

### Reproducing

Decodes the committed fixture and prints both candidate offsets (Windows, no build
required):

```python
import ctypes, struct
from ctypes import wintypes
raw = open(r"artifacts/testdata/files/VELOCIRAPTOR.EXE-DB95245D.pf", "rb").read()
fmt, uncomp = raw[3], struct.unpack("<I", raw[4:8])[0]          # MAM\x04 = XPRESS_HUFF
ws = wintypes.ULONG(); frag = wintypes.ULONG()
ctypes.WinDLL("ntdll").RtlGetCompressionWorkSpaceSize(wintypes.USHORT(fmt), ctypes.byref(ws), ctypes.byref(frag))
out, final = ctypes.create_string_buffer(uncomp), wintypes.ULONG()
ctypes.WinDLL("ntdll").RtlDecompressBufferEx(
    wintypes.USHORT(fmt), out, wintypes.ULONG(uncomp), ctypes.c_char_p(raw[8:]),
    wintypes.ULONG(len(raw) - 8), ctypes.byref(final), ctypes.create_string_buffer(ws.value))
d = out.raw[:final.value]
v = struct.unpack("<I", d[84+24:84+28])[0]                       # volumes offset (v30)
e = d[v:v+40]
print("DeviceName :", d[v+struct.unpack("<I", e[0:4])[0]:][:struct.unpack("<I", e[4:8])[0]*2].decode("utf-16-le"))
print("FILETIME@8 : 0x%016x" % struct.unpack("<Q", e[8:16])[0])
print("offset 12  : 0x%08x  <- currently read" % struct.unpack("<I", e[12:16])[0])
print("offset 16  : 0x%08x  <- libscca" % struct.unpack("<I", e[16:20])[0])
```

```
DeviceName : \VOLUME{01d8236a6bef56c6-006c4c5d}
FILETIME@8 : 0x01d8236a6bef56c6
offset 12  : 0x01d8236a  <- currently read
offset 16  : 0x006c4c5d  <- libscca
```

### Notes

- I have no Go toolchain on this machine, so I could not run `make test` locally.
  The two golden values were computed from the raw bytes of the fixture the test
  consumes, so they should be exactly what the test now produces — but CI is the
  authority, and I am happy to adjust if it disagrees.
- **Possibly related, not addressed here and not verified:** `VolumeInformation` is
  declared as 40 bytes, which is the version-17 entry size. libscca gives 104 for
  versions 23/26 and 96 for version 30/31. If the `Array` stride comes from the
  declared struct size, then a `.pf` with more than one volume would decode the
  second and later entries at the wrong offsets. Every record I have to hand has a
  single volume, so I could not test this and did not want to fold an unverified
  change into a one-character fix. Happy to open a separate issue if it is real.
- Only the offset is changed. `VolumeSerialNumberHex` uses `%#x`, so it renders as
  `0x6c4c5d`; the conventional forensic presentation is zero-padded to 8 digits
  (`006C4C5D`, as `DeviceName` and EZ Tools/libscca show it). I left the format
  alone to keep this minimal — say the word if you would like `%08x` here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
