### PR TITLE
Bugfix: transform hostname in pool client compressed responses

### DIFF
--- a/executor/pool.go
+++ b/executor/pool.go
@@ -128,8 +128,7 @@ func maybeTransformResponse(response *actions_proto.VQLResponse, id int) *action
 			// case the JSONL payload is stored in
 			// CompressedJsonResponse and JSONLResponse is empty.
 			jsonl := response.JSONLResponse
-			compressed := len(response.CompressedJsonResponse) > 0
-			if jsonl == "" && compressed {
+			if jsonl == "" && len(response.CompressedJsonResponse) > 0 {
 				decompressed, err := utils.Uncompress(
 					context.Background(), response.CompressedJsonResponse)
 				if err != nil {
@@ -159,19 +158,12 @@ func maybeTransformResponse(response *actions_proto.VQLResponse, id int) *action
 			}
 			result := proto.Clone(response).(*actions_proto.VQLResponse)
 
-			// Preserve the compression state of the original
-			// response so the server can still decode it.
-			if compressed {
-				compressed_rows, err := utils.Compress(new_rows)
-				if err != nil {
-					return response
-				}
-				result.CompressedJsonResponse = compressed_rows
-				result.UncompressedSize = uint64(len(new_rows))
-				result.JSONLResponse = ""
-			} else {
-				result.JSONLResponse = string(new_rows)
-			}
+			// The server falls back to handling uncompressed data so
+			// just clear the compressed field and pass the
+			// transformed rows uncompressed.
+			result.JSONLResponse = string(new_rows)
+			result.CompressedJsonResponse = nil
+			result.UncompressedSize = 0
 
 			return result
 		}

--- a/executor/pool.go
+++ b/executor/pool.go
@@ -124,7 +124,21 @@ func maybeTransformResponse(response *actions_proto.VQLResponse, id int) *action
 		// contains a Hostname we need to transform it. This
 		// specifically targets Generic.Client.Info interrogation.
 		if utils.InString(response.Columns, "Hostname") {
-			rows, err := utils.ParseJsonToDicts([]byte(response.JSONLResponse))
+			// The response may be compressed by the launcher. In that
+			// case the JSONL payload is stored in
+			// CompressedJsonResponse and JSONLResponse is empty.
+			jsonl := response.JSONLResponse
+			compressed := len(response.CompressedJsonResponse) > 0
+			if jsonl == "" && compressed {
+				decompressed, err := utils.Uncompress(
+					context.Background(), response.CompressedJsonResponse)
+				if err != nil {
+					return response
+				}
+				jsonl = string(decompressed)
+			}
+
+			rows, err := utils.ParseJsonToDicts([]byte(jsonl))
 			if err != nil || len(rows) == 0 {
 				return response
 			}
@@ -144,7 +158,20 @@ func maybeTransformResponse(response *actions_proto.VQLResponse, id int) *action
 				return response
 			}
 			result := proto.Clone(response).(*actions_proto.VQLResponse)
-			result.JSONLResponse = string(new_rows)
+
+			// Preserve the compression state of the original
+			// response so the server can still decode it.
+			if compressed {
+				compressed_rows, err := utils.Compress(new_rows)
+				if err != nil {
+					return response
+				}
+				result.CompressedJsonResponse = compressed_rows
+				result.UncompressedSize = uint64(len(new_rows))
+				result.JSONLResponse = ""
+			} else {
+				result.JSONLResponse = string(new_rows)
+			}
 
 			return result
 		}

--- a/executor/pool_test.go
+++ b/executor/pool_test.go
@@ -1,0 +1,116 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Velocidex/ordereddict"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
+	"www.velocidex.com/golang/velociraptor/json"
+	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+// Test that the hostname transform works when the response is
+// compressed by the launcher (the default for newer clients). The
+// transform must decompress the payload, apply the change and
+// re-compress it so the server can still decode it.
+func TestMaybeTransformResponseCompressed(t *testing.T) {
+	rows := []*ordereddict.Dict{
+		ordereddict.NewDict().
+			Set("Hostname", "testhost").
+			Set("Fqdn", "testhost.local"),
+	}
+	jsonl, err := json.MarshalJsonl(rows)
+	require.NoError(t, err)
+
+	compressed, err := utils.Compress(jsonl)
+	require.NoError(t, err)
+
+	response := &actions_proto.VQLResponse{
+		Columns:                []string{"Hostname", "Fqdn"},
+		CompressedJsonResponse: compressed,
+		UncompressedSize:       uint64(len(jsonl)),
+	}
+
+	result := maybeTransformResponse(response, 42)
+	require.NotNil(t, result)
+
+	// The result must remain compressed.
+	assert.Empty(t, result.JSONLResponse)
+	assert.NotEmpty(t, result.CompressedJsonResponse)
+	assert.Equal(t, uint64(len(jsonl)), result.UncompressedSize)
+
+	decompressed, err := utils.Uncompress(
+		context.Background(), result.CompressedJsonResponse)
+	require.NoError(t, err)
+
+	transformed_rows, err := utils.ParseJsonToDicts(decompressed)
+	require.NoError(t, err)
+	require.Len(t, transformed_rows, 1)
+
+	hostname, pres := transformed_rows[0].GetString("Hostname")
+	require.True(t, pres)
+	assert.Equal(t, "testhost-42", hostname)
+
+	fqdn, pres := transformed_rows[0].GetString("Fqdn")
+	require.True(t, pres)
+	assert.Equal(t, "testhost-42", fqdn)
+}
+
+// Test that the hostname transform still works on uncompressed
+// responses (older clients).
+func TestMaybeTransformResponseUncompressed(t *testing.T) {
+	rows := []*ordereddict.Dict{
+		ordereddict.NewDict().
+			Set("Hostname", "testhost").
+			Set("Fqdn", "testhost.local"),
+	}
+	jsonl, err := json.MarshalJsonl(rows)
+	require.NoError(t, err)
+
+	response := &actions_proto.VQLResponse{
+		Columns:       []string{"Hostname", "Fqdn"},
+		JSONLResponse: string(jsonl),
+	}
+
+	result := maybeTransformResponse(response, 7)
+	require.NotNil(t, result)
+
+	// The result must remain uncompressed.
+	assert.Empty(t, result.CompressedJsonResponse)
+	assert.NotEmpty(t, result.JSONLResponse)
+
+	transformed_rows, err := utils.ParseJsonToDicts(
+		[]byte(result.JSONLResponse))
+	require.NoError(t, err)
+	require.Len(t, transformed_rows, 1)
+
+	hostname, pres := transformed_rows[0].GetString("Hostname")
+	require.True(t, pres)
+	assert.Equal(t, "testhost-7", hostname)
+}
+
+// Test that responses without a Hostname column are returned
+// unchanged.
+func TestMaybeTransformResponseNoHostname(t *testing.T) {
+	rows := []*ordereddict.Dict{
+		ordereddict.NewDict().Set("Foo", "bar"),
+	}
+	jsonl, err := json.MarshalJsonl(rows)
+	require.NoError(t, err)
+
+	compressed, err := utils.Compress(jsonl)
+	require.NoError(t, err)
+
+	response := &actions_proto.VQLResponse{
+		Columns:                []string{"Foo"},
+		CompressedJsonResponse: compressed,
+		UncompressedSize:       uint64(len(jsonl)),
+	}
+
+	result := maybeTransformResponse(response, 42)
+	require.NotNil(t, result)
+	assert.Equal(t, response, result)
+}

--- a/executor/pool_test.go
+++ b/executor/pool_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Velocidex/ordereddict"
@@ -14,8 +13,9 @@ import (
 
 // Test that the hostname transform works when the response is
 // compressed by the launcher (the default for newer clients). The
-// transform must decompress the payload, apply the change and
-// re-compress it so the server can still decode it.
+// transform must decompress the payload, apply the change and return
+// the result uncompressed - the server falls back to handling
+// uncompressed data.
 func TestMaybeTransformResponseCompressed(t *testing.T) {
 	rows := []*ordereddict.Dict{
 		ordereddict.NewDict().
@@ -37,16 +37,13 @@ func TestMaybeTransformResponseCompressed(t *testing.T) {
 	result := maybeTransformResponse(response, 42)
 	require.NotNil(t, result)
 
-	// The result must remain compressed.
-	assert.Empty(t, result.JSONLResponse)
-	assert.NotEmpty(t, result.CompressedJsonResponse)
-	assert.Equal(t, uint64(len(jsonl)), result.UncompressedSize)
+	// The result must be uncompressed.
+	assert.NotEmpty(t, result.JSONLResponse)
+	assert.Empty(t, result.CompressedJsonResponse)
+	assert.Equal(t, uint64(0), result.UncompressedSize)
 
-	decompressed, err := utils.Uncompress(
-		context.Background(), result.CompressedJsonResponse)
-	require.NoError(t, err)
-
-	transformed_rows, err := utils.ParseJsonToDicts(decompressed)
+	transformed_rows, err := utils.ParseJsonToDicts(
+		[]byte(result.JSONLResponse))
 	require.NoError(t, err)
 	require.Len(t, transformed_rows, 1)
 


### PR DESCRIPTION
The pool client's hostname transform silently no-oped for newer clients because the launcher compresses VQL responses by default (FlowRequest_ZLIB). The payload lives in CompressedJsonResponse while JSONLResponse is empty, so the transform parsed an empty string and returned the response unchanged.

Decompress the payload before transforming and re-compress the result, preserving the original compression state.

History:

- The bug has existed since July 2025, when an unrelated filestore change (#4361) made compressed flow requests the default: the pool client's hostname transform, written in 2023 when responses were uncompressed, silently stopped working because it only read `JSONLResponse` while the payload now lived in `CompressedJsonResponse`. The failure was completely invisible - parsing the empty string returns no error, so the transform passed every response through unchanged without a single log line - and the symptom (all virtual clients showing the same hostname) was indistinguishable from expected behavior, since the pool client's entire premise is many simulated clients running on one real host. Combined with the fact that the pool client is a load-testing tool whose operators watch server metrics rather than client hostnames, the `-<id>` suffix was a purely cosmetic nicety whose absence looked normal, and the only alternative hostname path (the periodic `GetClientInfo()` update) was disabled by default, so nothing ever surfaced the discrepancy.

It surfaced now because I'm experimenting with giving pool clients unique hostnames, so that the feature can also be useful in training and development environments :sunglasses: 