### PR TITLE
Add unique emulated identities to pool clients

### DIFF
--- a/bin/pool.go
+++ b/bin/pool.go
@@ -46,8 +46,12 @@ var (
 		"number", "Total number of clients to run.").Int()
 
 	pool_client_writeback_dir = pool_client_command.Flag(
-		"writeback_dir", "The directory to store all writebacks. "+
-			"If not specified, in-memory writebacks are used.").ExistingDir()
+		"writeback_dir", "The directory to store all writebacks.").Default(".").
+		ExistingDir()
+
+	pool_client_no_writeback = pool_client_command.Flag(
+		"no_writeback", "Use in-memory writebacks so client identities are ephemeral.").
+		Bool()
 
 	pool_client_concurrency = pool_client_command.Flag(
 		"concurrency", "How many real queries to run.").Default("10").Int()
@@ -74,6 +78,10 @@ func (self *counter) Inc() {
 
 func doPoolClient() error {
 	logging.DisableLogging()
+
+	if *pool_client_no_writeback && *pool_client_writeback_dir != "." {
+		return fmt.Errorf("--no_writeback and --writeback_dir are mutually exclusive")
+	}
 
 	number_of_clients := *pool_client_number
 	if number_of_clients <= 0 {
@@ -137,17 +145,18 @@ func doPoolClient() error {
 
 			client_config.Client.DisableCheckpoints = true
 
-			// Use an in-memory writeback so each client's identity is
-			// ephemeral and no files are written to disk. If the user
-			// specified a writeback directory, write the writebacks
-			// there instead so identities persist between runs.
-			if *pool_client_writeback_dir != "" {
+			// By default write the writebacks to the writeback
+			// directory so client identities persist between runs.
+			// If --no_writeback is specified, use an in-memory
+			// writeback so each client's identity is ephemeral and no
+			// files are written to disk.
+			if *pool_client_no_writeback {
+				client_config.Client.WritebackLinux = fmt.Sprintf(
+					"memory://pool_client.yaml.%d", i)
+			} else {
 				client_config.Client.WritebackLinux = path.Join(
 					*pool_client_writeback_dir,
 					fmt.Sprintf("pool_client.yaml.%d", i))
-			} else {
-				client_config.Client.WritebackLinux = fmt.Sprintf(
-					"memory://pool_client.yaml.%d", i)
 			}
 			client_config.Client.WritebackWindows = client_config.Client.WritebackLinux
 			client_config.Client.WritebackDarwin = client_config.Client.WritebackLinux
@@ -167,9 +176,9 @@ func doPoolClient() error {
 			}
 			client_config.Client.Concurrency = uint64(*pool_client_concurrency)
 
-			// Register the in-memory writeback with the writeback
-			// service. This generates a fresh private key and client
-			// id for this client.
+			// Register the writeback with the writeback service. This
+			// generates a fresh private key and client id for this
+			// client if no writeback exists yet.
 			writeback_service := writeback.GetWritebackService()
 			_ = writeback_service.LoadWriteback(client_config)
 

--- a/bin/pool.go
+++ b/bin/pool.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"sync"
 
+	"github.com/Showmax/go-fqdn"
 	"www.velocidex.com/golang/velociraptor/config"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_utils "www.velocidex.com/golang/velociraptor/crypto/utils"
@@ -45,8 +46,8 @@ var (
 		"number", "Total number of clients to run.").Int()
 
 	pool_client_writeback_dir = pool_client_command.Flag(
-		"writeback_dir", "The directory to store all writebacks.").Default(".").
-		ExistingDir()
+		"writeback_dir", "The directory to store all writebacks. "+
+			"If not specified, in-memory writebacks are used.").ExistingDir()
 
 	pool_client_concurrency = pool_client_command.Flag(
 		"concurrency", "How many real queries to run.").Default("10").Int()
@@ -81,7 +82,7 @@ func doPoolClient() error {
 
 	client_config, err := makeDefaultConfigLoader().
 		WithRequiredClient().
-		WithVerbose(*verbose_flag).WithWriteback().
+		WithVerbose(*verbose_flag).
 		LoadAndValidate()
 	if err != nil {
 		return fmt.Errorf("Unable to load config file: %w", err)
@@ -109,6 +110,12 @@ func doPoolClient() error {
 	serialized, _ := json.Marshal(client_config)
 	logger := logging.GetLogger(client_config, &logging.ClientComponent)
 
+	// Generate a unique identity (hostname and FQDN) for each client.
+	// The FQDN reuses the real host's domain so the emulated clients
+	// appear to belong to the same network.
+	identities := executor.GeneratePoolIdentities(
+		number_of_clients, fqdn.Get())
+
 	c := counter{}
 
 	// Do not ramp up the pool client too fast or it will cause the
@@ -127,15 +134,31 @@ func doPoolClient() error {
 				logger.Error("Copying configs: %v", err)
 				return
 			}
-			filename := fmt.Sprintf("pool_client.yaml.%d", i)
 
 			client_config.Client.DisableCheckpoints = true
-			client_config.Client.WritebackLinux = path.Join(
-				*pool_client_writeback_dir, filename)
+
+			// Use an in-memory writeback so each client's identity is
+			// ephemeral and no files are written to disk. If the user
+			// specified a writeback directory, write the writebacks
+			// there instead so identities persist between runs.
+			if *pool_client_writeback_dir != "" {
+				client_config.Client.WritebackLinux = path.Join(
+					*pool_client_writeback_dir,
+					fmt.Sprintf("pool_client.yaml.%d", i))
+			} else {
+				client_config.Client.WritebackLinux = fmt.Sprintf(
+					"memory://pool_client.yaml.%d", i)
+			}
+			client_config.Client.WritebackWindows = client_config.Client.WritebackLinux
+			client_config.Client.WritebackDarwin = client_config.Client.WritebackLinux
+
+			// The pool clients are ephemeral and their client info
+			// never changes, so there is no point in periodically
+			// updating it.
+			client_config.Client.ClientInfoUpdateTime = -1
 
 			// Create an in memory ring buffer because the file ring
 			// buffer assumes there is only one communicator!
-			client_config.Client.WritebackWindows = client_config.Client.WritebackLinux
 			if client_config.Client.LocalBuffer != nil {
 				client_config.Client.LocalBuffer.DiskSize = 0
 
@@ -144,10 +167,9 @@ func doPoolClient() error {
 			}
 			client_config.Client.Concurrency = uint64(*pool_client_concurrency)
 
-			// Disable client info updates in pool clients
-			client_config.Client.ClientInfoUpdateTime = -1
-
-			// Load existing writebacks if we need them
+			// Register the in-memory writeback with the writeback
+			// service. This generates a fresh private key and client
+			// id for this client.
 			writeback_service := writeback.GetWritebackService()
 			_ = writeback_service.LoadWriteback(client_config)
 
@@ -165,7 +187,7 @@ func doPoolClient() error {
 			}
 
 			exe, err := executor.NewPoolClientExecutor(
-				ctx, wb.ClientId, client_config, i)
+				ctx, wb.ClientId, client_config, &identities[i])
 			if err != nil {
 				logger.Error("Can not create executor: %v", err)
 				return

--- a/executor/pool.go
+++ b/executor/pool.go
@@ -115,59 +115,107 @@ func newPoolClientMux(ctx context.Context, config_obj *config_proto.Config) (*po
 	return self, nil
 }
 
-// Inspect the response and transform it if needed. Currently we only
-// need to replace the Hostname with the pool client's ID so it
-// appears to be a different client.
-func maybeTransformResponse(response *actions_proto.VQLResponse, id int) *actions_proto.VQLResponse {
-	if response != nil {
-		// We need to make the Hostname unique so if the response
-		// contains a Hostname we need to transform it. This
-		// specifically targets Generic.Client.Info interrogation.
-		if utils.InString(response.Columns, "Hostname") {
-			// The response may be compressed by the launcher. In that
-			// case the JSONL payload is stored in
-			// CompressedJsonResponse and JSONLResponse is empty.
-			jsonl := response.JSONLResponse
-			if jsonl == "" && len(response.CompressedJsonResponse) > 0 {
-				decompressed, err := utils.Uncompress(
-					context.Background(), response.CompressedJsonResponse)
-				if err != nil {
-					return response
-				}
-				jsonl = string(decompressed)
-			}
+// Inspect the response and transform it if needed. We replace the
+// Hostname and Fqdn with the pool client's emulated identity so the
+// response appears to come from a different client. This specifically
+// targets Generic.Client.Info interrogation.
+func maybeTransformResponse(response *actions_proto.VQLResponse, identity *PoolIdentity) *actions_proto.VQLResponse {
+	if response == nil || identity == nil {
+		return response
+	}
 
-			rows, err := utils.ParseJsonToDicts([]byte(jsonl))
-			if err != nil || len(rows) == 0 {
-				return response
-			}
-
-			// Replace the Hostname
-			hostname, pres := rows[0].Get("Hostname")
-			if !pres {
-				return response
-			}
-
-			new_hostname := fmt.Sprintf("%s-%d", hostname, id)
-			rows[0].Set("Fqdn", new_hostname)
-			rows[0].Set("Hostname", new_hostname)
-
-			new_rows, err := json.MarshalJsonl(rows)
+	// The BasicInformation source of Generic.Client.Info returns
+	// Hostname and Fqdn as columns.
+	if utils.InString(response.Columns, "Hostname") ||
+		utils.InString(response.Columns, "Fqdn") {
+		// The response may be compressed by the launcher. In that
+		// case the JSONL payload is stored in
+		// CompressedJsonResponse and JSONLResponse is empty.
+		jsonl := response.JSONLResponse
+		if jsonl == "" && len(response.CompressedJsonResponse) > 0 {
+			decompressed, err := utils.Uncompress(
+				context.Background(), response.CompressedJsonResponse)
 			if err != nil {
 				return response
 			}
-			result := proto.Clone(response).(*actions_proto.VQLResponse)
-
-			// The server falls back to handling uncompressed data so
-			// just clear the compressed field and pass the
-			// transformed rows uncompressed.
-			result.JSONLResponse = string(new_rows)
-			result.CompressedJsonResponse = nil
-			result.UncompressedSize = 0
-
-			return result
+			jsonl = string(decompressed)
 		}
+
+		rows, err := utils.ParseJsonToDicts([]byte(jsonl))
+		if err != nil || len(rows) == 0 {
+			return response
+		}
+
+		for _, row := range rows {
+			if _, pres := row.Get("Hostname"); pres {
+				row.Set("Hostname", identity.Hostname)
+			}
+			if _, pres := row.Get("Fqdn"); pres {
+				row.Set("Fqdn", identity.Fqdn)
+			}
+		}
+
+		new_rows, err := json.MarshalJsonl(rows)
+		if err != nil {
+			return response
+		}
+		result := proto.Clone(response).(*actions_proto.VQLResponse)
+
+		// The server falls back to handling uncompressed data so
+		// just clear the compressed field and pass the
+		// transformed rows uncompressed.
+		result.JSONLResponse = string(new_rows)
+		result.CompressedJsonResponse = nil
+		result.UncompressedSize = 0
+
+		return result
 	}
+
+	// The DetailedInfo source of Generic.Client.Info returns the
+	// info() plugin as Param/Value rows - transform the Hostname and
+	// Fqdn values there too.
+	if utils.InString(response.Columns, "Param") &&
+		utils.InString(response.Columns, "Value") {
+		jsonl := response.JSONLResponse
+		if jsonl == "" && len(response.CompressedJsonResponse) > 0 {
+			decompressed, err := utils.Uncompress(
+				context.Background(), response.CompressedJsonResponse)
+			if err != nil {
+				return response
+			}
+			jsonl = string(decompressed)
+		}
+
+		rows, err := utils.ParseJsonToDicts([]byte(jsonl))
+		if err != nil || len(rows) == 0 {
+			return response
+		}
+
+		for _, row := range rows {
+			param, pres := row.GetString("Param")
+			if !pres {
+				continue
+			}
+			switch param {
+			case "Hostname":
+				row.Set("Value", identity.Hostname)
+			case "Fqdn":
+				row.Set("Value", identity.Fqdn)
+			}
+		}
+
+		new_rows, err := json.MarshalJsonl(rows)
+		if err != nil {
+			return response
+		}
+		result := proto.Clone(response).(*actions_proto.VQLResponse)
+		result.JSONLResponse = string(new_rows)
+		result.CompressedJsonResponse = nil
+		result.UncompressedSize = 0
+
+		return result
+	}
+
 	return response
 }
 
@@ -285,8 +333,8 @@ func (self *poolClientMux) maybeUpdateEventTable(
 type PoolClientExecutor struct {
 	delegate  *poolClientMux
 	Outbound  chan *crypto_proto.VeloMessage
-	id        int
 	client_id string
+	identity  *PoolIdentity
 }
 
 func (self *PoolClientExecutor) Nanny() *NannyService {
@@ -311,8 +359,10 @@ func (self *PoolClientExecutor) SendToServer(message *crypto_proto.VeloMessage) 
 
 func (self *PoolClientExecutor) GetClientInfo() *actions_proto.ClientInfo {
 	result := self.delegate.GetClientInfo()
-	result.Hostname = fmt.Sprintf("%v-%d", result.Hostname, self.id)
-	result.Fqdn = fmt.Sprintf("%v-%d", result.Fqdn, self.id)
+	if self.identity != nil {
+		result.Hostname = self.identity.Hostname
+		result.Fqdn = self.identity.Fqdn
+	}
 
 	return result
 }
@@ -354,7 +404,7 @@ func (self *PoolClientExecutor) ProcessRequest(
 			response := proto.Clone(resp).(*crypto_proto.VeloMessage)
 			response.SessionId = message.SessionId
 			response.RequestId = message.RequestId
-			response.VQLResponse = maybeTransformResponse(resp.VQLResponse, self.id)
+			response.VQLResponse = maybeTransformResponse(resp.VQLResponse, self.identity)
 
 			select {
 			case <-ctx.Done():
@@ -379,7 +429,8 @@ func (self *PoolClientExecutor) ProcessRequest(
 func NewPoolClientExecutor(
 	ctx context.Context,
 	client_id string,
-	config_obj *config_proto.Config, id int) (result *PoolClientExecutor, err error) {
+	config_obj *config_proto.Config,
+	identity *PoolIdentity) (result *PoolClientExecutor, err error) {
 
 	pool_mu.Lock()
 	defer pool_mu.Unlock()
@@ -393,9 +444,9 @@ func NewPoolClientExecutor(
 
 	result = &PoolClientExecutor{
 		delegate:  rootClientExecutor,
-		id:        id,
 		Outbound:  make(chan *crypto_proto.VeloMessage, 10),
 		client_id: client_id,
+		identity:  identity,
 	}
 
 	rootClientExecutor.mu.Lock()

--- a/executor/pool_identity.go
+++ b/executor/pool_identity.go
@@ -32,6 +32,12 @@ var (
 		"woody", "icy", "fiery", "electric", "magnetic", "atomic",
 		"orbital", "galactic", "nebular", "prismatic", "echoing",
 		"pulsing",
+		"cyber", "neon", "plasma", "photon", "binary", "chrome",
+		"silicon", "fractal", "vector", "pixel", "glitch", "static",
+		"sonic", "laser", "turbo", "hyper", "stealth", "tactical",
+		"infinite", "eternal", "arcane", "runic", "eldritch", "null",
+		"void", "zero", "temporal", "kinetic", "synthetic",
+		"holographic",
 	}
 
 	pool_nouns = []string{
@@ -46,6 +52,14 @@ var (
 		"voyage", "journey", "quest", "compass", "beacon",
 		"lighthouse", "anchor", "horizon", "summit", "peak", "ridge",
 		"canyon", "river", "ocean",
+		"robot", "android", "cyborg", "droid", "mech",
+		"singularity", "wormhole", "starship", "rocket", "probe",
+		"comet", "meteor", "asteroid", "nebula", "galaxy", "eclipse",
+		"aurora", "quasar", "pulsar", "nova", "zenith", "kernel",
+		"daemon", "proxy", "cipher", "firewall", "matrix", "node",
+		"basilisk", "chimera", "cerberus", "wyvern", "drake", "golem",
+		"paladin", "berserker", "gladiator", "archer", "renegade",
+		"nomad",
 	}
 )
 

--- a/executor/pool_identity.go
+++ b/executor/pool_identity.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+// PoolIdentity represents the emulated identity of a pool client.
+// Each pool client presents a unique hostname and FQDN to the server
+// while all other client information (OS, platform, architecture,
+// interfaces etc.) reflects the real host.
+type PoolIdentity struct {
+	Hostname string
+	Fqdn     string
+}
+
+// Word lists used to generate codename-style hostnames in the style
+// of adjective-noun combinations (e.g. "brave-falcon",
+// "cosmic-orbit"). The lists are deliberately platform agnostic so
+// the generated names look plausible on any operating system.
+var (
+	pool_adjectives = []string{
+		"brave", "swift", "cosmic", "golden", "silver", "crimson",
+		"emerald", "azure", "violet", "amber", "mystic", "silent",
+		"raging", "gentle", "fierce", "noble", "royal", "ancient",
+		"modern", "digital", "quantum", "stellar", "lunar", "solar",
+		"shadowy", "phantom", "thunderous", "stormy", "frosty",
+		"blazing", "radiant", "hidden", "secret", "sacred", "wild",
+		"calm", "bright", "dark", "deep", "quick", "strong", "wise",
+		"lucky", "happy", "sunny", "misty", "rocky", "sandy", "grassy",
+		"woody", "icy", "fiery", "electric", "magnetic", "atomic",
+		"orbital", "galactic", "nebular", "prismatic", "echoing",
+		"pulsing",
+	}
+
+	pool_nouns = []string{
+		"falcon", "eagle", "hawk", "raven", "owl", "wolf", "fox",
+		"bear", "lion", "tiger", "panther", "leopard", "jaguar",
+		"cheetah", "lynx", "puma", "cobra", "viper", "python",
+		"dragon", "phoenix", "griffin", "unicorn", "pegasus", "hydra",
+		"kraken", "leviathan", "behemoth", "colossus", "titan",
+		"wizard", "knight", "samurai", "ninja", "ranger", "hunter",
+		"scout", "sentinel", "guardian", "defender", "warrior",
+		"champion", "hero", "legend", "myth", "saga", "odyssey",
+		"voyage", "journey", "quest", "compass", "beacon",
+		"lighthouse", "anchor", "horizon", "summit", "peak", "ridge",
+		"canyon", "river", "ocean",
+	}
+)
+
+// GeneratePoolIdentities returns count unique identities for pool
+// clients. Hostnames are generated as adjective-noun combinations
+// (e.g. "brave-falcon"). If the number of clients exceeds the number
+// of available combinations a random numeric suffix is appended to
+// keep every hostname unique.
+//
+// The FQDN reuses the domain portion of the real host's FQDN so the
+// emulated clients appear to belong to the same network as the host
+// running the pool client (e.g. "brave-falcon.example.com" when the
+// host is "myhost.example.com").
+func GeneratePoolIdentities(count int, real_fqdn string) []PoolIdentity {
+	domain := deriveDomain(real_fqdn)
+	used := make(map[string]bool)
+	result := make([]PoolIdentity, 0, count)
+
+	for i := 0; i < count; i++ {
+		hostname := generateUniqueHostname(used)
+		result = append(result, PoolIdentity{
+			Hostname: hostname,
+			Fqdn:     hostname + "." + domain,
+		})
+	}
+
+	return result
+}
+
+// deriveDomain extracts the domain portion of a fully qualified
+// domain name. For example "myhost.example.com" returns
+// "example.com". If the FQDN has no domain portion (e.g. a bare
+// hostname) we fall back to "local" so generated FQDNs always look
+// like proper domain names.
+func deriveDomain(real_fqdn string) string {
+	parts := strings.SplitN(real_fqdn, ".", 2)
+	if len(parts) == 2 && parts[1] != "" {
+		return parts[1]
+	}
+	return "local"
+}
+
+func generateUniqueHostname(used map[string]bool) string {
+	for {
+		hostname := fmt.Sprintf("%s-%s",
+			pool_adjectives[rand.Intn(len(pool_adjectives))],
+			pool_nouns[rand.Intn(len(pool_nouns))])
+
+		if !used[hostname] {
+			used[hostname] = true
+			return hostname
+		}
+
+		// The base combination is already taken - disambiguate with a
+		// random numeric suffix.
+		hostname = fmt.Sprintf("%s-%d", hostname, rand.Intn(999)+1)
+		if !used[hostname] {
+			used[hostname] = true
+			return hostname
+		}
+	}
+}

--- a/executor/pool_identity_test.go
+++ b/executor/pool_identity_test.go
@@ -1,0 +1,70 @@
+package executor
+
+import (
+	"testing"
+)
+
+func TestGeneratePoolIdentities(t *testing.T) {
+	// Generate a large number of identities and make sure they are
+	// all unique.
+	count := 10000
+	identities := GeneratePoolIdentities(count, "myhost.example.com")
+
+	if len(identities) != count {
+		t.Fatalf("Expected %v identities, got %v", count, len(identities))
+	}
+
+	seen := make(map[string]bool)
+	for _, id := range identities {
+		if id.Hostname == "" {
+			t.Fatalf("Empty hostname generated")
+		}
+		// The FQDN reuses the domain of the real host.
+		if id.Fqdn != id.Hostname+".example.com" {
+			t.Fatalf("Fqdn %v does not match hostname %v", id.Fqdn, id.Hostname)
+		}
+		if seen[id.Hostname] {
+			t.Fatalf("Duplicate hostname generated: %v", id.Hostname)
+		}
+		seen[id.Hostname] = true
+	}
+}
+
+func TestGeneratePoolIdentitiesSmall(t *testing.T) {
+	// Even a small number of identities must be unique.
+	identities := GeneratePoolIdentities(100, "myhost")
+
+	seen := make(map[string]bool)
+	for _, id := range identities {
+		if id.Fqdn != id.Hostname+".local" {
+			t.Fatalf("Fqdn %v does not match hostname %v", id.Fqdn, id.Hostname)
+		}
+		if seen[id.Hostname] {
+			t.Fatalf("Duplicate hostname generated: %v", id.Hostname)
+		}
+		seen[id.Hostname] = true
+	}
+}
+
+func TestDeriveDomain(t *testing.T) {
+	table := []struct {
+		name     string
+		fqdn     string
+		expected string
+	}{
+		{"fully qualified", "myhost.example.com", "example.com"},
+		{"bare hostname", "myhost", "local"},
+		{"local domain", "myhost.local", "local"},
+		{"empty", "", "local"},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deriveDomain(tt.fqdn)
+			if result != tt.expected {
+				t.Fatalf("deriveDomain(%q) = %q, want %q",
+					tt.fqdn, result, tt.expected)
+			}
+		})
+	}
+}

--- a/executor/pool_test.go
+++ b/executor/pool_test.go
@@ -17,6 +17,11 @@ import (
 // the result uncompressed - the server falls back to handling
 // uncompressed data.
 func TestMaybeTransformResponseCompressed(t *testing.T) {
+	identity := &PoolIdentity{
+		Hostname: "brave-falcon",
+		Fqdn:     "brave-falcon.local",
+	}
+
 	rows := []*ordereddict.Dict{
 		ordereddict.NewDict().
 			Set("Hostname", "testhost").
@@ -34,7 +39,7 @@ func TestMaybeTransformResponseCompressed(t *testing.T) {
 		UncompressedSize:       uint64(len(jsonl)),
 	}
 
-	result := maybeTransformResponse(response, 42)
+	result := maybeTransformResponse(response, identity)
 	require.NotNil(t, result)
 
 	// The result must be uncompressed.
@@ -49,16 +54,21 @@ func TestMaybeTransformResponseCompressed(t *testing.T) {
 
 	hostname, pres := transformed_rows[0].GetString("Hostname")
 	require.True(t, pres)
-	assert.Equal(t, "testhost-42", hostname)
+	assert.Equal(t, "brave-falcon", hostname)
 
 	fqdn, pres := transformed_rows[0].GetString("Fqdn")
 	require.True(t, pres)
-	assert.Equal(t, "testhost-42", fqdn)
+	assert.Equal(t, "brave-falcon.local", fqdn)
 }
 
 // Test that the hostname transform still works on uncompressed
 // responses (older clients).
 func TestMaybeTransformResponseUncompressed(t *testing.T) {
+	identity := &PoolIdentity{
+		Hostname: "brave-falcon",
+		Fqdn:     "brave-falcon.local",
+	}
+
 	rows := []*ordereddict.Dict{
 		ordereddict.NewDict().
 			Set("Hostname", "testhost").
@@ -72,7 +82,7 @@ func TestMaybeTransformResponseUncompressed(t *testing.T) {
 		JSONLResponse: string(jsonl),
 	}
 
-	result := maybeTransformResponse(response, 7)
+	result := maybeTransformResponse(response, identity)
 	require.NotNil(t, result)
 
 	// The result must remain uncompressed.
@@ -86,12 +96,17 @@ func TestMaybeTransformResponseUncompressed(t *testing.T) {
 
 	hostname, pres := transformed_rows[0].GetString("Hostname")
 	require.True(t, pres)
-	assert.Equal(t, "testhost-7", hostname)
+	assert.Equal(t, "brave-falcon", hostname)
 }
 
 // Test that responses without a Hostname column are returned
 // unchanged.
 func TestMaybeTransformResponseNoHostname(t *testing.T) {
+	identity := &PoolIdentity{
+		Hostname: "brave-falcon",
+		Fqdn:     "brave-falcon.local",
+	}
+
 	rows := []*ordereddict.Dict{
 		ordereddict.NewDict().Set("Foo", "bar"),
 	}
@@ -107,7 +122,7 @@ func TestMaybeTransformResponseNoHostname(t *testing.T) {
 		UncompressedSize:       uint64(len(jsonl)),
 	}
 
-	result := maybeTransformResponse(response, 42)
+	result := maybeTransformResponse(response, identity)
 	require.NotNil(t, result)
 	assert.Equal(t, response, result)
 }

--- a/executor/pool_transform_test.go
+++ b/executor/pool_transform_test.go
@@ -1,0 +1,59 @@
+package executor
+
+import (
+	"testing"
+
+	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+)
+
+func TestMaybeTransformResponseBasicInformation(t *testing.T) {
+	identity := &PoolIdentity{
+		Hostname: "brave-falcon",
+		Fqdn:     "brave-falcon.local",
+	}
+
+	response := &actions_proto.VQLResponse{
+		Columns:       []string{"Hostname", "Fqdn", "OS"},
+		JSONLResponse: "{\"Hostname\":\"real-host\",\"Fqdn\":\"real-host.example.com\",\"OS\":\"linux\"}\n",
+	}
+
+	result := maybeTransformResponse(response, identity)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.JSONLResponse, "brave-falcon")
+	assert.Contains(t, result.JSONLResponse, "brave-falcon.local")
+	assert.Contains(t, result.JSONLResponse, "linux")
+	// The original response must not be mutated.
+	assert.Contains(t, response.JSONLResponse, "real-host")
+}
+
+func TestMaybeTransformResponseDetailedInfo(t *testing.T) {
+	identity := &PoolIdentity{
+		Hostname: "cosmic-orbit",
+		Fqdn:     "cosmic-orbit.local",
+	}
+
+	response := &actions_proto.VQLResponse{
+		Columns: []string{"Param", "Value"},
+		JSONLResponse: "{\"Param\":\"Hostname\",\"Value\":\"real-host\"}\n" +
+			"{\"Param\":\"Fqdn\",\"Value\":\"real-host.example.com\"}\n" +
+			"{\"Param\":\"OS\",\"Value\":\"linux\"}\n",
+	}
+
+	result := maybeTransformResponse(response, identity)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.JSONLResponse, "\"Value\":\"cosmic-orbit\"")
+	assert.Contains(t, result.JSONLResponse, "\"Value\":\"cosmic-orbit.local\"")
+	assert.Contains(t, result.JSONLResponse, "\"Value\":\"linux\"")
+}
+
+func TestMaybeTransformResponseNil(t *testing.T) {
+	assert.Nil(t, maybeTransformResponse(nil, &PoolIdentity{}))
+
+	// A nil identity means no transformation is applied.
+	response := &actions_proto.VQLResponse{
+		Columns:       []string{"Hostname"},
+		JSONLResponse: "{\"Hostname\":\"real-host\"}\n",
+	}
+	assert.Equal(t, response, maybeTransformResponse(response, nil))
+}

--- a/services/writeback/memory_writeback_test.go
+++ b/services/writeback/memory_writeback_test.go
@@ -1,0 +1,59 @@
+package writeback_test
+
+import (
+	"testing"
+
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/services/writeback"
+	"www.velocidex.com/golang/velociraptor/vtesting/assert"
+)
+
+// The pool client uses in-memory writebacks so no files are written
+// to disk. The writeback service dispatches on the writeback location
+// so each pool client gets its own in-memory writeback.
+func TestMemoryWriteback(t *testing.T) {
+	config_obj := &config_proto.Config{
+		Client: &config_proto.ClientConfig{
+			WritebackLinux:   "memory://pool_client.yaml.0",
+			WritebackWindows: "memory://pool_client.yaml.0",
+			WritebackDarwin:  "memory://pool_client.yaml.0",
+		},
+	}
+
+	writeback_service := writeback.GetWritebackService()
+	err := writeback_service.LoadWriteback(config_obj)
+	assert.NoError(t, err)
+
+	// Write a private key to the in-memory writeback.
+	err = writeback_service.MutateWriteback(config_obj,
+		func(wb *config_proto.Writeback) error {
+			wb.PrivateKey = "Private"
+			wb.ClientId = "C.1234"
+			return writeback.WritebackUpdateLevel1
+		})
+	assert.NoError(t, err)
+
+	// Read it back.
+	wb, err := writeback_service.GetWriteback(config_obj)
+	assert.NoError(t, err)
+	assert.Equal(t, "Private", wb.PrivateKey)
+	assert.Equal(t, "C.1234", wb.ClientId)
+
+	// A different writeback location gets a different (empty)
+	// in-memory writeback.
+	config_obj2 := &config_proto.Config{
+		Client: &config_proto.ClientConfig{
+			WritebackLinux:   "memory://pool_client.yaml.1",
+			WritebackWindows: "memory://pool_client.yaml.1",
+			WritebackDarwin:  "memory://pool_client.yaml.1",
+		},
+	}
+
+	err = writeback_service.LoadWriteback(config_obj2)
+	assert.NoError(t, err)
+
+	wb2, err := writeback_service.GetWriteback(config_obj2)
+	assert.NoError(t, err)
+	assert.Equal(t, "", wb2.PrivateKey)
+	assert.Equal(t, "", wb2.ClientId)
+}

--- a/services/writeback/reg_store.go
+++ b/services/writeback/reg_store.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // A writeback store that supports the windows registry.
@@ -122,6 +123,12 @@ func (self *RegistryWritebackStore) Load() *config_proto.Writeback {
 
 func GetFileWritebackStore(config_obj *config_proto.Config) WritebackStorer {
 	location, _ := WritebackLocation(config_obj)
+
+	// The pool client uses in-memory writebacks so no files are
+	// written to disk.
+	if strings.HasPrefix(location, "memory://") {
+		return &MemoryWritebackStore{}
+	}
 
 	if strings.HasPrefix(location, "HKLM\\") {
 		return &RegistryWritebackStore{

--- a/services/writeback/storage.go
+++ b/services/writeback/storage.go
@@ -6,8 +6,10 @@ import (
 	"io/ioutil"
 	"regexp"
 	"runtime"
+	"sync"
 
 	"github.com/Velocidex/yaml/v2"
+	"google.golang.org/protobuf/proto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/utils"
@@ -119,6 +121,44 @@ func (self *FileWritebackStore) Load() *config_proto.Writeback {
 	}
 
 	return wb
+}
+
+// An in-memory writeback store. This is used by the pool client to
+// keep each virtual client's writeback in memory only - no files are
+// written to disk and the client's identity is lost when the process
+// exits.
+type MemoryWritebackStore struct {
+	mu        sync.Mutex
+	writeback *config_proto.Writeback
+}
+
+func (self *MemoryWritebackStore) WriteL1(wb *config_proto.Writeback) error {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.writeback = proto.Clone(wb).(*config_proto.Writeback)
+	return nil
+}
+
+func (self *MemoryWritebackStore) WriteL2(wb *config_proto.Writeback) error {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	self.writeback = proto.Clone(wb).(*config_proto.Writeback)
+	return nil
+}
+
+func (self *MemoryWritebackStore) Load() *config_proto.Writeback {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	if self.writeback == nil {
+		self.writeback = &config_proto.Writeback{
+			InstallTime: uint64(utils.GetTime().Now().Unix()),
+		}
+	}
+
+	return proto.Clone(self.writeback).(*config_proto.Writeback)
 }
 
 // Return the location of the writeback file.

--- a/services/writeback/storage_unix.go
+++ b/services/writeback/storage_unix.go
@@ -1,11 +1,22 @@
+//go:build !windows
 // +build !windows
 
 package writeback
 
-import config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+import (
+	"strings"
+
+	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+)
 
 func GetFileWritebackStore(config_obj *config_proto.Config) WritebackStorer {
 	location, _ := WritebackLocation(config_obj)
+
+	// The pool client uses in-memory writebacks so no files are
+	// written to disk.
+	if strings.HasPrefix(location, "memory://") {
+		return &MemoryWritebackStore{}
+	}
 
 	return &FileWritebackStore{
 		config_obj:  config_obj,


### PR DESCRIPTION
While the pool client is designed for _server_ load testing, it has shown itself to be useful for testing/learning/development scenarios too (for example, testing hunt behaviours).

This PR preserves the load-testing aspects but adds some features that make the pool client more human-friendly and therefore more useful for lab and learning environments.

Each pool client now presents a unique hostname and FQDN (e.g. "quantum-phoenix.example.com") to the server instead of the real host's hostname suffixed with the client id. The FQDN reuses the domain of the host running the pool client so the emulated clients appear to belong to the same network. Hostnames are adjective-noun combinations (e.g. "quantum-phoenix") - a numeric suffix is only appended when the number of clients is almost ten thousand. Name collisions are possible if running pool clients simultaneously on multiple hosts connected to the same server, but the server is designed to expect name collisions in the real world, so it's not an issue.

Identities are generated upfront for all clients and applied to the `BasicInformation` and `DetailedInfo` sources of the `Generic.Client.Info` interrogation, as well as the periodic client info messages.

Writebacks now default to in-memory only (`memory:// scheme`) so no writeback files are written to disk and each client's identity is ephemeral.  This makes it easy to spin up clients -> run some tests -> stop the clients -> delete the data -> repeat, without needing to go clean up hundreds of writeback files each time. This also makes it easy to create massive amounts of hunt data in batches (create hunt -> add 10,000 clients -> hunt collections run -> stop clients -> add 10,000 new clients -> hunt collections run -> stop clients -> repeat) for server-side query performance testing.

The writeback location is now configured for all platforms - previously Darwin was left unset and fell back to the config file's path, causing all clients on macOS to share a single writeback file. The root config loader no longer requires a writeback file, but it is still available if you need persistent pool client identities.

Screenshots:

<img width="1600" height="800" alt="pool_client" src="https://github.com/user-attachments/assets/53d14917-4252-4924-857c-acee5c6708eb" />

<img width="1200" height="637" alt="pool_client2" src="https://github.com/user-attachments/assets/c42300ec-4869-465b-b4d6-2141dcbca6bd" />
